### PR TITLE
fix: skip node CI when package.json not present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   node:
     runs-on: ubuntu-latest
+    if: hashFiles('.claude/skills/yida-publish/scripts/package.json') != ''
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Add condition to skip node job when `.claude/skills/yida-publish/scripts/package.json` doesn't exist.

## Changes

- Add `if: hashFiles('.claude/skills/yida-publish/scripts/package.json') != ''` to node job

## Related Issue

Closes #7