### PR TITLE
feat: CI 自动更新 README contributors (closes #29)

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,149 @@
+name: Update Contributors
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  update-contributors:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Update README contributors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import subprocess
+          import json
+          import re
+          import sys
+          import os
+
+          repo = os.environ["REPO"]
+          print("📋 获取仓库所有贡献者...")
+
+          # 从 GitHub API 获取所有贡献者（gh cli 支持自动分页）
+          result = subprocess.run(
+              ["gh", "api", f"repos/{repo}/contributors?per_page=100&anon=false", "--paginate"],
+              capture_output=True, text=True
+          )
+          if result.returncode != 0:
+              print(f"⚠️  获取贡献者失败: {result.stderr}")
+              sys.exit(0)
+
+          # gh --paginate 返回多个 JSON 数组拼接，需要合并
+          raw = result.stdout.strip()
+          all_contributors = []
+          for chunk in re.findall(r'\[.*?\]', raw, re.DOTALL):
+              try:
+                  all_contributors.extend(json.loads(chunk))
+              except json.JSONDecodeError:
+                  pass
+
+          if not all_contributors:
+              print("⚠️  未获取到贡献者数据，跳过更新")
+              sys.exit(0)
+
+          print(f"✅ 共获取到 {len(all_contributors)} 位贡献者")
+
+          # 读取当前 README
+          with open("README.md", "r", encoding="utf-8") as f:
+              readme_content = f.read()
+
+          # 提取 README 中已有的贡献者用户名（小写，去重）
+          existing_users = set(
+              u.lower() for u in re.findall(r'href="https://github\.com/([^"]+)"', readme_content)
+          )
+          print(f"=== 当前 README 中已有贡献者 ===")
+          for u in sorted(existing_users):
+              print(f"  - {u}")
+
+          # 机器人账号关键词（跳过）
+          bot_patterns = re.compile(r'\[bot\]|dependabot|github-actions|renovate|actions-user', re.IGNORECASE)
+
+          # 找出新贡献者，按贡献数量排序（API 返回已按贡献数降序）
+          new_html_parts = []
+          for contributor in all_contributors:
+              login = contributor.get("login", "")
+              avatar_url = contributor.get("avatar_url", "")
+              html_url = contributor.get("html_url", f"https://github.com/{login}")
+
+              if not login:
+                  continue
+
+              # 跳过机器人
+              if bot_patterns.search(login):
+                  print(f"  🤖 跳过机器人: {login}")
+                  continue
+
+              # 跳过已在 README 中的贡献者
+              if login.lower() in existing_users:
+                  print(f"  ⏭️  已存在: {login}")
+                  continue
+
+              print(f"  ✨ 新贡献者: {login}")
+              # 构建头像 HTML（与现有格式完全一致）
+              avatar_48 = f"{avatar_url}&s=48"
+              new_html_parts.append(
+                  f'<a href="{html_url}"><img src="{avatar_48}" width="48" height="48" alt="{login}" title="{login}"/></a>'
+              )
+
+          if not new_html_parts:
+              print("\n✅ 没有新贡献者需要添加，README 无需更新")
+              sys.exit(0)
+
+          print(f"\n📝 添加 {len(new_html_parts)} 位新贡献者到 README...")
+
+          # 在 contributors 区域的 </p> 前插入新贡献者头像
+          # README 中 contributors 区域格式：
+          #   ### 贡献者
+          #   <p align="left">
+          #     <a href="..."><img .../></a> ...
+          #   </p>
+          new_html_str = " " + " ".join(new_html_parts)
+
+          pattern = r'(### 贡献者.*?<p align="left">)(.*?)(</p>)'
+
+          def replacer(m):
+              existing_block = m.group(2).rstrip()
+              return m.group(1) + existing_block + new_html_str + "\n" + m.group(3)
+
+          updated_content = re.sub(pattern, replacer, readme_content, flags=re.DOTALL)
+
+          if updated_content == readme_content:
+              print("⚠️  未找到 contributors 区域（### 贡献者 + <p align=\"left\">），跳过更新")
+              sys.exit(0)
+
+          with open("README.md", "w", encoding="utf-8") as f:
+              f.write(updated_content)
+
+          print("✅ README.md 已更新")
+          PYEOF
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet README.md; then
+            echo "✅ README.md 无变化，无需提交"
+            exit 0
+          fi
+
+          git add README.md
+          git commit -m "chore: 自动更新 README contributors [skip ci]"
+          git push origin main
+          echo "🚀 已推送更新到 main 分支"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ AI 生成灯谜图片，用户猜答案，猜错了有 AI 幽默提示。
 7. 重新登录
 8. 退出登录
 
+## 贡献者
+
+感谢所有为 OpenYida 做出贡献的开发者！
+
+### 贡献者
+<p align="left">
+  <a href="https://github.com/yize"><img src="https://avatars.githubusercontent.com/u/1011681?v=4&s=48" width="48" height="48" alt="yize" title="yize"/></a>
+</p>
+
 ## License
 
 [MIT](./LICENSE) © 2026 天晟


### PR DESCRIPTION
## 概述

实现 Issue #29：在 PR merge 到 main 时，通过 GitHub Actions 自动更新 README 中的贡献者列表。

## 变更内容

### README.md
- 新增 **贡献者** 区域（位于 License 前），包含初始贡献者头像

### .github/workflows/update-contributors.yml
- 新增 CI workflow，触发条件：
  - PR merge 到 main 时自动触发
  - 支持手动触发（workflow_dispatch）

## 工作原理

1. 通过 `gh api repos/{owner}/{repo}/contributors` 获取所有贡献者
2. 解析 README 中已有的贡献者用户名，过滤机器人账号
3. 识别新贡献者，生成头像 HTML 并插入 `### 贡献者` 区域
4. 自动提交并推送到 main（commit message 含 `[skip ci]` 避免循环触发）

## 效果

每次 PR merge 后，新贡献者头像会自动出现在 README 的贡献者区域，无需手动维护。

Closes #29