### PR TITLE
fix: 修复 CI 自动更新 contributor 头像 URL 版本参数错误 (closes #31)

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -96,7 +96,9 @@ jobs:
 
               print(f"  ✨ 新贡献者: {login}")
               # 构建头像 HTML（与现有格式完全一致）
-              avatar_48 = f"{avatar_url}&s=48"
+              # 强制将版本参数替换为 v=4，修复旧账号可能返回 v=3 的问题（issue #31）
+              avatar_url_v4 = re.sub(r'\?v=\d+', '?v=4', avatar_url)
+              avatar_48 = f"{avatar_url_v4}&s=48"
               new_html_parts.append(
                   f'<a href="{html_url}"><img src="{avatar_48}" width="48" height="48" alt="{login}" title="{login}"/></a>'
               )

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -452,3 +452,93 @@ describe("Skill 未安装时的错误提示", () => {
     expect(stderr).toContain("未找到 skill 脚本");
   });
 });
+
+// ── 头像 URL 版本参数修复测试（Issue #31）────────────────────────────
+//
+// workflow 中使用 re.sub(r'\?v=\d+', '?v=4', avatar_url) 修复版本参数。
+// 以下测试用 JS 等价逻辑验证该正则替换的正确性。
+
+/**
+ * 模拟 workflow 中的头像 URL 版本参数修复逻辑（Python re.sub 的 JS 等价实现）
+ */
+function fixAvatarUrlVersion(avatarUrl) {
+  return avatarUrl.replace(/\?v=\d+/, "?v=4");
+}
+
+/**
+ * 模拟 workflow 中完整的头像 URL 构建逻辑
+ */
+function buildAvatarUrl(avatarUrl) {
+  const avatarUrlV4 = fixAvatarUrlVersion(avatarUrl);
+  return `${avatarUrlV4}&s=48`;
+}
+
+describe("头像 URL 版本参数修复（Issue #31）", () => {
+  test("v=3 的旧版头像 URL 被替换为 v=4", () => {
+    const input = "https://avatars.githubusercontent.com/u/1578814?v=3";
+    expect(fixAvatarUrlVersion(input)).toBe(
+      "https://avatars.githubusercontent.com/u/1578814?v=4"
+    );
+  });
+
+  test("v=4 的头像 URL 保持不变", () => {
+    const input = "https://avatars.githubusercontent.com/u/1011681?v=4";
+    expect(fixAvatarUrlVersion(input)).toBe(
+      "https://avatars.githubusercontent.com/u/1011681?v=4"
+    );
+  });
+
+  test("v=1 的旧版头像 URL 被替换为 v=4", () => {
+    const input = "https://avatars.githubusercontent.com/u/12345?v=1";
+    expect(fixAvatarUrlVersion(input)).toBe(
+      "https://avatars.githubusercontent.com/u/12345?v=4"
+    );
+  });
+
+  test("不含版本参数的 URL 保持不变", () => {
+    const input = "https://avatars.githubusercontent.com/u/12345";
+    expect(fixAvatarUrlVersion(input)).toBe(
+      "https://avatars.githubusercontent.com/u/12345"
+    );
+  });
+
+  test("v=3 的 URL 构建后包含正确的 v=4&s=48 参数", () => {
+    const input = "https://avatars.githubusercontent.com/u/1578814?v=3";
+    const result = buildAvatarUrl(input);
+    expect(result).toBe("https://avatars.githubusercontent.com/u/1578814?v=4&s=48");
+    expect(result).not.toContain("v=3");
+  });
+
+  test("v=4 的 URL 构建后包含正确的 v=4&s=48 参数", () => {
+    const input = "https://avatars.githubusercontent.com/u/1011681?v=4";
+    const result = buildAvatarUrl(input);
+    expect(result).toBe("https://avatars.githubusercontent.com/u/1011681?v=4&s=48");
+  });
+
+  test("构建的头像 URL 不包含 v=3", () => {
+    const testCases = [
+      "https://avatars.githubusercontent.com/u/111?v=3",
+      "https://avatars.githubusercontent.com/u/222?v=3",
+      "https://avatars.githubusercontent.com/u/333?v=1",
+    ];
+    testCases.forEach((url) => {
+      const result = buildAvatarUrl(url);
+      expect(result).not.toContain("v=3");
+      expect(result).not.toContain("v=1");
+      expect(result).toContain("v=4");
+      expect(result).toContain("&s=48");
+    });
+  });
+
+  test("README 中已有的 v=4 头像 URL 格式正确", () => {
+    // 验证 README 中初始贡献者头像 URL 格式符合规范
+    const readmePath = require("path").resolve(__dirname, "../README.md");
+    const readmeContent = require("fs").readFileSync(readmePath, "utf-8");
+    const avatarUrls = readmeContent.match(/src="https:\/\/avatars\.githubusercontent\.com[^"]+"/g) || [];
+    avatarUrls.forEach((srcAttr) => {
+      // 所有头像 URL 应该包含 v=4 而不是 v=3
+      expect(srcAttr).not.toContain("v=3");
+      expect(srcAttr).toContain("v=4");
+    });
+  });
+});


### PR DESCRIPTION
## Bug 描述

Issue #31：CI 自动更新 contributor 功能中，GitHub API 返回的 `avatar_url` 对于旧账号可能含 `?v=3` 参数，直接拼接 `&s=48` 不会修正版本号，导致头像可能不显示或显示错误。

## 根本原因

```python
# 修复前：直接拼接，不处理版本号
avatar_48 = f"{avatar_url}&s=48"
# 若 avatar_url = "https://avatars.githubusercontent.com/u/xxx?v=3"
# 结果："...?v=3&s=48"  ❌
```

## 修复方案

在拼接 `&s=48` 前，用正则将版本参数强制替换为 `v=4`：

```python
# 修复后：强制替换为 v=4
avatar_url_v4 = re.sub(r'\?v=\d+', '?v=4', avatar_url)
avatar_48 = f"{avatar_url_v4}&s=48"
# 结果："...?v=4&s=48"  ✅
```

## 变更文件

- `.github/workflows/update-contributors.yml`：修复头像 URL 版本参数
- `tests/cli.test.js`：新增 8 个回归测试用例，覆盖 v=3/v=4/v=1/无版本参数等场景

## 测试结果

**47 个测试全部通过**，包含新增的 8 个头像 URL 版本参数修复测试：
- v=3 → v=4 替换
- v=4 保持不变
- v=1 → v=4 替换
- 无版本参数保持不变
- 构建后 URL 格式验证
- README 中现有头像 URL 格式验证

Closes #31