### PR TITLE
feat: 新增 yida-issue skill，一句话给 OpenYida 提需求并自动路由仓库

### DIFF
--- a/.openclaw/skills/yida-issue/scripts/create-issue.js
+++ b/.openclaw/skills/yida-issue/scripts/create-issue.js
@@ -144,7 +144,7 @@ ${description}
 - 相关版本：
 
 ---
-> 此 Issue 由 [yida-issue skill](https://github.com/openyida/yida-skills) 自动创建，路由到 **${repoLabel}**。`;
+> 此 Issue 由 [yida-issue skill](https://github.com/openyida/openyida/tree/main/.openclaw/skills/yida-issue) 自动创建，路由到 **${repoLabel}**。`;
   }
 
   return `## 需求描述
@@ -164,7 +164,7 @@ ${description}
 中
 
 ---
-> 此 Issue 由 [yida-issue skill](https://github.com/openyida/yida-skills) 自动创建，路由到 **${repoLabel}**。`;
+> 此 Issue 由 [yida-issue skill](https://github.com/openyida/openyida/tree/main/.openclaw/skills/yida-issue) 自动创建，路由到 **${repoLabel}**。`;
 }
 
 // ── 参数解析 ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## 关联 Issue
Closes #33

## 变更内容

### 新增
- `.openclaw/skills/yida-issue/`：专为 OpenClaw 设计的提需求 skill，一句话自动路由到 `openyida/openyida` 或 `openyida/yida-skills` 并创建格式规范的 GitHub Issue

### 重构
- `.claude/skills` 改为 git submodule，指向 `openyida/yida-skills` 仓库，替代原来的手动安装脚本方案
- 更新 `.gitignore` 允许 `.claude/skills` 被 git 追踪
- 移除手动维护的 `.openclaw/skills`（除 yida-issue 外）

### 文档
- `README.md` / `README_zh.md`：快速开始改为 `git clone --recurse-submodules`
- `CLAUDE.md`：标注 skills 目录为 git submodule
- `LICENSE` / README 版权更新为 Alibaba Group Holding Limited

### CI
- 修复 JS/JSON 校验路径适配 submodule 目录结构
- checkout 步骤加 `submodules: true`

### Bug Fix
- 修复 issue body 换行符丢失问题（改用 `--body-file` 临时文件）
- 修复 issue body 中 skill 链接指向错误