### PR TITLE
feat: add export/import commands for cross-environment app migration

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -20,6 +20,8 @@
  *   openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]  保存公开访问/分享配置
  *   openyida get-page-config <appType> <formUuid>       查询页面公开访问/分享配置
  *   openyida update-form-config <appType> <formUuid> <isRenderNav> <title>  更新表单配置
+ *   openyida export <appType> [output]                  导出应用所有表单 Schema（生成迁移包）
+ *   openyida import <file> [name]                       导入迁移包，在目标环境重建应用
  */
 
 "use strict";
@@ -55,6 +57,8 @@ openyida - 宜搭命令行工具
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
   get-page-config <appType> <formUuid>                         查询页面公开访问/分享配置
   update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
+  export <appType> [output]                                    导出应用所有表单 Schema（生成迁移包）
+  import <file> [name]                                         导入迁移包，在目标环境重建应用
 
 示例：
   openyida login
@@ -69,6 +73,10 @@ openyida - 宜搭命令行工具
   openyida save-share-config APP_XXX FORM-XXX /o/myapp y n
   openyida get-page-config APP_XXX FORM-XXX
   openyida update-form-config APP_XXX FORM-XXX false "页面标题"
+  openyida export APP_XXX
+  openyida export APP_XXX ./my-app-backup.json
+  openyida import ./yida-export.json
+  openyida import ./yida-export.json "质量追溯系统（生产环境）"
 `);
 }
 
@@ -194,6 +202,30 @@ async function main() {
       }
       process.argv = [process.argv[0], process.argv[1], ...args];
       require('../lib/update-form-config');
+      break;
+    }
+
+    case 'export': {
+      if (args.length < 1) {
+        console.error('用法: openyida export <appType> [output]');
+        console.error('示例: openyida export APP_XXX');
+        console.error('      openyida export APP_XXX ./my-app-backup.json');
+        process.exit(1);
+      }
+      const { run: runExport } = require('../lib/export-app');
+      await runExport(args);
+      break;
+    }
+
+    case 'import': {
+      if (args.length < 1) {
+        console.error('用法: openyida import <file> [name]');
+        console.error('示例: openyida import ./yida-export.json');
+        console.error('      openyida import ./yida-export.json "质量追溯系统（生产环境）"');
+        process.exit(1);
+      }
+      const { run: runImport } = require('../lib/import-app');
+      await runImport(args);
       break;
     }
 

--- a/lib/export-app.js
+++ b/lib/export-app.js
@@ -1,0 +1,196 @@
+/**
+ * export-app.js - 宜搭应用导出命令
+ *
+ * 导出应用的所有表单 Schema，生成可移植的迁移包（yida-export.json）。
+ *
+ * 用法：openyida export <appType> [output]
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpGet,
+  requestWithAutoLogin,
+} = require("./utils");
+
+// ── 获取应用下所有表单页面列表 ────────────────────────
+
+async function fetchFormPageList(appType, authRef) {
+  const result = await requestWithAutoLogin((auth) => {
+    return httpGet(
+      auth.baseUrl,
+      `/alibaba/web/${appType}/_view/query/app/getAppItemList.json`,
+      { appType },
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || result.success === false) {
+    throw new Error(`获取表单列表失败: ${result ? result.errorMsg || "未知错误" : "请求失败"}`);
+  }
+
+  // 过滤出表单类型的页面（formType 为 form 或 report）
+  const items = result.content || result.data || [];
+  const formPages = [];
+
+  function collectFormPages(nodes) {
+    for (const node of nodes) {
+      if (node.formType === "form" || node.formType === "report" || node.formType === "subForm") {
+        formPages.push({
+          formUuid: node.formUuid || node.pageId,
+          name: node.name || node.formName || node.pageTitle || "未命名表单",
+          formType: node.formType,
+        });
+      }
+      if (node.children && node.children.length > 0) {
+        collectFormPages(node.children);
+      }
+    }
+  }
+
+  collectFormPages(Array.isArray(items) ? items : [items]);
+  return formPages;
+}
+
+// ── 获取单个表单 Schema ───────────────────────────────
+
+async function fetchFormSchema(appType, formUuid, authRef) {
+  const result = await requestWithAutoLogin((auth) => {
+    return httpGet(
+      auth.baseUrl,
+      `/alibaba/web/${appType}/_view/query/formdesign/getFormSchema.json`,
+      { formUuid, schemaVersion: "V5" },
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || result.success === false) {
+    return null;
+  }
+
+  return result;
+}
+
+// ── 主逻辑 ────────────────────────────────────────────
+
+async function run(args) {
+  if (args.length < 1) {
+    console.error("用法: openyida export <appType> [output]");
+    console.error("示例: openyida export APP_XXXXXXXXXXXXX");
+    console.error("      openyida export APP_XXXXXXXXXXXXX ./my-app-backup.json");
+    process.exit(1);
+  }
+
+  const appType = args[0];
+  const outputPath = args[1] || path.join(process.cwd(), "yida-export.json");
+
+  console.error("=".repeat(50));
+  console.error("  openyida export - 宜搭应用导出工具");
+  console.error("=".repeat(50));
+  console.error(`\n  应用 ID:  ${appType}`);
+  console.error(`  输出文件: ${outputPath}`);
+
+  // Step 1: 读取登录态
+  console.error("\n🔑 Step 1: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+
+  const authRef = {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+  console.error(`  ✅ 登录态已就绪（${authRef.baseUrl}）`);
+
+  // Step 2: 获取表单页面列表
+  console.error("\n📋 Step 2: 获取应用表单列表");
+  let formPages;
+  try {
+    formPages = await fetchFormPageList(appType, authRef);
+  } catch (err) {
+    console.error(`  ❌ ${err.message}`);
+    process.exit(1);
+  }
+
+  if (formPages.length === 0) {
+    console.error("  ⚠️  未找到任何表单页面，请确认应用 ID 是否正确");
+    process.exit(1);
+  }
+
+  console.error(`  ✅ 找到 ${formPages.length} 个表单页面`);
+  formPages.forEach((page, index) => {
+    console.error(`     ${index + 1}. ${page.name} (${page.formUuid})`);
+  });
+
+  // Step 3: 逐个导出表单 Schema
+  console.error("\n📦 Step 3: 导出表单 Schema");
+  const exportedForms = [];
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const page of formPages) {
+    console.error(`\n  正在导出: ${page.name} (${page.formUuid})`);
+    const schema = await fetchFormSchema(appType, page.formUuid, authRef);
+    if (schema) {
+      exportedForms.push({
+        formUuid: page.formUuid,
+        name: page.name,
+        formType: page.formType,
+        schema,
+      });
+      console.error(`    ✅ 导出成功`);
+      successCount++;
+    } else {
+      console.error(`    ⚠️  导出失败，跳过`);
+      failCount++;
+    }
+  }
+
+  // Step 4: 写入导出文件
+  console.error("\n💾 Step 4: 写入导出文件");
+  const exportData = {
+    version: "1.0",
+    exportedAt: new Date().toISOString(),
+    sourceAppType: appType,
+    baseUrl: authRef.baseUrl,
+    forms: exportedForms,
+  };
+
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(exportData, null, 2), "utf-8");
+
+  // 输出结果
+  console.error("\n" + "=".repeat(50));
+  console.error("  ✅ 导出完成！");
+  console.error(`  成功: ${successCount} 个表单`);
+  if (failCount > 0) {
+    console.error(`  失败: ${failCount} 个表单（已跳过）`);
+  }
+  console.error(`  输出文件: ${outputPath}`);
+  console.error("=".repeat(50));
+
+  console.log(
+    JSON.stringify({
+      success: true,
+      appType,
+      outputPath,
+      totalForms: formPages.length,
+      successCount,
+      failCount,
+    })
+  );
+}
+
+module.exports = { run };

--- a/lib/import-app.js
+++ b/lib/import-app.js
@@ -1,0 +1,363 @@
+/**
+ * import-app.js - 宜搭应用导入命令
+ *
+ * 将 openyida export 生成的迁移包导入到目标宜搭环境，自动重建应用和所有表单页面。
+ *
+ * 用法：openyida import <file> [name]
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const querystring = require("querystring");
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpPost,
+  httpGet,
+  requestWithAutoLogin,
+} = require("./utils");
+
+// ── 创建新应用 ────────────────────────────────────────
+
+async function createApp(appName, authRef) {
+  const postData = querystring.stringify({
+    _csrf_token: authRef.csrfToken,
+    appName: JSON.stringify({ zh_CN: appName, en_US: appName, type: "i18n" }),
+    description: JSON.stringify({ zh_CN: appName, en_US: appName, type: "i18n" }),
+    icon: "xian-yingyong%%#0089FF",
+    iconUrl: "xian-yingyong%%#0089FF",
+    colour: "blue",
+    defaultLanguage: "zh_CN",
+    openExclusive: "n",
+    openPhysicColumn: "n",
+    openIsolationDatabase: "n",
+    openExclusiveUnit: "n",
+    group: "全部应用",
+  });
+
+  const result = await requestWithAutoLogin((auth) => {
+    return httpPost(auth.baseUrl, "/query/app/registerApp.json", postData, auth.cookies);
+  }, authRef);
+
+  if (!result || !result.success || !result.content) {
+    throw new Error(`创建应用失败: ${result ? result.errorMsg || "未知错误" : "请求失败"}`);
+  }
+
+  return result.content; // appType
+}
+
+// ── 创建空白表单页面 ──────────────────────────────────
+
+async function createBlankForm(appType, formTitle, authRef) {
+  const postData = querystring.stringify({
+    _csrf_token: authRef.csrfToken,
+    formType: "receipt",
+    title: JSON.stringify({ zh_CN: formTitle, en_US: formTitle, type: "i18n" }),
+  });
+
+  const result = await requestWithAutoLogin((auth) => {
+    return httpPost(
+      auth.baseUrl,
+      `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
+      postData,
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || !result.success || !result.content) {
+    throw new Error(`创建表单失败: ${result ? result.errorMsg || "未知错误" : "请求失败"}`);
+  }
+
+  const content = result.content;
+  return content.formUuid || content;
+}
+
+// ── 保存表单 Schema ───────────────────────────────────
+
+async function saveFormSchema(appType, formUuid, schema, authRef) {
+  const postData = querystring.stringify({
+    _csrf_token: authRef.csrfToken,
+    appType,
+    formUuid,
+    content: JSON.stringify(schema),
+    schemaVersion: "V5",
+  });
+
+  const result = await requestWithAutoLogin((auth) => {
+    return httpPost(
+      auth.baseUrl,
+      `/alibaba/web/${appType}/_view/query/formdesign/saveFormSchema.json`,
+      postData,
+      auth.cookies
+    );
+  }, authRef);
+
+  return result;
+}
+
+// ── 更新表单配置（发布表单）─────────────────────────────
+
+async function updateFormConfig(appType, formUuid, authRef) {
+  const postData = querystring.stringify({
+    _csrf_token: authRef.csrfToken,
+    appType,
+    formUuid,
+    setting: JSON.stringify({ MINI_RESOURCE: 0 }),
+    version: 1,
+  });
+
+  const result = await requestWithAutoLogin((auth) => {
+    return httpPost(
+      auth.baseUrl,
+      `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`,
+      postData,
+      auth.cookies
+    );
+  }, authRef);
+
+  return result;
+}
+
+// ── 适配 SerialNumberField formula ───────────────────
+//
+// 将 Schema 中所有 SerialNumberField 的 formula 里的旧 appType 替换为新 appType，
+// 同时将旧 formUuid 替换为新 formUuid。
+
+function adaptSerialNumberFormulas(schema, oldAppType, newAppType, oldFormUuid, newFormUuid) {
+  const schemaStr = JSON.stringify(schema);
+  const adapted = schemaStr
+    .replace(new RegExp(escapeRegExp(oldAppType), "g"), newAppType)
+    .replace(new RegExp(escapeRegExp(oldFormUuid), "g"), newFormUuid);
+  return JSON.parse(adapted);
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ── 从 Schema 中提取表单 Schema 内容 ─────────────────
+//
+// getFormSchema 接口返回的结构可能是 { content: {...} } 或直接是 schema 对象。
+
+function extractSchemaContent(schemaResult) {
+  if (!schemaResult) return null;
+  if (schemaResult.content && typeof schemaResult.content === "object") {
+    return schemaResult.content;
+  }
+  if (schemaResult.pages) {
+    return schemaResult;
+  }
+  return null;
+}
+
+// ── 主逻辑 ────────────────────────────────────────────
+
+async function run(args) {
+  if (args.length < 1) {
+    console.error("用法: openyida import <file> [name]");
+    console.error("示例: openyida import ./yida-export.json");
+    console.error("      openyida import ./yida-export.json \"质量追溯系统（生产环境）\"");
+    process.exit(1);
+  }
+
+  const exportFilePath = path.resolve(args[0]);
+  const targetAppName = args[1] || null;
+
+  console.error("=".repeat(50));
+  console.error("  openyida import - 宜搭应用导入工具");
+  console.error("=".repeat(50));
+  console.error(`\n  导入文件: ${exportFilePath}`);
+
+  // Step 1: 读取导出文件
+  console.error("\n📂 Step 1: 读取导出文件");
+  if (!fs.existsSync(exportFilePath)) {
+    console.error(`  ❌ 文件不存在: ${exportFilePath}`);
+    process.exit(1);
+  }
+
+  let exportData;
+  try {
+    exportData = JSON.parse(fs.readFileSync(exportFilePath, "utf-8"));
+  } catch (err) {
+    console.error(`  ❌ 解析导出文件失败: ${err.message}`);
+    process.exit(1);
+  }
+
+  const { sourceAppType, forms } = exportData;
+  if (!sourceAppType || !Array.isArray(forms) || forms.length === 0) {
+    console.error("  ❌ 导出文件格式无效，请使用 openyida export 生成");
+    process.exit(1);
+  }
+
+  const appName = targetAppName || `${sourceAppType}（迁移）`;
+  console.error(`  ✅ 读取成功，共 ${forms.length} 个表单`);
+  console.error(`  源应用 ID: ${sourceAppType}`);
+  console.error(`  目标应用名: ${appName}`);
+
+  // Step 2: 读取登录态
+  console.error("\n🔑 Step 2: 读取登录态");
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error("  ⚠️  未找到本地登录态，触发登录...");
+    cookieData = triggerLogin();
+  }
+
+  const authRef = {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+  console.error(`  ✅ 登录态已就绪（${authRef.baseUrl}）`);
+
+  // Step 3: 创建新应用
+  console.error("\n📦 Step 3: 创建新应用");
+  let newAppType;
+  try {
+    newAppType = await createApp(appName, authRef);
+  } catch (err) {
+    console.error(`  ❌ ${err.message}`);
+    process.exit(1);
+  }
+  console.error(`  ✅ 新应用已创建: ${newAppType}`);
+
+  // Step 4: 逐个重建表单页面
+  console.error("\n🔨 Step 4: 重建表单页面");
+  const migrationReport = {
+    version: "1.0",
+    migratedAt: new Date().toISOString(),
+    sourceAppType,
+    targetAppType: newAppType,
+    targetAppName: appName,
+    baseUrl: authRef.baseUrl,
+    forms: [],
+  };
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const form of forms) {
+    const { formUuid: oldFormUuid, name: formName, schema: formSchemaResult } = form;
+    console.error(`\n  正在迁移: ${formName} (${oldFormUuid})`);
+
+    // 4.1 创建空白表单
+    let newFormUuid;
+    try {
+      newFormUuid = await createBlankForm(newAppType, formName, authRef);
+      console.error(`    ✅ 空白表单已创建: ${newFormUuid}`);
+    } catch (err) {
+      console.error(`    ❌ 创建表单失败: ${err.message}`);
+      migrationReport.forms.push({
+        oldFormUuid,
+        newFormUuid: null,
+        name: formName,
+        status: "failed",
+        error: err.message,
+      });
+      failCount++;
+      continue;
+    }
+
+    // 4.2 提取并适配 Schema
+    const originalSchema = extractSchemaContent(formSchemaResult);
+    if (!originalSchema) {
+      console.error(`    ⚠️  Schema 内容为空，跳过`);
+      migrationReport.forms.push({
+        oldFormUuid,
+        newFormUuid,
+        name: formName,
+        status: "skipped",
+        error: "Schema 内容为空",
+      });
+      failCount++;
+      continue;
+    }
+
+    // 将 Schema 中所有旧 appType / formUuid 替换为新值
+    const adaptedSchema = adaptSerialNumberFormulas(
+      originalSchema,
+      sourceAppType,
+      newAppType,
+      oldFormUuid,
+      newFormUuid
+    );
+
+    // 4.3 保存 Schema
+    const saveResult = await saveFormSchema(newAppType, newFormUuid, adaptedSchema, authRef);
+    if (!saveResult || !saveResult.success) {
+      const errorMsg = saveResult ? saveResult.errorMsg || "未知错误" : "请求失败";
+      console.error(`    ❌ 保存 Schema 失败: ${errorMsg}`);
+      migrationReport.forms.push({
+        oldFormUuid,
+        newFormUuid,
+        name: formName,
+        status: "failed",
+        error: `保存 Schema 失败: ${errorMsg}`,
+      });
+      failCount++;
+      continue;
+    }
+    console.error(`    ✅ Schema 已保存`);
+
+    // 4.4 更新表单配置
+    const configResult = await updateFormConfig(newAppType, newFormUuid, authRef);
+    if (!configResult || !configResult.success) {
+      const errorMsg = configResult ? configResult.errorMsg || "未知错误" : "请求失败";
+      console.error(`    ⚠️  配置更新失败（Schema 已保存）: ${errorMsg}`);
+    } else {
+      console.error(`    ✅ 表单配置已更新`);
+    }
+
+    migrationReport.forms.push({
+      oldFormUuid,
+      newFormUuid,
+      name: formName,
+      status: "success",
+    });
+    successCount++;
+  }
+
+  // Step 5: 写入迁移报告
+  console.error("\n📄 Step 5: 写入迁移报告");
+  const reportPath = path.join(process.cwd(), "yida-migration-report.json");
+  fs.writeFileSync(reportPath, JSON.stringify(migrationReport, null, 2), "utf-8");
+  console.error(`  ✅ 迁移报告已写入: ${reportPath}`);
+
+  // 输出结果
+  const appUrl = `${authRef.baseUrl}/${newAppType}/admin`;
+  console.error("\n" + "=".repeat(50));
+  console.error("  ✅ 迁移完成！");
+  console.error(`  新应用 ID:   ${newAppType}`);
+  console.error(`  新应用名称:  ${appName}`);
+  console.error(`  访问地址:    ${appUrl}`);
+  console.error(`  成功迁移:    ${successCount} 个表单`);
+  if (failCount > 0) {
+    console.error(`  失败/跳过:   ${failCount} 个表单`);
+  }
+  console.error(`  迁移报告:    ${reportPath}`);
+  if (failCount > 0) {
+    console.error("\n  ⚠️  注意事项：");
+    console.error("  - 关联表单（associationFormField）的跨表单引用需根据迁移报告手动更新");
+    console.error("  - 自定义页面需使用 openyida publish 单独重新发布");
+  }
+  console.error("=".repeat(50));
+
+  console.log(
+    JSON.stringify({
+      success: true,
+      sourceAppType,
+      targetAppType: newAppType,
+      targetAppName: appName,
+      appUrl,
+      reportPath,
+      totalForms: forms.length,
+      successCount,
+      failCount,
+    })
+  );
+}
+
+module.exports = { run };


### PR DESCRIPTION
## 关联 Issue

Closes #62

## 变更说明

在 `bin/yida.js` 中新增两个命令，支持宜搭应用跨环境迁移：

### `yida export <app> [output]`
导出宜搭应用的所有表单 Schema，生成可移植的迁移包（`yida-export.json`）。

```bash
# 导出到默认文件
yida export APP_XXXXXXXXXXXXX

# 导出到指定文件
yida export APP_XXXXXXXXXXXXX ./my-app-backup.json
```

### `yida import <file> [name]`
将导出的迁移包导入到目标宜搭环境，自动重建应用和所有表单页面。

```bash
# 使用默认应用名称
yida import ./yida-export.json

# 指定目标应用名称
yida import ./yida-export.json "质量追溯系统（生产环境）"
```

## 迁移流程

```
yida export APP_源应用
  ↓ 生成 yida-export.json
yida import ./yida-export.json "新应用名称"
  ↓ 自动创建新应用
  ↓ 逐个重建表单页面
  ↓ 自动适配 SerialNumberField formula
  ↓ 生成迁移报告 yida-migration-report.json
```

## Skill 实现

对应的 `yida-export` 和 `yida-import` skill 实现已提交到 [openyida/yida-skills](https://github.com/openyida/yida-skills)（见关联 PR）。

## 注意事项

- 关联表单（`associationFormField`）的跨表单引用在迁移后需根据迁移报告手动更新
- 自定义页面需使用 `yida publish` 单独重新发布
- 流水号字段（`SerialNumberField`）的 formula 会自动适配新应用