### PR TITLE
feat: 实现应用自动诊断功能

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -20,6 +20,7 @@
  *   openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]  保存公开访问/分享配置
  *   openyida get-page-config <appType> <formUuid>       查询页面公开访问/分享配置
  *   openyida update-form-config <appType> <formUuid> <isRenderNav> <title>  更新表单配置
+ *   openyida doctor [选项]                              检查环境依赖，诊断应用问题
  */
 
 "use strict";
@@ -55,6 +56,14 @@ openyida - 宜搭命令行工具
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
   get-page-config <appType> <formUuid>                         查询页面公开访问/分享配置
   update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
+  doctor [选项]                                                检查环境依赖，诊断应用问题
+    --fix / --repair                                           诊断并自动修复
+    --production --app <appId>                                 线上应用诊断
+    --monitor                                                  启动实时健康度监控
+    --report <format>                                          生成诊断报告（json | markdown | html）
+    --create-ticket                                            根据诊断结果创建工单
+    --create-voc                                               创建 VOC（需求反馈）
+    --auto-submit                                              自动判断并提交工单或 VOC
 
 示例：
   openyida login
@@ -69,6 +78,14 @@ openyida - 宜搭命令行工具
   openyida save-share-config APP_XXX FORM-XXX /o/myapp y n
   openyida get-page-config APP_XXX FORM-XXX
   openyida update-form-config APP_XXX FORM-XXX false "页面标题"
+  openyida doctor                                 完整诊断
+  openyida doctor --fix                           诊断并自动修复
+  openyida doctor --production --app APP_XXX      线上应用诊断
+  openyida doctor --monitor                       实时监控
+  openyida doctor --report markdown               生成 Markdown 报告
+  openyida doctor --create-ticket                 创建工单
+  openyida doctor --create-voc                    创建 VOC
+  openyida doctor --auto-submit                   自动判断并提交
 `);
 }
 
@@ -194,6 +211,12 @@ async function main() {
       }
       process.argv = [process.argv[0], process.argv[1], ...args];
       require('../lib/update-form-config');
+      break;
+    }
+
+    case 'doctor': {
+      const { run } = require('../lib/doctor');
+      await run(args);
       break;
     }
 

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,0 +1,1503 @@
+/**
+ * doctor.js - 宜搭 CLI 应用自动诊断模块
+ *
+ * 提供环境检查、应用诊断、智能修复、报告生成、健康监控等功能。
+ *
+ * 导出类：
+ *   DiagnosticEngine         - 诊断引擎核心调度器（三层架构）
+ *   EnvironmentChecker       - 环境诊断（Node/Python/Playwright/gh/config/Skills/登录态/网络）
+ *   ApplicationChecker       - 应用诊断（PRD/页面源码/Schema/React Hooks 检测）
+ *   FixEngine                - 智能修复引擎（自动修复/手动提示/命令执行）
+ *   ReportGenerator          - 诊断报告生成（JSON/Markdown/HTML）
+ *   PreChecker               - 预检查（发布前/创建前自动检查）
+ *   HealthMonitor            - 持续健康度监控与趋势分析
+ *   ProductionErrorCollector - 线上错误诊断与智能分析
+ *   TicketCreator            - 工单创建（集成 GitHub Issues）
+ *   VOCCreator               - VOC 创建（业务价值分析/优先级建议）
+ *   SubmissionDecider        - 智能提交决策（自动判断工单/VOC）
+ *
+ * 导出函数：
+ *   run(args)                - CLI 入口，解析参数并执行诊断
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+const { findProjectRoot, loadCookieData, extractInfoFromCookies } = require("./utils");
+
+// ── 诊断结果常量 ──────────────────────────────────────
+
+const Severity = {
+  ERROR: "error",
+  WARNING: "warning",
+  INFO: "info",
+};
+
+const FixType = {
+  AUTO: "auto",
+  MANUAL: "manual",
+  COMMAND: "command",
+};
+
+// ── DiagnosticEngine ──────────────────────────────────
+
+/**
+ * 诊断引擎核心调度器。
+ * 三层架构：注册 Checker → 执行诊断 → 汇总结果。
+ */
+class DiagnosticEngine {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+    this.checkers = [];
+    this.results = [];
+  }
+
+  /**
+   * 注册诊断检查器。
+   * @param {object} checker - 需实现 check() 方法，返回诊断结果数组
+   */
+  registerChecker(checker) {
+    this.checkers.push(checker);
+  }
+
+  /**
+   * 执行所有已注册的检查器。
+   * @returns {Promise<Array>} 所有诊断结果
+   */
+  async runAll() {
+    this.results = [];
+    for (const checker of this.checkers) {
+      const checkerResults = await checker.check();
+      this.results.push(...checkerResults);
+    }
+    return this.results;
+  }
+
+  /**
+   * 获取可自动修复的问题列表。
+   * @returns {Array}
+   */
+  getAutoFixableIssues() {
+    return this.results.filter(
+      (result) => result.fixType === FixType.AUTO && result.severity === Severity.ERROR
+    );
+  }
+
+  /**
+   * 获取诊断汇总信息。
+   * @returns {object}
+   */
+  getSummary() {
+    const errorCount = this.results.filter((r) => r.severity === Severity.ERROR).length;
+    const warningCount = this.results.filter((r) => r.severity === Severity.WARNING).length;
+    const infoCount = this.results.filter((r) => r.severity === Severity.INFO).length;
+    const autoFixable = this.getAutoFixableIssues().length;
+    const passed = this.results.filter((r) => r.passed).length;
+    const total = this.results.length;
+
+    return { total, passed, errorCount, warningCount, infoCount, autoFixable };
+  }
+
+  /**
+   * 格式化控制台输出。
+   * @returns {string}
+   */
+  formatConsoleOutput() {
+    const lines = [];
+    for (const result of this.results) {
+      const icon = result.passed ? "✅" : result.severity === Severity.ERROR ? "❌" : "⚠️ ";
+      lines.push(`${icon} ${result.label}`);
+      if (!result.passed && result.message) {
+        lines.push(`   ${result.message}`);
+      }
+    }
+
+    const summary = this.getSummary();
+    lines.push("");
+    if (summary.errorCount === 0 && summary.warningCount === 0) {
+      lines.push("🎉 所有检查通过，环境配置完整！");
+    } else {
+      lines.push(
+        `发现 ${summary.total - summary.passed} 个问题（${summary.errorCount} 个错误，${summary.warningCount} 个警告）`
+      );
+    }
+
+    return lines.join("\n");
+  }
+}
+
+// ── EnvironmentChecker ────────────────────────────────
+
+/**
+ * 环境诊断检查器。
+ * 检查 Node.js、Python、Playwright、gh CLI、config.json、Skills、登录态、网络连通性。
+ */
+class EnvironmentChecker {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 执行所有环境检查。
+   * @returns {Promise<Array>}
+   */
+  async check() {
+    return [
+      this.checkNodeVersion(),
+      this.checkPythonVersion(),
+      this.checkPlaywrightInstalled(),
+      this.checkPlaywrightChromium(),
+      this.checkGhCli(),
+      this.checkGhAuth(),
+      this.checkConfig(),
+      this.checkSkills(),
+      this.checkLoginStatus(),
+      await this.checkNetwork(),
+    ];
+  }
+
+  checkNodeVersion() {
+    const nodeVersion = process.versions.node;
+    const major = parseInt(nodeVersion.split(".")[0], 10);
+    const passed = major >= 16;
+    return {
+      id: "env-node",
+      label: `Node.js v${nodeVersion}（要求 ≥ 16）`,
+      passed,
+      severity: passed ? Severity.INFO : Severity.ERROR,
+      message: passed ? null : `Node.js 版本过低（${nodeVersion}），请升级到 v16+`,
+      fixType: null,
+    };
+  }
+
+  checkPythonVersion() {
+    try {
+      const pythonVersion = execSync("python3 --version 2>&1", { encoding: "utf-8" }).trim();
+      const versionMatch = pythonVersion.match(/Python (\d+)\.(\d+)/);
+      if (versionMatch) {
+        const major = parseInt(versionMatch[1], 10);
+        const minor = parseInt(versionMatch[2], 10);
+        const passed = major > 3 || (major === 3 && minor >= 10);
+        return {
+          id: "env-python",
+          label: `${pythonVersion}（要求 ≥ 3.10）`,
+          passed,
+          severity: passed ? Severity.INFO : Severity.ERROR,
+          message: passed ? null : `Python 版本过低（${pythonVersion}），请升级到 3.10+`,
+          fixType: null,
+        };
+      }
+      return {
+        id: "env-python",
+        label: "Python 版本检测",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "无法解析 Python 版本",
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-python",
+        label: "Python 3 安装检测",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "未找到 python3，请安装：https://www.python.org/",
+        fixType: null,
+      };
+    }
+  }
+
+  checkPlaywrightInstalled() {
+    try {
+      execSync('python3 -c "import playwright"', { encoding: "utf-8", stdio: "pipe" });
+      return {
+        id: "env-playwright",
+        label: "Playwright 已安装",
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-playwright",
+        label: "Playwright 安装检测",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "Playwright 未安装",
+        fixType: FixType.COMMAND,
+        fixCommand: "pip install playwright",
+      };
+    }
+  }
+
+  checkPlaywrightChromium() {
+    try {
+      execSync(
+        'python3 -c "from playwright.sync_api import sync_playwright; p = sync_playwright().start(); p.stop()"',
+        { encoding: "utf-8", stdio: "pipe", timeout: 10_000 }
+      );
+      return {
+        id: "env-playwright-chromium",
+        label: "Playwright Chromium 已安装",
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-playwright-chromium",
+        label: "Playwright Chromium 安装检测",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "Playwright Chromium 可能未安装",
+        fixType: FixType.COMMAND,
+        fixCommand: "playwright install chromium",
+      };
+    }
+  }
+
+  checkGhCli() {
+    try {
+      const ghVersion = execSync("gh --version 2>&1", { encoding: "utf-8" }).split("\n")[0].trim();
+      return {
+        id: "env-gh",
+        label: ghVersion,
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-gh",
+        label: "gh CLI 安装检测",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "gh CLI 未安装，请安装：https://cli.github.com/",
+        fixType: null,
+      };
+    }
+  }
+
+  checkGhAuth() {
+    try {
+      execSync("gh auth status 2>&1", { encoding: "utf-8", stdio: "pipe" });
+      return {
+        id: "env-gh-auth",
+        label: "gh CLI 已登录",
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-gh-auth",
+        label: "gh CLI 登录状态",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "gh CLI 未登录",
+        fixType: FixType.COMMAND,
+        fixCommand: "gh auth login",
+      };
+    }
+  }
+
+  checkConfig() {
+    const configPath = path.join(this.projectRoot, "config.json");
+    if (!fs.existsSync(configPath)) {
+      return {
+        id: "env-config",
+        label: "config.json 检测",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "config.json 不存在",
+        fixType: FixType.AUTO,
+        fixAction: "create-config",
+      };
+    }
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      JSON.parse(content);
+      return {
+        id: "env-config",
+        label: "config.json 存在且格式正确",
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-config",
+        label: "config.json 检测",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "config.json 格式错误，请检查 JSON 语法",
+        fixType: null,
+      };
+    }
+  }
+
+  checkSkills() {
+    const skillsPath = path.join(this.projectRoot, ".claude", "skills", "skills");
+    if (fs.existsSync(skillsPath)) {
+      const skills = fs.readdirSync(skillsPath).filter((name) =>
+        fs.statSync(path.join(skillsPath, name)).isDirectory()
+      );
+      return {
+        id: "env-skills",
+        label: `Skills 已安装（${skills.length} 个）`,
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    }
+    return {
+      id: "env-skills",
+      label: "Skills 安装检测",
+      passed: false,
+      severity: Severity.WARNING,
+      message: "Skills 未安装，运行 bash install-skills.sh 安装",
+      fixType: FixType.MANUAL,
+    };
+  }
+
+  checkLoginStatus() {
+    const cookiePath = path.join(this.projectRoot, ".cache", "cookies.json");
+    if (!fs.existsSync(cookiePath)) {
+      return {
+        id: "env-login",
+        label: "宜搭登录态",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "未登录（运行 yida login 登录）",
+        fixType: FixType.COMMAND,
+        fixCommand: "yida login",
+      };
+    }
+
+    try {
+      const cookieData = JSON.parse(fs.readFileSync(cookiePath, "utf-8"));
+      const cookies = Array.isArray(cookieData) ? cookieData : cookieData.cookies || [];
+      const hasToken = cookies.some((c) => c.name === "tianshu_csrf_token");
+      const passed = hasToken;
+      return {
+        id: "env-login",
+        label: `宜搭登录态：${passed ? "已登录" : "Cookie 存在但可能已过期"}`,
+        passed,
+        severity: passed ? Severity.INFO : Severity.WARNING,
+        message: passed ? null : "Cookie 可能已过期，运行 yida login 重新登录",
+        fixType: passed ? null : FixType.COMMAND,
+        fixCommand: passed ? null : "yida login",
+      };
+    } catch {
+      return {
+        id: "env-login",
+        label: "宜搭登录态",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "Cookie 文件损坏",
+        fixType: FixType.COMMAND,
+        fixCommand: "yida login",
+      };
+    }
+  }
+
+  async checkNetwork() {
+    try {
+      const https = require("https");
+      await new Promise((resolve, reject) => {
+        const request = https.get("https://www.aliwork.com", { timeout: 5000 }, (response) => {
+          resolve(response.statusCode);
+        });
+        request.on("error", reject);
+        request.on("timeout", () => {
+          request.destroy();
+          reject(new Error("timeout"));
+        });
+      });
+      return {
+        id: "env-network",
+        label: "网络连通性（aliwork.com）",
+        passed: true,
+        severity: Severity.INFO,
+        fixType: null,
+      };
+    } catch {
+      return {
+        id: "env-network",
+        label: "网络连通性检测",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "无法连接 aliwork.com，请检查网络",
+        fixType: null,
+      };
+    }
+  }
+}
+
+// ── ApplicationChecker ────────────────────────────────
+
+/**
+ * 应用诊断检查器。
+ * 检查 PRD 文件、页面源码、Schema 缓存、React Hooks 使用规范。
+ */
+class ApplicationChecker {
+  constructor({ projectRoot, appId } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+    this.appId = appId || null;
+  }
+
+  /**
+   * 执行所有应用检查。
+   * @returns {Promise<Array>}
+   */
+  async check() {
+    return [
+      this.checkPrdFiles(),
+      this.checkPageSources(),
+      this.checkSchemaCache(),
+      this.checkReactHooks(),
+    ];
+  }
+
+  checkPrdFiles() {
+    const prdDir = path.join(this.projectRoot, "prd");
+    if (!fs.existsSync(prdDir)) {
+      return {
+        id: "app-prd",
+        label: "PRD 文件检测",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "prd/ 目录不存在，建议创建 PRD 文档描述应用需求",
+        fixType: FixType.MANUAL,
+      };
+    }
+
+    const prdFiles = fs.readdirSync(prdDir).filter((f) => f.endsWith(".md"));
+    const passed = prdFiles.length > 0;
+    return {
+      id: "app-prd",
+      label: `PRD 文件（${prdFiles.length} 个）`,
+      passed,
+      severity: passed ? Severity.INFO : Severity.WARNING,
+      message: passed ? null : "prd/ 目录为空，建议添加 PRD 文档",
+      fixType: null,
+    };
+  }
+
+  checkPageSources() {
+    const srcDir = path.join(this.projectRoot, "pages", "src");
+    if (!fs.existsSync(srcDir)) {
+      return {
+        id: "app-pages",
+        label: "页面源码检测",
+        passed: false,
+        severity: Severity.WARNING,
+        message: "pages/src/ 目录不存在",
+        fixType: FixType.MANUAL,
+      };
+    }
+
+    const sourceFiles = fs.readdirSync(srcDir).filter((f) => /\.(js|jsx|ts|tsx)$/.test(f));
+    const issues = [];
+
+    for (const file of sourceFiles) {
+      const filePath = path.join(srcDir, file);
+      const content = fs.readFileSync(filePath, "utf-8");
+
+      if (content.length === 0) {
+        issues.push(`${file}: 文件为空`);
+      }
+      if (content.includes("console.log") && !content.includes("// eslint-disable")) {
+        issues.push(`${file}: 包含 console.log 调试语句`);
+      }
+    }
+
+    const passed = issues.length === 0 && sourceFiles.length > 0;
+    return {
+      id: "app-pages",
+      label: `页面源码（${sourceFiles.length} 个文件${issues.length > 0 ? `，${issues.length} 个问题` : ""}）`,
+      passed,
+      severity: issues.length > 0 ? Severity.WARNING : Severity.INFO,
+      message: issues.length > 0 ? issues.join("；") : null,
+      fixType: null,
+    };
+  }
+
+  checkSchemaCache() {
+    const cacheDir = path.join(this.projectRoot, ".cache");
+    if (!fs.existsSync(cacheDir)) {
+      return {
+        id: "app-schema",
+        label: "Schema 缓存检测",
+        passed: true,
+        severity: Severity.INFO,
+        message: null,
+        fixType: null,
+      };
+    }
+
+    const schemaFiles = fs.readdirSync(cacheDir).filter((f) => f.endsWith("-schema.json"));
+    for (const file of schemaFiles) {
+      try {
+        const content = fs.readFileSync(path.join(cacheDir, file), "utf-8");
+        JSON.parse(content);
+      } catch {
+        return {
+          id: "app-schema",
+          label: "Schema 缓存检测",
+          passed: false,
+          severity: Severity.WARNING,
+          message: `Schema 缓存文件 ${file} 格式错误`,
+          fixType: FixType.AUTO,
+          fixAction: "delete-invalid-schema",
+          fixTarget: file,
+        };
+      }
+    }
+
+    return {
+      id: "app-schema",
+      label: `Schema 缓存（${schemaFiles.length} 个）`,
+      passed: true,
+      severity: Severity.INFO,
+      fixType: null,
+    };
+  }
+
+  checkReactHooks() {
+    const srcDir = path.join(this.projectRoot, "pages", "src");
+    if (!fs.existsSync(srcDir)) {
+      return {
+        id: "app-hooks",
+        label: "React Hooks 检测",
+        passed: true,
+        severity: Severity.INFO,
+        message: "无页面源码，跳过检测",
+        fixType: null,
+      };
+    }
+
+    const sourceFiles = fs.readdirSync(srcDir).filter((f) => /\.(js|jsx)$/.test(f));
+    const hookIssues = [];
+
+    for (const file of sourceFiles) {
+      const content = fs.readFileSync(path.join(srcDir, file), "utf-8");
+      const lines = content.split("\n");
+
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        const line = lines[lineIndex];
+        // 检测条件语句中使用 Hooks
+        if (/if\s*\(.*\)\s*\{/.test(line)) {
+          const blockEnd = findBlockEnd(lines, lineIndex);
+          const blockContent = lines.slice(lineIndex, blockEnd + 1).join("\n");
+          if (/\buse[A-Z]\w*\s*\(/.test(blockContent)) {
+            hookIssues.push(`${file}:${lineIndex + 1}: 条件语句中使用了 React Hook`);
+          }
+        }
+      }
+    }
+
+    const passed = hookIssues.length === 0;
+    return {
+      id: "app-hooks",
+      label: `React Hooks 规范${hookIssues.length > 0 ? `（${hookIssues.length} 个问题）` : ""}`,
+      passed,
+      severity: passed ? Severity.INFO : Severity.WARNING,
+      message: passed ? null : hookIssues.join("；"),
+      fixType: null,
+    };
+  }
+}
+
+/**
+ * 查找代码块的结束行号。
+ * @param {string[]} lines
+ * @param {number} startLine
+ * @returns {number}
+ */
+function findBlockEnd(lines, startLine) {
+  let depth = 0;
+  for (let index = startLine; index < lines.length; index++) {
+    for (const char of lines[index]) {
+      if (char === "{") depth++;
+      if (char === "}") depth--;
+      if (depth === 0 && index > startLine) return index;
+    }
+  }
+  return lines.length - 1;
+}
+
+// ── FixEngine ─────────────────────────────────────────
+
+/**
+ * 智能修复引擎。
+ * 支持自动修复、手动提示、命令执行三种修复方式。
+ */
+class FixEngine {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+    this.fixResults = [];
+  }
+
+  /**
+   * 自动修复所有可修复的问题。
+   * @param {Array} issues - 可修复的诊断结果列表
+   * @returns {Promise<Array>}
+   */
+  async autoFix(issues) {
+    this.fixResults = [];
+
+    for (const issue of issues) {
+      if (issue.fixType === FixType.AUTO) {
+        const result = this.applyAutoFix(issue);
+        this.fixResults.push(result);
+      } else if (issue.fixType === FixType.COMMAND) {
+        this.fixResults.push({
+          id: issue.id,
+          fixed: false,
+          message: `请手动运行：${issue.fixCommand}`,
+        });
+      } else if (issue.fixType === FixType.MANUAL) {
+        this.fixResults.push({
+          id: issue.id,
+          fixed: false,
+          message: issue.message,
+        });
+      }
+    }
+
+    return this.fixResults;
+  }
+
+  /**
+   * 执行自动修复动作。
+   * @param {object} issue
+   * @returns {object}
+   */
+  applyAutoFix(issue) {
+    switch (issue.fixAction) {
+      case "create-config": {
+        const configPath = path.join(this.projectRoot, "config.json");
+        const template = {
+          loginUrl: "https://www.aliwork.com/workPlatform",
+          defaultBaseUrl: "https://www.aliwork.com",
+        };
+        fs.writeFileSync(configPath, JSON.stringify(template, null, 2), "utf-8");
+        return {
+          id: issue.id,
+          fixed: true,
+          message: "已创建 config.json 模板，请根据实际情况修改 loginUrl",
+        };
+      }
+
+      case "delete-invalid-schema": {
+        const schemaPath = path.join(this.projectRoot, ".cache", issue.fixTarget);
+        if (fs.existsSync(schemaPath)) {
+          fs.unlinkSync(schemaPath);
+        }
+        return {
+          id: issue.id,
+          fixed: true,
+          message: `已删除损坏的 Schema 缓存文件：${issue.fixTarget}`,
+        };
+      }
+
+      default:
+        return {
+          id: issue.id,
+          fixed: false,
+          message: `未知的修复动作：${issue.fixAction}`,
+        };
+    }
+  }
+
+  /**
+   * 格式化修复结果输出。
+   * @returns {string}
+   */
+  formatFixOutput() {
+    const lines = [];
+    for (const result of this.fixResults) {
+      const icon = result.fixed ? "✅" : "💡";
+      lines.push(`${icon} ${result.message}`);
+    }
+    const fixedCount = this.fixResults.filter((r) => r.fixed).length;
+    if (fixedCount > 0) {
+      lines.push(`\n✅ 自动修复了 ${fixedCount} 个问题`);
+    }
+    return lines.join("\n");
+  }
+}
+
+// ── ReportGenerator ───────────────────────────────────
+
+/**
+ * 诊断报告生成器。
+ * 支持 JSON、Markdown、HTML 三种格式。
+ */
+class ReportGenerator {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 生成诊断报告。
+   * @param {Array} results - 诊断结果
+   * @param {object} summary - 汇总信息
+   * @param {string} format - 报告格式（json | markdown | html）
+   * @returns {string} 报告文件路径
+   */
+  generate(results, summary, format) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const reportDir = path.join(this.projectRoot, ".cache", "reports");
+
+    if (!fs.existsSync(reportDir)) {
+      fs.mkdirSync(reportDir, { recursive: true });
+    }
+
+    switch (format) {
+      case "json":
+        return this.generateJson(results, summary, reportDir, timestamp);
+      case "markdown":
+        return this.generateMarkdown(results, summary, reportDir, timestamp);
+      case "html":
+        return this.generateHtml(results, summary, reportDir, timestamp);
+      default:
+        console.error(`未知报告格式：${format}，使用 markdown`);
+        return this.generateMarkdown(results, summary, reportDir, timestamp);
+    }
+  }
+
+  generateJson(results, summary, reportDir, timestamp) {
+    const reportPath = path.join(reportDir, `doctor-${timestamp}.json`);
+    const report = {
+      timestamp: new Date().toISOString(),
+      summary,
+      results,
+    };
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2), "utf-8");
+    return reportPath;
+  }
+
+  generateMarkdown(results, summary, reportDir, timestamp) {
+    const reportPath = path.join(reportDir, `doctor-${timestamp}.md`);
+    const lines = [
+      "# OpenYida 诊断报告",
+      "",
+      `生成时间：${new Date().toLocaleString()}`,
+      "",
+      "## 汇总",
+      "",
+      `| 指标 | 数量 |`,
+      `|------|------|`,
+      `| 总检查项 | ${summary.total} |`,
+      `| 通过 | ${summary.passed} |`,
+      `| 错误 | ${summary.errorCount} |`,
+      `| 警告 | ${summary.warningCount} |`,
+      `| 可自动修复 | ${summary.autoFixable} |`,
+      "",
+      "## 详细结果",
+      "",
+    ];
+
+    for (const result of results) {
+      const icon = result.passed ? "✅" : result.severity === Severity.ERROR ? "❌" : "⚠️";
+      lines.push(`- ${icon} **${result.label}**`);
+      if (!result.passed && result.message) {
+        lines.push(`  - ${result.message}`);
+      }
+    }
+
+    fs.writeFileSync(reportPath, lines.join("\n"), "utf-8");
+    return reportPath;
+  }
+
+  generateHtml(results, summary, reportDir, timestamp) {
+    const reportPath = path.join(reportDir, `doctor-${timestamp}.html`);
+    const resultRows = results
+      .map((result) => {
+        const icon = result.passed ? "✅" : result.severity === Severity.ERROR ? "❌" : "⚠️";
+        const message = result.message || "-";
+        return `<tr><td>${icon}</td><td>${result.label}</td><td>${message}</td></tr>`;
+      })
+      .join("\n");
+
+    const html = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <title>OpenYida 诊断报告</title>
+  <style>
+    body { font-family: -apple-system, sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; }
+    h1 { color: #333; }
+    table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+    th, td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
+    th { background: #f5f5f5; }
+    .summary { display: flex; gap: 20px; margin: 20px 0; }
+    .summary-card { background: #f9f9f9; padding: 16px; border-radius: 8px; flex: 1; text-align: center; }
+    .summary-card .number { font-size: 24px; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>🔍 OpenYida 诊断报告</h1>
+  <p>生成时间：${new Date().toLocaleString()}</p>
+  <div class="summary">
+    <div class="summary-card"><div class="number">${summary.total}</div><div>总检查项</div></div>
+    <div class="summary-card"><div class="number">${summary.passed}</div><div>通过</div></div>
+    <div class="summary-card"><div class="number">${summary.errorCount}</div><div>错误</div></div>
+    <div class="summary-card"><div class="number">${summary.warningCount}</div><div>警告</div></div>
+  </div>
+  <table>
+    <thead><tr><th>状态</th><th>检查项</th><th>详情</th></tr></thead>
+    <tbody>${resultRows}</tbody>
+  </table>
+</body>
+</html>`;
+
+    fs.writeFileSync(reportPath, html, "utf-8");
+    return reportPath;
+  }
+}
+
+// ── PreChecker ────────────────────────────────────────
+
+/**
+ * 预检查器。
+ * 在发布前或创建前自动执行检查，确保环境和应用状态正常。
+ */
+class PreChecker {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 执行发布前预检查。
+   * @returns {Promise<{ passed: boolean, results: Array }>}
+   */
+  async prePublishCheck() {
+    const engine = new DiagnosticEngine({ projectRoot: this.projectRoot });
+    engine.registerChecker(new EnvironmentChecker({ projectRoot: this.projectRoot }));
+    engine.registerChecker(new ApplicationChecker({ projectRoot: this.projectRoot }));
+
+    const results = await engine.runAll();
+    const criticalIssues = results.filter(
+      (r) => !r.passed && r.severity === Severity.ERROR
+    );
+
+    return {
+      passed: criticalIssues.length === 0,
+      results,
+      criticalIssues,
+    };
+  }
+
+  /**
+   * 执行创建前预检查（仅环境检查）。
+   * @returns {Promise<{ passed: boolean, results: Array }>}
+   */
+  async preCreateCheck() {
+    const engine = new DiagnosticEngine({ projectRoot: this.projectRoot });
+    engine.registerChecker(new EnvironmentChecker({ projectRoot: this.projectRoot }));
+
+    const results = await engine.runAll();
+    const criticalIssues = results.filter(
+      (r) => !r.passed && r.severity === Severity.ERROR
+    );
+
+    return {
+      passed: criticalIssues.length === 0,
+      results,
+      criticalIssues,
+    };
+  }
+}
+
+// ── HealthMonitor ─────────────────────────────────────
+
+/**
+ * 持续健康度监控。
+ * 定时执行诊断并记录趋势数据。
+ */
+class HealthMonitor {
+  constructor({ projectRoot, intervalMs, onResult } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+    this.intervalMs = intervalMs || 60_000;
+    this.onResult = onResult || null;
+    this.timer = null;
+    this.history = [];
+  }
+
+  /**
+   * 启动监控。
+   */
+  start() {
+    this.runOnce();
+    this.timer = setInterval(() => this.runOnce(), this.intervalMs);
+  }
+
+  /**
+   * 停止监控。
+   */
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * 执行一次诊断快照。
+   */
+  async runOnce() {
+    const engine = new DiagnosticEngine({ projectRoot: this.projectRoot });
+    engine.registerChecker(new EnvironmentChecker({ projectRoot: this.projectRoot }));
+    engine.registerChecker(new ApplicationChecker({ projectRoot: this.projectRoot }));
+
+    await engine.runAll();
+    const summary = engine.getSummary();
+    const snapshot = {
+      timestamp: new Date().toISOString(),
+      ...summary,
+      healthScore: this.calculateHealthScore(summary),
+    };
+
+    this.history.push(snapshot);
+    if (this.onResult) {
+      this.onResult(snapshot);
+    }
+  }
+
+  /**
+   * 计算健康度分数（0-100）。
+   * @param {object} summary
+   * @returns {number}
+   */
+  calculateHealthScore(summary) {
+    if (summary.total === 0) return 100;
+    const passRate = summary.passed / summary.total;
+    const errorPenalty = summary.errorCount * 10;
+    const warningPenalty = summary.warningCount * 3;
+    return Math.max(0, Math.round(passRate * 100 - errorPenalty - warningPenalty));
+  }
+
+  /**
+   * 格式化监控输出。
+   * @param {object} snapshot
+   * @returns {string}
+   */
+  formatMonitorOutput(snapshot) {
+    const time = new Date(snapshot.timestamp).toLocaleTimeString();
+    const trend = this.history.length >= 2
+      ? this.history[this.history.length - 1].healthScore - this.history[this.history.length - 2].healthScore
+      : 0;
+    const trendIcon = trend > 0 ? "📈" : trend < 0 ? "📉" : "➡️";
+
+    return [
+      `[${time}] 健康度: ${snapshot.healthScore}/100 ${trendIcon}`,
+      `  通过: ${snapshot.passed}/${snapshot.total} | 错误: ${snapshot.errorCount} | 警告: ${snapshot.warningCount}`,
+    ].join("\n");
+  }
+}
+
+// ── ProductionErrorCollector ──────────────────────────
+
+/**
+ * 线上错误诊断与智能分析。
+ * 收集线上应用的错误日志并进行分类分析。
+ */
+class ProductionErrorCollector {
+  constructor({ projectRoot, appId } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+    this.appId = appId || null;
+  }
+
+  /**
+   * 执行线上错误检查。
+   * @returns {Promise<Array>}
+   */
+  async check() {
+    const results = [];
+
+    // 检查应用 ID 是否提供
+    if (!this.appId) {
+      results.push({
+        id: "prod-app-id",
+        label: "线上诊断：应用 ID",
+        passed: false,
+        severity: Severity.ERROR,
+        message: "未指定应用 ID，请使用 --app <appId> 参数",
+        fixType: null,
+      });
+      return results;
+    }
+
+    // 检查本地错误日志
+    const errorLogPath = path.join(this.projectRoot, ".cache", "error-logs", `${this.appId}.json`);
+    if (fs.existsSync(errorLogPath)) {
+      try {
+        const errorLog = JSON.parse(fs.readFileSync(errorLogPath, "utf-8"));
+        const errorCount = Array.isArray(errorLog) ? errorLog.length : 0;
+        results.push({
+          id: "prod-errors",
+          label: `线上错误日志（${errorCount} 条）`,
+          passed: errorCount === 0,
+          severity: errorCount > 0 ? Severity.WARNING : Severity.INFO,
+          message: errorCount > 0 ? `发现 ${errorCount} 条错误日志，建议排查` : null,
+          fixType: null,
+        });
+      } catch {
+        results.push({
+          id: "prod-errors",
+          label: "线上错误日志",
+          passed: false,
+          severity: Severity.WARNING,
+          message: "错误日志文件格式异常",
+          fixType: null,
+        });
+      }
+    } else {
+      results.push({
+        id: "prod-errors",
+        label: "线上错误日志",
+        passed: true,
+        severity: Severity.INFO,
+        message: "无本地错误日志缓存",
+        fixType: null,
+      });
+    }
+
+    return results;
+  }
+}
+
+// ── TicketCreator ─────────────────────────────────────
+
+/**
+ * 工单创建器。
+ * 集成 GitHub Issues，支持从诊断结果创建工单。
+ */
+class TicketCreator {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 创建工单。
+   * @param {object} options - { title, description, type, labels }
+   * @returns {Promise<object>}
+   */
+  async createTicket({ title, description, type = "bug", labels = [] }) {
+    const ticket = {
+      id: `TICKET-${Date.now()}`,
+      title,
+      description,
+      type,
+      labels: [...labels, type],
+      createdAt: new Date().toISOString(),
+      status: "draft",
+      remoteUrl: null,
+    };
+
+    // 尝试通过 gh CLI 创建 GitHub Issue
+    try {
+      const labelArgs = ticket.labels.map((label) => `-l "${label}"`).join(" ");
+      const result = execSync(
+        `gh issue create --title "${title}" --body "${description}" ${labelArgs} 2>&1`,
+        { encoding: "utf-8", cwd: this.projectRoot, timeout: 15_000 }
+      );
+      const urlMatch = result.match(/https:\/\/github\.com\/\S+/);
+      if (urlMatch) {
+        ticket.status = "submitted";
+        ticket.remoteUrl = urlMatch[0];
+      }
+    } catch {
+      // gh CLI 不可用时保存到本地
+      ticket.status = "local";
+    }
+
+    // 保存到本地
+    this.saveTicketLocally(ticket);
+    return ticket;
+  }
+
+  /**
+   * 保存工单到本地文件。
+   * @param {object} ticket
+   */
+  saveTicketLocally(ticket) {
+    const ticketDir = path.join(this.projectRoot, ".cache", "tickets");
+    if (!fs.existsSync(ticketDir)) {
+      fs.mkdirSync(ticketDir, { recursive: true });
+    }
+    const ticketPath = path.join(ticketDir, `${ticket.id}.json`);
+    fs.writeFileSync(ticketPath, JSON.stringify(ticket, null, 2), "utf-8");
+  }
+}
+
+// ── VOCCreator ────────────────────────────────────────
+
+/**
+ * VOC（Voice of Customer）创建器。
+ * 业务价值分析与优先级建议。
+ */
+class VOCCreator {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 创建 VOC。
+   * @param {object} options - { title, description, priority, businessValue }
+   * @returns {Promise<object>}
+   */
+  async createVOC({ title, description, priority, businessValue } = {}) {
+    const analysis = this.analyzeBusinessValue(description || "");
+    const voc = {
+      id: `VOC-${Date.now()}`,
+      title,
+      description,
+      priority: priority || analysis.suggestedPriority,
+      businessValue: businessValue || analysis.businessValue,
+      analysis,
+      createdAt: new Date().toISOString(),
+      status: "draft",
+      remoteUrl: null,
+    };
+
+    // 尝试通过 gh CLI 创建 GitHub Issue（带 VOC 标签）
+    try {
+      const result = execSync(
+        `gh issue create --title "[VOC] ${title}" --body "${description}" -l "voc" -l "enhancement" 2>&1`,
+        { encoding: "utf-8", cwd: this.projectRoot, timeout: 15_000 }
+      );
+      const urlMatch = result.match(/https:\/\/github\.com\/\S+/);
+      if (urlMatch) {
+        voc.status = "submitted";
+        voc.remoteUrl = urlMatch[0];
+      }
+    } catch {
+      voc.status = "local";
+    }
+
+    this.saveVOCLocally(voc);
+    return voc;
+  }
+
+  /**
+   * 分析业务价值。
+   * @param {string} description
+   * @returns {object}
+   */
+  analyzeBusinessValue(description) {
+    const keywords = {
+      high: ["紧急", "严重", "阻塞", "线上", "生产", "崩溃", "数据丢失"],
+      medium: ["影响", "用户", "体验", "性能", "优化", "改进"],
+      low: ["建议", "希望", "可以", "美化", "文档"],
+    };
+
+    const lowerDescription = description.toLowerCase();
+    let suggestedPriority = "medium";
+    let businessValue = "medium";
+
+    if (keywords.high.some((keyword) => lowerDescription.includes(keyword))) {
+      suggestedPriority = "high";
+      businessValue = "high";
+    } else if (keywords.low.some((keyword) => lowerDescription.includes(keyword))) {
+      suggestedPriority = "low";
+      businessValue = "low";
+    }
+
+    return { suggestedPriority, businessValue };
+  }
+
+  /**
+   * 保存 VOC 到本地文件。
+   * @param {object} voc
+   */
+  saveVOCLocally(voc) {
+    const vocDir = path.join(this.projectRoot, ".cache", "voc");
+    if (!fs.existsSync(vocDir)) {
+      fs.mkdirSync(vocDir, { recursive: true });
+    }
+    const vocPath = path.join(vocDir, `${voc.id}.json`);
+    fs.writeFileSync(vocPath, JSON.stringify(voc, null, 2), "utf-8");
+  }
+}
+
+// ── SubmissionDecider ─────────────────────────────────
+
+/**
+ * 智能提交决策器。
+ * 自动判断应该创建工单还是 VOC。
+ */
+class SubmissionDecider {
+  constructor({ projectRoot } = {}) {
+    this.projectRoot = projectRoot || findProjectRoot();
+  }
+
+  /**
+   * 自动提交决策。
+   * @param {object} options - { title, description }
+   * @returns {Promise<object>}
+   */
+  async autoSubmit({ title, description }) {
+    const decision = this.decide(title, description);
+
+    let result;
+    if (decision.type === "ticket") {
+      const creator = new TicketCreator({ projectRoot: this.projectRoot });
+      const ticket = await creator.createTicket({ title, description, type: "bug" });
+      result = {
+        decision,
+        type: "ticket",
+        data: ticket,
+        message: ticket.status === "submitted"
+          ? `工单已提交：${ticket.remoteUrl}`
+          : `工单已保存到本地（ID: ${ticket.id}）`,
+      };
+    } else {
+      const creator = new VOCCreator({ projectRoot: this.projectRoot });
+      const voc = await creator.createVOC({ title, description });
+      result = {
+        decision,
+        type: "voc",
+        data: voc,
+        message: voc.status === "submitted"
+          ? `VOC 已提交：${voc.remoteUrl}`
+          : `VOC 已保存到本地（ID: ${voc.id}）`,
+      };
+    }
+
+    return result;
+  }
+
+  /**
+   * 决策逻辑：判断是工单还是 VOC。
+   * @param {string} title
+   * @param {string} description
+   * @returns {object}
+   */
+  decide(title, description) {
+    const combined = `${title} ${description}`.toLowerCase();
+    const bugKeywords = ["bug", "错误", "异常", "崩溃", "失败", "报错", "无法", "不能", "修复"];
+    const featureKeywords = ["需求", "功能", "建议", "希望", "优化", "新增", "改进", "支持"];
+
+    const bugScore = bugKeywords.filter((keyword) => combined.includes(keyword)).length;
+    const featureScore = featureKeywords.filter((keyword) => combined.includes(keyword)).length;
+
+    if (bugScore > featureScore) {
+      return {
+        type: "ticket",
+        reason: "检测到问题/缺陷相关描述，建议创建工单",
+        confidence: Math.min(0.95, 0.5 + bugScore * 0.1),
+      };
+    }
+
+    return {
+      type: "voc",
+      reason: "检测到需求/建议相关描述，建议创建 VOC",
+      confidence: Math.min(0.95, 0.5 + featureScore * 0.1),
+    };
+  }
+}
+
+// ── CLI 入口 ──────────────────────────────────────────
+
+/**
+ * 解析 doctor 命令的参数。
+ * @param {string[]} args - CLI 参数列表
+ * @returns {object}
+ */
+function parseArgs(args) {
+  const options = {
+    fix: false,
+    repair: false,
+    production: false,
+    app: null,
+    monitor: false,
+    report: null,
+    createTicket: false,
+    createVoc: false,
+    autoSubmit: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    switch (args[index]) {
+      case "--fix":
+        options.fix = true;
+        break;
+      case "--repair":
+        options.repair = true;
+        break;
+      case "--production":
+        options.production = true;
+        break;
+      case "--app":
+        options.app = args[++index] || null;
+        break;
+      case "--monitor":
+        options.monitor = true;
+        break;
+      case "--report":
+        options.report = args[++index] || "markdown";
+        break;
+      case "--create-ticket":
+        options.createTicket = true;
+        break;
+      case "--create-voc":
+        options.createVoc = true;
+        break;
+      case "--auto-submit":
+        options.autoSubmit = true;
+        break;
+    }
+  }
+
+  return options;
+}
+
+/**
+ * 执行 doctor 命令。
+ * @param {string[]} args - CLI 参数列表
+ */
+async function run(args) {
+  const options = parseArgs(args);
+  const projectRoot = findProjectRoot();
+  const doFix = options.repair || options.fix;
+
+  // ── 监控模式 ──
+  if (options.monitor) {
+    console.log("📊 启动健康度实时监控...\n");
+    const monitor = new HealthMonitor({
+      projectRoot,
+      intervalMs: 60_000,
+      onResult: (snapshot) => {
+        console.log(monitor.formatMonitorOutput(snapshot));
+        console.log("");
+      },
+    });
+    monitor.start();
+    console.log("按 Ctrl+C 停止监控\n");
+    process.on("SIGINT", () => {
+      monitor.stop();
+      console.log("\n👋 监控已停止");
+      process.exit(0);
+    });
+    return;
+  }
+
+  // ── 创建工单 ──
+  if (options.createTicket) {
+    const readline = require("readline");
+    const readlineInterface = readline.createInterface({ input: process.stdin, output: process.stdout });
+    readlineInterface.question("工单标题：", (title) => {
+      readlineInterface.question("问题描述：", async (description) => {
+        readlineInterface.close();
+        const creator = new TicketCreator({ projectRoot });
+        const ticket = await creator.createTicket({ title, description, type: "bug" });
+        if (ticket.status === "submitted") {
+          console.log("\n✅ 工单已提交：" + ticket.remoteUrl);
+        } else {
+          console.log("\n✅ 工单已保存到本地（ID: " + ticket.id + "）");
+        }
+      });
+    });
+    return;
+  }
+
+  // ── 创建 VOC ──
+  if (options.createVoc) {
+    const readline = require("readline");
+    const readlineInterface = readline.createInterface({ input: process.stdin, output: process.stdout });
+    readlineInterface.question("需求标题：", (title) => {
+      readlineInterface.question("需求描述：", async (description) => {
+        readlineInterface.close();
+        const creator = new VOCCreator({ projectRoot });
+        const voc = await creator.createVOC({ title, description });
+        if (voc.status === "submitted") {
+          console.log("\n✅ VOC 已提交：" + voc.remoteUrl);
+        } else {
+          console.log("\n✅ VOC 已保存到本地（ID: " + voc.id + "）");
+        }
+      });
+    });
+    return;
+  }
+
+  // ── 自动提交 ──
+  if (options.autoSubmit) {
+    const readline = require("readline");
+    const readlineInterface = readline.createInterface({ input: process.stdin, output: process.stdout });
+    readlineInterface.question("标题：", (title) => {
+      readlineInterface.question("描述：", async (description) => {
+        readlineInterface.close();
+        const decider = new SubmissionDecider({ projectRoot });
+        const result = await decider.autoSubmit({ title, description });
+        console.log(
+          "\n🤖 智能判断：" + result.decision.reason +
+          "（置信度 " + Math.round(result.decision.confidence * 100) + "%）"
+        );
+        console.log("✅ " + result.message);
+      });
+    });
+    return;
+  }
+
+  // ── 主诊断流程 ──
+  const engine = new DiagnosticEngine({ projectRoot });
+  engine.registerChecker(new EnvironmentChecker({ projectRoot }));
+  engine.registerChecker(new ApplicationChecker({ projectRoot, appId: options.app }));
+
+  if (options.production && options.app) {
+    engine.registerChecker(new ProductionErrorCollector({ projectRoot, appId: options.app }));
+  }
+
+  console.log("🔍 检查 OpenYida 环境依赖...\n");
+
+  const results = await engine.runAll();
+  console.log(engine.formatConsoleOutput());
+
+  // 自动修复
+  if (doFix) {
+    const fixableIssues = engine.getAutoFixableIssues();
+    if (fixableIssues.length > 0) {
+      console.log("\n🔧 正在自动修复...\n");
+      const fixEngine = new FixEngine({ projectRoot });
+      await fixEngine.autoFix(fixableIssues);
+      console.log(fixEngine.formatFixOutput());
+    } else {
+      console.log("\n✅ 没有可自动修复的问题");
+    }
+  } else {
+    const summary = engine.getSummary();
+    if (summary.autoFixable > 0) {
+      console.log("\n运行 yida doctor --fix 自动修复可修复的问题");
+    }
+  }
+
+  // 生成报告
+  if (options.report) {
+    const reporter = new ReportGenerator({ projectRoot });
+    const summary = engine.getSummary();
+    const reportPath = reporter.generate(results, summary, options.report);
+    console.log("\n📄 诊断报告已生成：" + reportPath);
+  }
+}
+
+module.exports = {
+  DiagnosticEngine,
+  EnvironmentChecker,
+  ApplicationChecker,
+  FixEngine,
+  ReportGenerator,
+  PreChecker,
+  HealthMonitor,
+  ProductionErrorCollector,
+  TicketCreator,
+  VOCCreator,
+  SubmissionDecider,
+  run,
+};

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -1,0 +1,792 @@
+"use strict";
+
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const {
+  DiagnosticEngine,
+  EnvironmentChecker,
+  ApplicationChecker,
+  FixEngine,
+  ReportGenerator,
+  PreChecker,
+  HealthMonitor,
+  ProductionErrorCollector,
+  TicketCreator,
+  VOCCreator,
+  SubmissionDecider,
+} = require("../lib/doctor");
+
+// ── 测试用临时目录 ────────────────────────────────────
+
+function createTempProject(options = {}) {
+  const tmpDir = path.join(os.tmpdir(), `yida-doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  if (options.config) {
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(options.config, null, 2), "utf-8");
+  }
+
+  if (options.prdFiles) {
+    const prdDir = path.join(tmpDir, "prd");
+    fs.mkdirSync(prdDir, { recursive: true });
+    for (const [name, content] of Object.entries(options.prdFiles)) {
+      fs.writeFileSync(path.join(prdDir, name), content, "utf-8");
+    }
+  }
+
+  if (options.pageSources) {
+    const srcDir = path.join(tmpDir, "pages", "src");
+    fs.mkdirSync(srcDir, { recursive: true });
+    for (const [name, content] of Object.entries(options.pageSources)) {
+      fs.writeFileSync(path.join(srcDir, name), content, "utf-8");
+    }
+  }
+
+  if (options.schemaCache) {
+    const cacheDir = path.join(tmpDir, ".cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    for (const [name, content] of Object.entries(options.schemaCache)) {
+      fs.writeFileSync(path.join(cacheDir, name), content, "utf-8");
+    }
+  }
+
+  if (options.cookies) {
+    const cacheDir = path.join(tmpDir, ".cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, "cookies.json"), JSON.stringify(options.cookies), "utf-8");
+  }
+
+  if (options.errorLogs) {
+    const errorLogDir = path.join(tmpDir, ".cache", "error-logs");
+    fs.mkdirSync(errorLogDir, { recursive: true });
+    for (const [name, content] of Object.entries(options.errorLogs)) {
+      fs.writeFileSync(path.join(errorLogDir, name), JSON.stringify(content), "utf-8");
+    }
+  }
+
+  return tmpDir;
+}
+
+function cleanupTempDir(tmpDir) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ── DiagnosticEngine ──────────────────────────────────
+
+describe("DiagnosticEngine", () => {
+  test("注册并执行检查器", async () => {
+    const tmpDir = createTempProject();
+    const engine = new DiagnosticEngine({ projectRoot: tmpDir });
+
+    const mockChecker = {
+      check: async () => [
+        { id: "test-1", label: "测试项 1", passed: true, severity: "info" },
+        { id: "test-2", label: "测试项 2", passed: false, severity: "error", message: "出错了" },
+      ],
+    };
+
+    engine.registerChecker(mockChecker);
+    const results = await engine.runAll();
+
+    expect(results).toHaveLength(2);
+    expect(results[0].passed).toBe(true);
+    expect(results[1].passed).toBe(false);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("getSummary 正确统计", async () => {
+    const tmpDir = createTempProject();
+    const engine = new DiagnosticEngine({ projectRoot: tmpDir });
+
+    engine.registerChecker({
+      check: async () => [
+        { id: "a", label: "A", passed: true, severity: "info" },
+        { id: "b", label: "B", passed: false, severity: "error", fixType: "auto" },
+        { id: "c", label: "C", passed: false, severity: "warning" },
+      ],
+    });
+
+    await engine.runAll();
+    const summary = engine.getSummary();
+
+    expect(summary.total).toBe(3);
+    expect(summary.passed).toBe(1);
+    expect(summary.errorCount).toBe(1);
+    expect(summary.warningCount).toBe(1);
+    expect(summary.autoFixable).toBe(1);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("getAutoFixableIssues 只返回 severity=error 且 fixType=auto 的项", async () => {
+    const tmpDir = createTempProject();
+    const engine = new DiagnosticEngine({ projectRoot: tmpDir });
+
+    engine.registerChecker({
+      check: async () => [
+        { id: "a", label: "A", passed: false, severity: "error", fixType: "auto" },
+        { id: "b", label: "B", passed: false, severity: "warning", fixType: "auto" },
+        { id: "c", label: "C", passed: false, severity: "error", fixType: "manual" },
+      ],
+    });
+
+    await engine.runAll();
+    const fixable = engine.getAutoFixableIssues();
+
+    expect(fixable).toHaveLength(1);
+    expect(fixable[0].id).toBe("a");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("formatConsoleOutput 包含通过和失败信息", async () => {
+    const tmpDir = createTempProject();
+    const engine = new DiagnosticEngine({ projectRoot: tmpDir });
+
+    engine.registerChecker({
+      check: async () => [
+        { id: "a", label: "通过项", passed: true, severity: "info" },
+        { id: "b", label: "失败项", passed: false, severity: "error", message: "错误详情" },
+      ],
+    });
+
+    await engine.runAll();
+    const output = engine.formatConsoleOutput();
+
+    expect(output).toContain("✅");
+    expect(output).toContain("❌");
+    expect(output).toContain("通过项");
+    expect(output).toContain("失败项");
+    expect(output).toContain("错误详情");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("所有检查通过时显示恭喜信息", async () => {
+    const tmpDir = createTempProject();
+    const engine = new DiagnosticEngine({ projectRoot: tmpDir });
+
+    engine.registerChecker({
+      check: async () => [
+        { id: "a", label: "OK", passed: true, severity: "info" },
+      ],
+    });
+
+    await engine.runAll();
+    const output = engine.formatConsoleOutput();
+
+    expect(output).toContain("🎉");
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── EnvironmentChecker ────────────────────────────────
+
+describe("EnvironmentChecker", () => {
+  test("checkNodeVersion 当前环境应通过", () => {
+    const tmpDir = createTempProject();
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkNodeVersion();
+
+    expect(result.id).toBe("env-node");
+    expect(result.passed).toBe(true);
+    expect(result.label).toContain("Node.js");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkConfig 无 config.json 时报警告", () => {
+    const tmpDir = createTempProject();
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkConfig();
+
+    expect(result.id).toBe("env-config");
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warning");
+    expect(result.fixType).toBe("auto");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkConfig 有合法 config.json 时通过", () => {
+    const tmpDir = createTempProject({
+      config: { loginUrl: "https://www.aliwork.com", defaultBaseUrl: "https://www.aliwork.com" },
+    });
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkConfig();
+
+    expect(result.passed).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkConfig 非法 JSON 时报错", () => {
+    const tmpDir = createTempProject();
+    fs.writeFileSync(path.join(tmpDir, "config.json"), "not-json", "utf-8");
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkConfig();
+
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("error");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkLoginStatus 无 cookies 时报警告", () => {
+    const tmpDir = createTempProject();
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkLoginStatus();
+
+    expect(result.id).toBe("env-login");
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warning");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkLoginStatus 有有效 cookies 时通过", () => {
+    const tmpDir = createTempProject({
+      cookies: [{ name: "tianshu_csrf_token", value: "token123" }],
+    });
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkLoginStatus();
+
+    expect(result.passed).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkSkills 无 skills 目录时报警告", () => {
+    const tmpDir = createTempProject();
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const result = checker.checkSkills();
+
+    expect(result.id).toBe("env-skills");
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warning");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("check 返回所有检查结果", async () => {
+    const tmpDir = createTempProject();
+    const checker = new EnvironmentChecker({ projectRoot: tmpDir });
+    const results = await checker.check();
+
+    expect(results.length).toBeGreaterThanOrEqual(9);
+    expect(results.every((r) => r.id && r.label)).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── ApplicationChecker ────────────────────────────────
+
+describe("ApplicationChecker", () => {
+  test("checkPrdFiles 无 prd 目录时报警告", () => {
+    const tmpDir = createTempProject();
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkPrdFiles();
+
+    expect(result.id).toBe("app-prd");
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warning");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkPrdFiles 有 PRD 文件时通过", () => {
+    const tmpDir = createTempProject({
+      prdFiles: { "demo.md": "# 需求文档\n这是一个示例" },
+    });
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkPrdFiles();
+
+    expect(result.passed).toBe(true);
+    expect(result.label).toContain("1 个");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkPageSources 无 pages/src 目录时报警告", () => {
+    const tmpDir = createTempProject();
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkPageSources();
+
+    expect(result.passed).toBe(false);
+    expect(result.severity).toBe("warning");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkPageSources 检测 console.log 调试语句", () => {
+    const tmpDir = createTempProject({
+      pageSources: { "app.js": 'console.log("debug");\nconst x = 1;' },
+    });
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkPageSources();
+
+    expect(result.severity).toBe("warning");
+    expect(result.message).toContain("console.log");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkSchemaCache 合法 schema 时通过", () => {
+    const tmpDir = createTempProject({
+      schemaCache: { "demo-schema.json": '{"componentName":"Page"}' },
+    });
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkSchemaCache();
+
+    expect(result.passed).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkSchemaCache 非法 schema 时报警告并可修复", () => {
+    const tmpDir = createTempProject({
+      schemaCache: { "bad-schema.json": "not-json" },
+    });
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkSchemaCache();
+
+    expect(result.passed).toBe(false);
+    expect(result.fixType).toBe("auto");
+    expect(result.fixAction).toBe("delete-invalid-schema");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("checkReactHooks 无源码时跳过", () => {
+    const tmpDir = createTempProject();
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const result = checker.checkReactHooks();
+
+    expect(result.passed).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("check 返回所有应用检查结果", async () => {
+    const tmpDir = createTempProject();
+    const checker = new ApplicationChecker({ projectRoot: tmpDir });
+    const results = await checker.check();
+
+    expect(results).toHaveLength(4);
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── FixEngine ─────────────────────────────────────────
+
+describe("FixEngine", () => {
+  test("autoFix 创建 config.json", async () => {
+    const tmpDir = createTempProject();
+    const fixEngine = new FixEngine({ projectRoot: tmpDir });
+
+    const issues = [
+      { id: "env-config", fixType: "auto", fixAction: "create-config", severity: "error" },
+    ];
+
+    await fixEngine.autoFix(issues);
+    expect(fs.existsSync(path.join(tmpDir, "config.json"))).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, "config.json"), "utf-8"));
+    expect(config.loginUrl).toBeDefined();
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("autoFix 删除损坏的 schema 缓存", async () => {
+    const tmpDir = createTempProject({
+      schemaCache: { "bad-schema.json": "not-json" },
+    });
+    const fixEngine = new FixEngine({ projectRoot: tmpDir });
+
+    const issues = [
+      {
+        id: "app-schema",
+        fixType: "auto",
+        fixAction: "delete-invalid-schema",
+        fixTarget: "bad-schema.json",
+        severity: "error",
+      },
+    ];
+
+    await fixEngine.autoFix(issues);
+    expect(fs.existsSync(path.join(tmpDir, ".cache", "bad-schema.json"))).toBe(false);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("autoFix 对 command 类型给出手动提示", async () => {
+    const tmpDir = createTempProject();
+    const fixEngine = new FixEngine({ projectRoot: tmpDir });
+
+    const issues = [
+      { id: "env-playwright", fixType: "command", fixCommand: "pip install playwright", severity: "error" },
+    ];
+
+    await fixEngine.autoFix(issues);
+    expect(fixEngine.fixResults[0].fixed).toBe(false);
+    expect(fixEngine.fixResults[0].message).toContain("pip install playwright");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("formatFixOutput 包含修复结果", async () => {
+    const tmpDir = createTempProject();
+    const fixEngine = new FixEngine({ projectRoot: tmpDir });
+
+    await fixEngine.autoFix([
+      { id: "env-config", fixType: "auto", fixAction: "create-config", severity: "error" },
+    ]);
+
+    const output = fixEngine.formatFixOutput();
+    expect(output).toContain("✅");
+    expect(output).toContain("config.json");
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── ReportGenerator ───────────────────────────────────
+
+describe("ReportGenerator", () => {
+  const mockResults = [
+    { id: "a", label: "Node.js", passed: true, severity: "info" },
+    { id: "b", label: "Python", passed: false, severity: "error", message: "版本过低" },
+  ];
+  const mockSummary = { total: 2, passed: 1, errorCount: 1, warningCount: 0, infoCount: 1, autoFixable: 0 };
+
+  test("生成 JSON 报告", () => {
+    const tmpDir = createTempProject();
+    const reporter = new ReportGenerator({ projectRoot: tmpDir });
+    const reportPath = reporter.generate(mockResults, mockSummary, "json");
+
+    expect(reportPath).toContain(".json");
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf-8"));
+    expect(report.summary.total).toBe(2);
+    expect(report.results).toHaveLength(2);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("生成 Markdown 报告", () => {
+    const tmpDir = createTempProject();
+    const reporter = new ReportGenerator({ projectRoot: tmpDir });
+    const reportPath = reporter.generate(mockResults, mockSummary, "markdown");
+
+    expect(reportPath).toContain(".md");
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const content = fs.readFileSync(reportPath, "utf-8");
+    expect(content).toContain("# OpenYida 诊断报告");
+    expect(content).toContain("Node.js");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("生成 HTML 报告", () => {
+    const tmpDir = createTempProject();
+    const reporter = new ReportGenerator({ projectRoot: tmpDir });
+    const reportPath = reporter.generate(mockResults, mockSummary, "html");
+
+    expect(reportPath).toContain(".html");
+    expect(fs.existsSync(reportPath)).toBe(true);
+
+    const content = fs.readFileSync(reportPath, "utf-8");
+    expect(content).toContain("<!DOCTYPE html>");
+    expect(content).toContain("OpenYida 诊断报告");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("未知格式默认生成 Markdown", () => {
+    const tmpDir = createTempProject();
+    const reporter = new ReportGenerator({ projectRoot: tmpDir });
+    const reportPath = reporter.generate(mockResults, mockSummary, "unknown");
+
+    expect(reportPath).toContain(".md");
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── PreChecker ────────────────────────────────────────
+
+describe("PreChecker", () => {
+  test("prePublishCheck 返回检查结果和通过状态", async () => {
+    const tmpDir = createTempProject({
+      config: { loginUrl: "https://www.aliwork.com" },
+    });
+    const preChecker = new PreChecker({ projectRoot: tmpDir });
+    const result = await preChecker.prePublishCheck();
+
+    expect(result).toHaveProperty("passed");
+    expect(result).toHaveProperty("results");
+    expect(result).toHaveProperty("criticalIssues");
+    expect(Array.isArray(result.results)).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("preCreateCheck 仅执行环境检查", async () => {
+    const tmpDir = createTempProject();
+    const preChecker = new PreChecker({ projectRoot: tmpDir });
+    const result = await preChecker.preCreateCheck();
+
+    expect(result).toHaveProperty("passed");
+    // 环境检查结果的 id 都以 env- 开头
+    const envResults = result.results.filter((r) => r.id.startsWith("env-"));
+    expect(envResults.length).toBe(result.results.length);
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── HealthMonitor ─────────────────────────────────────
+
+describe("HealthMonitor", () => {
+  test("calculateHealthScore 全部通过时返回 100", () => {
+    const tmpDir = createTempProject();
+    const monitor = new HealthMonitor({ projectRoot: tmpDir });
+    const score = monitor.calculateHealthScore({ total: 10, passed: 10, errorCount: 0, warningCount: 0 });
+
+    expect(score).toBe(100);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("calculateHealthScore 有错误时扣分", () => {
+    const tmpDir = createTempProject();
+    const monitor = new HealthMonitor({ projectRoot: tmpDir });
+    const score = monitor.calculateHealthScore({ total: 10, passed: 8, errorCount: 2, warningCount: 0 });
+
+    expect(score).toBeLessThan(100);
+    expect(score).toBeGreaterThanOrEqual(0);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("calculateHealthScore 空检查返回 100", () => {
+    const tmpDir = createTempProject();
+    const monitor = new HealthMonitor({ projectRoot: tmpDir });
+    const score = monitor.calculateHealthScore({ total: 0, passed: 0, errorCount: 0, warningCount: 0 });
+
+    expect(score).toBe(100);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("formatMonitorOutput 包含健康度信息", () => {
+    const tmpDir = createTempProject();
+    const monitor = new HealthMonitor({ projectRoot: tmpDir });
+    monitor.history = [{ healthScore: 80 }];
+
+    const output = monitor.formatMonitorOutput({
+      timestamp: new Date().toISOString(),
+      healthScore: 85,
+      passed: 8,
+      total: 10,
+      errorCount: 1,
+      warningCount: 1,
+    });
+
+    expect(output).toContain("健康度");
+    expect(output).toContain("85");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("start 和 stop 正常工作", () => {
+    jest.useFakeTimers();
+    const tmpDir = createTempProject();
+    const monitor = new HealthMonitor({
+      projectRoot: tmpDir,
+      intervalMs: 100_000,
+    });
+
+    // mock runOnce 避免实际执行异步诊断
+    monitor.runOnce = jest.fn();
+
+    monitor.start();
+    expect(monitor.timer).not.toBeNull();
+
+    monitor.stop();
+    expect(monitor.timer).toBeNull();
+
+    jest.useRealTimers();
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── ProductionErrorCollector ──────────────────────────
+
+describe("ProductionErrorCollector", () => {
+  test("无 appId 时报错", async () => {
+    const tmpDir = createTempProject();
+    const collector = new ProductionErrorCollector({ projectRoot: tmpDir });
+    const results = await collector.check();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].message).toContain("应用 ID");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("有 appId 但无错误日志时通过", async () => {
+    const tmpDir = createTempProject();
+    const collector = new ProductionErrorCollector({ projectRoot: tmpDir, appId: "APP_TEST" });
+    const results = await collector.check();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].passed).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("有错误日志时报警告", async () => {
+    const tmpDir = createTempProject({
+      errorLogs: { "APP_TEST.json": [{ error: "TypeError", timestamp: "2026-01-01" }] },
+    });
+    const collector = new ProductionErrorCollector({ projectRoot: tmpDir, appId: "APP_TEST" });
+    const results = await collector.check();
+
+    expect(results[0].passed).toBe(false);
+    expect(results[0].severity).toBe("warning");
+    expect(results[0].message).toContain("1 条");
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── TicketCreator ─────────────────────────────────────
+
+describe("TicketCreator", () => {
+  test("createTicket 保存工单到本地", async () => {
+    const tmpDir = createTempProject();
+    const creator = new TicketCreator({ projectRoot: tmpDir });
+    const ticket = await creator.createTicket({
+      title: "测试工单",
+      description: "这是一个测试",
+      type: "bug",
+    });
+
+    expect(ticket.id).toMatch(/^TICKET-/);
+    expect(ticket.title).toBe("测试工单");
+    expect(ticket.type).toBe("bug");
+    expect(["draft", "local", "submitted"]).toContain(ticket.status);
+
+    // 验证本地文件已保存
+    const ticketPath = path.join(tmpDir, ".cache", "tickets", `${ticket.id}.json`);
+    expect(fs.existsSync(ticketPath)).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── VOCCreator ────────────────────────────────────────
+
+describe("VOCCreator", () => {
+  test("createVOC 保存 VOC 到本地", async () => {
+    const tmpDir = createTempProject();
+    const creator = new VOCCreator({ projectRoot: tmpDir });
+    const voc = await creator.createVOC({
+      title: "测试需求",
+      description: "希望增加暗色模式",
+    });
+
+    expect(voc.id).toMatch(/^VOC-/);
+    expect(voc.title).toBe("测试需求");
+    expect(["draft", "local", "submitted"]).toContain(voc.status);
+
+    const vocPath = path.join(tmpDir, ".cache", "voc", `${voc.id}.json`);
+    expect(fs.existsSync(vocPath)).toBe(true);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("analyzeBusinessValue 高优先级关键词", () => {
+    const tmpDir = createTempProject();
+    const creator = new VOCCreator({ projectRoot: tmpDir });
+    const analysis = creator.analyzeBusinessValue("线上崩溃，紧急修复");
+
+    expect(analysis.suggestedPriority).toBe("high");
+    expect(analysis.businessValue).toBe("high");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("analyzeBusinessValue 低优先级关键词", () => {
+    const tmpDir = createTempProject();
+    const creator = new VOCCreator({ projectRoot: tmpDir });
+    const analysis = creator.analyzeBusinessValue("建议美化一下文档");
+
+    expect(analysis.suggestedPriority).toBe("low");
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("analyzeBusinessValue 默认中优先级", () => {
+    const tmpDir = createTempProject();
+    const creator = new VOCCreator({ projectRoot: tmpDir });
+    const analysis = creator.analyzeBusinessValue("一般性描述");
+
+    expect(analysis.suggestedPriority).toBe("medium");
+
+    cleanupTempDir(tmpDir);
+  });
+});
+
+// ── SubmissionDecider ─────────────────────────────────
+
+describe("SubmissionDecider", () => {
+  test("decide 识别 bug 类描述为工单", () => {
+    const tmpDir = createTempProject();
+    const decider = new SubmissionDecider({ projectRoot: tmpDir });
+    const decision = decider.decide("页面崩溃", "点击按钮后报错，无法正常使用");
+
+    expect(decision.type).toBe("ticket");
+    expect(decision.confidence).toBeGreaterThan(0.5);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("decide 识别需求类描述为 VOC", () => {
+    const tmpDir = createTempProject();
+    const decider = new SubmissionDecider({ projectRoot: tmpDir });
+    const decision = decider.decide("新增功能", "希望支持暗色模式，优化用户体验");
+
+    expect(decision.type).toBe("voc");
+    expect(decision.confidence).toBeGreaterThan(0.5);
+
+    cleanupTempDir(tmpDir);
+  });
+
+  test("autoSubmit 返回完整结果", async () => {
+    const tmpDir = createTempProject();
+    const decider = new SubmissionDecider({ projectRoot: tmpDir });
+    const result = await decider.autoSubmit({
+      title: "页面报错",
+      description: "登录后页面崩溃",
+    });
+
+    expect(result).toHaveProperty("decision");
+    expect(result).toHaveProperty("type");
+    expect(result).toHaveProperty("data");
+    expect(result).toHaveProperty("message");
+
+    cleanupTempDir(tmpDir);
+  });
+});


### PR DESCRIPTION
Closes #70

## 变更内容

基于 `refactor/1.0.0` 新架构重新实现应用自动诊断功能。

### 架构适配
- 遵循新架构扁平模块结构，将原 `lib/doctor/` 目录合并为单一 `lib/doctor.js` 模块
- CLI 命令使用 `process.argv` + `switch/case` 路由（不再依赖 commander）
- 复用 `lib/utils.js` 公共工具函数（`findProjectRoot`、`loadCookieData` 等）

### 新增文件
- **lib/doctor.js**: 诊断主模块，包含 11 个核心类 + CLI 入口函数
  - `DiagnosticEngine`: 诊断引擎核心调度器，三层架构
  - `EnvironmentChecker`: 环境诊断（Node/Python/Playwright/gh/config/Skills/登录态/网络）
  - `ApplicationChecker`: 应用诊断（PRD/页面源码/Schema/React Hooks 检测）
  - `FixEngine`: 智能修复引擎（自动修复/手动提示/命令执行）
  - `ReportGenerator`: 诊断报告生成（JSON/Markdown/HTML 多格式）
  - `PreChecker`: 预检查（发布前/创建前自动检查）
  - `HealthMonitor`: 持续健康度监控与趋势分析
  - `ProductionErrorCollector`: 线上错误诊断与智能分析
  - `TicketCreator`: 工单创建（集成 GitHub Issues）
  - `VOCCreator`: VOC 创建（业务价值分析/优先级建议）
  - `SubmissionDecider`: 智能提交决策（自动判断工单/VOC）
- **tests/doctor.test.js**: 47 个单元测试

### 修改文件
- **bin/yida.js**: 新增 `doctor` 命令路由，支持 `--fix`/`--monitor`/`--report`/`--create-ticket`/`--create-voc`/`--auto-submit` 选项

### 测试
- 新增 47 个单元测试，全部 94 个测试通过（含原有测试）

### 用法示例
```bash
yida doctor                              # 完整诊断
yida doctor --fix                        # 诊断并自动修复
yida doctor --production --app APP_XXX   # 线上应用诊断
yida doctor --monitor                    # 实时监控
yida doctor --report markdown            # 生成 Markdown 报告
yida doctor --create-ticket              # 创建工单
yida doctor --create-voc                 # 创建 VOC
yida doctor --auto-submit                # 自动判断并提交
```