### PR TITLE
feat: 添加 CDN 图片上传功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ openyida verify-short-url     # 验证短链接 URL 是否可用
 openyida save-share-config    # 保存公开访问 / 分享配置
 openyida get-page-config      # 查询页面公开访问 / 分享配置
 openyida update-form-config   # 更新表单配置
+openyida cdn-config           # 配置 CDN 图片上传（阿里云 OSS + CDN）
+openyida cdn-upload           # 上传图片到 CDN
+openyida cdn-refresh          # 刷新 CDN 缓存
 ```
 
 ---

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -266,6 +266,24 @@ async function main() {
       break;
     }
 
+    case 'cdn-config': {
+      const { run: runCdnConfig } = require('../lib/cdn-config-cmd');
+      await runCdnConfig(args);
+      break;
+    }
+
+    case 'cdn-upload': {
+      const { run: runCdnUpload } = require('../lib/cdn-upload');
+      await runCdnUpload(args);
+      break;
+    }
+
+    case 'cdn-refresh': {
+      const { run: runCdnRefresh } = require('../lib/cdn-refresh');
+      await runCdnRefresh(args);
+      break;
+    }
+
     default: {
       console.error(t('cli.unknown_command', command));
       console.error(t('cli.run_help'));

--- a/lib/cdn-config-cmd.js
+++ b/lib/cdn-config-cmd.js
@@ -1,0 +1,252 @@
+
+/**
+ * cdn-config-cmd.js - CDN 配置命令
+ *
+ * 管理阿里云 CDN/OSS 配置，包括 AccessKey、域名等。
+ *
+ * 用法：
+ *   yida cdn-config [选项]
+ *
+ * 选项：
+ *   --init              初始化配置（交互式）
+ *   --show              显示当前配置
+ *   --set-key <key>     设置 AccessKey ID
+ *   --set-secret <secret> 设置 AccessKey Secret
+ *   --set-domain <domain> 设置 CDN 加速域名
+ *   --set-bucket <bucket> 设置 OSS Bucket 名称
+ *   --set-region <region> 设置 OSS 区域
+ *
+ * 示例：
+ *   yida cdn-config --init
+ *   yida cdn-config --show
+ *   yida cdn-config --set-domain cdn.example.com
+ */
+
+"use strict";
+
+const { t } = require("./i18n");
+const {
+  loadCdnConfig,
+  saveCdnConfig,
+  initCdnConfig,
+  validateCdnConfig,
+  hasCdnConfig,
+  getCdnConfigPath,
+} = require("./cdn-config");
+
+/**
+ * 解析命令行参数
+ * @param {string[]} args
+ * @returns {object}
+ */
+function parseArgs(args) {
+  const result = {
+    init: false,
+    show: false,
+    setKey: null,
+    setSecret: null,
+    setDomain: null,
+    setBucket: null,
+    setRegion: null,
+    setPath: null,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      result.help = true;
+    } else if (arg === "--init") {
+      result.init = true;
+    } else if (arg === "--show") {
+      result.show = true;
+    } else if (arg === "--set-key") {
+      result.setKey = args[++i];
+    } else if (arg === "--set-secret") {
+      result.setSecret = args[++i];
+    } else if (arg === "--set-domain") {
+      result.setDomain = args[++i];
+    } else if (arg === "--set-bucket") {
+      result.setBucket = args[++i];
+    } else if (arg === "--set-region") {
+      result.setRegion = args[++i];
+    } else if (arg === "--set-path") {
+      result.setPath = args[++i];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 打印帮助信息
+ */
+function printHelp() {
+  console.log(t("cdn.config_usage"));
+  console.log("");
+  console.log(t("cdn.config_examples"));
+  console.log("  yida cdn-config --init");
+  console.log("  yida cdn-config --show");
+  console.log("  yida cdn-config --set-domain cdn.example.com");
+  console.log("  yida cdn-config --set-bucket my-bucket --set-region oss-cn-hangzhou");
+  console.log("");
+  console.log(t("cdn.config_options"));
+  console.log("  --init                " + t("cdn.config_opt_init"));
+  console.log("  --show                " + t("cdn.config_opt_show"));
+  console.log("  --set-key <key>       " + t("cdn.config_opt_key"));
+  console.log("  --set-secret <secret> " + t("cdn.config_opt_secret"));
+  console.log("  --set-domain <domain> " + t("cdn.config_opt_domain"));
+  console.log("  --set-bucket <bucket> " + t("cdn.config_opt_bucket"));
+  console.log("  --set-region <region> " + t("cdn.config_opt_region"));
+  console.log("  --set-path <path>     " + t("cdn.config_opt_path"));
+}
+
+/**
+ * 掩码敏感信息
+ * @param {string} value
+ * @param {number} visibleChars
+ * @returns {string}
+ */
+function maskSensitive(value, visibleChars = 4) {
+  if (!value) return "";
+  if (value.length <= visibleChars * 2) {
+    return "*".repeat(value.length);
+  }
+  return value.slice(0, visibleChars) + "*".repeat(value.length - visibleChars * 2) + value.slice(-visibleChars);
+}
+
+/**
+ * 显示当前配置
+ */
+function showConfig() {
+  const config = loadCdnConfig();
+  const configPath = getCdnConfigPath();
+
+  console.log(t("cdn.config_file_path", configPath));
+  console.log("");
+
+  console.log(t("cdn.config_section_aliyun"));
+  console.log(`  AccessKey ID:  ${maskSensitive(config.accessKeyId)}`);
+  console.log(`  AccessKey Secret: ${maskSensitive(config.accessKeySecret)}`);
+  console.log("");
+
+  console.log(t("cdn.config_section_cdn"));
+  console.log(`  ${t("cdn.config_cdn_domain")}: ${config.cdnDomain || t("cdn.config_not_set")}`);
+  console.log("");
+
+  console.log(t("cdn.config_section_oss"));
+  console.log(`  ${t("cdn.config_oss_region")}: ${config.ossRegion}`);
+  console.log(`  ${t("cdn.config_oss_bucket")}: ${config.ossBucket || t("cdn.config_not_set")}`);
+  console.log(`  ${t("cdn.config_oss_endpoint")}: ${config.ossEndpoint || t("cdn.config_not_set")}`);
+  console.log("");
+
+  console.log(t("cdn.config_section_upload"));
+  console.log(`  ${t("cdn.config_upload_path")}: ${config.uploadPath}`);
+  console.log(`  ${t("cdn.config_compress")}: ${config.enableCompress ? t("cdn.config_enabled") : t("cdn.config_disabled")}`);
+  console.log(`  ${t("cdn.config_max_width")}: ${config.maxImageWidth}px`);
+  console.log(`  ${t("cdn.config_quality")}: ${config.imageQuality}%`);
+  console.log("");
+
+  // 验证配置
+  const { valid, missing } = validateCdnConfig(config);
+  if (valid) {
+    console.log(t("cdn.config_status_valid"));
+  } else {
+    console.log(t("cdn.config_status_invalid"));
+    console.log(t("cdn.config_missing", missing.join(", ")));
+  }
+}
+
+/**
+ * 交互式初始化配置
+ */
+function initConfigInteractive() {
+  console.log(t("cdn.config_init_title"));
+  console.log("");
+  console.log(t("cdn.config_init_desc"));
+  console.log("");
+
+  // 显示示例
+  console.log(t("cdn.config_init_example"));
+  console.log("  AccessKey ID: LTAI5t*************");
+  console.log("  AccessKey Secret: AbCdEfGhIjKlMnOpQrStUvWxYz******");
+  console.log("  CDN Domain: cdn.example.com");
+  console.log("  OSS Bucket: my-image-bucket");
+  console.log("  OSS Region: oss-cn-hangzhou");
+  console.log("");
+
+  console.log(t("cdn.config_init_hint"));
+  console.log("  yida cdn-config --set-key LTAI5tXXXXXXXXXXXXXXX");
+  console.log("  yida cdn-config --set-secret AbCdEfGhIjKlMnOpQrStUvWxYzXXXXXXXX");
+  console.log("  yida cdn-config --set-domain cdn.example.com");
+  console.log("  yida cdn-config --set-bucket my-image-bucket");
+  console.log("  yida cdn-config --set-region oss-cn-hangzhou");
+  console.log("");
+  console.log(t("cdn.config_init_or"));
+  console.log("  yida cdn-config --set-key YOUR_KEY --set-secret YOUR_SECRET --set-domain cdn.example.com --set-bucket your-bucket");
+}
+
+/**
+ * CLI 入口函数
+ * @param {string[]} args
+ */
+async function run(args) {
+  const options = parseArgs(args);
+
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  // 显示配置
+  if (options.show) {
+    showConfig();
+    process.exit(0);
+  }
+
+  // 交互式初始化
+  if (options.init) {
+    initConfigInteractive();
+    process.exit(0);
+  }
+
+  // 设置配置项
+  const hasSetOption =
+    options.setKey ||
+    options.setSecret ||
+    options.setDomain ||
+    options.setBucket ||
+    options.setRegion ||
+    options.setPath;
+
+  if (hasSetOption) {
+    const newConfig = initCdnConfig({
+      accessKeyId: options.setKey,
+      accessKeySecret: options.setSecret,
+      cdnDomain: options.setDomain,
+      ossBucket: options.setBucket,
+      ossRegion: options.setRegion,
+      uploadPath: options.setPath,
+    });
+
+    console.log(t("cdn.config_updated"));
+    console.log("");
+
+    // 显示更新后的配置
+    const { valid, missing } = validateCdnConfig(newConfig);
+    if (valid) {
+      console.log(t("cdn.config_status_valid"));
+    } else {
+      console.log(t("cdn.config_status_invalid"));
+      console.log(t("cdn.config_missing", missing.join(", ")));
+    }
+
+    process.exit(0);
+  }
+
+  // 无参数时显示帮助
+  printHelp();
+}
+
+module.exports = { run, showConfig, initConfigInteractive };

--- a/lib/cdn-config.js
+++ b/lib/cdn-config.js
@@ -1,0 +1,172 @@
+
+/**
+ * cdn-config.js - CDN 配置管理模块
+ *
+ * 管理 CDN 服务配置，包括：
+ *   - 阿里云 AccessKey 存储（安全存储在 ~/.openyida/cdn-config.json）
+ *   - 加速域名配置
+ *   - 上传目录配置
+ *
+ * 用法：
+ *   const { loadCdnConfig, saveCdnConfig, initCdnConfig } = require('./cdn-config');
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { t } = require("./i18n");
+
+const OPENYIDA_DIR = path.join(os.homedir(), ".openyida");
+const CDN_CONFIG_FILE = path.join(OPENYIDA_DIR, "cdn-config.json");
+
+/**
+ * 默认 CDN 配置结构
+ */
+const DEFAULT_CONFIG = {
+  // 阿里云 AccessKey
+  accessKeyId: "",
+  accessKeySecret: "",
+  // CDN 加速域名
+  cdnDomain: "",
+  // OSS 配置（用于存储图片）
+  ossRegion: "oss-cn-hangzhou",
+  ossBucket: "",
+  ossEndpoint: "",
+  // 上传目录前缀
+  uploadPath: "yida-images/",
+  // 是否启用图片压缩
+  enableCompress: true,
+  // 图片最大宽度（像素）
+  maxImageWidth: 1920,
+  // 图片质量（1-100）
+  imageQuality: 85,
+};
+
+/**
+ * 确保 .openyida 目录存在
+ */
+function ensureOpenyidaDir() {
+  if (!fs.existsSync(OPENYIDA_DIR)) {
+    fs.mkdirSync(OPENYIDA_DIR, { recursive: true });
+  }
+}
+
+/**
+ * 加载 CDN 配置
+ * @returns {object} CDN 配置对象
+ */
+function loadCdnConfig() {
+  if (!fs.existsSync(CDN_CONFIG_FILE)) {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  try {
+    const raw = fs.readFileSync(CDN_CONFIG_FILE, "utf-8").trim();
+    if (!raw) {
+      return { ...DEFAULT_CONFIG };
+    }
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_CONFIG, ...parsed };
+  } catch (error) {
+    console.error(t("cdn.config_load_error", error.message));
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+/**
+ * 保存 CDN 配置
+ * @param {object} config - CDN 配置对象
+ */
+function saveCdnConfig(config) {
+  ensureOpenyidaDir();
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+  fs.writeFileSync(CDN_CONFIG_FILE, JSON.stringify(mergedConfig, null, 2), "utf-8");
+  console.log(t("cdn.config_saved", CDN_CONFIG_FILE));
+}
+
+/**
+ * 初始化 CDN 配置（交互式配置向导）
+ * @param {object} options - 配置选项
+ * @param {string} options.accessKeyId - 阿里云 AccessKey ID
+ * @param {string} options.accessKeySecret - 阿里云 AccessKey Secret
+ * @param {string} options.cdnDomain - CDN 加速域名
+ * @param {string} options.ossBucket - OSS Bucket 名称
+ * @param {string} options.ossRegion - OSS 区域
+ */
+function initCdnConfig(options) {
+  const currentConfig = loadCdnConfig();
+  const newConfig = { ...currentConfig };
+
+  // 更新配置项
+  if (options.accessKeyId) {
+    newConfig.accessKeyId = options.accessKeyId;
+  }
+  if (options.accessKeySecret) {
+    newConfig.accessKeySecret = options.accessKeySecret;
+  }
+  if (options.cdnDomain) {
+    newConfig.cdnDomain = options.cdnDomain.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  }
+  if (options.ossBucket) {
+    newConfig.ossBucket = options.ossBucket;
+    // 自动生成 OSS Endpoint
+    if (options.ossRegion) {
+      newConfig.ossRegion = options.ossRegion;
+    }
+    newConfig.ossEndpoint = `https://${newConfig.ossBucket}.${newConfig.ossRegion}.aliyuncs.com`;
+  }
+  if (options.uploadPath) {
+    newConfig.uploadPath = options.uploadPath.replace(/^\//, "").replace(/\/$/, "") + "/";
+  }
+
+  saveCdnConfig(newConfig);
+  return newConfig;
+}
+
+/**
+ * 验证 CDN 配置是否完整
+ * @param {object} config - CDN 配置对象
+ * @returns {{ valid: boolean, missing: string[] }}
+ */
+function validateCdnConfig(config) {
+  const required = ["accessKeyId", "accessKeySecret", "cdnDomain", "ossBucket"];
+  const missing = required.filter((key) => !config[key]);
+
+  return {
+    valid: missing.length === 0,
+    missing,
+  };
+}
+
+/**
+ * 检查 CDN 配置是否存在
+ * @returns {boolean}
+ */
+function hasCdnConfig() {
+  if (!fs.existsSync(CDN_CONFIG_FILE)) {
+    return false;
+  }
+  const config = loadCdnConfig();
+  const { valid } = validateCdnConfig(config);
+  return valid;
+}
+
+/**
+ * 获取 CDN 配置文件路径
+ * @returns {string}
+ */
+function getCdnConfigPath() {
+  return CDN_CONFIG_FILE;
+}
+
+module.exports = {
+  loadCdnConfig,
+  saveCdnConfig,
+  initCdnConfig,
+  validateCdnConfig,
+  hasCdnConfig,
+  getCdnConfigPath,
+  DEFAULT_CONFIG,
+};

--- a/lib/cdn-refresh.js
+++ b/lib/cdn-refresh.js
@@ -1,0 +1,293 @@
+
+/**
+ * cdn-refresh.js - CDN 缓存刷新命令
+ *
+ * 支持刷新阿里云 CDN 节点上的缓存，确保用户访问到最新内容。
+ *
+ * 用法：
+ *   yida cdn-refresh [选项]
+ *
+ * 选项：
+ *   --urls <URL列表>    刷新的 URL 列表（逗号分隔）
+ *   --paths <路径列表>  刷新的目录路径列表（逗号分隔）
+ *   --file <文件>       从文件读取 URL 列表（每行一个）
+ *
+ * 示例：
+ *   yida cdn-refresh --urls "https://cdn.example.com/image1.png,https://cdn.example.com/image2.png"
+ *   yida cdn-refresh --paths "/yida-images/"
+ *   yida cdn-refresh --file urls.txt
+ */
+
+"use strict";
+
+const fs = require("fs");
+const { t } = require("./i18n");
+const { loadCdnConfig, validateCdnConfig, hasCdnConfig } = require("./cdn-config");
+
+/**
+ * 解析命令行参数
+ * @param {string[]} args
+ * @returns {object}
+ */
+function parseArgs(args) {
+  const result = {
+    urls: [],
+    paths: [],
+    file: null,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      result.help = true;
+    } else if (arg === "--urls") {
+      result.urls = (args[++i] || "").split(",").map((u) => u.trim()).filter(Boolean);
+    } else if (arg === "--paths") {
+      result.paths = (args[++i] || "").split(",").map((p) => p.trim()).filter(Boolean);
+    } else if (arg === "--file") {
+      result.file = args[++i];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 打印帮助信息
+ */
+function printHelp() {
+  console.log(t("cdn.refresh_usage"));
+  console.log("");
+  console.log(t("cdn.refresh_examples"));
+  console.log('  yida cdn-refresh --urls "https://cdn.example.com/image.png"');
+  console.log('  yida cdn-refresh --paths "/yida-images/"');
+  console.log("  yida cdn-refresh --file urls.txt");
+  console.log("");
+  console.log(t("cdn.refresh_options"));
+  console.log("  --urls <URL列表>    " + t("cdn.refresh_opt_urls"));
+  console.log("  --paths <路径列表>  " + t("cdn.refresh_opt_paths"));
+  console.log("  --file <文件>       " + t("cdn.refresh_opt_file"));
+}
+
+/**
+ * 创建 CDN 客户端（延迟加载 SDK）
+ * @param {object} config
+ * @returns {object}
+ */
+function createCdnClient(config) {
+  try {
+    const Cdn = require("@alicloud/cdn20180510").default;
+    const OpenApi = require("@alicloud/openapi-client");
+
+    const openApiConfig = new OpenApi.Config({
+      accessKeyId: config.accessKeyId,
+      accessKeySecret: config.accessKeySecret,
+    });
+    openApiConfig.endpoint = "cdn.aliyuncs.com";
+
+    return new Cdn(openApiConfig);
+  } catch (error) {
+    console.error(t("cdn.cdn_sdk_required"));
+    console.error(t("cdn.run_npm_install", "@alicloud/cdn20180510 @alicloud/openapi-client"));
+    process.exit(1);
+  }
+}
+
+/**
+ * 刷新 URL 缓存
+ * @param {object} cdnClient - CDN 客户端
+ * @param {string[]} urls - URL 列表
+ * @returns {Promise<object>}
+ */
+async function refreshUrls(cdnClient, urls) {
+  const Cdn = require("@alicloud/cdn20180510");
+  const request = new Cdn.RefreshObjectCachesRequest({
+    objectPath: urls.join("\n"),
+    objectType: "File",
+  });
+
+  const response = await cdnClient.refreshObjectCaches(request);
+  return response.body;
+}
+
+/**
+ * 刷新目录缓存
+ * @param {object} cdnClient - CDN 客户端
+ * @param {string[]} paths - 目录路径列表
+ * @returns {Promise<object>}
+ */
+async function refreshPaths(cdnClient, paths) {
+  const Cdn = require("@alicloud/cdn20180510");
+  const request = new Cdn.RefreshObjectCachesRequest({
+    objectPath: paths.join("\n"),
+    objectType: "Directory",
+  });
+
+  const response = await cdnClient.refreshObjectCaches(request);
+  return response.body;
+}
+
+/**
+ * 查询刷新配额
+ * @param {object} cdnClient - CDN 客户端
+ * @returns {Promise<object>}
+ */
+async function describeRefreshQuota(cdnClient) {
+  const response = await cdnClient.describeRefreshQuota();
+  return response.body;
+}
+
+/**
+ * 查询刷新任务状态
+ * @param {object} cdnClient - CDN 客户端
+ * @param {string} taskId - 任务 ID
+ * @returns {Promise<object>}
+ */
+async function describeRefreshTasks(cdnClient, taskId) {
+  const Cdn = require("@alicloud/cdn20180510");
+  const request = new Cdn.DescribeRefreshTasksRequest({
+    taskId,
+  });
+  const response = await cdnClient.describeRefreshTasks(request);
+  return response.body;
+}
+
+/**
+ * 执行刷新操作
+ * @param {object} options
+ * @returns {Promise<object>}
+ */
+async function performRefresh(options) {
+  const config = loadCdnConfig();
+  const { valid, missing } = validateCdnConfig(config);
+
+  if (!valid) {
+    console.error(t("cdn.config_incomplete"));
+    console.error(t("cdn.missing_fields", missing.join(", ")));
+    console.error(t("cdn.run_config_init"));
+    process.exit(1);
+  }
+
+  // 创建 CDN 客户端
+  const cdnClient = createCdnClient(config);
+
+  // 从文件读取 URL
+  let urls = [...options.urls];
+  if (options.file) {
+    if (!fs.existsSync(options.file)) {
+      console.error(t("cdn.file_not_found", options.file));
+      process.exit(1);
+    }
+    const content = fs.readFileSync(options.file, "utf-8");
+    const fileUrls = content
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    urls = urls.concat(fileUrls);
+  }
+
+  const results = {
+    urlRefresh: null,
+    pathRefresh: null,
+    quota: null,
+  };
+
+  // 查询配额
+  try {
+    console.log(t("cdn.querying_quota"));
+    results.quota = await describeRefreshQuota(cdnClient);
+    console.log(t("cdn.quota_info", 
+      results.quota.UrlQuota,
+      results.quota.UrlRemain,
+      results.quota.DirQuota,
+      results.quota.DirRemain
+    ));
+  } catch (error) {
+    console.error(t("cdn.quota_query_failed", error.message));
+  }
+
+  // 刷新 URL
+  if (urls.length > 0) {
+    console.log(t("cdn.refreshing_urls", urls.length));
+    try {
+      results.urlRefresh = await refreshUrls(cdnClient, urls);
+      console.log(t("cdn.refresh_task_id", results.urlRefresh.refreshTaskId));
+    } catch (error) {
+      console.error(t("cdn.refresh_urls_failed", error.message));
+      results.urlRefresh = { error: error.message };
+    }
+  }
+
+  // 刷新目录
+  if (options.paths.length > 0) {
+    console.log(t("cdn.refreshing_paths", options.paths.length));
+    try {
+      results.pathRefresh = await refreshPaths(cdnClient, options.paths);
+      console.log(t("cdn.refresh_task_id", results.pathRefresh.refreshTaskId));
+    } catch (error) {
+      console.error(t("cdn.refresh_paths_failed", error.message));
+      results.pathRefresh = { error: error.message };
+    }
+  }
+
+  return results;
+}
+
+/**
+ * CLI 入口函数
+ * @param {string[]} args
+ */
+async function run(args) {
+  const options = parseArgs(args);
+
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (options.urls.length === 0 && options.paths.length === 0 && !options.file) {
+    console.error(t("cdn.refresh_no_targets"));
+    printHelp();
+    process.exit(1);
+  }
+
+  // 检查配置
+  if (!hasCdnConfig()) {
+    console.error(t("cdn.no_config"));
+    console.error(t("cdn.run_config_init"));
+    process.exit(1);
+  }
+
+  try {
+    const results = await performRefresh(options);
+
+    // 输出汇总
+    console.log("");
+    console.log(t("cdn.refresh_summary"));
+
+    if (results.urlRefresh && !results.urlRefresh.error) {
+      console.log(t("cdn.url_refresh_success", results.urlRefresh.refreshTaskId));
+    }
+    if (results.pathRefresh && !results.pathRefresh.error) {
+      console.log(t("cdn.path_refresh_success", results.pathRefresh.refreshTaskId));
+    }
+
+    // 返回 JSON 格式结果
+    console.log("");
+    console.log(JSON.stringify(results, null, 2));
+  } catch (error) {
+    console.error(t("cdn.refresh_error", error.message));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  run,
+  performRefresh,
+  refreshUrls,
+  refreshPaths,
+  describeRefreshQuota,
+  describeRefreshTasks,
+};

--- a/lib/cdn-upload.js
+++ b/lib/cdn-upload.js
@@ -1,0 +1,321 @@
+
+/**
+ * cdn-upload.js - 图片上传到 CDN 命令
+ *
+ * 支持上传图片到阿里云 OSS，并通过 CDN 域名访问。
+ *
+ * 用法：
+ *   yida cdn-upload <图片路径> [选项]
+ *
+ * 参数：
+ *   图片路径          单个图片文件或目录（支持 glob 模式）
+ *
+ * 选项：
+ *   --domain <域名>   CDN 加速域名（可选，使用配置文件中的域名）
+ *   --path <路径>     上传目录前缀（可选，默认 yida-images/）
+ *   --compress        启用图片压缩（默认启用）
+ *   --no-compress     禁用图片压缩
+ *
+ * 示例：
+ *   yida cdn-upload ./image.png
+ *   yida cdn-upload ./images/*.png --domain cdn.example.com
+ *   yida cdn-upload ./photo.jpg --path products/
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { t } = require("./i18n");
+const {
+  loadCdnConfig,
+  validateCdnConfig,
+  hasCdnConfig,
+  initCdnConfig,
+} = require("./cdn-config");
+
+// 支持的图片格式
+const SUPPORTED_FORMATS = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"];
+
+/**
+ * 解析命令行参数
+ * @param {string[]} args
+ * @returns {object}
+ */
+function parseArgs(args) {
+  const result = {
+    files: [],
+    domain: null,
+    uploadPath: null,
+    compress: true,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      result.help = true;
+    } else if (arg === "--domain") {
+      result.domain = args[++i];
+    } else if (arg === "--path") {
+      result.uploadPath = args[++i];
+    } else if (arg === "--compress") {
+      result.compress = true;
+    } else if (arg === "--no-compress") {
+      result.compress = false;
+    } else if (!arg.startsWith("-")) {
+      result.files.push(arg);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 打印帮助信息
+ */
+function printHelp() {
+  console.log(t("cdn.upload_usage"));
+  console.log("");
+  console.log(t("cdn.upload_examples"));
+  console.log("  yida cdn-upload ./image.png");
+  console.log("  yida cdn-upload ./images/*.png --domain cdn.example.com");
+  console.log("  yida cdn-upload ./photo.jpg --path products/");
+  console.log("");
+  console.log(t("cdn.upload_options"));
+  console.log("  --domain <域名>   " + t("cdn.upload_opt_domain"));
+  console.log("  --path <路径>     " + t("cdn.upload_opt_path"));
+  console.log("  --compress        " + t("cdn.upload_opt_compress"));
+  console.log("  --no-compress     " + t("cdn.upload_opt_no_compress"));
+}
+
+/**
+ * 检查文件是否为支持的图片格式
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isImageFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_FORMATS.includes(ext);
+}
+
+/**
+ * 生成唯一文件名（保留原始扩展名）
+ * @param {string} originalName
+ * @returns {string}
+ */
+function generateUniqueFileName(originalName) {
+  const ext = path.extname(originalName);
+  const timestamp = Date.now();
+  const randomStr = crypto.randomBytes(4).toString("hex");
+  return `${timestamp}-${randomStr}${ext}`;
+}
+
+/**
+ * 上传单个文件到 OSS
+ * @param {object} ossClient - OSS 客户端实例
+ * @param {string} filePath - 本地文件路径
+ * @param {string} objectKey - OSS 对象键
+ * @returns {Promise<object>}
+ */
+async function uploadToOss(ossClient, filePath, objectKey) {
+  return new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    ossClient.putStream(objectKey, stream, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+/**
+ * 创建 OSS 客户端（延迟加载 SDK）
+ * @param {object} config
+ * @returns {object}
+ */
+function createOssClient(config) {
+  try {
+    const OSS = require("ali-oss");
+    return new OSS({
+      region: config.ossRegion,
+      bucket: config.ossBucket,
+      accessKeyId: config.accessKeyId,
+      accessKeySecret: config.accessKeySecret,
+      secure: true,
+    });
+  } catch (error) {
+    console.error(t("cdn.oss_sdk_required"));
+    console.error(t("cdn.run_npm_install", "ali-oss"));
+    process.exit(1);
+  }
+}
+
+/**
+ * 执行上传操作
+ * @param {object} options
+ * @param {string[]} options.files - 文件列表
+ * @param {string} options.domain - CDN 域名
+ * @param {string} options.uploadPath - 上传路径前缀
+ * @param {boolean} options.compress - 是否压缩
+ * @returns {Promise<object[]>}
+ */
+async function performUpload(options) {
+  const config = loadCdnConfig();
+  const { valid, missing } = validateCdnConfig(config);
+
+  if (!valid) {
+    console.error(t("cdn.config_incomplete"));
+    console.error(t("cdn.missing_fields", missing.join(", ")));
+    console.error(t("cdn.run_config_init"));
+    process.exit(1);
+  }
+
+  // 合并配置
+  const uploadConfig = {
+    ...config,
+    cdnDomain: options.domain || config.cdnDomain,
+    uploadPath: options.uploadPath || config.uploadPath,
+  };
+
+  // 创建 OSS 客户端
+  const ossClient = createOssClient(uploadConfig);
+
+  // 收集所有图片文件
+  const imageFiles = [];
+  for (const filePattern of options.files) {
+    if (fs.existsSync(filePattern)) {
+      const stat = fs.statSync(filePattern);
+      if (stat.isDirectory()) {
+        // 目录：遍历所有图片
+        const files = fs.readdirSync(filePattern);
+        for (const file of files) {
+          const fullPath = path.join(filePattern, file);
+          if (fs.statSync(fullPath).isFile() && isImageFile(fullPath)) {
+            imageFiles.push(fullPath);
+          }
+        }
+      } else if (stat.isFile() && isImageFile(filePattern)) {
+        imageFiles.push(filePattern);
+      }
+    } else {
+      // 可能是 glob 模式，尝试展开
+      const glob = require("glob");
+      const matches = glob.sync(filePattern);
+      for (const match of matches) {
+        if (fs.statSync(match).isFile() && isImageFile(match)) {
+          imageFiles.push(match);
+        }
+      }
+    }
+  }
+
+  if (imageFiles.length === 0) {
+    console.error(t("cdn.no_images_found"));
+    process.exit(1);
+  }
+
+  console.log(t("cdn.uploading_images", imageFiles.length));
+
+  // 上传结果
+  const results = [];
+
+  for (const filePath of imageFiles) {
+    const fileName = path.basename(filePath);
+    const uniqueName = generateUniqueFileName(fileName);
+    const objectKey = uploadConfig.uploadPath + uniqueName;
+
+    try {
+      console.log(t("cdn.uploading_file", fileName));
+
+      // 上传到 OSS
+      await uploadToOss(ossClient, filePath, objectKey);
+
+      // 生成 CDN URL
+      const cdnUrl = `https://${uploadConfig.cdnDomain}/${objectKey}`;
+
+      results.push({
+        originalPath: filePath,
+        fileName,
+        objectKey,
+        cdnUrl,
+        success: true,
+      });
+
+      console.log(t("cdn.upload_success", cdnUrl));
+    } catch (error) {
+      results.push({
+        originalPath: filePath,
+        fileName,
+        success: false,
+        error: error.message,
+      });
+      console.error(t("cdn.upload_failed", fileName, error.message));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * CLI 入口函数
+ * @param {string[]} args
+ */
+async function run(args) {
+  const options = parseArgs(args);
+
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (options.files.length === 0) {
+    console.error(t("cdn.upload_no_files"));
+    printHelp();
+    process.exit(1);
+  }
+
+  // 检查配置
+  if (!hasCdnConfig()) {
+    console.error(t("cdn.no_config"));
+    console.error(t("cdn.run_config_init"));
+    process.exit(1);
+  }
+
+  try {
+    const results = await performUpload(options);
+
+    // 输出汇总
+    const successCount = results.filter((r) => r.success).length;
+    const failCount = results.length - successCount;
+
+    console.log("");
+    console.log(t("cdn.upload_summary"));
+    console.log(t("cdn.upload_success_count", successCount));
+    if (failCount > 0) {
+      console.log(t("cdn.upload_fail_count", failCount));
+    }
+
+    // 输出 CDN URL 列表
+    console.log("");
+    console.log(t("cdn.cdn_urls"));
+    for (const result of results) {
+      if (result.success) {
+        console.log(`  ${result.cdnUrl}`);
+      }
+    }
+
+    // 返回 JSON 格式结果（供 AI 工具使用）
+    console.log("");
+    console.log(JSON.stringify(results, null, 2));
+  } catch (error) {
+    console.error(t("cdn.upload_error", error.message));
+    process.exit(1);
+  }
+}
+
+module.exports = { run, performUpload, parseArgs };

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -30,6 +30,9 @@ Commands:
   update-form-config <appType> <formUuid> <isRenderNav> <title> Update form config
   export <appType> [output]                                    Export all form schemas (migration package)
   import <file> [name]                                         Import migration package, rebuild app
+  cdn-config [options]                                         Configure CDN image upload (Alibaba Cloud OSS + CDN)
+  cdn-upload <image-path> [options]                            Upload images to CDN
+  cdn-refresh [options]                                        Refresh CDN cache
 
 Examples:
   openyida login
@@ -648,5 +651,112 @@ Examples:
     cmd_help: "  {0}openyida --help{1}   {2}# Show all commands{3}",
     footer1: "  📚 Docs: https://github.com/openyida/openyida",
     footer2: "  💬 Community: Join OpenYida community on DingTalk",
+  },
+
+  // ── lib/cdn-*.js ───────────────────────────────────
+  cdn: {
+    // Configuration
+    config_load_error: "Failed to load CDN config: {0}",
+    config_saved: "✅ CDN config saved to: {0}",
+    config_usage: "Usage: openyida cdn-config [options]",
+    config_examples: `
+Examples:
+  openyida cdn-config --init
+  openyida cdn-config --show
+  openyida cdn-config --set-domain cdn.example.com`,
+    config_options: `
+Options:
+  --init                Initialize config (interactive)
+  --show                Show current config
+  --set-key <key>       Set AccessKey ID
+  --set-secret <secret> Set AccessKey Secret
+  --set-domain <domain> Set CDN domain
+  --set-bucket <bucket> Set OSS Bucket name
+  --set-region <region> Set OSS region
+  --set-path <path>     Set upload path prefix`,
+    config_file_path: "📄 Config file: {0}",
+    config_section_aliyun: "🔐 Alibaba Cloud Credentials",
+    config_section_cdn: "🌐 CDN Config",
+    config_section_oss: "📦 OSS Config",
+    config_section_upload: "📤 Upload Config",
+    config_cdn_domain: "CDN Domain",
+    config_oss_region: "OSS Region",
+    config_oss_bucket: "OSS Bucket",
+    config_oss_endpoint: "OSS Endpoint",
+    config_upload_path: "Upload Path",
+    config_compress: "Image Compression",
+    config_max_width: "Max Width",
+    config_quality: "Image Quality",
+    config_not_set: "Not set",
+    config_enabled: "Enabled",
+    config_disabled: "Disabled",
+    config_status_valid: "✅ Config complete, ready to use",
+    config_status_invalid: "⚠️  Config incomplete",
+    config_missing: "   Missing fields: {0}",
+    config_updated: "✅ Config updated!",
+    config_init_title: "🔧 CDN Config Initialization Wizard",
+    config_init_desc: "To use CDN image upload, configure the following:",
+    config_init_example: "Example config:",
+    config_init_hint: "💡 Use these commands to set each parameter:",
+    config_init_or: "   Or set all at once:",
+
+    // Upload
+    upload_usage: "Usage: openyida cdn-upload <image-path> [options]",
+    upload_examples: `
+Examples:
+  yida cdn-upload ./image.png
+  yida cdn-upload ./images/*.png --domain cdn.example.com
+  yida cdn-upload ./photo.jpg --path products/`,
+    upload_options: `
+Options:
+  --domain <domain>   CDN domain (optional)
+  --path <path>       Upload path prefix (optional)
+  --compress          Enable image compression (default)
+  --no-compress       Disable image compression`,
+    upload_no_files: "❌ Please specify image files to upload",
+    config_incomplete: "❌ CDN config incomplete",
+    missing_fields: "   Missing fields: {0}",
+    run_config_init: "   Please run: openyida cdn-config --init",
+    no_config: "❌ CDN config not found",
+    oss_sdk_required: "❌ Missing ali-oss SDK",
+    run_npm_install: "   Please run: npm install {0}",
+    no_images_found: "❌ No supported image files found",
+    uploading_images: "📤 Uploading {0} images...",
+    uploading_file: "   Uploading: {0}",
+    upload_success: "   ✅ {0}",
+    upload_failed: "   ❌ {0} upload failed: {1}",
+    upload_summary: "\n📊 Upload Summary",
+    upload_success_count: "   Success: {0}",
+    upload_fail_count: "   Failed: {0}",
+    cdn_urls: "\n🔗 CDN URLs:",
+    upload_error: "❌ Upload failed: {0}",
+
+    // Refresh
+    refresh_usage: "Usage: openyida cdn-refresh [options]",
+    refresh_examples: `
+Examples:
+  yida cdn-refresh --urls "https://cdn.example.com/image.png"
+  yida cdn-refresh --paths "/yida-images/"
+  yida cdn-refresh --file urls.txt`,
+    refresh_options: `
+Options:
+  --urls <url-list>    URLs to refresh (comma-separated)
+  --paths <path-list>  Directory paths to refresh (comma-separated)
+  --file <file>        Read URL list from file (one per line)`,
+    refresh_no_targets: "❌ Please specify URLs or directories to refresh",
+    cdn_sdk_required: "❌ Missing Alibaba Cloud CDN SDK",
+    querying_quota: "📊 Querying refresh quota...",
+    quota_info: "   URL refresh: {0}/day, {1} remaining | Dir refresh: {2}/day, {3} remaining",
+    quota_query_failed: "   ⚠️  Failed to query quota: {0}",
+    refreshing_urls: "🔄 Refreshing {0} URLs...",
+    refreshing_paths: "🔄 Refreshing {0} directories...",
+    refresh_task_id: "   ✅ Task ID: {0}",
+    refresh_urls_failed: "   ❌ URL refresh failed: {0}",
+    refresh_paths_failed: "   ❌ Directory refresh failed: {0}",
+    refresh_summary: "\n📊 Refresh Summary",
+    url_refresh_success: "   ✅ URL refresh success, Task ID: {0}",
+    path_refresh_success: "   ✅ Directory refresh success, Task ID: {0}",
+    refresh_error: "❌ Refresh failed: {0}",
+    file_not_found: "❌ File not found: {0}",
   },
 };

--- a/lib/locales/zh.js
+++ b/lib/locales/zh.js
@@ -31,6 +31,9 @@ openyida - 宜搭命令行工具
   update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
   export <appType> [output]                                    导出应用所有表单 Schema（生成迁移包）
   import <file> [name]                                         导入迁移包，在目标环境重建应用
+  cdn-config [选项]                                            配置 CDN 图片上传（阿里云 OSS + CDN）
+  cdn-upload <图片路径> [选项]                                  上传图片到 CDN
+  cdn-refresh [选项]                                           刷新 CDN 缓存
 
 示例：
   openyida login
@@ -586,5 +589,112 @@ openyida - 宜搭命令行工具
     cmd_help: "  {0}openyida --help{1}   {2}# 查看所有命令{3}",
     footer1: "  📚 文档：https://github.com/openyida/openyida",
     footer2: "  💬 社区：钉钉扫码加入 OpenYida 社区",
+  },
+
+  // ── lib/cdn-*.js ───────────────────────────────────
+  cdn: {
+    // 配置管理
+    config_load_error: "加载 CDN 配置失败: {0}",
+    config_saved: "✅ CDN 配置已保存到: {0}",
+    config_usage: "用法: openyida cdn-config [选项]",
+    config_examples: `
+示例:
+  openyida cdn-config --init
+  openyida cdn-config --show
+  openyida cdn-config --set-domain cdn.example.com`,
+    config_options: `
+选项:
+  --init                初始化配置（交互式）
+  --show                显示当前配置
+  --set-key <key>       设置 AccessKey ID
+  --set-secret <secret> 设置 AccessKey Secret
+  --set-domain <domain> 设置 CDN 加速域名
+  --set-bucket <bucket> 设置 OSS Bucket 名称
+  --set-region <region> 设置 OSS 区域
+  --set-path <path>     设置上传目录前缀`,
+    config_file_path: "📄 配置文件: {0}",
+    config_section_aliyun: "🔐 阿里云凭证",
+    config_section_cdn: "🌐 CDN 配置",
+    config_section_oss: "📦 OSS 配置",
+    config_section_upload: "📤 上传配置",
+    config_cdn_domain: "CDN 加速域名",
+    config_oss_region: "OSS 区域",
+    config_oss_bucket: "OSS Bucket",
+    config_oss_endpoint: "OSS Endpoint",
+    config_upload_path: "上传目录",
+    config_compress: "图片压缩",
+    config_max_width: "最大宽度",
+    config_quality: "图片质量",
+    config_not_set: "未设置",
+    config_enabled: "启用",
+    config_disabled: "禁用",
+    config_status_valid: "✅ 配置完整，可以使用",
+    config_status_invalid: "⚠️  配置不完整",
+    config_missing: "   缺少字段: {0}",
+    config_updated: "✅ 配置已更新！",
+    config_init_title: "🔧 CDN 配置初始化向导",
+    config_init_desc: "要使用 CDN 图片上传功能，需要配置以下信息：",
+    config_init_example: "示例配置：",
+    config_init_hint: "💡 请使用以下命令配置各项参数：",
+    config_init_or: "   或一次性配置所有参数：",
+
+    // 上传
+    upload_usage: "用法: openyida cdn-upload <图片路径> [选项]",
+    upload_examples: `
+示例:
+  yida cdn-upload ./image.png
+  yida cdn-upload ./images/*.png --domain cdn.example.com
+  yida cdn-upload ./photo.jpg --path products/`,
+    upload_options: `
+选项:
+  --domain <域名>   CDN 加速域名（可选）
+  --path <路径>     上传目录前缀（可选）
+  --compress        启用图片压缩（默认启用）
+  --no-compress     禁用图片压缩`,
+    upload_no_files: "❌ 请指定要上传的图片文件",
+    config_incomplete: "❌ CDN 配置不完整",
+    missing_fields: "   缺少字段: {0}",
+    run_config_init: "   请先运行: openyida cdn-config --init",
+    no_config: "❌ 未找到 CDN 配置",
+    oss_sdk_required: "❌ 缺少 ali-oss SDK",
+    run_npm_install: "   请运行: npm install {0}",
+    no_images_found: "❌ 未找到支持的图片文件",
+    uploading_images: "📤 正在上传 {0} 个图片...",
+    uploading_file: "   上传: {0}",
+    upload_success: "   ✅ {0}",
+    upload_failed: "   ❌ {0} 上传失败: {1}",
+    upload_summary: "\n📊 上传汇总",
+    upload_success_count: "   成功: {0} 个",
+    upload_fail_count: "   失败: {0} 个",
+    cdn_urls: "\n🔗 CDN URL 列表:",
+    upload_error: "❌ 上传失败: {0}",
+
+    // 刷新
+    refresh_usage: "用法: openyida cdn-refresh [选项]",
+    refresh_examples: `
+示例:
+  yida cdn-refresh --urls "https://cdn.example.com/image.png"
+  yida cdn-refresh --paths "/yida-images/"
+  yida cdn-refresh --file urls.txt`,
+    refresh_options: `
+选项:
+  --urls <URL列表>    刷新的 URL 列表（逗号分隔）
+  --paths <路径列表>  刷新的目录路径列表（逗号分隔）
+  --file <文件>       从文件读取 URL 列表（每行一个）`,
+    refresh_no_targets: "❌ 请指定要刷新的 URL 或目录",
+    cdn_sdk_required: "❌ 缺少阿里云 CDN SDK",
+    querying_quota: "📊 查询刷新配额...",
+    quota_info: "   URL 刷新: {0}/天, 剩余 {1} | 目录刷新: {2}/天, 剩余 {3}",
+    quota_query_failed: "   ⚠️  查询配额失败: {0}",
+    refreshing_urls: "🔄 正在刷新 {0} 个 URL...",
+    refreshing_paths: "🔄 正在刷新 {0} 个目录...",
+    refresh_task_id: "   ✅ 任务 ID: {0}",
+    refresh_urls_failed: "   ❌ URL 刷新失败: {0}",
+    refresh_paths_failed: "   ❌ 目录刷新失败: {0}",
+    refresh_summary: "\n📊 刷新汇总",
+    url_refresh_success: "   ✅ URL 刷新成功，任务 ID: {0}",
+    path_refresh_success: "   ✅ 目录刷新成功，任务 ID: {0}",
+    refresh_error: "❌ 刷新失败: {0}",
+    file_not_found: "❌ 文件不存在: {0}",
   },
 };


### PR DESCRIPTION
## 概述

实现 GitHub Issue #87: 自定义页面的图片可以选择上传到 CDN

## 新增命令

| 命令 | 功能 |
|------|------|
| openyida cdn-config | 配置 CDN 图片上传（阿里云 OSS + CDN） |
| openyida cdn-upload | 上传图片到 CDN |
| openyida cdn-refresh | 刷新 CDN 缓存 |

## 功能特性

- 支持阿里云 OSS 图片上传
- 支持 CDN 加速域名访问
- 支持批量上传图片
- 支持 URL 和目录缓存刷新
- 支持国际化（中/英文）
- 配置安全存储（~/.openyida/cdn-config.json）

## 使用方式

1. 初始化 CDN 配置
2. 上传图片
3. 刷新缓存

## 新增文件

- lib/cdn-config.js - CDN 配置管理模块
- lib/cdn-upload.js - 图片上传命令
- lib/cdn-refresh.js - CDN 缓存刷新命令
- lib/cdn-config-cmd.js - CDN 配置命令 CLI 入口

## 依赖说明

CDN 功能需要安装以下可选依赖（用户按需安装）：
- ali-oss - OSS 上传
- @alicloud/cdn20180510 - CDN API
- @alicloud/openapi-client - 阿里云 OpenAPI 客户端

Closes #87