### PR TITLE
fix: 修复 publish.js require('./utils') 解构导入不完整导致 findProjectRoot is not defined

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -23,7 +23,7 @@ const http = require("http");
 const querystring = require("querystring");
 const { default: babelTransform } = require("./babel-transform");
 const UglifyJS = require("uglify-js");
-const { isLoginExpired, isCsrfTokenExpired } = require("./utils");
+const { findProjectRoot, isLoginExpired, isCsrfTokenExpired, loadCookieData, triggerLogin, refreshCsrfToken } = require("./utils");
 const { t } = require("./i18n");
 
 // ── 配置读取 ──────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "./bin/yida.js",


### PR DESCRIPTION
## 问题描述

`openyida publish` 命令执行时报错：

```
❌ 执行失败: findProjectRoot is not defined
```

## 根本原因

`lib/publish.js` 第 26 行的 `require('./utils')` 解构导入不完整，只导入了 `isLoginExpired` 和 `isCsrfTokenExpired`，但代码中实际调用了 `findProjectRoot`、`loadCookieData`、`triggerLogin`、`refreshCsrfToken` 等函数。

## 修复内容

```js
// 修复前
const { isLoginExpired, isCsrfTokenExpired } = require('./utils');

// 修复后
const { findProjectRoot, isLoginExpired, isCsrfTokenExpired, loadCookieData, triggerLogin, refreshCsrfToken } = require('./utils');
```

## 版本

升级至 `1.0.0-beta.4`