### PR TITLE
feat: support themeColor parameter in create-app command

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -16,7 +16,7 @@
  *   openyida auth logout                                退出登录
  *   openyida org list                                   列出可访问的组织
  *   openyida org switch --corp-id <corpId>              切换组织（无需重新登录）
- *   openyida create-app "<名称>" [desc] [icon] [color]  创建应用
+ *   openyida create-app "<名称>" [desc] [icon] [color] [themeColor]  创建应用
  *   openyida create-page <appType> "<页面名>"            创建自定义页面
  *   openyida create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
  *   openyida create-form update <appType> <formUuid> <修改JSON>  更新表单页面
@@ -55,7 +55,7 @@ openyida - 宜搭命令行工具
   copy [--force]                                               复制 project 工作目录到当前 AI 工具环境
   login                                                        登录态管理（优先缓存，否则扫码）
   logout                                                       退出登录 / 切换账号
-  create-app "<名称>" [描述] [图标] [颜色]                      创建应用，输出 appType
+  create-app "<名称>" [描述] [图标] [颜色] [主题色]             创建应用，输出 appType
   create-page <appType> "<页面名>"                             创建自定义页面，输出 pageId
   create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
   create-form update <appType> <formUuid> <修改JSON>           更新表单页面
@@ -78,6 +78,7 @@ openyida - 宜搭命令行工具
   openyida login
   openyida logout
   openyida create-app "考勤管理"
+  openyida create-app "考勤管理" "员工考勤系统" "xian-daka" "#00B853" "red"
   openyida create-page APP_XXX "游戏主页"
   openyida create-form create APP_XXX "员工信息" fields.json
   openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"备注"}}]'

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -95,6 +95,7 @@ async function run(args) {
   const description = args[1] || appName;
   const icon = args[2] || "xian-yingyong";
   const iconColor = args[3] || "#0089FF";
+  const themeColor = args[4] || "blue";
 
   const SEP = "=".repeat(50);
   console.error(SEP);
@@ -103,6 +104,7 @@ async function run(args) {
   console.error(t("create_app.app_name", appName));
   console.error(t("create_app.app_desc", description));
   console.error(t("create_app.app_icon", icon, iconColor));
+  console.error(t("create_app.app_theme", themeColor));
 
   // Step 1: 读取登录态
   console.error(t("common.step_login", 1));
@@ -131,7 +133,7 @@ async function run(args) {
       description: JSON.stringify({ zh_CN: description, en_US: description, type: "i18n" }),
       icon: iconValue,
       iconUrl: iconValue,
-      colour: "blue",
+      colour: themeColor,
       defaultLanguage: "zh_CN",
       openExclusive: "n",
       openPhysicColumn: "n",

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -208,8 +208,8 @@ Examples:
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
     title: "  yidacli create-app - Yida App Creation Tool",
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor]',
-    example: 'Example: yidacli create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853"',
+    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: 'Example: yidacli create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853" "red"',
     available_icons: "\nAvailable icons:",
     icons_list: "  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka",
     available_colors: "\nAvailable colors:",
@@ -217,6 +217,7 @@ Examples:
     app_name: "  App name:    {0}",
     app_desc: "  Description: {0}",
     app_icon: "  Icon:        {0} ({1})",
+    app_theme: "  Theme:       {0}",
     step_create: "\n📦 Step 2: Create App\n",
     success: "  ✅ App created successfully!",
     app_type_label: "  appType: {0}",

--- a/lib/locales/ja.js
+++ b/lib/locales/ja.js
@@ -206,8 +206,8 @@ openyida - Yida CLI ツール
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
     title: "  yidacli create-app - Yida アプリ作成ツール",
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor]',
-    example: '例: yidacli create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853"',
+    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '例: yidacli create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853" "red"',
     available_icons: "\n利用可能なアイコン:",
     icons_list: "  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka",
     available_colors: "\n利用可能な色:",
@@ -215,6 +215,7 @@ openyida - Yida CLI ツール
     app_name: "  アプリ名:   {0}",
     app_desc: "  説明:       {0}",
     app_icon: "  アイコン:   {0} ({1})",
+    app_theme: "  テーマカラー: {0}",
     step_create: "\n📦 Step 2: アプリを作成\n",
     success: "  ✅ アプリが正常に作成されました！",
     app_type_label: "  appType: {0}",

--- a/lib/locales/zh.js
+++ b/lib/locales/zh.js
@@ -205,8 +205,8 @@ openyida - 宜搭命令行工具
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
     title: "  yidacli create-app - 宜搭应用创建工具",
-    usage: "用法: yidacli create-app \"<appName>\" [description] [icon] [iconColor]",
-    example: '示例: yidacli create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853"',
+    usage: "用法: yidacli create-app \"<appName>\" [description] [icon] [iconColor] [themeColor]",
+    example: '示例: yidacli create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"',
     available_icons: "\n可用图标:",
     icons_list: "  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka",
     available_colors: "\n可用颜色:",
@@ -214,6 +214,7 @@ openyida - 宜搭命令行工具
     app_name: "  应用名称: {0}",
     app_desc: "  应用描述: {0}",
     app_icon: "  图标:     {0} ({1})",
+    app_theme: "  主题色:   {0}",
     step_create: "\n📦 Step 2: 创建应用\n",
     success: "  ✅ 应用创建成功！",
     app_type_label: "  appType: {0}",

--- a/yida-skills/skills/yida-create-app/SKILL.md
+++ b/yida-skills/skills/yida-create-app/SKILL.md
@@ -42,10 +42,10 @@ openyida create-app "考勤管理"
 ```
 
 ### 示例 2：完整参数
-**场景**：创建带描述和图标的应用
+**场景**：创建带描述、图标和主题色的应用
 **命令**：
 ```bash
-openyida create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853"
+openyida create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"
 ```
 
 ## 使用方式


### PR DESCRIPTION
## 功能描述

创建应用时支持设置主题色参数，允许用户在创建宜搭应用时自定义应用的主题色。

## 变更内容

- **`lib/create-app.js`**: 新增第 5 个参数 `themeColor`（默认值 `blue`），传递给 `registerApp` 接口的 `colour` 字段
- **`bin/yida.js`**: 更新命令说明和帮助文档，添加 `themeColor` 参数
- **`lib/locales/{zh,en,ja}.js`**: 添加主题色相关的 i18n 翻译
- **`yida-skills/skills/yida-create-app/SKILL.md`**: 更新技能文档，补充 `themeColor` 参数说明

## 用法

```bash
# 默认主题色（blue）
openyida create-app "考勤管理"

# 自定义主题色
openyida create-app "考勤管理" "员工考勤系统" "xian-daka" "#00B853" "red"
```

## 可用主题色

`blue`、`red`、`green`、`orange`、`purple`

## 向后兼容

`themeColor` 为可选参数，默认值 `blue`，与原有行为完全一致。

Closes #142