### PR TITLE
fix: remove export keywords from tabs-visibility-control.js example

### DIFF
--- a/yida-skills/skills/yida-custom-page/examples/tabs-visibility-control.js
+++ b/yida-skills/skills/yida-custom-page/examples/tabs-visibility-control.js
@@ -8,40 +8,40 @@ const _customState = {
   activeTab: 'tableA', // 当前激活的 Tab
 };
 
-export function getCustomState(key) {
+function getCustomState(key) {
   if (key) {
     return _customState[key];
   }
   return { ..._customState };
 }
 
-export function setCustomState(newState) {
+function setCustomState(newState) {
   Object.keys(newState).forEach(function(key) {
     _customState[key] = newState[key];
   });
   this.forceUpdate();
 }
 
-export function forceUpdate() {
+function forceUpdate() {
   this.setState({ timestamp: new Date().getTime() });
 }
 
-export function didMount() {
+function didMount() {
   // 初始化逻辑
 }
 
-export function didUnmount() {
+function didUnmount() {
   // 清理逻辑
 }
 
 /**
  * 下拉选项变更处理
  */
-export function handleTypeChange(value) {
+function handleTypeChange(value) {
   this.setCustomState({ selectedType: value });
 }
 
-export function renderJsx() {
+function renderJsx() {
   const { timestamp } = this.state;
   const selectedType = _customState.selectedType;
 


### PR DESCRIPTION
## 问题描述

`yida-skills/skills/yida-custom-page/examples/tabs-visibility-control.js` 示例文件中使用了 ES Module `export` 语法，但宜搭自定义页面**不支持 ES Module**，代码运行在宜搭的沙箱环境中，函数应该直接定义（不带 `export`），由宜搭平台通过约定的函数名自动识别和调用。

## 修复内容

移除所有 `export` 关键字，保持函数直接定义的形式，与宜搭自定义页面的实际运行规范保持一致。

涉及的函数：
- `getCustomState`
- `setCustomState`
- `forceUpdate`
- `didMount`
- `didUnmount`
- `handleTypeChange`
- `renderJsx`

## 影响

修复前，AI 助手读取此示例后可能会生成带有 `export` 的代码，导致宜搭自定义页面运行报错。

Closes #148