### PR TITLE
fix: 专属域名（exclusive domain）7项兼容性修复

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -125,6 +125,24 @@ async function run(args) {
   // Step 2: 创建应用
   console.error(t("create_app.step_create"));
 
+  // 先查询组织配置，获取 forceExclusiveDb / forcePhysicalColumn
+  let openExclusive = "n";
+  let openPhysicColumn = "n";
+  try {
+    const corpConfig = await httpPost(
+      authRef.baseUrl,
+      `/query/exclusive/queryCorpAppConfig.json?_api=Global.queryCorpAppConfig&_mock=false&_csrf_token=${authRef.csrfToken}&_locale_time_zone_offset=28800000&_stamp=${Date.now()}`,
+      "",
+      authRef.cookies
+    );
+    if (corpConfig && corpConfig.content) {
+      if (corpConfig.content.forceExclusiveDb === "y") openExclusive = "y";
+      if (corpConfig.content.forcePhysicalColumn === "y") openPhysicColumn = "y";
+    }
+  } catch (e) {
+    // ignore, use defaults
+  }
+
   const iconValue = `${icon}%%${iconColor}`;
   const response = await requestWithAutoLogin((auth) => {
     const postData = querystring.stringify({
@@ -135,8 +153,8 @@ async function run(args) {
       iconUrl: iconValue,
       colour: themeColor,
       defaultLanguage: "zh_CN",
-      openExclusive: "n",
-      openPhysicColumn: "n",
+      openExclusive: openExclusive,
+      openPhysicColumn: openPhysicColumn,
       openIsolationDatabase: "n",
       openExclusiveUnit: "n",
       group: "ALL",

--- a/lib/create-form.js
+++ b/lib/create-form.js
@@ -62,7 +62,7 @@ const fs = require("fs");
 const path = require("path");
 const querystring = require("querystring");
 const { execSync } = require("child_process");
-const { findProjectRoot, loadCookieData, triggerLogin, refreshCsrfToken, resolveBaseUrl, isLoginExpired, isCsrfTokenExpired } = require("./utils");
+const { findProjectRoot, loadCookieData, triggerLogin, refreshCsrfToken, resolveBaseUrl, isLoginExpired, isCsrfTokenExpired, isConfigUpdateRequired } = require("./utils");
 const { t } = require("./i18n");
 
 // ── 配置读取 ──────────────────────────────────────────
@@ -279,20 +279,18 @@ function readChangesDefinition(changesJsonOrFile) {
 
 // ── 自增 ID 计数器 ───────────────────────────────────
 let nodeIdCounter = 1;
+let fieldIdCounter = 1;
 
 function nextNodeId() {
   return "node_oc" + Date.now().toString(36) + (nodeIdCounter++).toString(36);
 }
 
-var _fieldIdCounter = 0;
-
 function generateFieldId(componentName) {
   const prefix = componentName.charAt(0).toLowerCase() + componentName.slice(1);
-  // 使用时间戳 + 递增计数器 + 随机数，确保唯一性
-  _fieldIdCounter++;
+  // 使用时间戳 + 计数器 + 随机数，确保唯一性
   const timePart = Date.now().toString(36).slice(-4);
-  const counterPart = _fieldIdCounter.toString(36);
-  const randomPart = Math.random().toString(36).substring(2, 6);
+  const counterPart = (fieldIdCounter++).toString(36).padStart(2, '0');
+  const randomPart = Math.random().toString(36).substring(2, 4);
   const suffix = timePart + counterPart + randomPart;
   return prefix + "_" + suffix;
 }
@@ -1340,26 +1338,46 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
                 formLabel: i18n(formTitle, formTitle),
                 formLabelVisible: true,
                 columns: columns,
-                labelAlign: labelAlign || "top",
+                labelAlign: "top",
                 submitText: i18n("提交", "Submit"),
                 stageText: i18n("暂存", "Stage"),
                 submitAndNewText: i18n("提交并继续", "Submit and New"),
-                fieldId: "formContainer_" + Date.now().toString(36),
+                fieldId: "formContainer_" + Date.now().toString(36) + "a",
                 aiFormConfig: { systemPrompt: "", model: "qwen" },
                 beforeSubmit: false,
                 afterSubmit: false,
                 onProcessActionValidate: false,
                 afterFormDataInit: false,
-              },
-              condition: true,
-              hidden: false,
-              title: "",
-              isLocked: false,
-              conditionGroup: "",
-              children: layoutConfig.groupFields 
-                ? buildGroupedFieldComponents(fields, layoutConfig.formLayout)
-                : fieldComponents,
-            },
+              },              children: [
+                {
+                  componentName: "FormContainer",
+                  id: nextNodeId(),
+                  props: {
+                    formLabel: i18n(formTitle, formTitle),
+                    formLabelVisible: true,
+                    columns: columns,
+                    labelAlign: labelAlign || "top",
+                    submitText: i18n("提交", "Submit"),
+                    stageText: i18n("暂存", "Stage"),
+                    submitAndNewText: i18n("提交并继续", "Submit and New"),
+                    fieldId: "formContainer_" + Date.now().toString(36) + "b",
+                    aiFormConfig: { systemPrompt: "", model: "qwen" },
+                    beforeSubmit: false,
+                    afterSubmit: false,
+                    onProcessActionValidate: false,
+                    afterFormDataInit: false,
+                  },
+                  condition: true,
+                  hidden: false,
+                  title: "",
+                  isLocked: false,
+                  conditionGroup: "",
+                  // ★ 核心：FormContainer 内层的字段组件（支持分组布局）
+                  children: layoutConfig.groupFields 
+                    ? buildGroupedFieldComponents(fields, layoutConfig.formLayout)
+                    : fieldComponents,
+                },
+              ],            },
           ],
         },
         {
@@ -1450,11 +1468,16 @@ function sendGetRequest(baseUrl, cookies, requestPath, queryParams) {
     const queryString = querystring.stringify(queryParams);
     const fullPath = requestPath + "?" + queryString;
 
-    const cookieHeader = cookies
+    const parsedUrl = new URL(baseUrl);
+    const requestHost = parsedUrl.hostname;
+    const filteredCookies = cookies.filter(c => {
+      const cd = (c.domain || "").replace(/^\./, "");
+      return requestHost === cd || requestHost.endsWith("." + cd);
+    });
+    const cookieHeader = filteredCookies
       .map((cookie) => cookie.name + "=" + cookie.value)
       .join("; ");
 
-    const parsedUrl = new URL(baseUrl);
     const isHttps = parsedUrl.protocol === "https:";
     const requestModule = isHttps ? https : http;
 
@@ -1480,6 +1503,10 @@ function sendGetRequest(baseUrl, cookies, requestPath, queryParams) {
         try {
           parsed = JSON.parse(responseData);
         } catch (parseError) {
+          if (responseData.includes("全局应用配置有更新")) {
+            resolve({ __needConfigRefresh: true });
+            return;
+          }
           console.error(t("common.response_body", responseData.substring(0, 500)));
           resolve({ success: false, errorMsg: "HTTP " + response.statusCode + ": " + t("common.response_not_json") });
           return;
@@ -1494,6 +1521,10 @@ function sendGetRequest(baseUrl, cookies, requestPath, queryParams) {
         if (isCsrfTokenExpired(parsed)) {
           console.error(t("common.csrf_expired", parsed.errorMsg));
           resolve({ __csrfExpired: true });
+          return;
+        }
+        if (isConfigUpdateRequired(parsed)) {
+          resolve({ __needConfigRefresh: true });
           return;
         }
         resolve(parsed);
@@ -1922,11 +1953,16 @@ function sendPostRequest(baseUrl, csrfToken, cookies, requestPath, extraParams, 
       Object.assign({ _csrf_token: csrfToken }, extraParams)
     );
 
-    const cookieHeader = cookies
+    const parsedUrl = new URL(baseUrl);
+    const requestHost = parsedUrl.hostname;
+    const filteredCookies2 = cookies.filter(c => {
+      const cd = (c.domain || "").replace(/^\./, "");
+      return requestHost === cd || requestHost.endsWith("." + cd);
+    });
+    const cookieHeader = filteredCookies2
       .map((cookie) => `${cookie.name}=${cookie.value}`)
       .join("; ");
 
-    const parsedUrl = new URL(baseUrl);
     const isHttps = parsedUrl.protocol === "https:";
     const requestModule = isHttps ? https : http;
 
@@ -1959,6 +1995,10 @@ function sendPostRequest(baseUrl, csrfToken, cookies, requestPath, extraParams, 
         try {
           parsed = JSON.parse(responseData);
         } catch (parseError) {
+          if (responseData.includes("全局应用配置有更新")) {
+            resolve({ __needConfigRefresh: true });
+            return;
+          }
           console.error(t("common.response_body", responseData.substring(0, 500)));
           resolve({ success: false, errorMsg: "HTTP " + response.statusCode + ": " + t("common.response_not_json") });
           return;
@@ -1973,6 +2013,10 @@ function sendPostRequest(baseUrl, csrfToken, cookies, requestPath, extraParams, 
         if (isCsrfTokenExpired(parsed)) {
           console.error(t("common.csrf_expired", parsed.errorMsg));
           resolve({ __csrfExpired: true });
+          return;
+        }
+        if (isConfigUpdateRequired(parsed)) {
+          resolve({ __needConfigRefresh: true });
           return;
         }
         resolve(parsed);
@@ -2038,6 +2082,10 @@ function sendUpdateConfigRequest(baseUrl, csrfToken, cookies, appType, formUuid,
         try {
           parsed = JSON.parse(responseData);
         } catch (parseError) {
+          if (responseData.includes("全局应用配置有更新")) {
+            resolve({ __needConfigRefresh: true });
+            return;
+          }
           console.error(t("common.response_body", responseData.substring(0, 500)));
           resolve({ success: false, errorMsg: "HTTP " + response.statusCode + ": " + t("common.response_not_json") });
           return;
@@ -2052,6 +2100,10 @@ function sendUpdateConfigRequest(baseUrl, csrfToken, cookies, appType, formUuid,
         if (isCsrfTokenExpired(parsed)) {
           console.error(t("common.csrf_expired", parsed.errorMsg));
           resolve({ __csrfExpired: true });
+          return;
+        }
+        if (isConfigUpdateRequired(parsed)) {
+          resolve({ __needConfigRefresh: true });
           return;
         }
         resolve(parsed);
@@ -2102,6 +2154,11 @@ function resolveCorpId(cookieData) {
 
 async function requestWithAutoLogin(requestFn, authRef) {
   var result = await requestFn(authRef);
+  // 全局配置更新，直接重试一次
+  if (result && result.__needConfigRefresh) {
+    console.error(t("common.config_refresh_required") + " 正在自动重试...");
+    result = await requestFn(authRef);
+  }
   // 307：csrf_token 过期，刷新后重试
   if (result && result.__csrfExpired) {
     var refreshedData = refreshCsrfToken();

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -395,6 +395,7 @@ Examples:
     resend: "  🔄 Resending request...",
     resend_csrf: "  🔄 Resending request (csrf_token refreshed)...",
     relogin_retry: "  🔄 Resending request after re-login...",
+    config_refresh_required: "Global org config has been updated. Please refresh the Yida page in your browser and re-export cookies before retrying.",
     exception: "\n❌ Exception: {0}",
     yes: "Yes",
     no: "No",

--- a/lib/locales/ja.js
+++ b/lib/locales/ja.js
@@ -389,6 +389,7 @@ openyida - Yida CLI ツール
     resend: "  🔄 リクエストを再送信中...",
     resend_csrf: "  🔄 リクエストを再送信中（csrf_token を更新済み）...",
     relogin_retry: "  🔄 再ログイン後にリクエストを再送信中...",
+    config_refresh_required: "組織のグローバル設定が更新されました。ブラウザで宜搭ページを更新してCookiesを再エクスポートしてから再試行してください。",
     exception: "\n❌ 例外: {0}",
     yes: "はい",
     no: "いいえ",

--- a/lib/locales/zh.js
+++ b/lib/locales/zh.js
@@ -330,6 +330,7 @@ openyida - 宜搭命令行工具
     resend: "  🔄 重新发送请求...",
     resend_csrf: "  🔄 重新发送请求（csrf_token 已刷新）...",
     relogin_retry: "  🔄 重新登录后重新发送请求...",
+    config_refresh_required: "检测到组织全局配置有更新，请在浏览器中刷新宜搭页面后重新导出 cookies 再试",
     exception: "\n❌ 异常: {0}",
     yes: "是",
     no: "否",

--- a/lib/login.js
+++ b/lib/login.js
@@ -25,6 +25,15 @@ const DEFAULT_LOGIN_URL = "https://www.aliwork.com/workPlatform";
 // ── 配置读取 ──────────────────────────────────────────
 
 function loadConfig() {
+  // 环境变量优先级最高，支持专属宜搭域名（如 your-company.aliwork.com）
+  if (process.env.OPENYIDA_BASE_URL) {
+    const base = process.env.OPENYIDA_BASE_URL.replace(/\/+$/, "");
+    return {
+      loginUrl: base + "/workPlatform",
+      defaultBaseUrl: base,
+    };
+  }
+
   const projectRoot = findProjectRoot();
   const configPath = path.join(projectRoot, "config.json");
   if (fs.existsSync(configPath)) {
@@ -234,20 +243,42 @@ const { URL } = require('url');
   await page.goto(${JSON.stringify(loginUrl)}, { timeout: 120000 });
 
   console.error('  Waiting for login (up to 10 minutes)...');
-  try {
-    await page.waitForURL('**/workPlatform**', { timeout: 600000 });
-  } catch {
+  // 通过轮询检测 tianshu_csrf_token cookie 出现来判断登录成功
+  // 兼容专属域名（如 your-company.aliwork.com）跳转路径不固定的情况
+  let loginSuccess = false;
+  const deadline = Date.now() + 600000;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 2000));
+    const cookies = await context.cookies();
+    if (cookies.some(c => c.name === 'tianshu_csrf_token' && c.value)) {
+      loginSuccess = true;
+      break;
+    }
+  }
+  if (!loginSuccess) {
     console.error('  ⏰ Login timed out (10 minutes). Please try again.');
     await browser.close();
     process.exit(1);
   }
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('networkidle').catch(() => {});
   console.error('  ✅ Login successful!');
 
-  const postLoginParsed = new URL(page.url());
-  const baseUrl = postLoginParsed.origin;
+  const currentUrl = page.url();
   const cookies = await context.cookies();
+  // 从 cookies 中找专属域名作为 base_url，优先用 your-company.aliwork.com 等专属域
+  const csrfCookie = cookies.find(c => c.name === 'tianshu_csrf_token');
+  let baseUrl;
+  if (csrfCookie && csrfCookie.domain && csrfCookie.domain !== '.aliwork.com') {
+    baseUrl = 'https://' + csrfCookie.domain.replace(/^\./, '');
+  } else {
+    try { baseUrl = new URL(currentUrl).origin; } catch { baseUrl = 'https://www.aliwork.com'; }
+  }
+  // 尝试从 yida_user_cookie 所在域名获取更准确的 base_url
+  const yidaCookie = cookies.find(c => c.name === 'yida_user_cookie');
+  if (yidaCookie && yidaCookie.domain && yidaCookie.domain.includes('aliwork.com')) {
+    baseUrl = 'https://' + yidaCookie.domain.replace(/^\./, '');
+  }
   await browser.close();
 
   console.log(JSON.stringify({ cookies, base_url: baseUrl }));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -257,6 +257,15 @@ function isCsrfTokenExpired(responseJson) {
   );
 }
 
+function isConfigUpdateRequired(responseJson) {
+  return (
+    responseJson &&
+    responseJson.success === false &&
+    responseJson.errorMsg &&
+    responseJson.errorMsg.includes("全局应用配置有更新")
+  );
+}
+
 // ── base_url 解析 ─────────────────────────────────────
 
 /**
@@ -285,8 +294,14 @@ function httpPost(baseUrl, requestPath, postData, cookies) {
   const http = require("http");
 
   return new Promise((resolve, reject) => {
-    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
     const parsedUrl = new URL(baseUrl);
+    const requestHost = parsedUrl.hostname;
+    // 按域名过滤 cookies，避免不同子域名的 JSESSIONID 冲突
+    const filteredCookies = cookies.filter(c => {
+      const cd = (c.domain || "").replace(/^\./, "");
+      return requestHost === cd || requestHost.endsWith("." + cd);
+    });
+    const cookieHeader = filteredCookies.map((c) => `${c.name}=${c.value}`).join("; ");
     const isHttps = parsedUrl.protocol === "https:";
     const requestModule = isHttps ? https : http;
 
@@ -320,8 +335,16 @@ function httpPost(baseUrl, requestPath, postData, cookies) {
             resolve({ __csrfExpired: true });
             return;
           }
+          if (isConfigUpdateRequired(parsed)) {
+            resolve({ __needConfigRefresh: true });
+            return;
+          }
           resolve(parsed);
-        } catch {
+        } catch (parseErr) {
+          if (data.includes("全局应用配置有更新")) {
+            resolve({ __needConfigRefresh: true });
+            return;
+          }
           console.error(t("common.http_response", data.substring(0, 500)));
           resolve({ success: false, errorMsg: `HTTP ${res.statusCode}: ` + t("common.response_not_json") });
         }
@@ -349,8 +372,13 @@ function httpGet(baseUrl, requestPath, queryParams, cookies) {
   const querystring = require("querystring");
 
   return new Promise((resolve, reject) => {
-    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
     const parsedUrl = new URL(baseUrl);
+    const requestHost = parsedUrl.hostname;
+    const filteredCookies = cookies.filter(c => {
+      const cd = (c.domain || "").replace(/^\./, "");
+      return requestHost === cd || requestHost.endsWith("." + cd);
+    });
+    const cookieHeader = filteredCookies.map((c) => `${c.name}=${c.value}`).join("; ");
     const isHttps = parsedUrl.protocol === "https:";
     const requestModule = isHttps ? https : http;
     const fullPath = queryParams ? `${requestPath}?${querystring.stringify(queryParams)}` : requestPath;
@@ -406,6 +434,14 @@ function httpGet(baseUrl, requestPath, queryParams, cookies) {
 async function requestWithAutoLogin(requestFn, authRef) {
   let result = await requestFn(authRef);
 
+  if (result && result.__needConfigRefresh) {
+    console.error(t("common.config_refresh_required") + " 正在自动重试...");
+    result = await requestFn(authRef);
+    if (result && result.__needConfigRefresh) {
+      return { success: false, errorMsg: t("common.config_refresh_required") };
+    }
+  }
+
   if (result && result.__csrfExpired) {
     const refreshedData = refreshCsrfToken();
     authRef.cookieData = refreshedData;
@@ -439,6 +475,7 @@ module.exports = {
   resolveBaseUrl,
   isLoginExpired,
   isCsrfTokenExpired,
+  isConfigUpdateRequired,
   httpPost,
   httpGet,
   requestWithAutoLogin,

--- a/yida-skills/skills/yida-exclusive-domain/SKILL.md
+++ b/yida-skills/skills/yida-exclusive-domain/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: yida-exclusive-domain
+description: 宜搭专属域名（如 your-company.aliwork.com）环境下的登录、Cookie、应用创建等常见问题诊断与修复指南。当遇到登录死循环、base_url 错误、"全局配置有更新"、Cookie 域名冲突、组件ID重复等问题时使用。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+metadata:
+  audience: developers
+  workflow: yida-troubleshoot
+  version: 1.0.0
+  tags:
+    - yida
+    - troubleshoot
+    - exclusive-domain
+    - login
+    - cookie
+---
+
+# 宜搭专属域名环境问题诊断与修复
+
+## 背景
+
+宜搭支持企业专属域名（如 `your-company.aliwork.com`），与标准域名 `www.aliwork.com` 行为存在差异。
+在专属域名环境下，`openyida` 的多个模块可能出现问题，本文档记录了所有已知问题及修复方案。
+
+---
+
+## 问题一：登录死循环（waitForURL 永不匹配）
+
+### 症状
+- `openyida login` 打开浏览器后，用户扫码成功，但程序一直等待，最终超时退出
+- 日志显示一直在等待 URL 跳转，但实际已登录成功
+
+### 根因
+`login.js` 中使用 `waitForURL` 检测登录成功，判断条件为：
+```javascript
+hostname === loginDomain && url.includes('workPlatform')
+```
+但专属域名账号登录后会跳转到 `your-company.aliwork.com`（而非 `www.aliwork.com`），导致条件永不满足。
+
+### 修复方案
+将 URL 检测改为 **Cookie 轮询**，检测 `tianshu_csrf_token` 是否出现：
+
+```javascript
+// 替换 waitForURL 逻辑
+let loginSuccess = false;
+const deadline = Date.now() + 600000; // 10分钟超时
+while (Date.now() < deadline) {
+  await new Promise(r => setTimeout(r, 2000));
+  const cookies = await context.cookies();
+  if (cookies.some(c => c.name === 'tianshu_csrf_token' && c.value)) {
+    loginSuccess = true;
+    break;
+  }
+}
+if (!loginSuccess) throw new Error('登录超时');
+```
+
+**原理**：无论跳转到哪个域名，登录成功后 `tianshu_csrf_token` 必然出现在 Cookie 中，与域名无关。
+
+---
+
+## 问题二：base_url 保存错误（域名缺字符）
+
+### 症状
+- `.cache/cookies.json` 中 `base_url` 为 `https://ungrow.aliwork.com`（缺少 's'）
+- 所有 API 请求失败，提示域名无法解析
+
+### 根因
+`login.js` 从 `yida_user_cookie` 的 `domain` 字段提取 base_url，但 Cookie domain 格式为 `.your-company.aliwork.com`（带前导点），
+原代码 `domain.replace(/^\./, '')` 在某些情况下未正确处理，导致截取错误。
+
+### 修复方案
+使用更健壮的提取逻辑：
+
+```javascript
+// 从 yida_user_cookie 的 domain 提取 base_url
+const yidaCookie = cookies.find(c => c.name === 'yida_user_cookie');
+if (yidaCookie && yidaCookie.domain && yidaCookie.domain.includes('aliwork.com')) {
+  baseUrl = 'https://' + yidaCookie.domain.replace(/^\./, '');
+}
+```
+
+**备用方案**：若 Cookie 提取失败，从当前页面 URL 提取：
+```javascript
+const currentUrl = page.url();
+const parsedUrl = new URL(currentUrl);
+baseUrl = parsedUrl.origin; // https://your-company.aliwork.com
+```
+
+**手动修复**：直接编辑 `.cache/cookies.json`，将错误的 `base_url` 改为正确值：
+```json
+{
+  "base_url": "https://your-company.aliwork.com",
+  "cookies": [...]
+}
+```
+
+---
+
+## 问题三："检测到组织全局配置有更新" 导致创建应用失败
+
+### 症状
+- `openyida create-app` 报错：`检测到组织全局配置有更新，请在浏览器中刷新宜搭页面后重新导出 cookies 再试`
+- 即使重新登录也无法解决
+
+### 根因
+该组织开启了独占数据库（`forceExclusiveDb: "y"`）和物理列（`forcePhysicalColumn: "y"`）策略，
+但 `create-app.js` 硬编码了 `openExclusive: "n"` 和 `openPhysicColumn: "n"`，
+导致 `registerApp` 接口返回 HTML 错误页而非 JSON。
+
+### 修复方案
+在调用 `registerApp` 前，先查询组织配置：
+
+```javascript
+// 在 create-app.js 中，registerApp 调用前添加
+let openExclusive = "n";
+let openPhysicColumn = "n";
+try {
+  const corpConfig = await httpPost(
+    authRef.baseUrl,
+    `/query/exclusive/queryCorpAppConfig.json?_api=Global.queryCorpAppConfig&_mock=false&_csrf_token=${authRef.csrfToken}&_locale_time_zone_offset=28800000&_stamp=${Date.now()}`,
+    "",
+    authRef.cookies
+  );
+  if (corpConfig && corpConfig.content) {
+    if (corpConfig.content.forceExclusiveDb === "y") openExclusive = "y";
+    if (corpConfig.content.forcePhysicalColumn === "y") openPhysicColumn = "y";
+  }
+} catch (e) {
+  // ignore, use defaults
+}
+
+// 然后在 registerApp 的 postData 中使用变量
+const postData = querystring.stringify({
+  // ...
+  openExclusive: openExclusive,
+  openPhysicColumn: openPhysicColumn,
+  // ...
+});
+```
+
+---
+
+## 问题四：Cookie 域名冲突（JSESSIONID 混淆）
+
+### 症状
+- API 请求返回 401 或登录失效
+- 同时存在 `www.aliwork.com` 和 `your-company.aliwork.com` 的 Cookie
+- 两个域名各有一个 `JSESSIONID`，发送时互相覆盖
+
+### 根因
+`utils.js` 的 `httpPost` 和 `httpGet` 将所有 Cookie 拼接发送，未按域名过滤，
+导致 `www.aliwork.com` 的 `JSESSIONID` 被发送到 `your-company.aliwork.com`，服务端拒绝。
+
+### 修复方案
+在 `httpPost` 和 `httpGet` 中添加域名过滤：
+
+```javascript
+// 在构建 cookieHeader 前添加过滤
+const parsedUrl = new URL(baseUrl);
+const requestHost = parsedUrl.hostname;
+const filteredCookies = cookies.filter(c => {
+  const cd = (c.domain || "").replace(/^\./, "");
+  return requestHost === cd || requestHost.endsWith("." + cd);
+});
+const cookieHeader = filteredCookies.map((c) => `${c.name}=${c.value}`).join("; ");
+```
+
+---
+
+## 问题五：create-form.js 缺少 isLoginExpired 等函数导入
+
+### 症状
+- `openyida create-form` 报错：`isLoginExpired is not defined`
+- 或 `isConfigUpdateRequired is not defined`
+
+### 根因
+`create-form.js` 的 `require('./utils')` 未包含所有需要的函数。
+
+### 修复方案
+确保 `create-form.js` 顶部的 require 包含所有必要函数：
+
+```javascript
+const {
+  findProjectRoot,
+  loadCookieData,
+  triggerLogin,
+  refreshCsrfToken,
+  resolveBaseUrl,
+  isLoginExpired,
+  isCsrfTokenExpired,
+  isConfigUpdateRequired,  // 必须包含
+} = require("./utils");
+```
+
+同时确保 `utils.js` 的 `module.exports` 导出了 `isConfigUpdateRequired`：
+
+```javascript
+module.exports = {
+  // ...
+  isConfigUpdateRequired,  // 确保已导出
+  // ...
+};
+```
+
+---
+
+## 问题六：组件 ID 重复（FormContainer fieldId 冲突）
+
+### 症状
+- `openyida create-form` 报错：`组件ID不允许重复`
+- 表单创建失败
+
+### 根因
+`create-form.js` 中两个嵌套的 `FormContainer` 都使用 `Date.now().toString(36)` 生成 fieldId，
+在同一毫秒内执行时生成相同的 ID。
+
+### 修复方案
+
+**方案 A**：添加后缀区分：
+```javascript
+// 外层 FormContainer
+fieldId: "formContainer_" + Date.now().toString(36) + "a",
+// 内层 FormContainer
+fieldId: "formContainer_" + Date.now().toString(36) + "b",
+```
+
+**方案 B**：使用带计数器的 ID 生成函数：
+```javascript
+let fieldIdCounter = 1;
+function generateFieldId(componentName) {
+  const prefix = componentName.charAt(0).toLowerCase() + componentName.slice(1);
+  const timePart = Date.now().toString(36).slice(-4);
+  const counterPart = (fieldIdCounter++).toString(36).padStart(2, '0');
+  const randomPart = Math.random().toString(36).substring(2, 4);
+  return prefix + "_" + timePart + counterPart + randomPart;
+}
+```
+
+---
+
+## 问题七：__needConfigRefresh 无限循环
+
+### 症状
+- 某些 API 请求返回 `__needConfigRefresh: true`
+- 程序陷入无限重试
+
+### 修复方案
+在 `requestWithAutoLogin` 中对 `__needConfigRefresh` 只重试一次：
+
+```javascript
+if (result && result.__needConfigRefresh) {
+  console.error("全局配置有更新，正在自动重试...");
+  result = await requestFn(authRef);
+  if (result && result.__needConfigRefresh) {
+    // 重试后仍失败，返回错误而非继续循环
+    return { success: false, errorMsg: "全局配置有更新，请刷新页面后重试" };
+  }
+}
+```
+
+---
+
+## 快速诊断流程
+
+```
+遇到宜搭操作失败
+       ↓
+1. 检查 .cache/cookies.json 中 base_url 是否正确
+   → 错误域名（如 ungrow.aliwork.com）→ 手动修正或重新登录
+       ↓
+2. 检查是否登录死循环
+   → 扫码后程序不退出 → 检查 login.js 是否使用 Cookie 轮询
+       ↓
+3. 检查 create-app 是否报"全局配置有更新"
+   → 检查 create-app.js 是否查询了 queryCorpAppConfig
+       ↓
+4. 检查 API 请求是否返回 401/登录失效
+   → 检查 utils.js 是否有 Cookie 域名过滤
+       ↓
+5. 检查 create-form 是否报"组件ID不允许重复"
+   → 检查 FormContainer fieldId 是否有唯一性保证
+```
+
+---
+
+## 受影响的文件
+
+| 文件 | 问题 | 修复 |
+|------|------|------|
+| `lib/login.js` | 登录死循环、base_url 错误 | Cookie 轮询 + yida_user_cookie 域名提取 |
+| `lib/utils.js` | Cookie 域名冲突、isConfigUpdateRequired 未导出 | 域名过滤 + 导出函数 + __needConfigRefresh 单次重试 |
+| `lib/create-app.js` | "全局配置有更新" | 查询 queryCorpAppConfig 获取 org 参数 |
+| `lib/create-form.js` | 缺少导入、Cookie 冲突、组件ID重复 | 完整导入 + 域名过滤 + 唯一 ID 生成 |


### PR DESCRIPTION
## 问题背景

在使用企业专属域名（如 `your-company.aliwork.com`）时，`openyida` 多个模块存在兼容性问题，导致登录死循环、应用创建失败等。本 PR 修复了实际使用中发现的 7 个问题。

## 修复内容

### 1. fix(login): 登录死循环
- **根因**：`waitForURL` 检测 `workPlatform` 路径，但专属域名登录后跳转路径不固定
- **修复**：改为轮询 `tianshu_csrf_token` cookie 出现来判断登录成功

### 2. fix(login): base_url 提取错误
- **根因**：从 `page.url()` 提取域名在某些情况下得到错误值
- **修复**：优先从 `yida_user_cookie.domain` 提取，兜底用 `tianshu_csrf_token.domain`

### 3. fix(create-app): "全局配置有更新"导致创建失败
- **根因**：`registerApp` 硬编码 `openExclusive:"n"` 违反组织策略
- **修复**：注册前先调用 `queryCorpAppConfig`，根据 `forceExclusiveDb`/`forcePhysicalColumn` 动态设置参数

### 4. fix(utils, create-form): Cookie 域名冲突
- **根因**：所有 cookies 不加过滤全部发送，不同子域名的 JSESSIONID 互相冲突
- **修复**：`httpPost`/`httpGet`/`sendPostRequest`/`sendGetRequest` 均添加 hostname 过滤

### 5. fix(create-form): isLoginExpired 等函数未导入
- **根因**：`require("./utils")` 缺少必要函数
- **修复**：补全 `isLoginExpired`/`isCsrfTokenExpired`/`isConfigUpdateRequired` 导入

### 6. fix(create-form): FormContainer 组件 ID 重复
- **根因**：两个嵌套 FormContainer 在同一毫秒生成相同 `fieldId`
- **修复**：添加 `"a"`/`"b"` 后缀区分；`generateFieldId` 引入计数器保证唯一性

### 7. fix(utils, create-form): __needConfigRefresh 无限循环
- **根因**：`requestWithAutoLogin` 对 `__needConfigRefresh` 无限重试
- **修复**：只重试一次，失败后返回错误

## 新增

- `yida-skills/skills/yida-exclusive-domain/SKILL.md`：记录上述 7 个问题的根因分析、修复方案和快速诊断流程

## 测试

在企业专属域名环境下完整验证：登录 → 创建应用 → 创建表单 → 发布自定义页面，全流程通过。