### PR TITLE
feat: support processDetailUrl in configure-process definition JSON

### DIFF
--- a/lib/configure-process.js
+++ b/lib/configure-process.js
@@ -500,15 +500,18 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
   });
   processNodes.push(finishProcessNode);
 
+  const defaultProcessDetailUrl = baseUrl + "/alibaba/web/" + appType + "/inst/taskDetail.htm";
+  const defaultProcessMobileDetailUrl = baseUrl + "/alibaba/mobile/" + appType + "/inst/detail/taskDetail/";
+
   const processJson = {
     props: {
       allowWithdraw: true,
       allowCollaboration: true,
       allowTemporaryStorage: true,
       processCode: processCode,
-      processDetailUrl: baseUrl + "/alibaba/web/" + appType + "/inst/taskDetail.htm",
+      processDetailUrl: definition.processDetailUrl || defaultProcessDetailUrl,
       processInitUrl: baseUrl + "/alibaba/web/" + appType + "/inst/instStart.htm?processCode=" + processCode,
-      processMobileDetailUrl: baseUrl + "/alibaba/mobile/" + appType + "/inst/detail/taskDetail/",
+      processMobileDetailUrl: definition.processMobileDetailUrl || defaultProcessMobileDetailUrl,
       bindingForm: formUuid,
       stopAssociationRulesIfFailed: false,
       noRecordRecall: false,

--- a/yida-skills/skills/yida-process-rule/SKILL.md
+++ b/yida-skills/skills/yida-process-rule/SKILL.md
@@ -289,7 +289,25 @@ openyida configure-process "APP_XXX" "FORM-YYY" process-definition.json
 }
 ```
 
-### 示例 4：带跳转规则的审批流程
+### 示例 4：配置自定义详情页（解决钉钉工作通知链接问题）
+
+```json
+{
+  "processDetailUrl": "https://mson55.aliwork.com/alibaba/web/APP_XXX/inst/taskDetail.htm?customPage=true&pageId=PAGE-YYY",
+  "processMobileDetailUrl": "https://mson55.aliwork.com/alibaba/mobile/APP_XXX/inst/detail/taskDetail/",
+  "nodes": [
+    {
+      "type": "approval",
+      "name": "主管审批",
+      "approver": "originator"
+    }
+  ]
+}
+```
+
+配置 `processDetailUrl` 后，钉钉工作通知推送的链接将直接指向自定义详情页，而不再是原生 `taskDetail.htm`。
+
+### 示例 5：带跳转规则的审批流程
 
 ```json
 {


### PR DESCRIPTION
## 问题

关联 Issue：#167

通过 `configure-process` 配置了 `processDetailUrl` 指向自定义详情页后，钉钉工作通知推送的链接仍然打开原生 `taskDetail.htm`，而不是自定义页面。

**根本原因**：`buildProcessAndViewJson()` 函数中 `processDetailUrl` 和 `processMobileDetailUrl` 被硬编码为平台默认地址，推送通知时链接已固定，无法动态读取流程配置。

## 解决方案

在流程定义 JSON 的顶层支持 `processDetailUrl` 和 `processMobileDetailUrl` 字段，`configure-process` 在构建 `processJson` 时优先使用用户配置的值，未配置时 fallback 到默认地址（完全向后兼容）。

## 使用方式

在流程定义 JSON 中加入顶层字段：

```json
{
  "processDetailUrl": "https://your-domain.aliwork.com/alibaba/web/APP_XXX/inst/taskDetail.htm?customPage=true&pageId=PAGE-YYY",
  "nodes": [...]
}
```

配置后，钉钉工作通知推送的链接将直接指向自定义详情页。

## 变更文件

- `lib/configure-process.js`：`buildProcessAndViewJson()` 读取 `definition.processDetailUrl` / `definition.processMobileDetailUrl`，fallback 到默认值
- `yida-skills/skills/yida-process-rule/SKILL.md`：补充顶层字段文档说明和使用示例