### PR TITLE
fix: misc improvements - commands, i18n, postinstall, logout

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -75,8 +75,17 @@ openyida - 宜搭命令行工具
     --create-ticket                                            根据诊断结果创建工单
     --create-voc                                               创建 VOC（需求反馈）
     --auto-submit                                              自动判断并提交工单或 VOC
+  auth status                                                  查看当前登录状态
+  auth login                                                   执行登录
+  auth refresh                                                 刷新登录态
+  auth logout                                                  退出登录
+  org list                                                     列出可访问的组织
+  org switch --corp-id <corpId>                                切换组织（无需重新登录）
   get-permission <appType> <formUuid>                          查询表单权限配置
   save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]  保存表单权限配置
+  configure-process <appType> <formUuid> <processDefinitionFile> [processCode]  配置并发布流程
+  create-process <appType> <formTitle> <fieldsJsonFile> <processDefinitionFile>  创建流程表单（一体化）
+  create-process <appType> --formUuid <formUuid> <processDefinitionFile>         复用已有表单创建流程
 
 示例：
   openyida login
@@ -397,8 +406,8 @@ async function main() {
 
     case 'get-permission': {
       if (args.length < 2) {
-        console.error('用法: openyida get-permission <appType> <formUuid>');
-        console.error('示例: openyida get-permission APP_XXX FORM-XXX');
+        console.error(t('cli.get_permission_usage'));
+        console.error(t('cli.get_permission_example'));
         process.exit(1);
       }
       const { run: runGetPermission } = require('../lib/get-permission');
@@ -408,8 +417,8 @@ async function main() {
 
     case 'save-permission': {
       if (args.length < 2) {
-        console.error('用法: openyida save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]');
-        console.error("示例: openyida save-permission APP_XXX FORM-XXX --data-permission '{\"role\":\"DEFAULT\",\"dataRange\":\"SELF\"}'");
+        console.error(t('cli.save_permission_usage'));
+        console.error(t('cli.save_permission_example'));
         process.exit(1);
       }
       const { run: runSavePermission } = require('../lib/save-permission');
@@ -417,6 +426,27 @@ async function main() {
       break;
     }
 
+    case 'configure-process': {
+      if (args.length < 3) {
+        console.error(t('cli.configure_process_usage'));
+        console.error(t('cli.configure_process_example'));
+        process.exit(1);
+      }
+      const { run: runConfigureProcess } = require('../lib/configure-process');
+      await runConfigureProcess(args);
+      break;
+    }
+
+    case 'create-process': {
+      if (args.length < 2) {
+        console.error(t('cli.create_process_usage'));
+        console.error(t('cli.create_process_example'));
+        process.exit(1);
+      }
+      const { run: runCreateProcess } = require('../lib/create-process');
+      await runCreateProcess(args);
+      break;
+    }
     case 'cdn-config': {
       const { run: runCdnConfig } = require('../lib/cdn-config-cmd');
       await runCdnConfig(args);

--- a/lib/check-update.js
+++ b/lib/check-update.js
@@ -8,6 +8,7 @@
 "use strict";
 
 const https = require("https");
+const { t } = require("./i18n");
 
 const REGISTRY_URL = "https://registry.npmjs.org/openyida/latest";
 
@@ -58,10 +59,7 @@ async function checkUpdate(currentVersion) {
 
     if (latestVersion && isNewer(currentVersion, latestVersion)) {
       process.nextTick(() => {
-        console.error(
-          `\n💡 发现新版本 ${latestVersion}（当前 ${currentVersion}）` +
-          `\n   运行以下命令更新：\n   npm install -g openyida@latest\n`
-        );
+        console.error(t("check_update.new_version", latestVersion, currentVersion));
       });
     }
   } catch {

--- a/lib/locales/en.js
+++ b/lib/locales/en.js
@@ -74,6 +74,10 @@ Examples:
     configure_process_example: 'Example: openyida configure-process "APP_XXX" "FORM-YYY" process-definition.json',
     create_process_usage: 'Usage: openyida create-process <appType> <formTitle> <fieldsJsonFile> <processDefinitionFile>\n        openyida create-process <appType> --formUuid <formUuid> <processDefinitionFile>',
     create_process_example: 'Example: openyida create-process "APP_XXX" "Order Form" fields.json process-definition.json',
+    get_permission_usage: 'Usage: openyida get-permission <appType> <formUuid>',
+    get_permission_example: 'Example: openyida get-permission APP_XXX FORM-XXX',
+    save_permission_usage: 'Usage: openyida save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]',
+    save_permission_example: "Example: openyida save-permission APP_XXX FORM-XXX --data-permission '{\"role\":\"DEFAULT\",\"dataRange\":\"SELF\"}'",
     exec_failed: "\n❌ Execution failed: {0}",
     auth_usage: "Usage: openyida auth <status|login|refresh|logout>",
     auth_example: "Examples:\n  openyida auth status   # View login status\n  openyida auth login    # Perform login\n  openyida auth refresh  # Refresh login session\n  openyida auth logout   # Logout",
@@ -97,6 +101,11 @@ Examples:
     first_run_footer1: "  Supported AI tools: Claude Code / Aone Copilot / Cursor / OpenCode",
     first_run_footer2: "  📚 Docs: https://github.com/openyida/openyida",
     first_run_footer3: "  (This guide only shows on first run. Use openyida --help to see all commands)",
+  },
+
+  // ── lib/check-update.js ────────────────────────────
+  check_update: {
+    new_version: "\n💡 New version available: {0} (current: {1})\n   Run the following command to update:\n   npm install -g openyida@latest\n",
   },
 
   // ── lib/env.js ─────────────────────────────────────

--- a/lib/locales/zh.js
+++ b/lib/locales/zh.js
@@ -75,6 +75,10 @@ openyida - 宜搭命令行工具
     configure_process_example: '示例: openyida configure-process "APP_XXX" "FORM-YYY" process-definition.json',
     create_process_usage: '用法: openyida create-process <appType> <formTitle> <fieldsJsonFile> <processDefinitionFile>\n      openyida create-process <appType> --formUuid <formUuid> <processDefinitionFile>',
     create_process_example: '示例: openyida create-process "APP_XXX" "订单处理表" fields.json process-definition.json',
+    get_permission_usage: '用法: openyida get-permission <appType> <formUuid>',
+    get_permission_example: '示例: openyida get-permission APP_XXX FORM-XXX',
+    save_permission_usage: '用法: openyida save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]',
+    save_permission_example: "示例: openyida save-permission APP_XXX FORM-XXX --data-permission '{\"role\":\"DEFAULT\",\"dataRange\":\"SELF\"}'",
     exec_failed: "\n❌ 执行失败: {0}",
     first_run_title: "  🤖 OpenYida - AI 问答模式已开启！                         ",
     first_run_welcome: "  {0}欢迎首次使用 OpenYida！{1} 以下是快速上手指南：",
@@ -498,6 +502,11 @@ openyida - 宜搭命令行工具
     remove_failed: "    ❌ 删除失败: {0} ({1})",
     symlink_fallback_copy: "    ⚠️  Windows 软链创建失败（需要管理员权限），降级为目录复制: {0}",
     symlink_failed: "    ❌ 软链接创建失败: {0} ({1})",
+  },
+
+  // ── lib/check-update.js ────────────────────────────
+  check_update: {
+    new_version: "\n💡 发现新版本 {0}（当前 {1}）\n   运行以下命令更新：\n   npm install -g openyida@latest\n",
   },
 
   // ── lib/publish.js ─────────────────────────────────

--- a/lib/login.js
+++ b/lib/login.js
@@ -328,7 +328,7 @@ function logout() {
   console.error(t("login.cookie_file_label", projectCookieFile));
 
   if (fs.existsSync(projectCookieFile)) {
-    fs.writeFileSync(projectCookieFile, "", "utf-8");
+    fs.unlinkSync(projectCookieFile);
     console.error(t("login.logout_success"));
     console.error(t("login.logout_hint"));
   } else {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -75,7 +75,9 @@ function installSymlink(ideConfigDir) {
 
 // Claude Code
 safeExec(() => {
-  installSymlink(path.join(HOME_DIR, ".claude"));
+  if (fs.existsSync(path.join(HOME_DIR, ".claude"))) {
+    installSymlink(path.join(HOME_DIR, ".claude"));
+  }
 });
 
 // OpenCode

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -38,7 +38,7 @@ metadata:
 
 | 依赖 | 版本 | 用途 |
 |------|------|------|
-| Node.js | ≥ 16 | 运行 openyida |
+| Node.js | ≥ 18 | 运行 openyida |
 
 ```bash
 # 安装 openyida（首次使用前执行）


### PR DESCRIPTION
## 修复内容

本 PR 修复了 8 个小问题，对应 Issues #174 ~ #181。

### 变更详情

| 文件 | 修复内容 | 关联 Issue |
|------|---------|-----------|
| `bin/yida.js` | 注册 `configure-process` 和 `create-process` 命令路由 | #174 |
| `bin/yida.js` | `get-permission`/`save-permission` 错误提示改用 i18n | #175 |
| `bin/yida.js` | `printHelp` 补充 `auth`/`org` 子命令说明 | #176 |
| `lib/check-update.js` | 版本更新提示改用 i18n（不再硬编码中文） | #177 |
| `scripts/postinstall.js` | Claude Code 软链改为检测 `~/.claude` 目录存在才创建 | #178 |
| `yida-skills/SKILL.md` | Node.js 版本要求从 ≥16 统一为 ≥18 | #179 |
| `lib/login.js` | `logout` 改为 `fs.unlinkSync` 删除 Cookie 文件，而非写空字符串 | #180 |
| `lib/locales/zh.js` / `en.js` | 新增 `check_update`、`get_permission`、`save_permission` i18n key | #181 |

### 测试

- `node --check bin/yida.js` ✅
- `node --check lib/check-update.js` ✅
- `node --check lib/login.js` ✅
- `node --check scripts/postinstall.js` ✅