### PR TITLE
fix: 修正 .gitignore 中工作区路径前缀 openyida/ → project/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,20 +40,21 @@ coverage/
 # AI 工具配置（保留 CLAUDE.md）
 .claude/*
 !.claude/CLAUDE.md
+
 # ── openyida 用户工作区 ────────────────────────────
 # 登录态 & Schema 缓存（敏感信息，不入库）
-openyida/.cache/*
-!openyida/.cache/.gitkeep
-!openyida/.cache/demo-*
+project/.cache/*
+!project/.cache/.gitkeep
+!project/.cache/demo-*
 
 # 自定义页面编译产物
-openyida/pages/dist/*
-!openyida/pages/dist/.gitkeep
+project/pages/dist/*
+!project/pages/dist/.gitkeep
 
 # 用户自定义页面源码（保留 demo 示例）
-openyida/pages/src/*
-!openyida/pages/src/demo-*
+project/pages/src/*
+!project/pages/src/demo-*
 
 # 需求文档（保留 demo 示例）
-openyida/prd/*
-!openyida/prd/demo-*
+project/prd/*
+!project/prd/demo-*


### PR DESCRIPTION
## 变更说明

修正 `.gitignore` 中用户工作区路径的前缀，与项目实际目录结构保持一致。

## 修改内容

将以下路径前缀从 `openyida/` 改为 `project/`：

- `project/.cache/*`（登录态 & Schema 缓存）
- `project/pages/dist/*`（自定义页面编译产物）
- `project/pages/src/*`（用户自定义页面源码）
- `project/prd/*`（需求文档）

## 原因

项目实际工作目录为 `project/`（见 `AGENTS.md` 项目结构说明），原来的 `openyida/` 前缀导致这些 ignore 规则实际上不生效，用户的缓存文件和编译产物可能被误提交。