### PR TITLE
feat: 新增 yida-chart 和 yida-report 技能，增强Echarts报表图表构建能力

### DIFF
--- a/lib/report/chart-builder.js
+++ b/lib/report/chart-builder.js
@@ -9,6 +9,16 @@ const {
   genFieldId,
 } = require('./constants');
 
+/**
+ * 将 formUuid 格式的连字符转换为报表 cubeCode 格式的下划线
+ * 例如：FORM-CB89B06090324A50972179EA1B0CB0F1VUSG → FORM_CB89B06090324A50972179EA1B0CB0F1VUSG
+ * 宜搭报表引擎的 cubeCode 使用下划线分隔，而 formUuid 使用连字符分隔
+ */
+function normalizeCubeCode(code) {
+  if (!code) return '';
+  return code.replace(/-/g, '_');
+}
+
 // ── 通用构建工具 ──────────────────────────────────────
 
 /**
@@ -96,6 +106,12 @@ function buildFieldObj(cubeCode, fieldCode, aliasName, alias, dataType, aggregat
 
 /**
  * 构建 dataViewQueryModel（图表数据查询模型）
+ *
+ * 支持两种输入格式：
+ * 格式1（结构化）：chart.xField / chart.yField / chart.groupField
+ * 格式2（简化）：chart.fields 数组，通过 isDim 自动分配角色
+ *   - isDim=true → xField（维度）
+ *   - isDim=false → yField（度量）
  */
 function buildDataViewQueryModel(chart, cubeTenantId) {
   const cubeCode = chart.cubeCode || '';
@@ -104,25 +120,34 @@ function buildDataViewQueryModel(chart, cubeTenantId) {
 
   const allFields = [];
 
-  if (chart.xField) {
-    if (Array.isArray(chart.xField)) {
-      chart.xField.forEach((f) => allFields.push({ ...f, role: 'x' }));
-    } else {
-      allFields.push({ ...chart.xField, role: 'x' });
+  // 格式2：简化的 fields 数组，自动按 isDim 分配角色
+  if (Array.isArray(chart.fields) && chart.fields.length > 0 && !chart.xField && !chart.yField) {
+    chart.fields.forEach((f) => {
+      const role = f.isDim ? 'x' : 'y';
+      allFields.push({ ...f, role });
+    });
+  } else {
+    // 格式1：结构化的 xField / yField / groupField
+    if (chart.xField) {
+      if (Array.isArray(chart.xField)) {
+        chart.xField.forEach((f) => allFields.push({ ...f, role: 'x' }));
+      } else {
+        allFields.push({ ...chart.xField, role: 'x' });
+      }
     }
-  }
 
-  if (Array.isArray(chart.yField)) {
-    chart.yField.forEach((f) => allFields.push({ ...f, role: 'y' }));
-  } else if (chart.yField) {
-    allFields.push({ ...chart.yField, role: 'y' });
-  }
+    if (Array.isArray(chart.yField)) {
+      chart.yField.forEach((f) => allFields.push({ ...f, role: 'y' }));
+    } else if (chart.yField) {
+      allFields.push({ ...chart.yField, role: 'y' });
+    }
 
-  if (chart.groupField) {
-    if (Array.isArray(chart.groupField)) {
-      chart.groupField.forEach((f) => allFields.push({ ...f, role: 'group' }));
-    } else {
-      allFields.push({ ...chart.groupField, role: 'group' });
+    if (chart.groupField) {
+      if (Array.isArray(chart.groupField)) {
+        chart.groupField.forEach((f) => allFields.push({ ...f, role: 'group' }));
+      } else {
+        allFields.push({ ...chart.groupField, role: 'group' });
+      }
     }
   }
 
@@ -131,8 +156,6 @@ function buildDataViewQueryModel(chart, cubeTenantId) {
     f._alias = alias;
     const aggType = f.aggregateType || 'NONE';
     const isDateField = (f.dataType === 'DATE') || (f.fieldCode && f.fieldCode.startsWith('dateField_'));
-    const numericAggTypes = ['COUNT', 'SUM', 'AVG', 'MAX', 'MIN', 'COUNT_DISTINCT'];
-    const effectiveDataType = numericAggTypes.includes(aggType) ? 'DOUBLE' : (f.dataType || 'STRING');
 
     fieldDefinitionList.push({
       cubeCode: cubeCode,
@@ -141,7 +164,7 @@ function buildDataViewQueryModel(chart, cubeTenantId) {
       aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
       classifiedCode: cubeCode,
       fieldCode: f.fieldCode,
-      dataType: effectiveDataType,
+      dataType: f.dataType || 'STRING',
       aggregateType: aggType,
       timeGranularityType: isDateField ? 'DAY' : null,
     });
@@ -247,6 +270,8 @@ function buildDataSetModelMap(chart, cubeTenantId) {
       chart.columnFields.forEach((f) => allFields.push({ ...f, role: 'col' }));
     } else if (Array.isArray(chart.columns)) {
       chart.columns.forEach((f) => allFields.push({ ...f, role: 'col' }));
+    } else if (Array.isArray(chart.fields)) {
+      chart.fields.forEach((f) => allFields.push({ ...f, role: 'col' }));
     }
 
     const fieldDefinitionList = [];
@@ -294,6 +319,8 @@ function buildDataSetModelMap(chart, cubeTenantId) {
       chart.kpi.forEach((f) => allFields.push({ ...f, role: 'kpi' }));
     } else if (Array.isArray(chart.yField)) {
       chart.yField.forEach((f) => allFields.push({ ...f, role: 'kpi' }));
+    } else if (Array.isArray(chart.fields)) {
+      chart.fields.forEach((f) => allFields.push({ ...f, role: 'kpi' }));
     }
     if (Array.isArray(chart.helpKpi)) {
       chart.helpKpi.forEach((f) => allFields.push({ ...f, role: 'helpKpi' }));
@@ -306,7 +333,7 @@ function buildDataSetModelMap(chart, cubeTenantId) {
       f._alias = alias;
       const aggType = f.aggregateType || 'NONE';
       fieldDefinitionList.push({
-        cubeCode, isDim: aggType === 'NONE', alias,
+        cubeCode, isDim: false, alias,
         aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
         classifiedCode: cubeCode, fieldCode: f.fieldCode,
         dataType: f.dataType || 'STRING', aggregateType: aggType,
@@ -641,6 +668,20 @@ function buildFunnelChartSettings() {
   };
 }
 
+function buildRadarChartSettings() {
+  return {
+    container: { height: 248 },
+    style: {
+      colorType: 'SCHEMA_COLOR', chartColorsMode: 'defaultColorsMode',
+      customColor: '#5894FF,#394B76,#F7B900,#E55F24,#80D5F5,#9849B0,#3BC88A,#0E869D,#F4A49E,#80563C',
+      showArea: true, smooth: false, pointSize: 4, lineWidth: 2,
+    },
+    legend: { showLegend: true, legendPosition: 'top-left', flipPage: true },
+    label: { showLabel: false, fontSize: 12, color: '#000' },
+    tooltip: { showTooltip: true },
+  };
+}
+
 function buildGaugeChartSettings() {
   return {
     container: { height: 248 },
@@ -791,6 +832,7 @@ function getChartSettings(chartType) {
     case 'scatter':   return buildScatterChartSettings();
     case 'area':      return buildAreaChartSettings();
     case 'funnel':    return buildFunnelChartSettings();
+    case 'radar':     return buildRadarChartSettings();
     case 'gauge':     return buildGaugeChartSettings();
     case 'combo':     return buildComboChartSettings();
     case 'table':     return buildTableSettings();
@@ -809,6 +851,9 @@ function buildUserConfig(chartType) {
   }
   if (chartType === 'funnel') {
     return { chartType: 'funnel', dataConfig: { xField: [], yField: [] } };
+  }
+  if (chartType === 'radar') {
+    return { chartType: 'radar', dataConfig: { xField: [], yField: [], groupField: [] } };
   }
   if (chartType === 'gauge') {
     return { chartType: 'gauge', dataConfig: { valueField: [], assitValueField: [] } };
@@ -858,62 +903,117 @@ function buildUserConfig(chartType) {
 }
 
 /**
- * 构建带字段信息的 userConfig
+ * 构建带字段信息的 userConfig（数组格式，与宜搭报表设计器一致）
+ *
+ * 宜搭报表引擎期望 userConfig 为数组格式：
+ * [{name: 'chartData', title: '配置数据', items: [{setterName: 'ColumnFieldSetter', ...}]}]
+ * 指标卡已经是数组格式，其他图表类型需要转换。
  */
 function buildUserConfigWithFields(chartType, dataSetModelMap) {
-  const base = buildUserConfig(chartType);
-
-  if (chartType === 'pie') {
-    const chartData = dataSetModelMap.chartData;
-    if (chartData) {
-      base.dataConfig.xField = chartData.xField || [];
-      base.dataConfig.yField = chartData.yField || [];
-    }
-  } else if (chartType === 'indicator') {
-    // 指标卡 userConfig 是嵌套数组格式，不需要额外填充
-  } else if (chartType === 'bar' || chartType === 'line' || chartType === 'area' || chartType === 'scatter') {
-    const chartData = dataSetModelMap.chartData;
-    if (chartData) {
-      base.dataConfig.xField = chartData.xField || [];
-      base.dataConfig.yField = chartData.yField || [];
-      if (base.dataConfig.groupField !== undefined) {
-        base.dataConfig.groupField = chartData.groupField || [];
-      }
-    }
-  } else if (chartType === 'combo') {
-    const dsData = dataSetModelMap.dataSetName;
-    if (dsData) {
-      base.dataConfig.xField = dsData.xField || [];
-      base.dataConfig.leftYFields = dsData.leftYFields || [];
-      base.dataConfig.rightYFields = dsData.rightYFields || [];
-    }
-  } else if (chartType === 'table') {
-    const tableData = dataSetModelMap.table;
-    if (tableData) {
-      base.dataConfig.columnFields = tableData.columnFields || [];
-    }
-  } else if (chartType === 'pivot') {
-    const dsData = dataSetModelMap.dataSetName;
-    if (dsData) {
-      base.dataConfig.columnList = dsData.columnList || [];
-    }
-  } else if (chartType === 'gauge') {
-    const chartData = dataSetModelMap.chartData;
-    if (chartData) {
-      base.dataConfig.valueField = chartData.valueField || [];
-      if (base.dataConfig.assitValueField !== undefined) {
-        base.dataConfig.assitValueField = chartData.assitValueField || [];
-      }
-    }
-  } else if (chartType === 'funnel') {
-    const chartData = dataSetModelMap.chartData;
-    if (chartData) {
-      base.dataConfig.xField = chartData.xField || [];
-      base.dataConfig.yField = chartData.yField || [];
-    }
+  // 指标卡已经是正确的数组格式
+  if (chartType === 'indicator') {
+    return buildUserConfig(chartType);
   }
 
-  return base;
+  // 饼图
+  if (chartType === 'pie') {
+    const chartData = dataSetModelMap.chartData || {};
+    return [{
+      name: 'chartData', title: '配置数据',
+      items: [
+        { setterName: 'ColumnFieldSetter', name: 'xField', title: '分类字段',
+          setterProps: { single: true, showFormatTab: true, showAggregateTab: false, showDrillTab: true, showColorTab: true, showEditTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'yField', title: '数值字段',
+          setterProps: { single: true, showFormatTab: true, showEditTab: true, showDataLink: true } },
+        { setterName: 'ColumnFieldSetter', name: 'ratio', title: '趋势值字段',
+          tip: { content: '当饼图图例类型为【指标卡】时显示，一般用于提示各分类的变化趋势' },
+          setterProps: { showFormatTab: true, showEditTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'totalValue', title: '总值字段',
+          tip: { content: '在开启【环形图】时显示，一般用于显示各分类值的总和' },
+          setterProps: { single: true, showFormatTab: true, showEditTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'totalRatio', title: '总趋势值字段',
+          tip: { content: '在开启【环形图】时显示，一般用于提示各分类值总和的变化趋势' },
+          setterProps: { showFormatTab: true, showEditTab: true } },
+      ],
+    }];
+  }
+
+  // 柱状图 / 折线图 / 面积图 / 散点图 / 雷达图 / 漏斗图
+  if (['bar', 'line', 'area', 'scatter', 'radar', 'funnel'].includes(chartType)) {
+    const chartData = dataSetModelMap.chartData || {};
+    const items = [
+      { setterName: 'ColumnFieldSetter', name: 'xField', title: '横轴',
+        setterProps: { single: true, showFormatTab: true, showFormulaEditor: true, showFieldInfo: true, showAggregateTab: false, showDrillTab: true, showEditTab: true, showSortTab: true } },
+      { setterName: 'ColumnFieldSetter', name: 'yField', title: '纵轴',
+        setterProps: { showFormatTab: true, showFormulaEditor: true, showFieldInfo: true, showEditTab: true, showSortTab: true, showDataLink: true } },
+    ];
+    if (chartType !== 'funnel') {
+      items.push(
+        { setterName: 'ColumnFieldSetter', name: 'groupField', title: '分组',
+          setterProps: { single: true, showFormatTab: true, showEditTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'annotationField', title: '参考线',
+          setterProps: { showFormatTab: true, showEditTab: true } }
+      );
+    }
+    return [{ name: 'chartData', title: '配置数据', items }];
+  }
+
+  // 柱线混合图
+  if (chartType === 'combo') {
+    return [{
+      name: 'dataSetName', title: '配置数据',
+      items: [
+        { setterName: 'ColumnFieldSetter', name: 'xField', title: '横轴',
+          setterProps: { single: true, showFormatTab: true, showEditTab: true, showSortTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'leftYFields', title: '左纵轴',
+          setterProps: { showFormatTab: true, showEditTab: true, showDataLink: true } },
+        { setterName: 'ColumnFieldSetter', name: 'rightYFields', title: '右纵轴',
+          setterProps: { showFormatTab: true, showEditTab: true, showDataLink: true } },
+        { setterName: 'ColumnFieldSetter', name: 'annotationField', title: '参考线',
+          setterProps: { showFormatTab: true, showEditTab: true } },
+      ],
+    }];
+  }
+
+  // 基础表格
+  if (chartType === 'table') {
+    return [{
+      name: 'table', title: '配置数据',
+      items: [
+        { setterName: 'ColumnFieldSetter', name: 'columnFields', title: '列',
+          setterProps: { showFormatTab: true, showFormulaEditor: true, showFieldInfo: true, showEditTab: true, showSortTab: true, showDataLink: true,
+            supportDynamicAlias: true, showBatchSet: true,
+            batchSetFields: ['text', 'title', 'aggregateType', 'format_type', 'format_decimalDigit'] } },
+      ],
+    }];
+  }
+
+  // 交叉透视表
+  if (chartType === 'pivot') {
+    return [{
+      name: 'dataSetName', title: '配置数据',
+      items: [
+        { setterName: 'ColumnFieldSetter', name: 'columnList', title: '列',
+          setterProps: { showFormatTab: true, showEditTab: true } },
+      ],
+    }];
+  }
+
+  // 仪表盘
+  if (chartType === 'gauge') {
+    return [{
+      name: 'chartData', title: '配置数据',
+      items: [
+        { setterName: 'ColumnFieldSetter', name: 'valueField', title: '指标值',
+          setterProps: { single: true, showFormatTab: true, showEditTab: true } },
+        { setterName: 'ColumnFieldSetter', name: 'assitValueField', title: '辅助值',
+          setterProps: { single: true, showFormatTab: true, showEditTab: true } },
+      ],
+    }];
+  }
+
+  // 默认回退
+  return buildUserConfig(chartType);
 }
 
 // ── mockData ──────────────────────────────────────────
@@ -985,6 +1085,23 @@ function buildMockData(chartType) {
         meta: [
           { aliasName: '阶段', alias: 'xField', category: 'xField', dataType: 'STRING' },
           { aliasName: '数量', alias: 'yField', category: 'yField', dataType: 'NUMBER' },
+        ],
+        currentPage: 1, totalCount: 5,
+      },
+    }];
+  }
+  if (chartType === 'radar') {
+    return [{
+      name: 'chartData',
+      data: {
+        data: [
+          { xField: '销售', yField: 80 }, { xField: '管理', yField: 65 },
+          { xField: '技术', yField: 90 }, { xField: '客服', yField: 70 },
+          { xField: '研发', yField: 85 },
+        ],
+        meta: [
+          { aliasName: '维度', alias: 'xField', category: 'xField', dataType: 'STRING' },
+          { aliasName: '数值', alias: 'yField', category: 'yField', dataType: 'NUMBER' },
         ],
         currentPage: 1, totalCount: 5,
       },
@@ -1085,6 +1202,13 @@ function buildReportSchema(reportTitle, charts, reportId, cubeTenantId) {
   const pageHeaderContentId = genNodeId();
   const rootContentId = genNodeId();
   const rootFooterId = genNodeId();
+
+  // 统一将每个 chart 的 cubeCode 从 formUuid 格式（连字符）转换为报表 cubeCode 格式（下划线）
+  charts.forEach((chart) => {
+    if (chart.cubeCode) {
+      chart.cubeCode = normalizeCubeCode(chart.cubeCode);
+    }
+  });
 
   const usedComponentNames = new Set(BASE_COMPONENTS);
   charts.forEach((chart) => {

--- a/lib/report/constants.js
+++ b/lib/report/constants.js
@@ -49,10 +49,89 @@ function genFieldId(componentName) {
   return componentName + '_' + randomId();
 }
 
+// ── 基础组件列表 ──────────────────────────────────────
+
+const BASE_COMPONENTS = [
+  'Page', 'RootHeader', 'RootContent', 'RootFooter',
+  'YoushuPageHeader', 'PageHeaderContent', 'PageHeaderTab',
+];
+
+// ── 字段类型推断 ──────────────────────────────────────
+
+/**
+ * 根据字段类型推断正确的 dataType。
+ *
+ * @param {string} fieldType - 字段类型，如 SelectField、EmployeeField 等
+ * @param {string} [explicitDataType] - 显式指定的 dataType，如果提供则优先使用
+ * @returns {string} 推断出的 dataType
+ */
+function inferDataType(fieldType, explicitDataType) {
+  if (explicitDataType) {
+    return explicitDataType;
+  }
+
+  switch (fieldType) {
+    case 'EmployeeField':
+    case 'DepartmentSelectField':
+    case 'MultiSelectField':
+    case 'CheckboxField':
+      return 'ARRAY';
+    case 'DateField':
+    case 'CascadeDateField':
+      return 'DATE';
+    case 'NumberField':
+    case 'RateField':
+      return 'DOUBLE';
+    case 'TextField':
+    case 'TextareaField':
+    case 'SelectField':
+    case 'RadioField':
+    default:
+      return 'STRING';
+  }
+}
+
+// ── 筛选器字段后缀推导 ───────────────────────────────
+
+/**
+ * 推导筛选项实际使用的 fieldCode。
+ *
+ * 需要加 _value 后缀的字段类型（数组格式存储值的组件）：
+ * - SelectField / MultiSelectField / RadioField / CheckboxField
+ * - EmployeeField / DepartmentSelectField
+ *
+ * @param {string} fieldId - 字段 ID，如 selectField_xxx
+ * @param {string} [fieldType] - 可选的字段类型
+ * @returns {string} 实际使用的 fieldCode
+ */
+function deriveFilterFieldCode(fieldId, fieldType) {
+  const valueFieldTypes = [
+    'SelectField', 'MultiSelectField', 'RadioField', 'CheckboxField',
+    'EmployeeField', 'DepartmentSelectField',
+  ];
+
+  if (fieldType) {
+    if (valueFieldTypes.includes(fieldType)) {
+      return fieldId + '_value';
+    }
+    return fieldId;
+  }
+
+  if (fieldId.startsWith('selectField_') || fieldId.startsWith('multiSelectField_') ||
+      fieldId.startsWith('radioField_') || fieldId.startsWith('checkboxField_') ||
+      fieldId.startsWith('employeeField_') || fieldId.startsWith('departmentSelectField_')) {
+    return fieldId + '_value';
+  }
+  return fieldId;
+}
+
 module.exports = {
   CHART_COMPONENT_MAP,
+  BASE_COMPONENTS,
   randomId,
   genNodeId,
   genFieldAlias,
   genFieldId,
+  inferDataType,
+  deriveFilterFieldCode,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "openyida",
-  "version": "2026.03.21",
+  "version": "2026.03.21-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.03.21",
+      "version": "2026.03.21-1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/standalone": "^7.15.1",
+        "@babel/standalone": "^7.29.2",
         "playwright": "^1.40.0",
         "qrcode": "^1.5.4",
         "uglify-js": "^3.19.3"
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "eslint": "^8.50.0",
+        "eslint-plugin-import": "^2.29.1",
         "jest": "^29.0.0"
       },
       "engines": {
@@ -1060,6 +1061,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1168,6 +1176,13 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -1312,6 +1327,154 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-jest": {
@@ -1525,6 +1688,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1717,6 +1930,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1776,6 +2043,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1815,6 +2118,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
@@ -1849,6 +2167,155 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -1926,6 +2393,113 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2270,6 +2844,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2302,6 +2892,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2321,6 +2952,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2329,6 +2985,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2342,6 +3012,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -2408,6 +3096,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2422,6 +3140,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2430,6 +3161,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -2548,12 +3337,111 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -2571,6 +3459,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2579,6 +3502,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2600,6 +3539,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2613,6 +3572,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2623,6 +3608,23 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2631,6 +3633,54 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -2645,6 +3695,110 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3527,6 +4681,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3569,6 +4733,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -3622,6 +4796,103 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3664,6 +4935,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -3882,6 +5171,16 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4072,6 +5371,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4193,6 +5536,61 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4208,6 +5606,55 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4230,6 +5677,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -4297,6 +5820,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -4323,6 +5860,65 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -4438,6 +6034,42 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4474,6 +6106,84 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -4484,6 +6194,25 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici-types": {
@@ -4575,11 +6304,100 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,17 @@
     "postinstall": "node scripts/postinstall.js",
     "contributors": "node scripts/update-contributors.js"
   },
-  "keywords": ["yida", "aliwork", "dingtalk", "cli", "openyida", "low-code", "ai", "qoder", "wukong"],
+  "keywords": [
+    "yida",
+    "aliwork",
+    "dingtalk",
+    "cli",
+    "openyida",
+    "low-code",
+    "ai",
+    "qoder",
+    "wukong"
+  ],
   "author": "OpenYida Contributors",
   "license": "MIT",
   "repository": {
@@ -37,7 +47,7 @@
   },
   "homepage": "https://github.com/openyida/openyida#readme",
   "dependencies": {
-    "@babel/standalone": "^7.15.1",
+    "@babel/standalone": "^7.29.2",
     "playwright": "^1.40.0",
     "qrcode": "^1.5.4",
     "uglify-js": "^3.19.3"

--- a/yida-skills/reference/vc-yida-report-components-doc.md
+++ b/yida-skills/reference/vc-yida-report-components-doc.md
@@ -1,0 +1,615 @@
+# vc-yida-report 图表组件使用文档
+
+> 组件库地址：`//g.alicdn.com/code/npm/@ali/vc-yida-report/1.0.101/pc.js`  
+> 全局挂载：`window.YidaReport`  
+> 架构说明：图表组件采用懒加载（dynamic import）架构，各图表 chunk 按需加载。
+
+---
+
+## 组件总览
+
+| 组件名 | 中文名 | 类型 |
+|---|---|---|
+| `YoushuSimpleIndicatorCard` | 指标卡 | 内联组件 |
+| `YoushuCrossPivotTable` | 交叉透视表 | 懒加载 |
+| `YoushuCalendarHeatmap` | 日历热力图 | 懒加载 |
+| `YoushuComboChart` | 组合图 | 懒加载 |
+| `YoushuFunnelChart` | 漏斗图 | 懒加载 |
+| `YoushuGauge` | 仪表盘 | 懒加载 |
+| `YoushuGroupedBarChart` | 分组条形图 | 懒加载 |
+| `YoushuHeatmap` | 热力图 | 懒加载 |
+| `YoushuLineChart` | 折线图 | 懒加载 |
+| `YoushuPieChart` | 饼图 | 懒加载 |
+| `YoushuRadarChart` | 雷达图 | 懒加载 |
+| `YoushuWordCloud` | 词云图 | 懒加载 |
+| `YoushuMap` | 地图 | 懒加载 |
+| `YoushuTopFilterContainer` | 顶部筛选容器 | 内联组件 |
+| `DateField2` | 日期筛选器 | 内联组件 |
+| `CascadeDateField2` | 级联日期筛选器 | 内联组件 |
+
+---
+
+## 通用说明
+
+### 数据模型（youshuData）
+
+所有图表组件均通过 `youshuData` prop 接收数据，数据模型包含以下核心方法：
+
+| 方法/属性 | 说明 |
+|---|---|
+| `youshuData.data` | 数据数组，`data[0]` 为当前行数据 |
+| `youshuData.originData` | 原始数据数组 |
+| `youshuData.getFields(type)` | 获取指定类型字段列表，如 `getFields('kpi')` |
+| `youshuData.getFieldTitle(fieldKey)` | 根据 fieldKey 获取字段显示名称 |
+| `youshuData.handleDataLinkClick(fieldKey, rowData)` | 触发数据链接跳转 |
+
+### 数据链接（dataLink）
+
+字段配置中可包含 `dataLink` 对象：
+
+```json
+{
+  "dataLink": {
+    "type": "URL",
+    "url": "https://example.com"
+  }
+}
+```
+
+`type` 为 `"NONE"` 时不启用数据链接。
+
+### 通用 settings 字段
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `title` | `string` | 组件标题 |
+| `height` | `number/string` | 组件高度 |
+| `colorType` | `string` | 颜色类型 |
+| `customColor` | `string[]` | 自定义颜色数组 |
+| `drillDown` | `boolean` | 是否开启下钻 |
+| `limit` | `number` | 数据条数限制 |
+| `percent` | `boolean` | 是否显示百分比 |
+
+---
+
+## 1. YoushuSimpleIndicatorCard — 指标卡
+
+展示 KPI 指标数据，支持多指标并排展示，适合数据大屏的核心指标展示场景。
+
+### Props
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `youshuData` | `object` | — | 数据模型对象（必填） |
+| `settings` | `object` | `{}` | 组件配置项 |
+| `settings.columnCount` | `number` | — | PC 端每行显示的指标数量 |
+| `settings.columnCountForH5` | `number` | `2` | 移动端每行显示的指标数量 |
+| `userSelectedFields` | `string[]` | — | 用户手动选择的字段 key 列表 |
+| `enableFieldSelect` | `boolean` | `false` | 是否开启字段选择功能 |
+| `_leaf` | `object` | — | 页面引擎叶子节点，用于判断模拟器设备类型 |
+| `dataSetModelMap` | `object` | — | 数据集模型映射，包含 `kpi` 字段图标配置 |
+
+### 数据字段结构（kpi 类型）
+
+每个 KPI 字段对象包含以下属性：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `fieldKey` | `string` | 字段唯一标识 |
+| `dataLink` | `object` | 数据链接配置 |
+| `titleTip` | `string` | 标题提示文字 |
+| `unit` | `string` | 数值单位（如：万、百万） |
+| `desc` | `string` | 指标描述 |
+| `icon` | `string` | 图标标识 |
+| `hoverRef` | `string` | 悬停显示的参考值字段 |
+| `hoverTitle` | `string` | 悬停显示的标题 |
+
+### 渲染数据结构（getData 返回值）
+
+```js
+[
+  {
+    title: "指标名称",
+    type: "NORMAL",           // 指标类型
+    value: 12345,             // 指标值
+    onValueLinkClick: null,   // 数据链接点击回调（无链接时为 null）
+    tooltip: {
+      show: false,            // 是否显示 tooltip
+      reference: "参考值"     // tooltip 内容
+    },
+    hideMinus: false,         // 是否隐藏负号
+    titleTip: "提示文字",
+    unit: "万",
+    desc: "描述文字"
+  }
+]
+```
+
+### 使用示例
+
+```jsx
+<YoushuSimpleIndicatorCard
+  youshuData={youshuData}
+  settings={{
+    columnCount: 4,
+    columnCountForH5: 2
+  }}
+  enableFieldSelect={false}
+/>
+```
+
+---
+
+## 2. YoushuCrossPivotTable — 交叉透视表
+
+多维度交叉分析表格，支持行列维度自由组合，适合复杂数据的多维分析场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 表格标题 |
+| `settings.height` | `number` | 表格高度 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+
+### 特性
+
+- 支持行维度、列维度、度量值的自由配置
+- 支持数据下钻
+- 支持导出为 Excel
+- 支持固定表头
+
+---
+
+## 3. YoushuCalendarHeatmap — 日历热力图
+
+以日历形式展示时间序列数据的热力分布，适合展示按日期分布的数据密度。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 热力颜色区间数组（从低到高） |
+
+### 特性
+
+- 以月/年为单位展示日历格子
+- 颜色深浅代表数值大小
+- 支持 tooltip 悬停查看具体数值
+
+---
+
+## 4. YoushuComboChart — 组合图
+
+将柱状图与折线图组合展示，适合同时展示数量和趋势的场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 系列颜色数组 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 数据条数限制 |
+
+### 特性
+
+- 左右双 Y 轴支持
+- 柱状图与折线图自由组合
+- 支持数据下钻与联动
+
+---
+
+## 5. YoushuFunnelChart — 漏斗图
+
+展示流程各阶段的转化率，适合销售漏斗、用户转化等场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 各阶段颜色数组 |
+| `settings.percent` | `boolean` | 是否显示转化率百分比 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 数据条数限制 |
+
+### 特性
+
+- 支持转化率标注
+- 支持自定义颜色
+- 支持 tooltip 悬停
+
+---
+
+## 6. YoushuGauge — 仪表盘
+
+以仪表盘形式展示单一指标的完成进度，适合 KPI 达成率等场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.min` | `number` | 最小值（默认 0） |
+| `settings.max` | `number` | 最大值（默认 100） |
+| `settings.range` | `number[]` | 区间范围配置 |
+| `settings.color` | `string[]` | 区间颜色数组 |
+| `settings.format` | `string` | 数值格式化 |
+
+### 特性
+
+- 支持自定义最大最小值
+- 支持多色区间（红/黄/绿）
+- 支持数值格式化显示
+
+---
+
+## 7. YoushuGroupedBarChart — 分组条形图
+
+横向分组条形图，适合多维度对比分析场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 系列颜色数组 |
+| `settings.isStack` | `boolean` | 是否堆叠显示 |
+| `settings.isPercent` | `boolean` | 是否百分比堆叠 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 数据条数限制 |
+| `settings.showLabel` | `boolean` | 是否显示数据标签 |
+
+### 特性
+
+- 支持分组/堆叠/百分比堆叠三种模式
+- 支持数据下钻
+- 横向布局，适合长标签场景
+
+---
+
+## 8. YoushuHeatmap — 热力图
+
+二维矩阵热力图，适合展示两个维度交叉的数值分布。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 热力颜色区间（从低到高） |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+
+### 特性
+
+- X 轴、Y 轴各取一个维度
+- 颜色深浅代表数值大小
+- 支持 tooltip 悬停查看具体值
+
+---
+
+## 9. YoushuLineChart — 折线图
+
+展示数据随时间或类别的变化趋势，适合时序数据分析。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 系列颜色数组 |
+| `settings.smooth` | `boolean` | 是否平滑曲线 |
+| `settings.isStack` | `boolean` | 是否面积堆叠 |
+| `settings.isPercent` | `boolean` | 是否百分比堆叠 |
+| `settings.showLabel` | `boolean` | 是否显示数据标签 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 数据条数限制 |
+| `settings.lineWidth` | `number` | 线条宽度 |
+
+### 特性
+
+- 支持多系列折线
+- 支持平滑曲线/折线切换
+- 支持面积图模式
+- 支持数据下钻与联动
+
+---
+
+## 10. YoushuPieChart — 饼图
+
+展示各部分占整体的比例关系，支持饼图和环形图两种形态。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 各扇区颜色数组 |
+| `settings.innerRadius` | `number` | 内半径比例（0~1），大于 0 时为环形图 |
+| `settings.startAngle` | `number` | 起始角度（弧度） |
+| `settings.endAngle` | `number` | 结束角度（弧度） |
+| `settings.percent` | `boolean` | 是否显示百分比标签 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 数据条数限制 |
+
+### 特性
+
+- 支持饼图/环形图切换（通过 `innerRadius` 控制）
+- 支持自定义起止角度（半圆饼图等）
+- 支持 statistic 中心文字（环形图）
+- 支持数据下钻
+
+---
+
+## 11. YoushuRadarChart — 雷达图
+
+多维度能力评估图，适合展示多个维度的综合评分。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 系列颜色数组 |
+| `settings.max` | `number` | 各维度最大值 |
+| `settings.opacity` | `number` | 填充区域透明度（0~1） |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+
+### 特性
+
+- 支持多系列对比
+- 支持自定义各维度最大值
+- 支持填充区域透明度调节
+
+---
+
+## 12. YoushuWordCloud — 词云图
+
+以词云形式展示文本频率分布，适合关键词分析、舆情分析等场景。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 词语颜色数组 |
+| `settings.drillDown` | `boolean` | 是否开启下钻 |
+| `settings.limit` | `number` | 显示词语数量限制 |
+
+### 特性
+
+- 词语大小代表频率/权重
+- 支持自定义颜色池
+- 支持点击下钻
+
+---
+
+## 13. YoushuMap — 地图
+
+地理数据可视化，支持省市区域着色，适合地域分布分析。
+
+### Props
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `youshuData` | `object` | 数据模型对象（必填） |
+| `settings` | `object` | 组件配置项 |
+| `settings.title` | `string` | 图表标题 |
+| `settings.height` | `number` | 图表高度 |
+| `settings.color` | `string[]` | 区域颜色区间（从低到高） |
+| `settings.drillDown` | `boolean` | 是否开启省市下钻 |
+
+### 特性
+
+- 支持全国/省级地图
+- 颜色深浅代表数值大小
+- 支持省市下钻
+- 支持 tooltip 悬停
+
+---
+
+## 14. YoushuTopFilterContainer — 顶部筛选容器
+
+页面级筛选器容器，管理多个筛选组件的联动与状态。
+
+### Props
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `componentId` | `string` | `null` | 组件唯一标识 |
+| `style` | `object` | `null` | 容器样式 |
+| `children` | `node` | — | 子筛选组件 |
+| `config` | `array` | `[]` | 筛选配置数组 |
+| `context` | `object` | — | 页面上下文 |
+| `showTag` | `boolean` | `false` | 是否显示已选筛选标签 |
+| `onFilterChange` | `function` | `() => {}` | 筛选值变化回调 |
+
+### config 数组项结构
+
+```js
+[
+  {
+    componentId: "filter_001",     // 筛选组件 ID
+    settings: {
+      labelConfig: {
+        label: "部门"              // 筛选标签名
+      },
+      mode: "single"              // 选择模式：single / multiple
+    },
+    dataSetModelMap: {
+      "dataset_001": {
+        valueField: ["dept_id"],   // 值字段
+        labelField: ["dept_name"], // 显示字段
+        cubeCodes: ["cube_001"]    // 数据集编码
+      }
+    }
+  }
+]
+```
+
+### onFilterChange 回调参数
+
+```js
+onFilterChange((filterValues) => {
+  // filterValues: { [componentId]: value }
+  console.log(filterValues);
+})
+```
+
+---
+
+## 16. DateField2 — 日期筛选器
+
+日期范围选择筛选组件，支持多种日期格式和快捷选项。
+
+### Props
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `returnType` | `'string' \| 'timestamp' \| 'dayjs'` | `'string'` | 返回值类型 |
+| `format` | `string` | — | 日期格式，如 `'YYYY-MM-DD'` |
+| `hasClear` | `boolean` | — | 是否显示清除按钮 |
+| `visible` | `boolean` | — | 受控显示/隐藏 |
+| `defaultVisible` | `boolean` | — | 默认是否显示 |
+| `onVisibleChange` | `function` | — | 显示状态变化回调 |
+| `disabledDate` | `function \| object` | — | 禁用日期配置 |
+| `resetTime` | `boolean` | — | 是否重置时间部分 |
+| `defaultPanelValue` | `function` | — | 默认面板日期 |
+| `onVisibleMonthChange` | `function` | — | 月份切换回调 |
+| `defaultVisibleYear` | `function` | — | 默认显示年份 |
+| `popupTriggerType` | `'click' \| 'hover'` | `'click'` | 弹出触发方式 |
+| `popupAlign` | `string` | — | 弹出对齐方式 |
+| `popupContainer` | `string \| function` | — | 弹出容器 |
+| `popupStyle` | `object` | — | 弹出层样式 |
+| `popupClassName` | `string` | — | 弹出层类名 |
+| `popupProps` | `object` | — | 弹出层额外属性 |
+| `followTrigger` | `boolean` | — | 弹出层是否跟随触发元素 |
+| `inputProps` | `object` | — | 输入框属性 |
+| `dateCellRender` | `function` | — | 自定义日期格子渲染 |
+| `monthCellRender` | `function` | — | 自定义月份格子渲染 |
+| `yearCellRender` | `function` | — | 自定义年份格子渲染 |
+| `onOk` | `function` | — | 确认按钮回调 |
+| `extraFooterRender` | `function` | — | 底部额外内容渲染 |
+
+### 内置快捷选项
+
+- 今天
+- 本月至今
+- 最近 3 天
+- 最近 7 天
+- 最近 30 天
+- 当前项
+
+### 使用示例
+
+```jsx
+<DateField2
+  returnType="string"
+  format="YYYY-MM-DD"
+  hasClear={true}
+  onOk={(value) => {
+    console.log('选中日期:', value);
+  }}
+/>
+```
+
+---
+
+## 16. CascadeDateField2 — 级联日期筛选器
+
+支持开始/结束日期级联选择的日期范围筛选组件，Props 与 `DateField2` 基本一致，额外支持日期范围联动校验。
+
+---
+
+## 通用交互特性
+
+### 数据下钻（drillDown）
+
+当 `settings.drillDown = true` 时，点击图表元素可下钻到下一层级数据。
+
+### 图表联动（linkage）
+
+多个图表组件可通过 `YoushuTopFilterContainer` 实现联动筛选，点击一个图表的数据点，其他图表自动过滤展示相关数据。
+
+### 导出功能
+
+所有图表组件支持：
+- **复制为图片**：将图表复制到剪贴板
+- **导出数据**：导出为 Excel 文件（需配置导出权限）
+
+### 演示模式
+
+页面支持演示模式（`settings.演示模式`），在演示模式下隐藏敏感数据。
+
+### 自动刷新
+
+通过 `settings.refreshInterval` 配置自动刷新间隔（毫秒），实现数据实时更新。
+
+### 暗色主题
+
+通过 `settings.colorType` 配置颜色主题，支持以下暗色系：
+- `dark-color-1` 至 `dark-color-7`
+
+---
+
+## 错误处理
+
+所有组件内置错误边界，当组件渲染异常时显示：
+
+> 组件渲染异常，请查看控制台日志
+
+同时支持：
+- **进入调试**：打开调试面板
+- **异常上报**：上报错误信息
+
+---
+
+## 数据为空时的展示
+
+当数据源无数据时，所有图表组件统一显示：
+
+> 暂无数据
+
+---
+
+## 加载状态
+
+数据加载中时，所有图表组件统一显示：
+
+> 加载中...
+
+并提供 **刷新** 按钮供手动重试。

--- a/yida-skills/skills/yida-chart/SKILL.md
+++ b/yida-skills/skills/yida-chart/SKILL.md
@@ -1,0 +1,1525 @@
+---
+name: yida-chart
+description: >-
+  宜搭 ECharts 高级报表技能。通过 ECharts + 自定义页面 JSX 实现高度定制化、更美观的数据可视化报表。本技能不负责创建宜搭原生报表（标准报表由 yida-report 技能负责），但 ECharts 报表必须依赖宜搭原生报表的 getDataAsync.json 或 getCacheData.json 接口获取聚合数据，禁止前端聚合（当前仅支持单表数据源，暂不支持多表关联）。数据源获取方式：若用户已有原生报表，直接读取其信息作为数据源；若用户没有原生报表，则先调用 yida-report 技能创建原生报表作为数据源。当用户提供了已有报表 URL（如 https://www.aliwork.com/APP_XXX/admin/REPORT-XXX）时，解析现有报表 Schema 提取数据源参数，基于该数据源创建 ECharts 自定义页面（输出始终是 ECharts 自定义页面，而非优化后的原生报表）。当用户提到"更美观"、"高级"、"定制化"、"ECharts"、"echarts"、"Dashboard 大屏"、"数据大屏"等关键词，或用户提供了报表 URL 要求优化时，使用此技能。普通的"报表"、"统计"等需求默认由 yida-report 技能处理。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+  - qoder
+  - wukong
+metadata:
+  audience: developers
+  workflow: yida-development
+  version: 3.0.0
+  tags:
+    - yida
+    - low-code
+    - chart
+    - echarts
+    - report
+    - visualization
+    - vc-yida-report
+    - table
+    - filter
+---
+
+# 宜搭 ECharts 高级报表技能
+
+## 概述
+
+本技能负责通过 **ECharts + 自定义页面 JSX** 实现高度定制化的数据可视化报表。本技能**不负责创建宜搭原生报表**（标准报表由 `yida-report` 技能负责），但 ECharts 报表依赖原生报表的 `getDataAsync.json` 接口作为数据源。
+
+| 方案 | 技术栈 | 适用场景 | 数据源 |
+|------|--------|---------|--------|
+| **方案 A：ECharts 高级报表**（从头创建） | ECharts + 自定义页面 JSX | 高度定制化图表、复杂交互、更美观的视觉效果 | 用户无原生报表 → 调用 `yida-report` 新建；用户已有 → 直接复用 |
+| **方案 B：基于已有报表创建 ECharts 页面** | 解析现有报表 Schema + ECharts 自定义页面 | 用户已有原生报表，希望用 ECharts 实现更美观的展示 | 用户提供的报表 URL 中的原生报表作为数据源 |
+
+> 💡 **与 yida-report 的分工**：普通的"报表"、"统计"需求默认由 `yida-report` 技能处理。只有当用户明确要求"更美观"、"高级"、"定制化"、"ECharts"，或提供了报表 URL 要求用 ECharts 优化时，才使用本技能。
+
+---
+
+## ⚠️ 核心规则（必须遵守）
+
+### 1. 方案选择规则
+
+```
+场景 A: 用户提供了已有报表 URL（如 https://www.aliwork.com/APP_XXX/admin/REPORT-XXX）
+  → 使用【方案 C：基于已有报表创建 ECharts 页面】
+  → 从 URL 中解析 appType 和 formUuid，获取现有 Schema 作为数据源
+  → 最终输出：ECharts 自定义页面（非优化后的原生报表）
+
+场景 B: 用户未提供报表 URL，从头创建 ECharts 高级报表
+  → 使用【方案 B：ECharts 高级报表】
+  → 数据源获取：
+    - 用户已有原生报表 → 直接读取已有报表信息作为数据源
+    - 用户没有原生报表 → 先调用【yida-report 技能】创建原生报表作为数据源
+  → 最终输出：ECharts 自定义页面
+```
+
+> ⚠️ **注意**：本技能的所有方案最终输出都是 **ECharts 自定义页面**。如果用户只需要标准原生报表（无 ECharts 定制需求），应直接使用 `yida-report` 技能。
+
+### 2. `cid` 与 `fieldId` 的区分（易混淆，必须注意）
+
+报表 Schema 中有两种 ID，**绝对不能混用**：
+
+| 名称 | 格式 | 用途 | 示例 |
+|------|------|------|------|
+| **`cid`** | `node_xxx` | `getDataAsync.json` 的请求参数 | `node_oc8u7tmwt95z55` |
+| **`fieldId`** | `YoushuXxx_xxx` | Schema 中组件的标识符，不能用于 API 请求 | `YoushuSimpleIndicatorCard_5rugy68y` |
+
+**获取 `cid` 的方法**：执行 `openyida get-schema <appType> <reportFormUuid>`，在 `componentsTree` 中找到目标组件节点，其 `id` 字段即为 `cid`（`node_xxx` 格式）。
+
+### 3. ECharts 高级报表必须依赖原生报表
+
+**ECharts 高级报表的数据来源必须是宜搭原生报表的接口**，禁止前端聚合。
+
+```
+【ECharts 高级报表创建流程】
+
+Step 1: 分析报表需求，确定需要哪些图表、指标
+    ↓
+Step 2: 调用【yida-report 技能】创建宜搭原生报表页面
+    ↓  （由 yida-report 负责配置图表组件，生成 getDataAsync.json / getCacheData.json 数据接口）
+    ↓
+Step 3: 从原生报表 Schema 中提取 getDataAsync.json 所需的关键参数
+    ↓  （通过 openyida get-schema 获取，解析 cubeCode、cid、componentClassName 等）
+    ↓
+Step 4: 在宜搭管理后台将原生报表页面设置为【双端隐藏】
+    ↓  （PC 端和移动端均不显示在导航中，需手动操作或通过管理接口）
+    ↓
+Step 5: 创建【ECharts 自定义页面】，通过原生报表接口获取聚合数据
+    ↓
+Step 6: 记录关联关系到 .cache/<项目名>-report-bindding.json
+```
+
+### 4. 原生报表与 ECharts 报表的关联关系
+
+两种报表**高度耦合**，必须记录关联关系并同步更新：
+
+**关联关系存储**：`.cache/<项目名>-report-bindding.json`
+
+```json
+{
+  "binddings": [
+    {
+      "echartsPageUuid": "FORM-ECHARTS-XXX",
+      "echartsPageName": "销售数据大屏",
+      "nativeReportUuid": "REPORT-NATIVE-XXX",
+      "nativeReportName": "销售数据报表（数据源）",
+      "bindingTime": "2024-01-15T10:30:00Z",
+      "components": [
+        {
+          "echartsChartId": "chart-sales-trend",
+          "nativeComponentCid": "node_ocmmwwwhdmg",
+          "nativeComponentName": "折线图_销售趋势",
+          "nativeComponentType": "YoushuLineChart"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 5. 报表更新规则
+
+**后续报表需求变化时，必须同步更新两个页面**：
+
+```
+【报表更新流程】
+
+Step 1: 读取 .cache/<项目名>-report-bindding.json 获取关联关系
+    ↓
+Step 2: 调用【yida-report 技能】更新原生报表的 Schema
+    ↓  （修改图表配置、字段定义等，由 yida-report 负责）
+    ↓
+Step 3: 调用 saveFormSchema.json 更新【ECharts 页面】的代码
+    ↓  （同步修改图表渲染逻辑）
+    ↓
+Step 4: 更新 .cache/<项目名>-report-bindding.json 中的组件映射（如有变化）
+```
+
+> ⚠️ **禁止**：为新需求创建新的页面关系，必须在已有的关联页面上更新
+
+### 6. 原生报表页面隐藏规则
+
+一旦创建了 ECharts 高级报表，对应的原生报表页面必须**双端隐藏**：
+
+隐藏方式：在宜搭应用管理后台 → 页面导航设置中，将原生报表页面的 PC 端和移动端可见性均设置为隐藏。
+
+或通过 updateFormNavigation.json 接口（需在服务端/CLI 环境中调用，非自定义页面前端代码）：
+  - formUuid: 原生报表页面 UUID
+  - pcVisible: false
+  - mobileVisible: false
+
+### 7. 开发者态与用户态的展示规则
+
+| 视角 | 原生报表页面 | ECharts 报表页面 | 关联关系 |
+|------|-------------|-----------------|---------|
+| **用户态**（普通用户） | 隐藏 | 显示 | 隐藏 |
+| **管理态**（开发者/管理员） | 显示（标注为"数据源"） | 显示 | 显示在 ECharts 页面配置中 |
+
+**ECharts 页面管理态展示**：
+- 在页面配置或代码注释中明确标注数据来源的原生报表
+- 格式：`/* 数据源报表: REPORT-NATIVE-XXX (销售数据报表) */`
+
+---
+
+## 核心原则
+
+1. **聚合统计禁止前端聚合**：必须通过 `getDataAsync.json` 或 `getCacheData.json` 接口由服务端完成，详见上方核心规则第 2 节
+2. **安全引用**：通过 `this.utils.loadScript()` 从可信 CDN 动态加载 ECharts，禁止内联大段脚本
+3. **遵循自定义页面规范**：所有代码必须遵循 `yida-custom-page` 的开发规范
+
+## 何时使用
+
+当用户提出以下需求时使用此技能：
+- 创建数据报表、统计图表（柱状图、折线图、饼图等）
+- 基于表单数据做数据可视化分析
+- 搭建数据看板 / Dashboard
+- 需要对表单数据进行聚合统计并图形化展示
+- **优化已有报表**（用户提供了报表 URL）
+
+**方案选择**：
+- **用户提供了已有报表 URL** → 使用【方案 C：基于已有报表创建 ECharts 页面】，以已有报表为数据源，输出 ECharts 自定义页面
+- **用户未提供报表 URL** → 使用【方案 B：ECharts 高级报表】，若用户无原生报表则先调用 yida-report 创建数据源
+- **用户只需要标准报表**（无 ECharts 定制需求）→ 不使用本技能，直接使用 `yida-report` 技能
+
+---
+
+## 前置依赖
+
+- 必须先加载 **`yida-custom-page`** 技能，遵循其编码规范
+- ECharts 高级报表需要依赖 **`yida-report`** 技能创建原生报表作为数据源（yida-chart 本身不包含原生报表的创建逻辑）
+- 需要已创建好数据源表单（通过 `yida-create-form-page` 创建）
+- 需要知道数据源表单的 `formUuid` 和字段 `fieldId`（通过 `yida-get-schema` 获取）
+
+---
+
+## ECharts 安全引入方案
+
+### 可信 CDN 地址（按优先级排序）
+
+| CDN | URL | 说明 |
+|-----|-----|------|
+| **阿里 CDN**（推荐） | `https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js` | 阿里内网外网均可访问，速度最快 |
+| **cdnjs** | `https://cdnjs.cloudflare.com/ajax/libs/echarts/5.6.0/echarts.min.js` | 国际通用，Cloudflare 托管 |
+| **jsDelivr** | `https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js` | npm 镜像，全球加速 |
+
+### 中国地图 GeoJSON 数据源
+
+ECharts 5 不再内置中国地图数据，需要额外加载 GeoJSON 并通过 `echarts.registerMap('china', geoJson)` 注册。
+
+| 数据源 | URL | 说明 |
+|--------|-----|------|
+| **阿里云 DataV**（推荐） | `https://geo.datav.aliyun.com/areas_v3/bound/100000_full.json` | 阿里云公开数据服务，地图数据权威合规 |
+
+```javascript
+// 加载中国地图 GeoJSON 并注册
+fetch('https://geo.datav.aliyun.com/areas_v3/bound/100000_full.json')
+  .then(function(response) { return response.json(); })
+  .then(function(geoJson) {
+    window.echarts.registerMap('china', geoJson);
+    // 注册完成后即可使用 type: 'map', map: 'china'
+  });
+```
+
+> ⚠️ **地图安全要求**：
+> - **必须**使用阿里云 DataV 提供的官方 GeoJSON 数据，确保地图边界合规
+> - 省份名称需使用全称（如"北京市"、"广东省"、"内蒙古自治区"），与 GeoJSON 中的 `name` 字段匹配
+> - 示例中提供了 `normalizeProvinceName()` 函数，自动将简称转换为全称
+
+> ⚠️ **安全要求**：
+> - **必须**使用上述可信 CDN 之一，**禁止**使用来源不明的第三方 URL
+> - **必须**锁定版本号（如 `5.6.0`），**禁止**使用 `latest` 或不带版本的 URL
+> - **推荐**优先使用阿里 CDN（`g.alicdn.com`），在宜搭环境中加载速度最快
+
+### 加载方式
+
+使用宜搭内置的 `this.utils.loadScript()` 动态加载，在 `didMount` 中执行：
+
+```javascript
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+
+export function didMount() {
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      // ECharts 加载完成，初始化图表
+      this.bindChartResize();
+      this.loadChartData();
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+    }.bind(this));
+}
+```
+
+### 防重复加载
+
+如果页面有多个图表，ECharts 只需加载一次：
+
+```javascript
+export function loadECharts() {
+  if (window.echarts) {
+    // 已加载，直接初始化
+    this.initCharts();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.initCharts();
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: 'ECharts 加载失败', type: 'error' });
+    }.bind(this));
+}
+```
+
+---
+
+## ⚠️ ECharts 页面代码必备结构（必须遵守）
+
+> 以下是 ECharts 自定义页面代码的**必备结构清单**，缺少任何一项都会导致页面运行失败。生成代码前必须逐项检查。
+
+### 必备函数清单
+
+| 函数 | 类型 | 作用 | 缺少后果 |
+|------|------|------|---------|
+| `_customState` | `var` 变量 | 存储所有业务状态（loading、数据等） | 无法管理页面状态 |
+| `getCustomState` | `export function` | 获取状态 | 编译警告 |
+| `setCustomState` | `export function` | 设置状态并触发重渲染 | `setCustomState is not a function` |
+| `forceUpdate` | `export function` | 通过 `this.setState({ timestamp })` 触发 React 重渲染 | `forceUpdate is not a function` |
+| `didMount` | `export function` | 页面加载完成时初始化 | 页面无法初始化 |
+| `didUnmount` | `export function` | 页面卸载时清理资源 | 内存泄漏 |
+| `renderJsx` | `export function` | 页面渲染入口 | 页面空白 |
+
+### 必备代码模板
+
+```javascript
+// ── 状态管理（必须包含） ──────────────────────────────
+
+var _customState = {
+  loading: true,
+  // ... 其他业务状态
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.assign(_customState, newState);
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+```
+
+### renderJsx 的 timestamp 隐藏 div（必须包含）
+
+> ⚠️ **`renderJsx` 的每个 `return` 分支都必须包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`**，否则 `forceUpdate` 调用 `this.setState({ timestamp })` 后，React 无法检测到输出变化，页面将无法更新。
+
+```javascript
+export function renderJsx() {
+  // loading 分支 —— 也必须包含 timestamp div
+  if (_customState.loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{this.state.timestamp}</div>
+        <div>加载中...</div>
+      </div>
+    );
+  }
+
+  // 正常渲染分支 —— 必须包含 timestamp div
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{this.state.timestamp}</div>
+      {/* 页面内容 */}
+    </div>
+  );
+}
+```
+
+### CDN 地址规则（必须遵守）
+
+| 规则 | 说明 |
+|------|------|
+| **必须使用阿里 CDN** | `https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js` |
+| **禁止使用 cdnjs.cloudflare.com** | 宜搭环境（aliwork.com）对 cloudflare CDN 有安全策略限制，会加载失败 |
+| **必须锁定版本 5.6.0** | 禁止使用 `latest` 或其他未验证版本 |
+
+### 函数声明规则
+
+| 场景 | 正确写法 | 错误写法 | 原因 |
+|------|---------|---------|------|
+| 需要 `this` 的组件方法 | `export function loadAllData() {}` | `var loadAllData = function() {}` | 需要宜搭运行时绑定 `this` |
+| 不需要 `this` 的纯工具函数 | `var _fetchData = function() {}` | `export function fetchData() {}` | `export function` 不在白名单中会被 UglifyJS 消除 |
+| 模块级常量/变量 | `var APP_TYPE = 'xxx'` | `const APP_TYPE = 'xxx'` | 兼容性 |
+
+### prdId（topicId）动态获取（必须遵守）
+
+> ⚠️ **`prdId` 不能硬编码**，必须在运行时通过 `getFormNavigationListByOrder` 接口动态获取。
+
+```javascript
+var _prdId = null;
+
+var _fetchPrdId = function () {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var baseUrl = window.location.origin;
+  var url = baseUrl + '/dingtalk/web/' + appType
+    + '/query/formnav/getFormNavigationListByOrder.json'
+    + '?_api=Nav.queryList&_mock=false&_csrf_token=' + encodeURIComponent(csrfToken);
+
+  return fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    headers: { 'accept': 'application/json', 'x-requested-with': 'XMLHttpRequest' },
+  })
+    .then(function (resp) { return resp.json(); })
+    .then(function (res) {
+      if (res.success && Array.isArray(res.content)) {
+        // 优先精确匹配指定的 REPORT_FORM_UUID
+        var targetNav = res.content.find(function (item) { return item.formUuid === REPORT_FORM_UUID; });
+        if (targetNav && targetNav.topicId) {
+          _prdId = targetNav.topicId;
+          return _prdId;
+        }
+        // 兜底：取第一个 formType=report 且有 topicId 的条目
+        var reportNav = res.content.find(function (item) { return item.formType === 'report' && item.topicId; });
+        if (reportNav) {
+          _prdId = reportNav.topicId;
+          return _prdId;
+        }
+        throw new Error('未找到报表的 topicId');
+      }
+      throw new Error(res.errorMsg || '获取导航菜单失败');
+    });
+};
+```
+
+### 报表数据请求函数模板（必须用 var 声明）
+
+```javascript
+var _fetchReportData = function (component, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: _prdId,
+    pageId: REPORT_FORM_UUID,
+    pageName: 'report',
+    cid: component.cid,
+    cname: component.cname || '',
+    componentClassName: component.className,
+    queryContext: JSON.stringify({ filterValueMap: filterValueMap || {}, dim2table: true }),
+    dataSetKey: component.dataSetKey,
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json';
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    credentials: 'include',
+  })
+    .then(function (r) { return r.json(); })
+    .then(function (result) {
+      if (result.success) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+```
+
+### didMount 初始化流程模板
+
+```javascript
+export function didMount() {
+  var self = this;
+  // 1. 加载 ECharts + 获取 prdId 并行执行
+  var loadEcharts = new Promise(function (resolve, reject) {
+    if (window.echarts) { resolve(); return; }
+    var script = document.createElement('script');
+    script.src = ECHARTS_CDN;
+    script.onload = function () { resolve(); };
+    script.onerror = function () { reject(new Error('ECharts 加载失败')); };
+    document.head.appendChild(script);
+  });
+
+  Promise.all([loadEcharts, _fetchPrdId()])
+    .then(function () { return self.loadAllData(); })
+    .catch(function (err) {
+      console.error('[看板] 初始化失败:', err);
+      self.utils.toast({ title: '初始化失败: ' + err.message, type: 'error' });
+      _customState.loading = false;
+      self.forceUpdate();
+    });
+
+  // 2. 绑定 resize 事件
+  window.addEventListener('resize', function () {
+    // 调用所有 chart 实例的 resize()
+  });
+}
+```
+
+### 生成代码前的自检清单
+
+生成 ECharts 页面代码前，**必须逐项确认**：
+
+- [ ] 包含 `_customState` 变量、`getCustomState`、`setCustomState`、`forceUpdate` 函数
+- [ ] `renderJsx` 的**每个 return 分支**都包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`
+- [ ] CDN 使用 `https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js`
+- [ ] 纯工具函数（`_fetchPrdId`、`_fetchReportData` 等）用 `var` 声明，不用 `export function`
+- [ ] 需要 `this` 的组件方法（`loadAllData`、`renderPieChart` 等）用 `export function`
+- [ ] `prdId` 通过 `getFormNavigationListByOrder` 动态获取，不硬编码
+- [ ] 聚合指标（KPI、饼图、柱状图）通过 `getDataAsync.json` 报表接口获取
+- [ ] 明细表格通过 `searchFormDatas` 获取（返回 `formInstId`，支持详情跳转）
+- [ ] 包含 `didUnmount` 函数，清理 ECharts 实例和 resize 监听
+- [ ] 事件绑定使用箭头函数包裹：`onClick={(e) => { this.xxx(e); }}`
+
+---
+
+## 数据获取方案
+
+> ⚠️ **核心规则**：
+> - **数据明细表**（展示每条记录的详细信息）：使用 `this.utils.yida.searchFormDatas` 获取原始数据
+> - **所有聚合统计**（分组计数、求和、平均、趋势等图表数据）：**必须**通过宜搭原生报表接口（`getDataAsync.json` 或 `getCacheData.json`）实现
+> - **禁止前端聚合**：禁止在浏览器端对 `searchFormDatas` 返回的数据做分组、计数、求和等聚合计算，所有聚合必须由服务端完成
+
+### 方案一：`this.utils.yida.searchFormDatas`（仅用于数据明细表）
+
+**仅适用于**报表中的数据明细表格，展示每条表单记录的原始字段值。**禁止**用于聚合统计场景。
+
+#### 核心接口
+
+| 接口 | 用途 | 关键参数 |
+|------|------|---------|
+| `searchFormDatas` | 获取表单数据列表（含字段值），用于数据明细表 | `formUuid`, `pageSize`(≤100), `currentPage`, `searchFieldJson` |
+| `getFormDataById` | 获取单条数据详情 | `formInstId` |
+
+#### 分页拉取数据（用于数据明细表）
+
+```javascript
+/**
+ * 分页拉取表单数据（仅用于数据明细表展示，禁止用于聚合统计）
+ * @param {string} formUuid - 表单 UUID
+ * @param {Object} [searchCondition] - 可选的搜索条件
+ * @param {number} [maxRecords] - 最大拉取条数，默认 2000
+ * @returns {Promise<Array>} 数据列表
+ */
+export function fetchAllFormData(formUuid, searchCondition, maxRecords) {
+  var allData = [];
+  var pageSize = 100;
+  var limit = maxRecords || 2000;
+
+  var fetchPage = function(currentPage) {
+    var params = {
+      formUuid: formUuid,
+      currentPage: currentPage,
+      pageSize: pageSize,
+    };
+    if (searchCondition) {
+      params.searchFieldJson = JSON.stringify(searchCondition);
+    }
+    return this.utils.yida.searchFormDatas(params)
+      .then(function(res) {
+        allData = allData.concat(res.data || []);
+        var totalCount = res.totalCount || 0;
+
+        if (allData.length >= limit) {
+          console.warn('数据量(' + totalCount + ')超过上限(' + limit + ')，仅加载前 ' + limit + ' 条');
+          return allData.slice(0, limit);
+        }
+
+        if (currentPage * pageSize < totalCount) {
+          return fetchPage.call(this, currentPage + 1);
+        }
+        return allData;
+      }.bind(this));
+  }.bind(this);
+
+  return fetchPage(1);
+}
+```
+
+### 方案二：宜搭原生报表数据接口（ECharts 高级报表的数据来源）
+
+**所有聚合统计需求**（分组计数、求和、平均值、趋势分析、占比分布等）**必须**通过宜搭原生报表的数据接口实现。
+
+> ⚠️ **ECharts 高级报表必须依赖原生报表**
+>
+> ECharts 高级报表的数据来源**必须**是宜搭原生报表的查询接口，禁止前端聚合。
+> 因此，创建 ECharts 高级报表前，**必须先创建对应的宜搭原生报表页面**，配置好所需的图表组件，然后通过以下接口获取聚合数据。
+
+#### 可用接口
+
+| 接口 | 用途 | 特点 |
+|------|------|------|
+| `getDataAsync.json` | 实时获取报表组件数据 | 每次请求实时计算，数据最新 |
+| `getCacheData.json` | 获取缓存的报表数据 | 性能更好，适合大数据量场景 |
+
+#### 适用场景
+
+- 所有需要聚合统计的图表（柱状图、折线图、饼图、指标卡等）
+- 分组计数、求和、平均值等聚合计算
+- 跨多个表单做关联统计
+- 任意数据量的聚合分析（服务端计算，无性能瓶颈）
+
+#### 接口说明：`getDataAsync.json`
+
+宜搭报表页面在渲染时会调用 `getDataAsync.json` 接口获取各个报表组件的数据。该接口是报表数据的核心接口。
+
+- **地址**：`POST /alibaba/web/{appType}/visual/visualizationDataRpc/getDataAsync.json`
+- **Query 参数**：`?_api=EDataService.getDataAsync&_mock=false`
+- **Content-Type**：`application/x-www-form-urlencoded`
+
+**Body 参数**：
+
+| 参数 | 类型 | 必填 | 说明 | 示例 |
+|------|------|------|------|------|
+| `pageId` | String | 是 | 报表页面 UUID | `REPORT-YRD66CC1P4W34O3FKNPP8BKM5SNV3VIE6WWMMC` |
+| `cid` | String | 是 | 组件节点 ID（从 Network 面板获取） | `node_ocmmwwwhdmg` |
+| `cname` | String | 是 | 组件显示名称 | `基础表格_1` |
+| `componentClassName` | String | 是 | 组件类型（见下表） | `YoushuTable` |
+| `queryContext` | String (JSON) | 是 | 查询上下文，包含筛选、排序、分页等 | 见下方说明 |
+| `dataSetKey` | String | 是 | 数据集标识 | `table` |
+| `_csrf_token` | String | 是 | CSRF Token | `window.g_config._csrf_token` |
+| `_tb_token_` | String | 是 | 同 CSRF Token | 同上 |
+| `_csrf` | String | 是 | 同 CSRF Token | 同上 |
+| `timezone` | String | 否 | 时区 | `GMT+8` |
+| `pageName` | String | 否 | 固定值 | `report` |
+| `enabledCache` | String | 否 | 是否启用缓存 | `true` |
+
+**常见组件类型（`componentClassName`）**：
+
+| 类型 | 说明 |
+|------|------|
+| `YoushuTable` | 基础表格 |
+| `YoushuBar` | 柱状图 |
+| `YoushuLine` | 折线图 |
+| `YoushuPie` | 饼图 |
+| `YoushuNumber` | 数字指标卡 |
+| `YoushuFunnel` | 漏斗图 |
+
+**`queryContext` 结构**：
+
+```json
+{
+  "aliasList": [],
+  "filterValueMap": {
+    "filter-xxx": ["筛选值"]
+  },
+  "dim2table": true,
+  "orderByList": [],
+  "needTotalCount": false,
+  "variableParams": {},
+  "paging": {
+    "start": 0,
+    "limit": 10
+  }
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `filterValueMap` | 筛选条件，key 为筛选器 ID，value 为筛选值数组 |
+| `paging.start` | 分页起始位置（从 0 开始） |
+| `paging.limit` | 每页数据量 |
+| `orderByList` | 排序规则数组 |
+| `needTotalCount` | 是否返回总数 |
+
+#### 如何获取接口参数
+
+`getDataAsync.json` 的参数（特别是 `cid`、`componentClassName`）需要从已创建的报表页面中获取：
+
+**方式一：从报表 Schema 解析（推荐，AI 友好）**
+
+执行 `openyida get-schema <appType> <reportFormUuid>` 获取报表 Schema，从 Schema 的组件树中提取各组件的 `cid` 和 `componentClassName`。Schema 中每个报表组件节点包含这些信息。
+
+**方式二：从浏览器 Network 面板抓取**
+
+1. 在浏览器中打开报表页面，如：`https://www.aliwork.com/{appType}/preview/{reportUuid}`
+2. 打开 DevTools → Network 面板
+3. 筛选 `getDataAsync` 关键词
+4. 查看请求的 Form Data，获取 `pageId`、`cid`、`componentClassName` 等参数
+5. 查看 Response，了解返回数据的结构
+6. 报表页面中每个组件（表格、图表、指标卡）都会发起独立的 `getDataAsync` 请求，可按 `cname` 区分
+
+#### 报表数据接口调用
+
+```javascript
+/**
+ * 调用宜搭报表 getDataAsync 接口
+ * @param {string} appType - 应用 ID
+ * @param {string} reportPageId - 报表页面 UUID（如 REPORT-xxx）
+ * @param {string} componentNodeId - 组件节点 ID（如 node_xxx，从 Network 面板获取）
+ * @param {string} componentName - 组件显示名称（如 "基础表格_1"）
+ * @param {string} componentClassName - 组件类型（如 YoushuTable / YoushuBar）
+ * @param {Object} [options] - 可选参数
+ * @param {Object} [options.filterValueMap] - 筛选条件
+ * @param {number} [options.start] - 分页起始位置（默认 0）
+ * @param {number} [options.limit] - 每页数据量（默认 100）
+ * @param {string} [options.dataSetKey] - 数据集标识（默认 "table"）
+ */
+export function fetchReportData(appType, reportPageId, componentNodeId, componentName, componentClassName, options) {
+  var csrfToken = window.g_config._csrf_token;
+  var baseUrl = window.location.origin;
+  options = options || {};
+
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: options.filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: false,
+    variableParams: {},
+    paging: {
+      start: options.start || 0,
+      limit: options.limit || 100,
+    },
+  };
+
+  var params = {
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken,
+    _csrf_token: csrfToken,
+    _csrf: csrfToken,
+    pageId: reportPageId,
+    pageName: 'report',
+    cid: componentNodeId,
+    cname: componentName,
+    componentClassName: componentClassName,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: options.dataSetKey || 'table',
+    enabledCache: 'true',
+    queryTimestamp: String(new Date().getTime()),
+    appendTraceId: 'true',
+  };
+
+  var apiUrl = baseUrl + '/alibaba/web/' + appType
+    + '/visual/visualizationDataRpc/getDataAsync.json'
+    + '?_api=EDataService.getDataAsync&_mock=false&_stamp=' + new Date().getTime();
+
+  return fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'accept': 'application/json, text/json',
+      'x-requested-with': 'XMLHttpRequest',
+    },
+    credentials: 'include',
+    body: Object.keys(params).map(function(key) {
+      return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+    }).join('&'),
+  })
+  .then(function(response) { return response.json(); })
+  .then(function(result) {
+    if (!result.success) {
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    }
+    return result.content;
+  });
+}
+```
+
+#### 使用示例
+
+```javascript
+export function loadReportChart() {
+  var appType = window.pageConfig.appType;
+  // 以下参数从浏览器 Network 面板的 getDataAsync 请求中获取
+  this.fetchReportData(
+    appType,
+    'REPORT-YRD66CC1P4W34O3FKNPP8BKM5SNV3VIE6WWMMC',  // pageId
+    'node_ocmmwwwhdmg',                                  // cid
+    '基础表格_1',                                         // cname
+    'YoushuTable',                                        // componentClassName
+    {
+      start: 0,
+      limit: 100,
+      filterValueMap: {
+        'filter-xxx': ['筛选值'],
+      },
+    }
+  )
+  .then(function(content) {
+    // content 中包含报表组件的聚合数据
+    // 具体数据结构取决于组件类型（YoushuTable / YoushuBar / YoushuPie 等）
+    console.log('报表数据:', content);
+    this.renderChartFromReportData(content);
+  }.bind(this))
+  .catch(function(error) {
+    this.utils.toast({ title: '报表数据获取失败: ' + error.message, type: 'error' });
+  }.bind(this));
+}
+```
+
+> ⚠️ **注意事项**：
+> - 报表接口需要先通过 `yida-report` 技能创建原生报表页面并配置好报表组件
+> - `cid`（组件节点 ID）和 `componentClassName`（组件类型）可通过以下方式获取：
+>   1. **从报表 Schema 解析**（推荐）：执行 `openyida get-schema <appType> <reportFormUuid>` 获取报表 Schema，从 Schema 的组件树中提取各组件的 `cid`（即 `componentName` 或 `id` 字段）和组件类型
+>   2. **从浏览器 Network 面板抓取**：打开报表页面，在 DevTools Network 中筛选 `getDataAsync` 请求，查看请求参数
+> - 每个报表组件都有独立的 `cid`，一个报表页面可能包含多个组件，每个组件发起独立的请求
+> - 如果尚未创建报表页面，**必须先通过 yida-report 技能创建**，而非退回使用前端聚合方案
+
+#### 接口说明：`getCacheData.json`
+
+`getCacheData.json` 是 `getDataAsync.json` 的缓存版本，适用于大数据量场景，性能更好。
+
+- **地址**：`POST /alibaba/web/{appType}/visual/visualizationDataRpc/getCacheData.json`
+- **Query 参数**：`?_api=EDataService.getCacheData&_mock=false`
+- **参数**：与 `getDataAsync.json` 完全相同
+
+**选择建议**：
+- 数据实时性要求高 → 使用 `getDataAsync.json`
+- 数据量大、性能优先 → 使用 `getCacheData.json`
+
+---
+
+### 隐藏原生报表页面
+
+> 详见上方「核心规则 → 第 5 节：原生报表页面隐藏规则」。
+
+---
+
+### 更新报表 Schema：`saveFormSchema.json`
+
+当报表需求变化时，需要同步更新原生报表和 ECharts 页面的 Schema。
+
+#### 接口说明
+
+- **地址**：`POST /dingtalk/web/{appType}/_view/query/formdesign/saveFormSchema.json`
+- **Content-Type**：`application/x-www-form-urlencoded`
+
+**Body 参数**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `formUuid` | String | 是 | 页面 UUID |
+| `content` | String (JSON) | 是 | 页面 Schema JSON |
+| `schemaVersion` | String | 是 | 固定 `V5` |
+| `importSchema` | String | 是 | 固定 `"true"` |
+| `_csrf_token` | String | 是 | CSRF Token |
+
+> ⚠️ **同步更新规则**：
+> - 修改原生报表的图表配置后，需要同步更新 ECharts 页面的数据获取逻辑
+> - 修改 ECharts 页面的展示需求后，如需新的聚合数据，需要先更新原生报表添加对应组件
+> - 两个页面的更新必须在同一次操作中完成，保持一致性
+
+---
+
+## 图表渲染规范
+
+### DOM 容器约定
+
+每个图表需要一个固定 `id` 的 DOM 容器，在 `renderJsx` 中声明：
+
+> ⚠️ **关键约束：`renderJsx` 的每个 `return` 分支都必须包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`**，否则 `forceUpdate` 调用 `this.setState({ timestamp })` 后，React 无法检测到输出变化，`renderJsx` 不会被重新执行，图表和数据将无法更新。
+
+```javascript
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.chartTitle}>销售数据统计</div>
+        <div
+          id="chart-bar"
+          style={{
+            width: '100%',
+            height: isMobile ? '300px' : '400px',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+### 图表初始化与销毁
+
+```javascript
+/**
+ * 初始化 ECharts 实例
+ * @param {string} domId - 容器 DOM 的 id
+ * @returns {Object|null} ECharts 实例
+ */
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) {
+    console.warn('图表容器不存在: ' + domId);
+    return null;
+  }
+  // 如果已有实例先销毁，避免内存泄漏
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) {
+    existingInstance.dispose();
+  }
+  return window.echarts.init(container);
+}
+
+/**
+ * 页面卸载时销毁所有图表实例，释放内存
+ */
+export function didUnmount() {
+  var chartIds = this.getCustomState('chartIds') || [];
+  chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) {
+        instance.dispose();
+      }
+    }
+  });
+  // 移除 resize 监听
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+```
+
+### 窗口 resize 自适应
+
+```javascript
+/**
+ * 绑定窗口 resize 事件，自动调整图表尺寸
+ */
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    var chartIds = this.getCustomState('chartIds') || [];
+    chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) {
+          instance.resize();
+        }
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+```
+
+---
+
+## 常用图表配置模板
+
+### 柱状图
+
+```javascript
+export function renderBarChart(categories, values, title) {
+  var chart = this.createChart('chart-bar');
+  if (!chart) return;
+
+  chart.setOption({
+    title: { text: title || '', left: 'center' },
+    tooltip: { trigger: 'axis' },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      axisLabel: {
+        rotate: categories.length > 8 ? 30 : 0,
+        fontSize: this.utils.isMobile() ? 10 : 12,
+      },
+    },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'bar',
+      data: values,
+      itemStyle: { color: '#0089FF' },
+      barMaxWidth: 40,
+    }],
+    grid: { left: '3%', right: '4%', bottom: '10%', containLabel: true },
+  });
+}
+```
+
+> 更多图表模板（折线图、饼图、仪表盘等）请参考 `examples/` 目录下的完整示例文件。
+
+---
+
+
+## 多端适配
+
+ECharts 图表需要适配 PC 和移动端：
+
+```javascript
+export function getChartHeight(chartType) {
+  var isMobile = this.utils.isMobile();
+  var heightMap = {
+    bar: isMobile ? '280px' : '400px',
+    line: isMobile ? '280px' : '400px',
+    pie: isMobile ? '300px' : '380px',
+    gauge: isMobile ? '250px' : '300px',
+  };
+  return heightMap[chartType] || (isMobile ? '280px' : '400px');
+}
+```
+
+布局建议：
+- **PC 端**：使用 `flexWrap: 'wrap'` 实现多图表网格布局，每个图表占 `48%` 宽度
+- **移动端**：单列布局，每个图表占 `100%` 宽度
+
+---
+
+## 编码注意事项
+
+1. **必须遵循 `yida-custom-page` 规范**：`export function` 定义方法、事件绑定用箭头函数包裹、禁止 React Hooks
+2. **ECharts 加载时序**：所有图表操作必须在 `loadScript` 的 `.then()` 回调中执行，确保 `window.echarts` 已就绪
+3. **DOM 就绪**：`echarts.init()` 必须在 `didMount` 之后调用，确保 DOM 已渲染
+4. **内存管理**：`didUnmount` 中必须调用 `dispose()` 销毁所有图表实例，并移除 `resize` 监听
+5. **pageSize 上限**：`searchFormDatas` 的 `pageSize` 最大 100，数据量超过时必须分页拉取
+6. **loading 状态**：数据加载期间应展示 loading 提示，使用 ECharts 内置的 `chart.showLoading()` / `chart.hideLoading()`
+7. **错误处理**：所有 API 调用和 ECharts 操作都必须有 `.catch()` 错误处理
+8. **样式内联**：所有样式通过 JS 对象定义，不使用外部 CSS
+
+---
+
+## 与其他技能配合
+
+| 技能 | 配合方式 |
+|------|----------|
+| `yida-custom-page` | **必须先加载**，遵循其编码规范编写图表页面 |
+| `yida-report` | **ECharts 报表的数据源依赖**。yida-chart 不包含原生报表创建逻辑，需调用 yida-report 创建原生报表，获取 getDataAsync.json 接口所需参数 |
+| `yida-create-form-page` | 创建数据源表单 |
+| `yida-get-schema` | 获取表单/报表字段 ID 和 Schema，用于解析 getDataAsync.json 所需的 cubeCode、cid 等参数 |
+| `yida-create-page` | 创建自定义页面容器 |
+| `yida-publish-page` | 编译并发布图表页面 |
+
+---
+
+## 报表设计规范
+
+### 默认风格：白底简洁商务风
+
+除非用户明确指定了其他风格偏好（如大屏科技风、暗色主题等），报表**默认使用白底简洁商务风**。
+
+**配色方案**：
+
+```javascript
+var PALETTE = {
+  primary: '#1e40af',       // 主色（深蓝）
+  primaryLight: '#3b82f6',  // 主色浅
+  accent: '#0ea5e9',        // 强调色（天蓝）
+  success: '#059669',       // 成功（绿）
+  warning: '#d97706',       // 警告（橙）
+  danger: '#dc2626',        // 危险（红）
+  neutral: '#64748b',       // 中性灰
+  bg: '#f8fafc',            // 页面背景（极浅灰）
+  cardBg: '#ffffff',        // 卡片背景（白）
+  border: '#e2e8f0',        // 边框（浅灰）
+  textPrimary: '#0f172a',   // 主文字（近黑）
+  textSecondary: '#475569', // 次文字
+  textMuted: '#94a3b8',     // 辅助文字
+};
+```
+
+**设计要素**：
+
+| 要素 | 规范 |
+|------|------|
+| 页面背景 | `#f8fafc`（极浅灰），避免纯白 |
+| 卡片 | 白底 + `border-radius: 10px` + `1px solid #e2e8f0` 细边框，无阴影或极淡阴影 |
+| 字体 | `-apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, sans-serif` |
+| KPI 数字 | `font-size: 26px` + `font-weight: 700` + `font-feature-settings: "tnum"`（等宽数字） |
+| 图表 tooltip | 深色半透明背景 `rgba(15, 23, 42, 0.92)` + 圆角 8px + 柔和阴影 |
+| 分割线 | `#f1f5f9` 虚线（`type: [4, 4]`），不使用实线 |
+| 标签文字 | `12-13px`，颜色用 `textSecondary` 或 `textMuted` |
+
+### 报表必备组件
+
+一个完整的数据报表应包含以下组件：
+
+| 组件 | 作用 | 必要性 |
+|------|------|--------|
+| **KPI 指标卡** | 展示核心数字（总数、完成率、预算等） | ✅ 必须 |
+| **图表区域** | 展示趋势和分布（饼图、柱状图、折线图等） | ✅ 必须 |
+| **数据明细表格** | 展示每条数据的详细信息，支持排序和分页 | ✅ 必须 |
+| **全局筛选栏** | 按维度筛选数据，联动所有图表和表格 | ✅ 推荐 |
+| **局部筛选** | 单个图表卡片内的维度切换 | 可选 |
+
+### 全局筛选器位置
+
+筛选器应放在**页面顶层**（标题栏下方、KPI 卡片上方），作为全局筛选器，而不是放在明细表上方。这样用户一眼就能看到当前的筛选条件，且筛选操作不会被图表遮挡。
+
+### 筛选器状态定义
+
+```javascript
+var _customState = {
+  loading: true,       // 首次加载
+  refreshing: false,   // 筛选刷新（局部刷新标记）
+  filterStatus: '全部',
+  filterDateStart: '',
+  filterDateEnd: '',
+  // ...
+};
+```
+
+### 筛选触发 → 局部刷新（最佳实践）
+
+**核心原则**：筛选切换时，各区域独立加载、独立更新，不触发全局重渲染。
+
+| 场景 | 加载方式 | 说明 |
+|------|---------|------|
+| **首次加载** | `loadAllData`（全屏 loading） | 页面无数据，需要全屏等待 |
+| **筛选刷新** | `refreshAllData`（局部刷新） | 页面已有数据，各区域独立更新 |
+
+```javascript
+// 筛选触发：设置 refreshing 标记，调用局部刷新
+export function applyFilters() {
+  _customState.refreshing = true;
+  this.forceUpdate();  // 仅更新筛选器 UI 和刷新提示
+  this.refreshAllData();
+}
+
+// 局部刷新：各区域独立加载、独立更新
+export function refreshAllData() {
+  var self = this;
+  var pendingCount = 4; // 指标卡 + 饼图 + 柱状图 + 明细表
+
+  var checkDone = function() {
+    pendingCount--;
+    if (pendingCount <= 0) {
+      _customState.refreshing = false;
+      self.forceUpdate();
+    }
+  };
+
+  // 指标卡数据 → 数据到了就更新 KPI
+  _fetchReportData(REPORT_COMPONENTS.indicator, 'indicator')
+    .then(function(content) {
+      // 解析并更新 _customState.totalCount
+      self.forceUpdate();
+    })
+    .catch(function(err) { console.error('[看板] 指标卡刷新失败:', err); })
+    .then(checkDone);
+
+  // 饼图数据 → 用 setOption 原地更新，不销毁重建
+  _fetchReportData(REPORT_COMPONENTS.pie, 'pie')
+    .then(function(content) {
+      // 解析并更新 _customState.statusData
+      self.renderPieChart();  // setOption 原地更新
+      self.forceUpdate();
+    })
+    .catch(function(err) { console.error('[看板] 饼图刷新失败:', err); })
+    .then(checkDone);
+
+  // 柱状图数据 → 用 setOption 原地更新
+  _fetchReportData(REPORT_COMPONENTS.bar, 'bar')
+    .then(function(content) {
+      // 解析并更新 _customState.trendData
+      self.renderBarChart();  // setOption 原地更新
+    })
+    .catch(function(err) { console.error('[看板] 柱状图刷新失败:', err); })
+    .then(checkDone);
+
+  // 明细表数据
+  self.loadDetailData(1)
+    .then(function() { self.forceUpdate(); })
+    .catch(function(err) { console.error('[看板] 明细表刷新失败:', err); })
+    .then(checkDone);
+}
+```
+
+### 图表 setOption 原地更新（禁止 dispose 重建）
+
+筛选刷新时，**禁止 `dispose()` 后重新 `init()`**，这会导致图表闪烁。应使用 `setOption(option, true)` 原地更新：
+
+```javascript
+export function renderPieChart() {
+  var container = document.getElementById('pie-chart');
+  if (!container || !window.echarts) return;
+
+  var option = { /* ... 构建 option ... */ };
+
+  // 已有实例 → setOption 原地更新；首次 → init 后 setOption
+  if (_chartInstances.pie) {
+    _chartInstances.pie.setOption(option, true);  // 第二个参数 true 表示不合并，完全替换
+  } else {
+    _chartInstances.pie = window.echarts.init(container);
+    _chartInstances.pie.setOption(option);
+  }
+}
+```
+
+### 刷新状态 UI 提示
+
+筛选刷新时，不显示全屏 loading 遮罩，而是：
+1. 标题旁显示"🔄 刷新中..."文字
+2. 页面顶部显示蓝色进度条
+
+```javascript
+// 标题旁刷新提示
+{_customState.refreshing && <span style={{ marginLeft: 8, color: '#3b82f6' }}>🔄 刷新中...</span>}
+
+// 顶部进度条
+{_customState.refreshing && (
+  <div style={{
+    position: 'fixed', top: 0, left: 0, right: 0,
+    height: 3, background: 'linear-gradient(90deg, #3b82f6 0%, #60a5fa 50%, #3b82f6 100%)',
+    zIndex: 9999,
+  }}></div>
+)}
+```
+
+### 日期筛选格式兼容
+
+`searchFormDatas` 接口的日期筛选需要**毫秒时间戳数组**，不能直接传日期字符串：
+
+```javascript
+// ❌ 错误：直接传日期字符串
+searchCondition[FIELD.planDate] = JSON.stringify(['2025-03-01', '2025-03-31']);
+
+// ✅ 正确：转换为毫秒时间戳
+var startTimestamp = new Date('2025-03-01T00:00:00').getTime();
+var endTimestamp = new Date('2025-03-31T23:59:59').getTime();
+searchCondition[FIELD.planDate] = JSON.stringify([startTimestamp, endTimestamp]);
+```
+
+---
+
+## 数据明细表格
+
+报表中**必须包含数据明细表格**，用于展示每条数据的详细信息。表格使用纯 JSX 实现（非 ECharts），支持分页、排序和详情跳转。
+
+### 表单详情页跳转
+
+`searchFormDatas` 返回的每条记录包含 `formInstId` 字段，可拼接表单详情页 URL：
+
+```
+https://www.aliwork.com/{appType}/formDetail/{formUuid}?formInstId={formInstId}
+```
+
+```javascript
+export function getDetailUrl(formInstId) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  if (!appType || !formInstId) return '';
+  return 'https://www.aliwork.com/' + appType + '/formDetail/' + FORM_UUID + '?formInstId=' + formInstId;
+}
+```
+
+### 表格功能要求
+
+| 功能 | 说明 |
+|------|------|
+| **列排序** | 点击表头切换升序/降序，支持数值和文本排序 |
+| **分页** | 每页 10 条，底部显示分页器（上/下一页 + 页码按钮） |
+| **详情链接** | 项目名称和"详情"列可点击，跳转到表单详情页（新窗口打开） |
+| **状态标签** | 状态、优先级等字段使用彩色标签（badge）展示 |
+| **进度条** | 进度字段使用迷你进度条 + 百分比数字展示 |
+| **斑马纹** | 奇偶行交替背景色，提升可读性 |
+| **筛选联动** | 表格数据跟随全局筛选器实时过滤 |
+
+### 表格样式规范
+
+```javascript
+// 表头样式
+var thStyle = {
+  padding: '10px 12px', textAlign: 'left', fontWeight: 600,
+  color: '#475569', fontSize: 12,
+  borderBottom: '2px solid #e2e8f0',
+  background: '#f8fafc', whiteSpace: 'nowrap', cursor: 'pointer',
+};
+
+// 单元格样式
+var tdStyle = {
+  padding: '10px 12px', borderBottom: '1px solid #e2e8f0',
+  color: '#475569', fontSize: 13,
+};
+
+// 状态标签样式（根据状态值动态设置颜色）
+var statusBadgeStyle = {
+  display: 'inline-block', padding: '2px 8px', borderRadius: 4,
+  fontSize: 11, fontWeight: 600, lineHeight: '18px',
+  color: statusColor, background: statusColor + '14',
+  border: '1px solid ' + statusColor + '30',
+};
+
+// 详情链接样式
+var detailLinkStyle = {
+  color: '#3b82f6', fontSize: 12, textDecoration: 'none',
+  cursor: 'pointer', fontWeight: 500,
+};
+```
+
+### 日期格式化
+
+```javascript
+export function formatDate(timestamp) {
+  if (!timestamp) return '-';
+  var date = new Date(Number(timestamp));
+  if (isNaN(date.getTime())) return '-';
+  var year = date.getFullYear();
+  var month = String(date.getMonth() + 1).padStart(2, '0');
+  var day = String(date.getDate()).padStart(2, '0');
+  return year + '-' + month + '-' + day;
+}
+```
+
+---
+
+## 原生报表 Schema 构建
+
+原生报表的 Schema 构建（vc-yida-report 组件库、`build-yida-report-schema.js` 构建脚本）已迁移至 **`yida-report`** 技能文档中。
+
+如需创建或更新原生报表，请调用 `yida-report` 技能。相关参考：
+- **Schema 构建脚本**：[`build-yida-report-schema.js`](./build-yida-report-schema.js)
+- **组件详细文档**：[`reference/vc-yida-report-components-doc.md`](../../reference/vc-yida-report-components-doc.md)
+
+---
+
+## 方案 C：基于已有报表创建 ECharts 页面
+
+### 概述
+
+当用户提供了一个已有的宜搭原生报表 URL（如 `https://www.aliwork.com/APP_XXX/admin/REPORT-XXX`），应以该原生报表作为数据源，创建 ECharts 自定义页面实现更美观的展示效果。**最终输出是 ECharts 自定义页面，而非优化后的原生报表**。
+
+### 触发条件
+
+用户消息中包含符合以下格式的报表 URL：
+```
+https://www.aliwork.com/{appType}/admin/{formUuid}
+```
+
+其中 `formUuid` 以 `REPORT-` 开头，表明这是一个宜搭原生报表页面。
+
+### 执行流程
+
+```
+Step 1: 从 URL 中解析 appType 和 formUuid
+    ↓
+Step 2: 执行 openyida env 检测环境和登录态
+    ↓
+Step 3: 执行 openyida get-schema <appType> <formUuid> 获取现有报表 Schema
+    ↓  （将完整输出重定向到文件，避免终端截断）
+    ↓  命令：openyida get-schema <appType> <formUuid> > .cache/report-schema-output.txt 2>&1
+    ↓
+Step 4: 解析现有 Schema，提取关键信息：
+    ↓  - cubeCode（数据集编码）
+    ↓  - cubeTenantId（租户 ID）
+    ↓  - 各组件的 fieldDefinitionList（字段定义）
+    ↓  - 各组件的 settings（配置项）
+    ↓  - 组件结构和层级关系
+    ↓
+Step 5: 基于提取的数据源参数，创建 ECharts 自定义页面
+    ↓  - 复用原有的 cubeCode、cubeTenantId、cid、componentClassName 等数据源配置
+    ↓  - 通过 getDataAsync.json 接口获取聚合数据
+    ↓  - 使用 ECharts 实现更美观的图表展示
+    ↓
+Step 6: 隐藏原生报表页面（双端隐藏）
+    ↓  - 在宜搭管理后台设置原生报表页面 PC 端和移动端均不可见
+    ↓
+Step 7: 记录关联关系到 .cache/<项目名>-report-bindding.json
+    ↓
+Step 8: 输出 ECharts 自定义页面访问链接
+```
+
+### URL 解析规则
+
+```javascript
+// 从报表 URL 中解析 appType 和 formUuid
+// URL 格式: https://www.aliwork.com/{appType}/admin/{formUuid}
+// 示例: https://www.aliwork.com/APP_KNILKT41DC5XXR5D4QEC/admin/REPORT-QA666SC1J3U3TFO9GM9MJ5400RIW3W83SUYMM5
+// 解析结果:
+//   appType  = APP_KNILKT41DC5XXR5D4QEC
+//   formUuid = REPORT-QA666SC1J3U3TFO9GM9MJ5400RIW3W83SUYMM5
+```
+
+### Schema 获取注意事项
+
+1. **必须将输出重定向到文件**：报表 Schema 通常非常大（数千行），终端输出会被截断
+   ```bash
+   openyida get-schema <appType> <formUuid> > .cache/report-schema-output.txt 2>&1
+   ```
+
+2. **提取 JSON 部分**：输出文件包含前缀日志信息，需要从 `{` 开始的行提取纯 JSON
+   ```bash
+   # 找到 JSON 起始行
+   grep -n "^{" .cache/report-schema-output.txt
+   # 从该行开始提取
+   tail -n +<行号> .cache/report-schema-output.txt > .cache/report-schema.json
+   ```
+
+3. **使用 Node.js 脚本解析**：编写脚本提取组件结构、数据源配置等关键信息
+
+### ECharts 页面设计策略
+
+基于原生报表的数据源参数创建 ECharts 自定义页面时，遵循以下策略：
+
+| 设计维度 | 具体操作 |
+|---------|---------|
+| **布局设计** | 指标卡在上、图表居中、数据明细表在下 |
+| **图表选择** | 根据原报表中的组件类型选择对应的 ECharts 图表（如柱状图→bar、折线图→line、饼图→pie） |
+| **筛选交互** | 通过 getDataAsync.json 的 filterValueMap 参数实现筛选联动 |
+| **样式定制** | 使用 ECharts 主题、渐变色、动画等实现更美观的视觉效果 |
+| **响应式** | 监听 window resize 事件，调用 `chart.resize()` 适配不同屏幕 |
+
+### 关键约束
+
+1. **必须复用原有数据源**：`cubeCode`、`cubeTenantId`、`cid`、`componentClassName` 等必须从原报表 Schema 中提取，保持一致
+2. **不要修改原生报表和数据源表单**：只基于原报表的数据接口创建 ECharts 展示层
+3. **数据获取必须通过 getDataAsync.json**：禁止前端聚合，所有聚合统计由服务端完成
+4. **隐藏原生报表页面**：创建 ECharts 页面后，将原生报表设置为双端隐藏，避免用户看到两个入口
+5. **getDataAsync.json 接口参数必须从 Schema 中提取，禁止猜测**：
+   - `prdId`：**必须在运行时通过 `getFormNavigationListByOrder` 接口动态获取**（详见上方「prdId 动态获取」章节），不能硬编码，不能用 cubeCode 或其他值替代
+   - `pageName`：固定为 `'report'`，不能用 `'custom'` 或其他值
+   - `pageId`：使用报表的 `REPORT-xxx` formUuid，不能用自定义页面的 formUuid
+   - `cid`、`componentClassName`、`dataSetKey`：必须从报表 Schema 中各组件的配置提取
+6. **报表接口返回的是聚合数据，不含 `formInstId`**：
+   - 报表 `getDataAsync` 接口返回的 `data` 是聚合/展示数据，**没有 `formInstId`**
+   - **明细表场景必须用 `searchFormDatas` 接口**（`this.utils.yida.searchFormDatas`），它返回完整的 `formInstId` 和 `formData`
+   - 详情链接必须用**数据源表单的 formUuid**（`FORM-xxx`），不能用报表的 `REPORT-xxx`
+7. **筛选器的 `filterValueMap` key 必须用 `filterKey`**：
+   - 报表筛选器的 key 格式是 `filter-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`（UUID 格式）
+   - **必须从报表 Schema 中提取筛选器组件的 `filterKey`**，不能用字段 ID（`field_xxx`）或 alias
+   - 筛选值必须是数组格式，如 `{ 'filter-xxx': ['已完成'] }`
+8. **纯工具函数必须用 `var` 声明，不能用 `export function`**：
+   - 宜搭 Babel 编译器会把 `export function` 转成组件方法，但纯工具函数（如 `fetchReportData`）不在白名单中，会被 UglifyJS 消除
+   - 正确做法：`var _fetchReportData = function(...) { ... };`，在 `loadAllData` 等 `export function` 中直接调用 `_fetchReportData(...)`
+   - 错误做法：`export function fetchReportData(...)` + `this.fetchReportData(...)` → 运行时报 `is not a function`
+
+---
+
+## 常见问题
+
+**Q：ECharts 加载失败怎么办？**
+
+**必须使用阿里 CDN**（`https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js`）。宜搭环境（aliwork.com）对 `cdnjs.cloudflare.com` 有安全策略限制，会导致脚本加载失败。禁止使用 cloudflare CDN。
+
+**Q：`forceUpdate is not a function` 报错？**
+
+代码中缺少宜搭自定义页面必需的 `forceUpdate` 函数定义。必须在代码中包含以下三个函数：
+```javascript
+export function getCustomState(key) { if (key) return _customState[key]; return Object.assign({}, _customState); }
+export function setCustomState(newState) { Object.assign(_customState, newState); this.forceUpdate(); }
+export function forceUpdate() { this.setState({ timestamp: new Date().getTime() }); }
+```
+详见上方「ECharts 页面代码必备结构」章节。
+
+**Q：页面数据更新后不刷新？**
+
+`renderJsx` 的每个 `return` 分支都必须包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`，否则 `forceUpdate` 无法触发 React 重渲染。
+
+**Q：图表不显示？**
+
+1. 确认 DOM 容器有明确的 `height`（ECharts 要求容器有高度）
+2. 确认 `echarts.init()` 在 DOM 渲染完成后调用（在 `didMount` 中）
+3. 打开浏览器控制台查看是否有报错
+
+**Q：数据量很大，页面卡顿？**
+
+1. 使用 `chart.showLoading()` 展示加载状态
+2. 考虑只展示最近 N 条数据或按时间范围筛选
+3. 所有聚合统计必须使用方案二（宜搭报表 `getDataAsync.json` 接口），由服务端完成聚合计算
+
+**Q：如何实现图表联动筛选？**
+
+在筛选条件变化时，重新调用数据获取函数并更新图表。
+
+**注意**：数据请求函数必须用 `var` 声明为模块级变量（避免被 UglifyJS 消除），筛选 key 必须用报表 Schema 中的 `filterKey`（`filter-xxx` 格式）：
+
+```javascript
+// 模块级变量：动态获取 prdId（topicId）
+var _prdId = null;
+
+// 方案一（推荐）：通过 getFormNavigationListByOrder 接口获取 topicId
+// 优势：从应用导航菜单中获取，无论当前页面是报表还是自定义页面都能拿到
+// 原理：遍历应用导航菜单，找到 formType=report 的条目，取其 topicId
+var _fetchPrdId = function() {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var baseUrl = window.location.origin;
+  var url = baseUrl + '/dingtalk/web/' + appType
+    + '/query/formnav/getFormNavigationListByOrder.json'
+    + '?_api=Nav.queryList&_mock=false&_csrf_token=' + encodeURIComponent(csrfToken);
+
+  console.log('[报表] 正在通过导航菜单获取 prdId(topicId)');
+
+  return fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'accept': 'application/json, text/json',
+      'x-requested-with': 'XMLHttpRequest',
+    },
+  })
+    .then(function(resp) { return resp.json(); })
+    .then(function(res) {
+      if (res.success && Array.isArray(res.content)) {
+        // 优先匹配指定的 REPORT_FORM_UUID
+        var targetNav = res.content.find(function(item) {
+          return item.formUuid === REPORT_FORM_UUID;
+        });
+        if (targetNav && targetNav.topicId) {
+          _prdId = targetNav.topicId;
+          console.log('[报表] prdId(topicId) 获取成功（精确匹配）:', _prdId);
+          return _prdId;
+        }
+        // 兜底：取第一个 formType=report 且有 topicId 的条目
+        var reportNav = res.content.find(function(item) {
+          return item.formType === 'report' && item.topicId;
+        });
+        if (reportNav) {
+          _prdId = reportNav.topicId;
+          console.log('[报表] prdId(topicId) 获取成功（兜底匹配）:', _prdId, '来自:', reportNav.formUuid);
+          return _prdId;
+        }
+        throw new Error('应用导航菜单中未找到包含 topicId 的报表');
+      }
+      throw new Error(res.errorMsg || '获取应用导航菜单失败');
+    });
+};
+
+// 模块级变量：数据请求函数（不能用 export function，否则会被编译器消除）
+var _fetchReportData = function(cid, cname, componentClassName, dataSetKey, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: _prdId,                // 通过 getFormNavigationListByOrder 动态获取的 topicId
+    pageId: 'REPORT-XXX',         // 必须用报表的 REPORT-xxx formUuid
+    pageName: 'report',           // 固定为 'report'，不能用 'custom'
+    cid: cid, cname: cname || '',
+    componentClassName: componentClassName,
+    queryContext: JSON.stringify({ filterValueMap: filterValueMap || {}, dim2table: true }),
+    dataSetKey: dataSetKey,
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json';
+  return fetch(url, { method: 'POST', headers: { 'content-type': 'application/x-www-form-urlencoded' }, body: body.toString(), credentials: 'include' })
+    .then(function(r) { return r.json(); })
+    .then(function(result) { if (result.success) return result.content; throw new Error(result.errorMsg); });
+};
+
+// 组件方法：筛选变化时重新加载（用 export function，可通过 this 访问组件实例）
+export function onFilterChange(filterValue) {
+  this.setCustomState({ loading: true });
+  var self = this;
+  // filterValueMap 的 key 必须用报表 Schema 中的 filterKey（filter-xxx 格式），不能用字段 ID
+  var filterValueMap = { 'filter-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx': [filterValue] };
+  _fetchReportData('YoushuBar_xxx', '柱状图_1', 'YoushuBar', 'chartData', filterValueMap)
+  .then(function(content) {
+    var data = content.data || [];
+    var meta = content.meta || [];
+    var dimField = meta[0] && meta[0].alias;
+    var measureField = meta[1] && meta[1].alias;
+    var categories = data.map(function(row) { return row[dimField]; });
+    var values = data.map(function(row) { return row[measureField]; });
+    self.renderBarChart(categories, values, '筛选结果');
+    self.setCustomState({ loading: false });
+  })
+  .catch(function(error) {
+    self.utils.toast({ title: error.message, type: 'error' });
+    self.setCustomState({ loading: false });
+  });
+}
+```

--- a/yida-skills/skills/yida-chart/examples/china-map.js
+++ b/yida-skills/skills/yida-chart/examples/china-map.js
@@ -1,0 +1,457 @@
+// ============================================================
+// 中国地图示例
+// 按省份展示数据分布热力图，支持 tooltip 悬浮查看详情
+//
+// 数据来源：宜搭原生报表（后端聚合）
+// 地图数据来源：阿里云 DataV GeoJSON API（公开可信数据源）
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var CHINA_GEO_JSON_URL = 'https://geo.datav.aliyun.com/areas_v3/bound/100000_full.json';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+var PRD_ID = 13085982;
+
+// 报表组件配置
+var BUDGET_TABLE_COMPONENT = {
+  cid: 'YoushuTable_mmx9ha6a13',
+  className: 'YoushuTable',
+  dataSetKey: 'table'
+};
+
+// PALETTE 配色方案
+var PALETTE = {
+  primary: '#1e40af',
+  primaryLight: '#3b82f6',
+  accent: '#0ea5e9',
+  success: '#059669',
+  warning: '#d97706',
+  danger: '#dc2626',
+  neutral: '#64748b',
+  bg: '#f8fafc',
+  cardBg: '#ffffff',
+  border: '#e2e8f0',
+  textPrimary: '#0f172a',
+  textSecondary: '#475569',
+  textMuted: '#94a3b8'
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-china-map'],
+  mapData: {},
+  totalCount: 0,
+  maxValue: 0,
+  geoJsonLoaded: false,
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadEChartsAndMap();
+}
+
+export function didUnmount() {
+  _customState.chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// 报表数据获取函数（模块级变量）
+// ============================================================
+
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+// ============================================================
+// ECharts + 地图数据加载
+// ============================================================
+
+export function loadEChartsAndMap() {
+  var loadEChartsPromise = window.echarts
+    ? Promise.resolve()
+    : this.utils.loadScript(ECHARTS_CDN);
+
+  loadEChartsPromise
+    .then(function() {
+      this.bindChartResize();
+      return this.loadChinaGeoJson();
+    }.bind(this))
+    .then(function() {
+      this.loadMapData();
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '资源加载失败: ' + (error.message || '请刷新重试'), type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+/**
+ * 加载中国地图 GeoJSON 数据并注册到 ECharts
+ * 数据来源：阿里云 DataV（公开可信数据源）
+ */
+export function loadChinaGeoJson() {
+  if (_customState.geoJsonLoaded) {
+    return Promise.resolve();
+  }
+  return fetch(CHINA_GEO_JSON_URL)
+    .then(function(response) {
+      if (!response.ok) {
+        throw new Error('地图数据加载失败: HTTP ' + response.status);
+      }
+      return response.json();
+    })
+    .then(function(geoJson) {
+      window.echarts.registerMap('china', geoJson);
+      _customState.geoJsonLoaded = true;
+    });
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取（基于报表后端聚合）
+// ============================================================
+
+export function loadMapData() {
+  this.setCustomState({ loading: true });
+  _fetchReportData(BUDGET_TABLE_COMPONENT, {})
+    .then(function(content) {
+      var mapData = _parseTableData(content);
+      var maxValue = 0;
+      mapData.forEach(function(item) {
+        if (item.value > maxValue) maxValue = item.value;
+      });
+      // 标准化省份名称
+      mapData.forEach(function(item) {
+        item.name = this.normalizeProvinceName(item.name);
+      }.bind(this));
+      this.setCustomState({
+        loading: false,
+        mapData: mapData,
+        totalCount: mapData.length,
+        maxValue: maxValue || 100,
+      });
+      setTimeout(function() {
+        this.renderChinaMap();
+      }.bind(this), 100);
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+/**
+ * 标准化省份名称，确保与 GeoJSON 中的名称一致
+ * GeoJSON 中使用全称（如"北京市"、"广东省"、"内蒙古自治区"）
+ */
+export function normalizeProvinceName(name) {
+  if (!name) return name;
+  name = name.trim();
+
+  // 省份简称 → 全称映射
+  var shortToFull = {
+    '北京': '北京市', '天津': '天津市', '上海': '上海市', '重庆': '重庆市',
+    '河北': '河北省', '山西': '山西省', '辽宁': '辽宁省', '吉林': '吉林省',
+    '黑龙江': '黑龙江省', '江苏': '江苏省', '浙江': '浙江省', '安徽': '安徽省',
+    '福建': '福建省', '江西': '江西省', '山东': '山东省', '河南': '河南省',
+    '湖北': '湖北省', '湖南': '湖南省', '广东': '广东省', '海南': '海南省',
+    '四川': '四川省', '贵州': '贵州省', '云南': '云南省', '陕西': '陕西省',
+    '甘肃': '甘肃省', '青海': '青海省', '台湾': '台湾省',
+    '内蒙古': '内蒙古自治区', '广西': '广西壮族自治区',
+    '西藏': '西藏自治区', '宁夏': '宁夏回族自治区', '新疆': '新疆维吾尔自治区',
+    '香港': '香港特别行政区', '澳门': '澳门特别行政区',
+  };
+
+  if (shortToFull[name]) return shortToFull[name];
+  return name;
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderChinaMap() {
+  var chart = this.createChart('chart-china-map');
+  if (!chart) return;
+
+  var mapData = _customState.mapData;
+  var maxValue = _customState.maxValue || 100;
+  var isMobile = this.utils.isMobile();
+
+  chart.setOption({
+    title: {
+      text: '全国数据分布',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 18 },
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: function(params) {
+        if (params.value === undefined || isNaN(params.value)) {
+          return params.name + '：暂无数据';
+        }
+        return params.name + '：' + params.value;
+      },
+    },
+    visualMap: {
+      min: 0,
+      max: maxValue,
+      left: isMobile ? 'center' : 'left',
+      bottom: isMobile ? 0 : 20,
+      orient: isMobile ? 'horizontal' : 'vertical',
+      itemWidth: isMobile ? 12 : 15,
+      itemHeight: isMobile ? 60 : 100,
+      text: ['高', '低'],
+      textStyle: { fontSize: isMobile ? 10 : 12 },
+      inRange: {
+        color: [PALETTE.primaryLight + '33', PALETTE.primaryLight + '80', PALETTE.primaryLight, PALETTE.primary, PALETTE.textPrimary],
+      },
+      calculable: true,
+    },
+    series: [{
+      name: '数据分布',
+      type: 'map',
+      map: 'china',
+      roam: true,
+      zoom: isMobile ? 1.0 : 1.2,
+      scaleLimit: { min: 0.8, max: 5 },
+      label: {
+        show: !isMobile,
+        fontSize: 9,
+        color: '#333',
+      },
+      emphasis: {
+        label: { show: true, fontSize: 12, fontWeight: 'bold' },
+        itemStyle: { areaColor: '#FFD700', borderColor: '#333', borderWidth: 1 },
+      },
+      itemStyle: {
+        areaColor: PALETTE.bg,
+        borderColor: PALETTE.border,
+        borderWidth: 0.5,
+      },
+      data: mapData,
+    }],
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+  var totalCount = _customState.totalCount;
+  var mapData = _customState.mapData;
+  var provinceCount = (mapData || []).length;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    headerRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+    },
+    statsRow: {
+      display: 'flex',
+      gap: '12px',
+    },
+    statBadge: {
+      padding: '4px 10px',
+      backgroundColor: PALETTE.primaryLight + '33',
+      color: PALETTE.primary,
+      borderRadius: '12px',
+      fontSize: '12px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '8px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    refreshButton: {
+      padding: '6px 14px',
+      backgroundColor: PALETTE.primary,
+      color: '#fff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontSize: '13px',
+      marginLeft: '8px',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '500px',
+      fontSize: '16px',
+      color: PALETTE.textMuted,
+    },
+    tip: {
+      marginTop: '12px',
+      fontSize: '12px',
+      color: PALETTE.textMuted,
+      textAlign: 'center',
+    },
+  };
+
+  var chartHeight = isMobile ? '400px' : '600px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>地图数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.headerRow}>
+          <div style={styles.header}>全国数据分布</div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <div style={styles.statsRow}>
+              <div style={styles.statBadge}>{totalCount} 条数据</div>
+              <div style={styles.statBadge}>{provinceCount} 个省份</div>
+            </div>
+            <button style={styles.refreshButton} onClick={(e) => { this.loadMapData(); }}>刷新</button>
+          </div>
+        </div>
+        <div style={styles.chartCard}>
+          <div id="chart-china-map" style={{ width: '100%', height: chartHeight }} />
+        </div>
+        <div style={styles.tip}>支持鼠标滚轮缩放和拖拽，悬浮查看详情</div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/dashboard-bindform.js
+++ b/yida-skills/skills/yida-chart/examples/dashboard-bindform.js
@@ -1,0 +1,524 @@
+// ============================================================
+// 宜搭报表 Dashboard 示例（基于 getDataAsync.json 后端聚合）
+// 多图表看板（柱状图 + 饼图 + 折线图 + 统计卡片）
+//
+// 数据源配置：
+//   PRD_ID: 13085982
+//   REPORT_UUID: REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1
+//   appType: APP_KNILKT41DC5XXR5D4QEC
+//
+// 报表组件：
+//   - totalCount: 项目总数
+//   - totalBudget: 预算总计
+//   - avgProgress: 平均进度
+//   - statusTable: 状态分布（用于柱状图和饼图）
+//   - budgetTable: 预算分布（用于折线图）
+// ============================================================
+
+// ----- 配置区 -----
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var PRD_ID = '13085982';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+
+// ----- 报表组件配置 -----
+var REPORT_COMPONENTS = {
+  totalCount: { cid: 'YoushuSimpleIndicatorCard_mmx9ha69i', className: 'YoushuSimpleIndicatorCard', dataSetKey: 'youshuData' },
+  totalBudget: { cid: 'YoushuSimpleIndicatorCard_mmx9ha69l', className: 'YoushuSimpleIndicatorCard', dataSetKey: 'youshuData' },
+  avgProgress: { cid: 'YoushuSimpleIndicatorCard_mmx9ha6ao', className: 'YoushuSimpleIndicatorCard', dataSetKey: 'youshuData' },
+  statusTable: { cid: 'YoushuTable_mmx9ha6ar', className: 'YoushuTable', dataSetKey: 'table' },
+  budgetTable: { cid: 'YoushuTable_mmx9ha6a13', className: 'YoushuTable', dataSetKey: 'table' },
+};
+
+// ----- 筛选器配置 -----
+var FILTER_KEYS = {
+  status: 'filter-64d734db-c105-4372-ad2a-7833427d965b',
+  priority: 'filter-1e6ace6c-10cf-4da4-bbdd-d433af52b9dc',
+};
+
+// ----- 颜色主题 -----
+var STATUS_COLORS = { '规划中': '#6366f1', '进行中': '#0ea5e9', '已完成': '#059669', '已延期': '#d97706', '已取消': '#94a3b8' };
+var PALETTE = {
+  primary: '#1e40af',
+  primaryLight: '#3b82f6',
+  accent: '#0ea5e9',
+  success: '#059669',
+  warning: '#d97706',
+  danger: '#dc2626',
+  neutral: '#64748b',
+  bg: '#f8fafc',
+  cardBg: '#ffffff',
+  border: '#e2e8f0',
+  textPrimary: '#0f172a',
+  textSecondary: '#475569',
+  textMuted: '#94a3b8',
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  totalCount: 0,
+  totalBudget: 0,
+  avgProgress: 0,
+  statusData: [],
+  budgetData: [],
+  chartIds: ['chart-bar', 'chart-pie', 'chart-line'],
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  var chartIds = _customState.chartIds || [];
+  chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadDashboardData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadDashboardData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    var chartIds = _customState.chartIds || [];
+    chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取（基于 getDataAsync.json 后端聚合）
+// ============================================================
+
+/**
+ * 获取报表数据（使用 var 声明，避免被 UglifyJS 消除）
+ */
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+/**
+ * 解析表格数据
+ */
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+/**
+ * 解析指标值
+ */
+var _parseIndicatorValue = function(content) {
+  var data = content.data || content.dataList || [];
+  if (data.length === 0) return null;
+  var firstRow = data[0];
+  var keys = Object.keys(firstRow);
+  for (var i = 0; i < keys.length; i++) {
+    if (typeof firstRow[keys[i]] === 'number') return firstRow[keys[i]];
+  }
+  return keys.length > 0 ? firstRow[keys[0]] : null;
+};
+
+export function loadDashboardData() {
+  this.setCustomState({ loading: true });
+
+  // 并行获取所有报表组件数据
+  Promise.all([
+    _fetchReportData(REPORT_COMPONENTS.totalCount),
+    _fetchReportData(REPORT_COMPONENTS.totalBudget),
+    _fetchReportData(REPORT_COMPONENTS.avgProgress),
+    _fetchReportData(REPORT_COMPONENTS.statusTable),
+    _fetchReportData(REPORT_COMPONENTS.budgetTable),
+  ])
+  .then(function(results) {
+    this.setCustomState({
+      loading: false,
+      totalCount: _parseIndicatorValue(results[0]) || 0,
+      totalBudget: _parseIndicatorValue(results[1]) || 0,
+      avgProgress: _parseIndicatorValue(results[2]) || 0,
+      statusData: _parseTableData(results[3]),
+      budgetData: _parseTableData(results[4]),
+    });
+
+    // 渲染图表（需要延迟一帧确保 DOM 更新完成）
+    setTimeout(function() {
+      this.renderAllCharts();
+    }.bind(this), 100);
+  }.bind(this))
+  .catch(function(error) {
+    this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+    this.setCustomState({ loading: false });
+  }.bind(this));
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function renderAllCharts() {
+  if (!window.echarts) return;
+  this.renderBarChart();
+  this.renderPieChart();
+  this.renderLineChart();
+}
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderBarChart() {
+  var chart = this.createChart('chart-bar');
+  if (!chart) return;
+
+  var statusData = _customState.statusData || [];
+  var categories = statusData.map(function(item) { return item.name; });
+  var values = statusData.map(function(item) { return item.value; });
+
+  chart.setOption({
+    title: { text: '状态统计', left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'axis' },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      axisLabel: {
+        rotate: categories.length > 6 ? 30 : 0,
+        fontSize: this.utils.isMobile() ? 10 : 12,
+      },
+    },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'bar',
+      data: values,
+      itemStyle: {
+        color: function(params) {
+          var statusName = categories[params.dataIndex];
+          return STATUS_COLORS[statusName] || PALETTE.primary;
+        },
+      },
+      barMaxWidth: 40,
+    }],
+    grid: { left: '3%', right: '4%', bottom: '12%', containLabel: true },
+  });
+}
+
+export function renderPieChart() {
+  var chart = this.createChart('chart-pie');
+  if (!chart) return;
+
+  var statusData = _customState.statusData || [];
+  var pieData = statusData.map(function(item) {
+    return {
+      name: item.name,
+      value: item.value,
+      itemStyle: { color: STATUS_COLORS[item.name] || PALETTE.primary },
+    };
+  });
+
+  chart.setOption({
+    title: { text: '状态占比', left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { bottom: 0, type: 'scroll' },
+    series: [{
+      type: 'pie',
+      radius: ['40%', '70%'],
+      avoidLabelOverlap: true,
+      itemStyle: { borderRadius: 6, borderColor: '#fff', borderWidth: 2 },
+      label: { show: true, formatter: '{b}: {d}%', fontSize: this.utils.isMobile() ? 10 : 12 },
+      data: pieData,
+    }],
+  });
+}
+
+export function renderLineChart() {
+  var chart = this.createChart('chart-line');
+  if (!chart) return;
+
+  var budgetData = _customState.budgetData || [];
+  var categories = budgetData.map(function(item) { return item.name; });
+  var values = budgetData.map(function(item) { return item.value; });
+
+  chart.setOption({
+    title: { text: '预算分布', left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'axis' },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      boundaryGap: false,
+      axisLabel: { fontSize: this.utils.isMobile() ? 10 : 12 },
+    },
+    yAxis: { type: 'value' },
+    series: [{
+      type: 'line',
+      data: values,
+      smooth: true,
+      areaStyle: { color: 'rgba(59,130,246,0.15)' },
+      lineStyle: { color: PALETTE.primaryLight, width: 2 },
+      itemStyle: { color: PALETTE.primaryLight },
+    }],
+    grid: { left: '3%', right: '4%', bottom: '10%', containLabel: true },
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+  var totalCount = _customState.totalCount;
+  var totalBudget = _customState.totalBudget;
+  var avgProgress = _customState.avgProgress;
+  var statusCount = (_customState.statusData || []).length;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    statsRow: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: isMobile ? '8px' : '16px',
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    statCard: {
+      flex: isMobile ? '1 1 45%' : '1 1 22%',
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '16px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    statLabel: {
+      fontSize: '12px',
+      color: PALETTE.textMuted,
+      marginBottom: '4px',
+    },
+    statValue: {
+      fontSize: isMobile ? '20px' : '28px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+    },
+    chartsRow: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: isMobile ? '8px' : '16px',
+    },
+    chartCard: {
+      flex: isMobile ? '1 1 100%' : '1 1 48%',
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '16px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+      marginBottom: isMobile ? '8px' : '16px',
+    },
+    chartCardFull: {
+      flex: '1 1 100%',
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '16px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+      marginBottom: isMobile ? '8px' : '16px',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: PALETTE.textMuted,
+    },
+    refreshButton: {
+      padding: '8px 16px',
+      backgroundColor: PALETTE.primary,
+      color: '#fff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontSize: '13px',
+    },
+  };
+
+  var chartHeight = isMobile ? '280px' : '380px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        {/* 标题栏 */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: isMobile ? '12px' : '20px' }}>
+          <div style={styles.header}>项目看板</div>
+          <button style={styles.refreshButton} onClick={(e) => { this.loadDashboardData(); }}>刷新数据</button>
+        </div>
+
+        {/* 统计卡片 */}
+        <div style={styles.statsRow}>
+          <div style={styles.statCard}>
+            <div style={styles.statLabel}>项目总数</div>
+            <div style={styles.statValue}>{totalCount}</div>
+          </div>
+          <div style={styles.statCard}>
+            <div style={styles.statLabel}>状态数</div>
+            <div style={styles.statValue}>{statusCount}</div>
+          </div>
+          <div style={styles.statCard}>
+            <div style={styles.statLabel}>预算总计</div>
+            <div style={Object.assign({}, styles.statValue, { color: PALETTE.primaryLight })}>{totalBudget.toLocaleString()}</div>
+          </div>
+          <div style={styles.statCard}>
+            <div style={styles.statLabel}>平均进度</div>
+            <div style={Object.assign({}, styles.statValue, { color: PALETTE.success })}>{avgProgress.toFixed(1)}%</div>
+          </div>
+        </div>
+
+        {/* 图表区域 */}
+        <div style={styles.chartsRow}>
+          <div style={styles.chartCard}>
+            <div id="chart-bar" style={{ width: '100%', height: chartHeight }} />
+          </div>
+          <div style={styles.chartCard}>
+            <div id="chart-pie" style={{ width: '100%', height: chartHeight }} />
+          </div>
+          <div style={styles.chartCardFull}>
+            <div id="chart-line" style={{ width: '100%', height: chartHeight }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/line-trend.js
+++ b/yida-skills/skills/yida-chart/examples/line-trend.js
@@ -1,0 +1,391 @@
+// ============================================================
+// 折线趋势图示例（基于 getDataAsync.json 后端聚合）
+// 展示多条数据的时间趋势变化，支持多系列对比
+//
+// 数据源配置：
+//   PRD_ID: 13085982
+//   REPORT_UUID: REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1
+//   appType: APP_KNILKT41DC5XXR5D4QEC
+//
+// 报表组件：
+//   - statusTable: 状态分布（用于状态系列）
+//   - priorityTable: 优先级分布（用于优先级系列）
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var PRD_ID = '13085982';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+
+// ----- 报表组件配置 -----
+var REPORT_COMPONENTS = {
+  statusTable: { cid: 'YoushuTable_mmx9ha6ar', className: 'YoushuTable', dataSetKey: 'table' },
+  priorityTable: { cid: 'YoushuTable_mmx9ha6ax', className: 'YoushuTable', dataSetKey: 'table' },
+};
+
+// ----- 筛选器配置 -----
+var FILTER_KEYS = {
+  status: 'filter-64d734db-c105-4372-ad2a-7833427d965b',
+  priority: 'filter-1e6ace6c-10cf-4da4-bbdd-d433af52b9dc',
+};
+
+// ----- 颜色主题 -----
+var STATUS_COLORS = { '规划中': '#6366f1', '进行中': '#0ea5e9', '已完成': '#059669', '已延期': '#d97706', '已取消': '#94a3b8' };
+var PRIORITY_COLORS = { '低': '#94a3b8', '中': '#0ea5e9', '高': '#d97706', '紧急': '#dc2626' };
+var PALETTE = {
+  primary: '#1e40af',
+  primaryLight: '#3b82f6',
+  accent: '#0ea5e9',
+  success: '#059669',
+  warning: '#d97706',
+  danger: '#dc2626',
+  neutral: '#64748b',
+  bg: '#f8fafc',
+  cardBg: '#ffffff',
+  border: '#e2e8f0',
+  textPrimary: '#0f172a',
+  textSecondary: '#475569',
+  textMuted: '#94a3b8',
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-line-trend'],
+  statusData: [],
+  priorityData: [],
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  var chartIds = _customState.chartIds || [];
+  chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadTrendData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadTrendData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取（基于 getDataAsync.json 后端聚合）
+// ============================================================
+
+/**
+ * 获取报表数据（使用 var 声明，避免被 UglifyJS 消除）
+ */
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+/**
+ * 解析表格数据
+ */
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+export function loadTrendData() {
+  this.setCustomState({ loading: true });
+
+  // 并行获取所有报表组件数据
+  Promise.all([
+    _fetchReportData(REPORT_COMPONENTS.statusTable),
+    _fetchReportData(REPORT_COMPONENTS.priorityTable),
+  ])
+  .then(function(results) {
+    this.setCustomState({
+      loading: false,
+      statusData: _parseTableData(results[0]),
+      priorityData: _parseTableData(results[1]),
+    });
+
+    setTimeout(function() {
+      this.renderTrendChart();
+    }.bind(this), 100);
+  }.bind(this))
+  .catch(function(error) {
+    this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+    this.setCustomState({ loading: false });
+  }.bind(this));
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderTrendChart() {
+  var chart = this.createChart('chart-line-trend');
+  if (!chart) return;
+
+  var statusData = _customState.statusData || [];
+  var priorityData = _customState.priorityData || [];
+  var isMobile = this.utils.isMobile();
+
+  // 构建系列数据
+  var seriesList = [];
+  
+  // 状态系列
+  if (statusData.length > 0) {
+    var statusCategories = statusData.map(function(item) { return item.name; });
+    var statusValues = statusData.map(function(item) { return item.value; });
+    seriesList.push({
+      name: '状态分布',
+      type: 'line',
+      data: statusValues,
+      smooth: true,
+      symbol: 'circle',
+      symbolSize: 6,
+      lineStyle: { width: 2, color: PALETTE.primaryLight },
+      itemStyle: { color: PALETTE.primaryLight },
+      emphasis: { focus: 'series' },
+    });
+  }
+
+  // 优先级系列
+  if (priorityData.length > 0) {
+    var priorityCategories = priorityData.map(function(item) { return item.name; });
+    var priorityValues = priorityData.map(function(item) { return item.value; });
+    seriesList.push({
+      name: '优先级分布',
+      type: 'line',
+      data: priorityValues,
+      smooth: true,
+      symbol: 'circle',
+      symbolSize: 6,
+      lineStyle: { width: 2, color: PALETTE.warning },
+      itemStyle: { color: PALETTE.warning },
+      emphasis: { focus: 'series' },
+    });
+  }
+
+  // 使用状态类别作为 X 轴
+  var categories = statusData.length > 0 ? statusData.map(function(item) { return item.name; }) : [];
+
+  chart.setOption({
+    title: {
+      text: '状态与优先级分布对比',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 16 },
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'cross' },
+    },
+    legend: {
+      bottom: 0,
+      type: 'scroll',
+      textStyle: { fontSize: isMobile ? 10 : 12 },
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+      boundaryGap: false,
+      axisLabel: { fontSize: isMobile ? 10 : 12, rotate: categories.length > 8 ? 30 : 0 },
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: { fontSize: isMobile ? 10 : 12 },
+    },
+    series: seriesList,
+    grid: { left: '3%', right: '4%', bottom: '15%', top: '15%', containLabel: true },
+    dataZoom: categories.length > 12 ? [{
+      type: 'inside',
+      start: 0,
+      end: 100,
+    }] : [],
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: PALETTE.textMuted,
+    },
+  };
+
+  var chartHeight = isMobile ? '320px' : '450px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.header}>项目趋势分析</div>
+        <div style={styles.chartCard}>
+          <div id="chart-line-trend" style={{ width: '100%', height: chartHeight }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/multi-bar-compare.js
+++ b/yida-skills/skills/yida-chart/examples/multi-bar-compare.js
@@ -1,0 +1,331 @@
+// ============================================================
+// 多维度对比柱状图示例
+// 支持分组柱状图 + 堆叠柱状图两种模式切换
+// 基于宜搭原生报表后端聚合方案
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+var PRD_ID = '13085982';
+
+var STATUS_LIST = ['规划中', '进行中', '已完成', '已延期', '已取消'];
+var PRIORITY_LIST = ['低', '中', '高', '紧急'];
+var STATUS_COLORS = {规划中: '#6366f1', 进行中: '#0ea5e9', 已完成: '#059669', 已延期: '#d97706', 已取消: '#94a3b8'};
+var PRIORITY_COLORS = {低: '#94a3b8', 中: '#0ea5e9', 高: '#d97706', 紧急: '#dc2626'};
+var PALETTE = {primary: '#1e40af', primaryLight: '#3b82f6', accent: '#0ea5e9', success: '#059669', warning: '#d97706', danger: '#dc2626', neutral: '#64748b', bg: '#f8fafc', cardBg: '#ffffff', border: '#e2e8f0', textPrimary: '#0f172a', textSecondary: '#475569', textMuted: '#94a3b8'};
+
+var COMPONENT_CONFIGS = {
+  statusTable: {cid: 'YoushuTable_mmx9ha6ar', className: 'YoushuTable', dataSetKey: 'table'},
+  priorityTable: {cid: 'YoushuTable_mmx9ha6ax', className: 'YoushuTable', dataSetKey: 'table'},
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-multi-bar'],
+  barData: {},
+  isStacked: false,
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  _customState.chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadBarData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadBarData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取
+// ============================================================
+
+export function loadBarData() {
+  this.setCustomState({ loading: true });
+  this.fetchAllFormData(DATA_FORM_UUID)
+    .then(function(dataList) {
+      var barData = this.buildMultiBarData(dataList);
+      this.setCustomState({ loading: false, barData: barData });
+      setTimeout(function() {
+        this.renderMultiBarChart();
+      }.bind(this), 100);
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function fetchAllFormData(formUuid, searchCondition) {
+  var allData = [];
+  var pageSize = 100;
+  var fetchPage = function(currentPage) {
+    var params = { formUuid: formUuid, currentPage: currentPage, pageSize: pageSize };
+    if (searchCondition) {
+      params.searchFieldJson = JSON.stringify(searchCondition);
+    }
+    return this.utils.yida.searchFormDatas(params)
+      .then(function(res) {
+        allData = allData.concat(res.data || []);
+        if (currentPage * pageSize < (res.totalCount || 0)) {
+          return fetchPage.call(this, currentPage + 1);
+        }
+        return allData;
+      }.bind(this));
+  }.bind(this);
+  return fetchPage(1);
+}
+
+/**
+ * 构建多维度柱状图数据
+ * 主分类作为 X 轴，子分类作为不同系列
+ * @returns {{ mainCategories: string[], subCategories: string[], matrix: Object }}
+ */
+export function buildMultiBarData(dataList) {
+  var matrix = {};
+  var mainCatSet = {};
+  var subCatSet = {};
+
+  dataList.forEach(function(item) {
+    var mainCat = item.formData[MAIN_CATEGORY_FIELD] || '未分类';
+    var subCat = item.formData[SUB_CATEGORY_FIELD] || '未分类';
+    var numValue = Number(item.formData[NUMBER_FIELD]) || 0;
+
+    mainCatSet[mainCat] = true;
+    subCatSet[subCat] = true;
+
+    if (!matrix[mainCat]) matrix[mainCat] = {};
+    matrix[mainCat][subCat] = (matrix[mainCat][subCat] || 0) + numValue;
+  });
+
+  return {
+    mainCategories: Object.keys(mainCatSet),
+    subCategories: Object.keys(subCatSet),
+    matrix: matrix,
+  };
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderMultiBarChart() {
+  var chart = this.createChart('chart-multi-bar');
+  if (!chart) return;
+
+  var barData = _customState.barData;
+  var mainCategories = barData.mainCategories || [];
+  var subCategories = barData.subCategories || [];
+  var matrix = barData.matrix || {};
+  var isStacked = _customState.isStacked;
+  var isMobile = this.utils.isMobile();
+
+  var series = subCategories.map(function(subCat, index) {
+    var color = subCat === '状态' ? PALETTE.primaryLight : PALETTE.accent;
+    return {
+      name: subCat,
+      type: 'bar',
+      stack: isStacked ? 'total' : undefined,
+      data: mainCategories.map(function(mainCat) {
+        return (matrix[mainCat] && matrix[mainCat][subCat]) || 0;
+      }),
+      itemStyle: { color: color },
+      barMaxWidth: 30,
+      emphasis: { focus: 'series' },
+    };
+  });
+
+  chart.setOption({
+    title: {
+      text: isStacked ? '堆叠对比' : '分组对比',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 16 },
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+    },
+    legend: {
+      bottom: 0,
+      type: 'scroll',
+      textStyle: { fontSize: isMobile ? 10 : 12 },
+    },
+    xAxis: {
+      type: 'category',
+      data: mainCategories,
+      axisLabel: {
+        rotate: mainCategories.length > 6 ? 30 : 0,
+        fontSize: isMobile ? 10 : 12,
+      },
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: { fontSize: isMobile ? 10 : 12 },
+    },
+    series: series,
+    grid: { left: '3%', right: '4%', bottom: '15%', top: '15%', containLabel: true },
+  });
+}
+
+export function toggleStackMode() {
+  _customState.isStacked = !_customState.isStacked;
+  this.renderMultiBarChart();
+  this.forceUpdate();
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+  var isStacked = _customState.isStacked;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    headerRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: '#1a1a1a',
+    },
+    toggleButton: {
+      padding: '6px 14px',
+      backgroundColor: isStacked ? PALETTE.success : PALETTE.primary,
+      color: '#fff',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontSize: '13px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: '#999',
+    },
+  };
+
+  var chartHeight = isMobile ? '320px' : '450px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.headerRow}>
+          <div style={styles.header}>多维度对比</div>
+          <button style={styles.toggleButton} onClick={(e) => { this.toggleStackMode(); }}>
+            {isStacked ? '切换为分组' : '切换为堆叠'}
+          </button>
+        </div>
+        <div style={styles.chartCard}>
+          <div id="chart-multi-bar" style={{ width: '100%', height: chartHeight }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/radar-chart.js
+++ b/yida-skills/skills/yida-chart/examples/radar-chart.js
@@ -1,0 +1,430 @@
+// ============================================================
+// 雷达图示例
+// 多维度能力评估 / 指标对比，适合展示各分类在多个指标上的表现
+//
+// 数据来源：宜搭原生报表（后端聚合）
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+var PRD_ID = 13085982;
+
+// 报表组件配置
+var STATUS_TABLE_COMPONENT = {
+  cid: 'YoushuTable_mmx9ha6ar',
+  className: 'YoushuTable',
+  dataSetKey: 'table'
+};
+
+var PRIORITY_TABLE_COMPONENT = {
+  cid: 'YoushuTable_mmx9ha6ax',
+  className: 'YoushuTable',
+  dataSetKey: 'table'
+};
+
+// PALETTE 配色方案
+var PALETTE = {
+  primary: '#1e40af',
+  primaryLight: '#3b82f6',
+  accent: '#0ea5e9',
+  success: '#059669',
+  warning: '#d97706',
+  danger: '#dc2626',
+  neutral: '#64748b',
+  bg: '#f8fafc',
+  cardBg: '#ffffff',
+  border: '#e2e8f0',
+  textPrimary: '#0f172a',
+  textSecondary: '#475569',
+  textMuted: '#94a3b8'
+};
+
+var STATUS_COLORS = {
+  '规划中': '#6366f1',
+  '进行中': '#0ea5e9',
+  '已完成': '#059669',
+  '已延期': '#d97706',
+  '已取消': '#94a3b8'
+};
+
+var PRIORITY_COLORS = {
+  '低': '#94a3b8',
+  '中': '#0ea5e9',
+  '高': '#d97706',
+  '紧急': '#dc2626'
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-radar'],
+  radarData: {},
+  statusData: [],
+  priorityData: [],
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  _customState.chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// 报表数据获取函数（模块级变量）
+// ============================================================
+
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadRadarData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadRadarData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取（基于报表后端聚合）
+// ============================================================
+
+export function loadRadarData() {
+  this.setCustomState({ loading: true });
+  Promise.all([
+    _fetchReportData(STATUS_TABLE_COMPONENT, {}),
+    _fetchReportData(PRIORITY_TABLE_COMPONENT, {})
+  ])
+    .then(function(results) {
+      var statusContent = results[0];
+      var priorityContent = results[1];
+      var statusData = _parseTableData(statusContent);
+      var priorityData = _parseTableData(priorityContent);
+      var radarData = this.buildRadarData(statusData, priorityData);
+      this.setCustomState({
+        loading: false,
+        statusData: statusData,
+        priorityData: priorityData,
+        radarData: radarData
+      });
+      setTimeout(function() {
+        this.renderRadarChart();
+      }.bind(this), 100);
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+/**
+ * 构建雷达图数据
+ * 从报表聚合数据中提取状态和优先级分布
+ * @returns {{ categories: string[], seriesData: { name: string, values: number[] }[] }}
+ */
+export function buildRadarData(statusData, priorityData) {
+  var categories = ['状态分布', '优先级分布'];
+  var seriesData = [
+    {
+      name: '状态分布',
+      values: this._calculateDimensionValues(statusData, STATUS_COLORS)
+    },
+    {
+      name: '优先级分布',
+      values: this._calculateDimensionValues(priorityData, PRIORITY_COLORS)
+    }
+  ];
+  return { categories: categories, seriesData: seriesData };
+}
+
+export function _calculateDimensionValues(data, colorMap) {
+  var maxValues = [];
+  Object.keys(colorMap).forEach(function(key) {
+    var found = data.find(function(item) { return item.name === key; });
+    maxValues.push(found ? found.value : 0);
+  });
+  return maxValues;
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderRadarChart() {
+  var chart = this.createChart('chart-radar');
+  if (!chart) return;
+
+  var radarData = _customState.radarData;
+  var seriesData = radarData.seriesData || [];
+  var isMobile = this.utils.isMobile();
+
+  // 构建雷达图指示器：状态和优先级的各个维度
+  var allIndicators = [];
+  var statusLabels = Object.keys(STATUS_COLORS);
+  var priorityLabels = Object.keys(PRIORITY_COLORS);
+  
+  statusLabels.forEach(function(label) {
+    allIndicators.push({ name: label, max: 100 });
+  });
+  priorityLabels.forEach(function(label) {
+    allIndicators.push({ name: label, max: 100 });
+  });
+
+  // 合并状态和优先级数据
+  var mergedSeriesData = seriesData.map(function(s) {
+    var allValues = [];
+    statusLabels.forEach(function(label) {
+      var found = _customState.statusData.find(function(item) { return item.name === label; });
+      allValues.push(found ? found.value : 0);
+    });
+    priorityLabels.forEach(function(label) {
+      var found = _customState.priorityData.find(function(item) { return item.name === label; });
+      allValues.push(found ? found.value : 0);
+    });
+    return {
+      name: s.name,
+      value: allValues,
+      lineStyle: { color: PALETTE.primary, width: 2 },
+      itemStyle: { color: PALETTE.primary },
+      areaStyle: { color: PALETTE.primary, opacity: 0.15 },
+    };
+  });
+
+  chart.setOption({
+    title: {
+      text: '任务状态与优先级分布',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 16, color: PALETTE.textPrimary },
+    },
+    tooltip: {
+      trigger: 'item',
+    },
+    legend: {
+      bottom: 0,
+      type: 'scroll',
+      data: seriesData.map(function(s) { return s.name; }),
+      textStyle: { fontSize: isMobile ? 10 : 12, color: PALETTE.textSecondary },
+    },
+    radar: {
+      indicator: allIndicators,
+      radius: isMobile ? '55%' : '65%',
+      center: ['50%', '50%'],
+      name: {
+        textStyle: { fontSize: isMobile ? 10 : 12, color: PALETTE.textSecondary },
+      },
+      splitArea: {
+        areaStyle: {
+          color: [PALETTE.bg, PALETTE.cardBg]
+        }
+      },
+      axisLine: {
+        lineStyle: {
+          color: PALETTE.border
+        }
+      },
+      splitLine: {
+        lineStyle: {
+          color: PALETTE.border
+        }
+      }
+    },
+    series: [{
+      type: 'radar',
+      data: mergedSeriesData,
+    }],
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: PALETTE.textMuted,
+    },
+  };
+
+  var chartHeight = isMobile ? '350px' : '480px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.header}>任务状态与优先级分布</div>
+        <div style={styles.chartCard}>
+          <div id="chart-radar" style={{ width: '100%', height: chartHeight }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/scatter-bindform.js
+++ b/yida-skills/skills/yida-chart/examples/scatter-bindform.js
@@ -1,0 +1,400 @@
+// ============================================================
+// 散点图示例
+// 展示两个数值维度之间的相关性，支持按分类着色和气泡大小
+// 基于宜搭原生报表后端聚合方案
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+var PRD_ID = '13085982';
+
+var STATUS_LIST = ['规划中', '进行中', '已完成', '已延期', '已取消'];
+var PRIORITY_LIST = ['低', '中', '高', '紧急'];
+var STATUS_COLORS = {规划中: '#6366f1', 进行中: '#0ea5e9', 已完成: '#059669', 已延期: '#d97706', 已取消: '#94a3b8'};
+var PRIORITY_COLORS = {低: '#94a3b8', 中: '#0ea5e9', 高: '#d97706', 紧急: '#dc2626'};
+var PALETTE = {primary: '#1e40af', primaryLight: '#3b82f6', accent: '#0ea5e9', success: '#059669', warning: '#d97706', danger: '#dc2626', neutral: '#64748b', bg: '#f8fafc', cardBg: '#ffffff', border: '#e2e8f0', textPrimary: '#0f172a', textSecondary: '#475569', textMuted: '#94a3b8'};
+
+var COMPONENT_CONFIGS = {
+  budgetTable: {cid: 'YoushuTable_mmx9ha6a13', className: 'YoushuTable', dataSetKey: 'table'},
+};
+
+var X_AXIS_LABEL = '预算';
+var Y_AXIS_LABEL = '实际支出';
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-scatter'],
+  scatterData: {},
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  _customState.chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadScatterData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadScatterData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取
+// ============================================================
+
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+export function loadScatterData() {
+  this.setCustomState({ loading: true });
+  _fetchReportData(COMPONENT_CONFIGS.budgetTable)
+    .then(function(content) {
+      var scatterData = this.buildScatterData(content);
+      this.setCustomState({ loading: false, scatterData: scatterData });
+      setTimeout(function() {
+        this.renderScatterChart();
+      }.bind(this), 100);
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+/**
+ * 构建散点图数据
+ * 从后端聚合数据中提取维度和度量值
+ * @returns {{ categories: string[], seriesMap: Object }}
+ */
+export function buildScatterData(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  var seriesMap = {};
+
+  if (data.length === 0) return { categories: [], seriesMap: {} };
+
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+
+  if (!dimField || !measureField) return { categories: [], seriesMap: {} };
+
+  data.forEach(function(row) {
+    var category = row[dimField] || '未分类';
+    var xVal = Number(row[measureField]) || 0;
+    var yVal = Number(row[measureField]) || 0;
+
+    if (!seriesMap[category]) seriesMap[category] = [];
+    seriesMap[category].push([xVal, yVal, xVal]);
+  });
+
+  return {
+    categories: Object.keys(seriesMap),
+    seriesMap: seriesMap,
+  };
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderScatterChart() {
+  var chart = this.createChart('chart-scatter');
+  if (!chart) return;
+
+  var scatterData = _customState.scatterData;
+  var categories = scatterData.categories || [];
+  var seriesMap = scatterData.seriesMap || {};
+  var isMobile = this.utils.isMobile();
+  var hasSizeField = SIZE_FIELD !== null;
+
+  var series = categories.map(function(cat, index) {
+    var color = STATUS_COLORS[cat] || PRIORITY_COLORS[cat] || PALETTE.primaryLight;
+    return {
+      name: cat,
+      type: 'scatter',
+      data: seriesMap[cat],
+      symbolSize: function(data) {
+        var sizeVal = data[2] || 1;
+        return Math.max(8, Math.min(40, Math.sqrt(sizeVal) * 4));
+      },
+      itemStyle: { color: color, opacity: 0.7 },
+      emphasis: {
+        focus: 'series',
+        itemStyle: { opacity: 1, borderColor: '#333', borderWidth: 1 },
+      },
+    };
+  });
+
+  chart.setOption({
+    title: {
+      text: '相关性分析',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 16 },
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: function(params) {
+        var data = params.data;
+        var tip = params.seriesName + '<br/>'
+          + X_AXIS_LABEL + ': ' + data[0] + '<br/>'
+          + Y_AXIS_LABEL + ': ' + data[1];
+        if (hasSizeField && data[2] !== undefined) {
+          tip += '<br/>数值: ' + data[2];
+        }
+        return tip;
+      },
+    },
+    legend: {
+      bottom: 0,
+      type: 'scroll',
+      data: categories,
+      textStyle: { fontSize: isMobile ? 10 : 12 },
+    },
+    xAxis: {
+      type: 'value',
+      name: X_AXIS_LABEL,
+      nameLocation: 'center',
+      nameGap: 30,
+      axisLabel: { fontSize: isMobile ? 10 : 12 },
+    },
+    yAxis: {
+      type: 'value',
+      name: Y_AXIS_LABEL,
+      nameLocation: 'center',
+      nameGap: 40,
+      axisLabel: { fontSize: isMobile ? 10 : 12 },
+    },
+    series: series,
+    grid: { left: '5%', right: '5%', bottom: '15%', top: '12%', containLabel: true },
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+  var scatterData = _customState.scatterData;
+  var totalPoints = 0;
+  var categories = scatterData.categories || [];
+  categories.forEach(function(cat) {
+    totalPoints += (scatterData.seriesMap[cat] || []).length;
+  });
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    headerRow: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+    },
+    badge: {
+      padding: '4px 10px',
+      backgroundColor: PALETTE.bg,
+      color: PALETTE.primary,
+      borderRadius: '12px',
+      fontSize: '12px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: '#999',
+    },
+  };
+
+  var chartHeight = isMobile ? '320px' : '480px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.headerRow}>
+          <div style={styles.header}>散点分析</div>
+          <div style={styles.badge}>{totalPoints} 个数据点 · {categories.length} 个分类</div>
+        </div>
+        <div style={styles.chartCard}>
+          <div id="chart-scatter" style={{ width: '100%', height: chartHeight }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-chart/examples/stacked-area.js
+++ b/yida-skills/skills/yida-chart/examples/stacked-area.js
@@ -1,0 +1,357 @@
+// ============================================================
+// 堆叠面积图示例
+// 展示各分类随时间的占比变化趋势，适合分析结构性变化
+// 基于宜搭原生报表后端聚合方案
+// ============================================================
+
+var ECHARTS_CDN = 'https://g.alicdn.com/code/lib/echarts/5.6.0/echarts.min.js';
+var REPORT_UUID = 'REPORT-0R8665A1ED54RG45IJWIX55W9Q8U2U6AH9XMM1';
+var PRD_ID = '13085982';
+
+var STATUS_LIST = ['规划中', '进行中', '已完成', '已延期', '已取消'];
+var PRIORITY_LIST = ['低', '中', '高', '紧急'];
+var STATUS_COLORS = {规划中: '#6366f1', 进行中: '#0ea5e9', 已完成: '#059669', 已延期: '#d97706', 已取消: '#94a3b8'};
+var PRIORITY_COLORS = {低: '#94a3b8', 中: '#0ea5e9', 高: '#d97706', 紧急: '#dc2626'};
+var PALETTE = {primary: '#1e40af', primaryLight: '#3b82f6', accent: '#0ea5e9', success: '#059669', warning: '#d97706', danger: '#dc2626', neutral: '#64748b', bg: '#f8fafc', cardBg: '#ffffff', border: '#e2e8f0', textPrimary: '#0f172a', textSecondary: '#475569', textMuted: '#94a3b8'};
+
+var COMPONENT_CONFIGS = {
+  statusTable: {cid: 'YoushuTable_mmx9ha6ar', className: 'YoushuTable', dataSetKey: 'table'},
+  priorityTable: {cid: 'YoushuTable_mmx9ha6ax', className: 'YoushuTable', dataSetKey: 'table'},
+};
+
+// ============================================================
+// 状态管理
+// ============================================================
+
+var _customState = {
+  loading: true,
+  chartIds: ['chart-stacked-area'],
+  areaData: {},
+  showPercentage: false,
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) {
+    _customState[key] = newState[key];
+  });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+
+// ============================================================
+// 生命周期
+// ============================================================
+
+export function didMount() {
+  this.loadECharts();
+}
+
+export function didUnmount() {
+  _customState.chartIds.forEach(function(domId) {
+    var container = document.getElementById(domId);
+    if (container) {
+      var instance = window.echarts.getInstanceByDom(container);
+      if (instance) instance.dispose();
+    }
+  });
+  if (this._resizeHandler) {
+    window.removeEventListener('resize', this._resizeHandler);
+  }
+}
+
+// ============================================================
+// ECharts 加载
+// ============================================================
+
+export function loadECharts() {
+  if (window.echarts) {
+    this.bindChartResize();
+    this.loadAreaData();
+    return;
+  }
+  this.utils.loadScript(ECHARTS_CDN)
+    .then(function() {
+      this.bindChartResize();
+      this.loadAreaData();
+    }.bind(this))
+    .catch(function() {
+      this.utils.toast({ title: 'ECharts 加载失败，请刷新重试', type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+export function bindChartResize() {
+  this._resizeHandler = function() {
+    _customState.chartIds.forEach(function(domId) {
+      var container = document.getElementById(domId);
+      if (container) {
+        var instance = window.echarts.getInstanceByDom(container);
+        if (instance) instance.resize();
+      }
+    });
+  }.bind(this);
+  window.addEventListener('resize', this._resizeHandler);
+}
+
+// ============================================================
+// 数据获取
+// ============================================================
+
+var _fetchReportData = function(componentConfig, filterValueMap) {
+  var appType = window.pageConfig && window.pageConfig.appType;
+  var csrfToken = window.g_config && window.g_config._csrf_token;
+  var queryContext = {
+    aliasList: [],
+    filterValueMap: filterValueMap || {},
+    dim2table: true,
+    orderByList: [],
+    needTotalCount: componentConfig.className === 'YoushuTable',
+    variableParams: {},
+    paging: { start: 0, limit: 100 },
+  };
+  var body = new URLSearchParams({
+    timezone: 'GMT+8',
+    _tb_token_: csrfToken, _csrf_token: csrfToken, _csrf: csrfToken,
+    prdId: PRD_ID,
+    pageId: REPORT_UUID,
+    pageName: 'report',
+    cid: componentConfig.cid,
+    cname: '',
+    componentClassName: componentConfig.className,
+    queryContext: JSON.stringify(queryContext),
+    dataSetKey: componentConfig.dataSetKey,
+    enabledCache: 'true',
+    queryTimestamp: String(Date.now()),
+    appendTraceId: 'true',
+  });
+  var url = '/alibaba/web/' + appType + '/visual/visualizationDataRpc/getDataAsync.json?_api=EDataService.getDataAsync&_mock=false&_stamp=' + Date.now();
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', 'accept': 'application/json, text/json', 'x-requested-with': 'XMLHttpRequest' },
+    body: body.toString(),
+    credentials: 'include',
+  }).then(function(r) { return r.json(); })
+    .then(function(result) {
+      if (result.success && result.content) return result.content;
+      throw new Error(result.errorMsg || '报表数据获取失败');
+    });
+};
+
+var _parseTableData = function(content) {
+  var data = content.data || content.dataList || [];
+  var meta = content.meta || [];
+  if (data.length === 0) return [];
+  var dimField = null;
+  var measureField = null;
+  if (meta.length >= 2) {
+    dimField = meta[0].alias;
+    measureField = meta[1].alias;
+  } else if (data.length > 0) {
+    var firstRow = data[0];
+    Object.keys(firstRow).forEach(function(key) {
+      if (typeof firstRow[key] === 'string' && !dimField) dimField = key;
+      else if (typeof firstRow[key] === 'number' && !measureField) measureField = key;
+    });
+  }
+  if (!dimField || !measureField) return [];
+  var result = [];
+  data.forEach(function(row) {
+    if (row[dimField] != null) {
+      result.push({ name: String(row[dimField]), value: Number(row[measureField]) || 0 });
+    }
+  });
+  return result;
+};
+
+export function loadAreaData() {
+  this.setCustomState({ loading: true });
+  Promise.all([
+    _fetchReportData(COMPONENT_CONFIGS.statusTable),
+    _fetchReportData(COMPONENT_CONFIGS.priorityTable),
+  ])
+    .then(function(results) {
+      var statusData = _parseTableData(results[0]);
+      var priorityData = _parseTableData(results[1]);
+      var areaData = this.buildAreaData(statusData, priorityData);
+      this.setCustomState({ loading: false, areaData: areaData });
+      setTimeout(function() {
+        this.renderAreaChart();
+      }.bind(this), 100);
+    }.bind(this))
+    .catch(function(error) {
+      this.utils.toast({ title: '数据加载失败: ' + error.message, type: 'error' });
+      this.setCustomState({ loading: false });
+    }.bind(this));
+}
+
+/**
+ * 构建堆叠面积图数据
+ * 从后端聚合数据中提取维度和度量值
+ */
+export function buildAreaData(statusData, priorityData) {
+  var allData = statusData.concat(priorityData);
+  var seriesMap = {};
+  var monthSet = {};
+
+  allData.forEach(function(item) {
+    var category = item.name || '未分类';
+    var numValue = item.value || 0;
+    var month = '2024-01';
+    monthSet[month] = true;
+
+    if (!seriesMap[category]) seriesMap[category] = {};
+    seriesMap[category][month] = (seriesMap[category][month] || 0) + numValue;
+  });
+
+  var months = Object.keys(monthSet).sort();
+  var categories = Object.keys(seriesMap);
+  var series = categories.map(function(cat) {
+    return {
+      name: cat,
+      data: months.map(function(m) { return seriesMap[cat][m] || 0; }),
+    };
+  });
+
+  return { months: months, series: series };
+}
+
+// ============================================================
+// 图表渲染
+// ============================================================
+
+export function createChart(domId) {
+  var container = document.getElementById(domId);
+  if (!container) return null;
+  var existingInstance = window.echarts.getInstanceByDom(container);
+  if (existingInstance) existingInstance.dispose();
+  return window.echarts.init(container);
+}
+
+export function renderAreaChart() {
+  var chart = this.createChart('chart-stacked-area');
+  if (!chart) return;
+
+  var areaData = _customState.areaData;
+  var months = areaData.months || [];
+  var seriesList = areaData.series || [];
+  var isMobile = this.utils.isMobile();
+
+  chart.setOption({
+    title: {
+      text: '趋势占比分析',
+      left: 'center',
+      textStyle: { fontSize: isMobile ? 14 : 16 },
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'cross' },
+    },
+    legend: {
+      bottom: 0,
+      type: 'scroll',
+      textStyle: { fontSize: isMobile ? 10 : 12 },
+    },
+    xAxis: {
+      type: 'category',
+      data: months,
+      boundaryGap: false,
+      axisLabel: { fontSize: isMobile ? 10 : 12, rotate: months.length > 8 ? 30 : 0 },
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: { fontSize: isMobile ? 10 : 12 },
+    },
+    series: seriesList.map(function(s, index) {
+      var color = STATUS_COLORS[s.name] || PRIORITY_COLORS[s.name] || PALETTE.primaryLight;
+      return {
+        name: s.name,
+        type: 'line',
+        stack: 'total',
+        data: s.data,
+        smooth: true,
+        lineStyle: { width: 1, color: color },
+        itemStyle: { color: color },
+        areaStyle: { color: color, opacity: 0.4 },
+        emphasis: { focus: 'series' },
+      };
+    }),
+    grid: { left: '3%', right: '4%', bottom: '15%', top: '15%', containLabel: true },
+    dataZoom: months.length > 12 ? [{
+      type: 'inside',
+      start: 0,
+      end: 100,
+    }] : [],
+  });
+}
+
+// ============================================================
+// 渲染
+// ============================================================
+
+export function renderJsx() {
+  var timestamp = this.state.timestamp;
+  var isMobile = this.utils.isMobile();
+  var loading = _customState.loading;
+
+  var styles = {
+    container: {
+      padding: isMobile ? '12px' : '24px',
+      minHeight: '100vh',
+      backgroundColor: PALETTE.bg,
+      borderRadius: '0 !important',
+    },
+    header: {
+      fontSize: isMobile ? '18px' : '22px',
+      fontWeight: 'bold',
+      color: PALETTE.textPrimary,
+      marginBottom: isMobile ? '12px' : '20px',
+    },
+    chartCard: {
+      backgroundColor: PALETTE.cardBg,
+      borderRadius: '8px',
+      padding: isMobile ? '12px' : '20px',
+      boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
+    },
+    loadingContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      minHeight: '400px',
+      fontSize: '16px',
+      color: '#999',
+    },
+  };
+
+  var chartHeight = isMobile ? '320px' : '450px';
+
+  if (loading) {
+    return (
+      <div>
+        <div style={{ display: 'none' }}>{timestamp}</div>
+        <div style={styles.container}>
+          <div style={styles.loadingContainer}>数据加载中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'none' }}>{timestamp}</div>
+      <div style={styles.container}>
+        <div style={styles.header}>堆叠面积趋势</div>
+        <div style={styles.chartCard}>
+          <div id="chart-stacked-area" style={{ width: '100%', height: chartHeight }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -426,6 +426,8 @@ openyida publish <源文件路径> <appType> <formUuid>
 - didUnmount 函数
 - renderJsx 函数
 
+> ⚠️ **关键约束：`renderJsx` 的每个 `return` 分支都必须包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`**，否则 `forceUpdate` 调用 `this.setState({ timestamp })` 后，React 无法检测到输出变化，`renderJsx` 不会被重新执行，页面将无法更新。这是宜搭渲染引擎触发重渲染的核心机制。
+
 以下是一个完整自定义页面示例，包含状态管理、生命周期钩子、渲染函数
 
 ```jsx

--- a/yida-skills/skills/yida-report/SKILL.md
+++ b/yida-skills/skills/yida-report/SKILL.md
@@ -1,0 +1,774 @@
+# 宜搭原生报表 + ECharts 自定义看板 技能文档
+
+## 概述
+
+本技能记录了通过宜搭原生报表（YoushuTable）的聚合数据驱动 ECharts 图表看板的完整实践经验，包含 API 调用方式、数据解析、踩坑记录和最佳实践。
+
+---
+
+## 核心架构
+
+```
+宜搭表单（数据源）
+    ↓ 数据写入
+宜搭原生报表（服务端聚合）
+    ↓ 报表 API
+ECharts 自定义页面（前端渲染）
+```
+
+**为什么不用 `searchFormDatas` 前端聚合？**
+
+| 对比项 | `searchFormDatas` 前端聚合 | 原生报表 API |
+|--------|--------------------------|-------------|
+| 数据准确性 | ❌ pageSize 最大 100，数据量大时不完整 | ✅ 服务端聚合，数据 100% 准确 |
+| 性能 | ❌ 需要分页拉取全部数据再前端计算 | ✅ 服务端直接返回聚合结果 |
+| 适用场景 | 数据量 < 100 条的简单统计 | 任意数据量的聚合统计 |
+
+---
+
+## 报表 API 详解
+
+### 接口地址
+
+```
+POST /alibaba/web/{appType}/visual/visualizationDataRpc/getDataAsync.json
+```
+
+### 关键参数
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `pageName` | String | 是 | 固定值 `"report"` |
+| `prdId` | String | 是 | 报表的 prdId（从报表 URL 中获取） |
+| `cid` | String | 是 | 报表组件 ID（如 `YoushuTable_mmx9ha6ar`） |
+| `cname` | String | 是 | 组件名称（如 `"按状态统计"`） |
+| `className` | String | 是 | 组件类名（如 `"YoushuTable"`、`"YoushuSimpleIndicatorCard"`） |
+| `dataSetKey` | String | 是 | 数据集 key（表格用 `"table"`，指标卡用 `"youshuData"`） |
+
+### 请求示例
+
+```javascript
+var requestBody = {
+  pageName: "report",
+  prdId: "13085982",
+  cid: "YoushuTable_mmx9ha6ar",
+  cname: "按状态统计",
+  className: "YoushuTable",
+  dataSetKey: "table",
+};
+
+this.utils.yida.request({
+  url: "/alibaba/web/" + APP_TYPE + "/visual/visualizationDataRpc/getDataAsync.json",
+  method: "POST",
+  data: requestBody,
+});
+```
+
+### 返回数据结构
+
+```json
+{
+  "content": {
+    "data": [
+      ["进行中", 8],
+      ["已完成", 5],
+      ["规划中", 4],
+      ["已延期", 2],
+      ["已取消", 1]
+    ],
+    "meta": [
+      {
+        "alias": "项目状态",
+        "dataType": "STRING",
+        "type": "DIMENSION"
+      },
+      {
+        "alias": "项目数量",
+        "dataType": "LONG",
+        "type": "MEASURE"
+      }
+    ]
+  }
+}
+```
+
+### 数据解析方法
+
+```javascript
+function parseTableData(responseData) {
+  var dataArray = responseData.data || [];
+  var metaArray = responseData.meta || [];
+
+  // 从 meta 中识别维度字段和度量字段
+  var dimensionIndex = -1;
+  var measureIndex = -1;
+  var dimensionAlias = "";
+  var measureAlias = "";
+
+  metaArray.forEach(function(m, i) {
+    if (m.type === "DIMENSION") {
+      dimensionIndex = i;
+      dimensionAlias = m.alias;
+    } else if (m.type === "MEASURE") {
+      measureIndex = i;
+      measureAlias = m.alias;
+    }
+  });
+
+  // 如果 meta 没有 type 字段，按顺序推断：第一个是维度，第二个是度量
+  if (dimensionIndex === -1 && metaArray.length >= 2) {
+    dimensionIndex = 0;
+    measureIndex = 1;
+    dimensionAlias = metaArray[0].alias;
+    measureAlias = metaArray[1].alias;
+  }
+
+  return dataArray.map(function(row) {
+    return {
+      name: String(row[dimensionIndex] || ""),
+      value: parseFloat(row[measureIndex]) || 0,
+    };
+  });
+}
+```
+
+---
+
+## 报表组件类型
+
+### YoushuSimpleIndicatorCard（指标卡）
+
+- **用途**：显示单个聚合数值（如项目总数、总预算）
+- **dataSetKey**：`"youshuData"`
+- **返回格式**：`{ content: { data: [[42]], meta: [...] } }`
+- **取值方式**：`data[0][0]`
+
+### YoushuTable（统计表格）
+
+- **用途**：按维度分组统计（如按状态统计项目数）
+- **dataSetKey**：`"table"`
+- **返回格式**：`{ content: { data: [["进行中", 8], ["已完成", 5]], meta: [...] } }`
+- **取值方式**：遍历 `data` 数组，每行 `[维度值, 度量值]`
+
+---
+
+## 🔥 踩坑记录
+
+### 坑 1：数值聚合必须使用 NumberField
+
+**现象**：报表对"项目预算"字段做 SUM 聚合时返回 0 或报错。
+
+**原因**：预算字段使用了 `TextField`（文本组件），文本类型无法进行数值聚合（SUM、AVG 等）。
+
+**解决**：将字段类型从 `TextField` 改为 `NumberField`。
+
+```bash
+# 更新表单字段类型
+openyida create-form update <appType> <formUuid> '[
+  {"action":"delete","fieldId":"textField_j2xeja4e"},
+  {"action":"add","field":{"type":"NumberField","label":"项目预算","placeholder":"请输入预算金额"}}
+]'
+```
+
+**⚠️ 注意**：改字段类型后，旧数据中该字段的值会丢失，需要重新写入。
+
+### 坑 2：报表 API 路径
+
+**错误路径**：
+```
+❌ /yida-report/data/queryReportData.json
+❌ /alibaba/web/{appType}/query/reportData.json
+```
+
+**正确路径**：
+```
+✅ /alibaba/web/{appType}/visual/visualizationDataRpc/getDataAsync.json
+```
+
+### 坑 3：prdId 获取方式
+
+**prdId 不是 formUuid**，而是报表页面 URL 中的数字 ID。
+
+获取方式：
+1. 在浏览器中打开报表页面
+2. 打开开发者工具 → Network
+3. 搜索 `getDataAsync` 请求
+4. 在请求参数中找到 `prdId` 值
+
+### 坑 4：组件 ID（cid）获取方式
+
+每个报表组件都有唯一的 `cid`，格式为 `{组件类名}_{随机字符串}`。
+
+获取方式：同上，在 Network 中查看 `getDataAsync` 请求的参数。
+
+### 坑 5：dataSetKey 区分
+
+| 组件类型 | dataSetKey |
+|---------|-----------|
+| `YoushuSimpleIndicatorCard`（指标卡） | `"youshuData"` |
+| `YoushuTable`（统计表格） | `"table"` |
+
+**用错 dataSetKey 会导致返回空数据。**
+
+### 坑 6：searchFormDatas 没有 HTTP API
+
+`searchFormDatas` 是宜搭前端 JS SDK 的接口（`this.utils.yida.searchFormDatas`），**不能**通过 HTTP 直接调用。
+
+```
+❌ POST /dingtalk/web/{appType}/query/punchFormDataProvider/searchFormDatas.json → 404
+❌ POST /dingtalk/web/{appType}/v1/form/searchFormDatas.json → 超时
+```
+
+但 `saveFormData` 可以通过 HTTP 调用：
+```
+✅ POST /dingtalk/web/{appType}/query/punchFormDataProvider/saveFormData.json
+```
+
+### 坑 7：cookies.json 格式
+
+openyida 的 `.cache/cookies.json` 中，cookies 是**数组**格式，不是字符串：
+
+```json
+{
+  "cookies": [
+    {"name": "cna", "value": "xxx", "domain": ".aliwork.com", "path": "/"},
+    {"name": "tianshu_csrf_token", "value": "xxx", "domain": ".aliwork.com", "path": "/"}
+  ],
+  "base_url": "https://www.aliwork.com"
+}
+```
+
+使用时需要拼接：
+```javascript
+var cookieStr = cookies.map(ck => ck.name + '=' + ck.value).join('; ');
+```
+
+### 坑 8：不要用 fallback 逻辑
+
+**反模式**：报表 API 失败时回退到 `searchFormDatas` 前端聚合。
+
+**问题**：`searchFormDatas` 的 pageSize 最大 100，数据量超过 100 条时聚合结果不准确，用户看到错误数据比看到错误提示更糟糕。
+
+**正确做法**：报表 API 失败时直接显示错误信息，方便排查问题。
+
+---
+
+## 完整开发流程
+
+### Step 1：创建数据源表单
+
+确保需要聚合的字段使用正确的组件类型：
+
+| 聚合类型 | 必须使用的组件 | 不能使用的组件 |
+|---------|-------------|-------------|
+| SUM / AVG | `NumberField` | ❌ `TextField` |
+| COUNT | 任意组件 | — |
+| COUNT_DISTINCT | 任意组件 | — |
+| MIN / MAX | `NumberField` / `DateField` | ❌ `TextField` |
+
+### Step 2：创建原生报表
+
+```bash
+openyida create-report <appType> <formUuid> <报表配置JSON>
+```
+
+报表配置中定义需要的统计组件（指标卡、统计表格等）。
+
+### Step 3：获取报表参数
+
+- `prdId`：通过 `getFormSchema.json` 接口动态获取（`content.topicId`），或从浏览器 Network 中手动获取
+- 各组件的 `cid`、`cname`、`className`、`dataSetKey`：从报表 Schema 中提取
+
+### Step 4：编写 ECharts 自定义页面
+
+```javascript
+// 1. 定义报表组件配置
+var REPORT_COMPONENTS = {
+  totalCount: {
+    cid: "YoushuSimpleIndicatorCard_xxx",
+    cname: "项目总数",
+    className: "YoushuSimpleIndicatorCard",
+    dataSetKey: "youshuData",
+  },
+  statusTable: {
+    cid: "YoushuTable_xxx",
+    cname: "按状态统计",
+    className: "YoushuTable",
+    dataSetKey: "table",
+  },
+};
+
+// 2. 调用报表 API
+function fetchReportData(component) {
+  return this.utils.yida.request({
+    url: "/alibaba/web/" + APP_TYPE + "/visual/visualizationDataRpc/getDataAsync.json",
+    method: "POST",
+    data: {
+      pageName: "report",
+      prdId: PRD_ID,
+      cid: component.cid,
+      cname: component.cname,
+      className: component.className,
+      dataSetKey: component.dataSetKey,
+    },
+  });
+}
+
+// 3. 解析数据并渲染 ECharts
+```
+
+### Step 5：发布
+
+```bash
+openyida publish <源文件路径> <appType> <formUuid>
+```
+
+---
+
+## 表单数据批量写入（HTTP API）
+
+通过 openyida 的 `lib/utils.js` 中的 `httpPost` 方法批量写入数据：
+
+```javascript
+const { httpPost } = require('lib/utils.js');
+const querystring = require('querystring');
+
+const postData = querystring.stringify({
+  _csrf_token: csrfToken,
+  formUuid: FORM_UUID,
+  formDataJson: JSON.stringify({
+    textField_xxx: '项目名称',
+    numberField_xxx: 280,
+    selectField_xxx: '进行中',
+  }),
+});
+
+await httpPost(baseUrl, `/dingtalk/web/${APP_TYPE}/query/punchFormDataProvider/saveFormData.json`, postData, cookies);
+```
+
+**注意**：`cookies` 参数是数组格式 `[{name, value, domain, path}]`，`httpPost` 内部会自动拼接。
+
+---
+
+## 可用的聚合函数
+
+| 聚合函数 | 说明 | 适用字段类型 |
+|---------|------|------------|
+| `COUNT` | 计数 | 所有类型 |
+| `COUNT_DISTINCT` | 去重计数 | 所有类型 |
+| `SUM` | 求和 | `NumberField` |
+| `AVG` | 平均值 | `NumberField` |
+| `MIN` | 最小值 | `NumberField`、`DateField` |
+| `MAX` | 最大值 | `NumberField`、`DateField` |
+
+---
+
+## 常见问题
+
+**Q：报表 API 返回空数据？**
+- 检查 `prdId` 是否正确
+- 检查 `cid` 是否与报表中的组件匹配
+- 检查 `dataSetKey` 是否正确（指标卡用 `youshuData`，表格用 `table`）
+
+**Q：SUM 聚合返回 0？**
+- 检查字段是否为 `NumberField` 类型
+- `TextField` 无法进行数值聚合，必须改为 `NumberField`
+- 改字段类型后旧数据会丢失，需要重新写入
+
+**Q：如何调试报表 API？**
+1. 在浏览器中打开报表页面
+2. 打开 DevTools → Network → 搜索 `getDataAsync`
+3. 查看请求参数和返回数据
+4. 将参数复制到自定义页面代码中
+
+**Q：ECharts 图表不显示？**
+- 确认 ECharts CDN 加载成功：`https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js`
+- 确认 DOM 元素已渲染后再调用 `echarts.init()`
+- 使用 `setTimeout` 延迟初始化图表
+
+---
+
+## 原生报表 Schema 构建（vc-yida-report）
+
+### 概述
+
+宜搭提供了原生报表组件库 `vc-yida-report`，包含 **16 种**开箱即用的报表组件，涵盖图表、表格、筛选器、指标卡等。通过 Schema 构建脚本 `build-yida-report-schema.js` 可以快速生成报表页面的完整 Schema，无需手写配置。
+
+- **组件库地址**：`//g.alicdn.com/code/npm/@ali/vc-yida-report/1.0.101/pc.js`
+- **全局挂载**：`window.YidaReport`
+- **Schema 构建脚本**：[`build-yida-report-schema.js`](./build-yida-report-schema.js)
+- **组件详细文档**：[`reference/vc-yida-report-components-doc.md`](../../reference/vc-yida-report-components-doc.md)
+
+### 组件总览
+
+| 组件名 | 中文名 | 构建函数 | 类型 |
+|--------|--------|---------|------|
+| `YoushuSimpleIndicatorCard` | 指标卡 | `buildSchema.simpleIndicatorCard()` | KPI 展示 |
+| `YoushuLineChart` | 折线图 | `buildSchema.lineChart()` | 图表 |
+| `YoushuPieChart` | 饼图 | `buildSchema.pieChart()` | 图表 |
+| `YoushuGroupedBarChart` | 分组条形图 | `buildSchema.groupedBarChart()` | 图表 |
+| `YoushuFunnelChart` | 漏斗图 | `buildSchema.funnelChart()` | 图表 |
+| `YoushuGauge` | 仪表盘 | `buildSchema.gauge()` | 图表 |
+| `YoushuRadarChart` | 雷达图 | `buildSchema.radarChart()` | 图表 |
+| `YoushuHeatmap` | 热力图 | `buildSchema.heatmap()` | 图表 |
+| `YoushuCalendarHeatmap` | 日历热力图 | `buildSchema.calendarHeatmap()` | 图表 |
+| `YoushuComboChart` | 组合图 | `buildSchema.comboChart()` | 图表 |
+| `YoushuWordCloud` | 词云图 | `buildSchema.wordCloud()` | 图表 |
+| `YoushuMap` | 地图 | `buildSchema.map()` | 图表 |
+| `YoushuCrossPivotTable` | 交叉透视表 | `buildSchema.crossPivotTable()` | 表格 |
+| `YoushuTable` | 基础表格 | `buildSchema.table()` | 表格 |
+| `YoushuPageHeader` | 页面标题栏 | `buildSchema.pageHeader()` | 布局 |
+| `YoushuTopFilterContainer` | 顶部筛选容器 | `buildSchema.topFilterContainer()` | 筛选 |
+| `YoushuSelectFilter` | 下拉筛选器 | `buildSchema.selectFilter()` | 筛选 |
+| `YoushuTimeFilter` | 时间筛选器 | `buildSchema.timeFilter()` | 筛选 |
+| `YoushuInputFilter` | 区间筛选器 | `buildSchema.inputFilter()` | 筛选 |
+
+### 核心工具函数
+
+Schema 构建脚本提供以下核心函数，使用前需先引入：
+
+```javascript
+const {
+  buildSchema,           // 各组件 Schema 构建器
+  buildDataSetEntry,     // 构建数据集配置
+  buildFieldDefinition,  // 构建字段定义
+  buildFilterItem,       // 构建过滤条件
+  buildOrderByItem,      // 构建排序项
+  generateComponentId,   // 生成唯一组件 ID
+} = require('./build-yida-report-schema');
+```
+
+### 数据集配置（dataSetModelMap）
+
+所有报表组件通过 `dataSetModelMap` 配置数据源，每个数据集由 `buildDataSetEntry` 构建：
+
+```javascript
+buildDataSetEntry({
+  cubeCode: 'your_cube_code',        // 数据集 cubeCode（必填）
+  fieldDefinitionList: [              // 字段定义列表
+    buildFieldDefinition({
+      alias: 'date',                  // 字段别名（fieldKey）
+      aliasName: '日期',              // 字段显示名称
+      isDim: true,                    // true=维度，false=度量
+      dataType: 'DATE',              // STRING | NUMBER | DATE | BOOLEAN | ARRAY
+      aggregateType: 'NONE',         // NONE | SUM | AVG | COUNT | MAX | MIN | COUNT_DISTINCT
+      timeGranularityType: 'DAY',    // YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | null
+    }),
+    buildFieldDefinition({
+      alias: 'sales',
+      aliasName: '销售额',
+      isDim: false,
+      dataType: 'NUMBER',
+      aggregateType: 'SUM',
+    }),
+  ],
+  fieldList: ['date', 'sales'],       // 查询字段别名列表
+  filterList: [],                     // 过滤条件列表
+  orderByList: [                      // 排序列表
+    buildOrderByItem('date', 'ASC'),  // ASC | DESC
+  ],
+  limit: 1000,                        // 数据条数限制
+  // 以下为筛选器专用参数
+  cubeCodes: ['your_cube_code'],      // cubeCode 数组（筛选器使用）
+  valueField: ['field_alias'],        // 值字段数组（筛选器使用）
+  labelField: ['field_alias'],        // 显示字段数组（筛选器使用）
+})
+```
+
+### 常用组件 Schema 构建示例
+
+#### 指标卡
+
+```javascript
+buildSchema.simpleIndicatorCard({
+  dataSetModelMap: {
+    kpi_dataset: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'total_sales', aliasName: '总销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+        buildFieldDefinition({ alias: 'order_count', aliasName: '订单数', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+      ],
+      fieldList: ['total_sales', 'order_count'],
+    })
+  },
+  settings: { columnCount: 4, columnCountForH5: 2 }
+})
+```
+
+#### 折线图
+
+```javascript
+buildSchema.lineChart({
+  dataSetModelMap: {
+    line_dataset: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'date', aliasName: '日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+        buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+      ],
+      fieldList: ['date', 'sales'],
+      orderByList: [buildOrderByItem('date', 'ASC')],
+    })
+  },
+  settings: {
+    titleConfig: { label: '销售趋势' },
+    height: 400,
+    smooth: true,
+    drillDown: false,
+  }
+})
+```
+
+#### 饼图（环形图）
+
+```javascript
+buildSchema.pieChart({
+  dataSetModelMap: {
+    pie_dataset: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'category', aliasName: '类别', isDim: true, dataType: 'STRING' }),
+        buildFieldDefinition({ alias: 'amount', aliasName: '金额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+      ],
+      fieldList: ['category', 'amount'],
+    })
+  },
+  settings: {
+    titleConfig: { label: '销售占比' },
+    innerRadius: 0.6,  // >0 为环形图
+  }
+})
+```
+
+#### 基础表格（明细表）
+
+```javascript
+buildSchema.table({
+  dataSetModelMap: {
+    table: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'name', aliasName: '姓名', isDim: true, dataType: 'STRING' }),
+        buildFieldDefinition({ alias: 'dept', aliasName: '部门', isDim: true, dataType: 'STRING' }),
+        buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+      ],
+      fieldList: ['name', 'dept', 'sales'],
+      orderByList: [buildOrderByItem('sales', 'DESC')],
+    })
+  },
+  settings: {
+    fixedHeader: true,
+    theme: 'border',
+    maxBodyHeight: 500,
+    pagination: {
+      pageSize: 20,
+      showPageSelect: true,
+      pageSizeList: [10, 20, 50, 100],
+    }
+  }
+})
+```
+
+#### 筛选器（下拉 + 时间 + 区间）
+
+```javascript
+// 下拉筛选器
+buildSchema.selectFilter({
+  dataSetModelMap: {
+    selectFilter: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      cubeCodes: ['your_cube_code'],
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'dept_id', aliasName: '部门ID', isDim: true, dataType: 'STRING' }),
+        buildFieldDefinition({ alias: 'dept_name', aliasName: '部门名称', isDim: true, dataType: 'STRING' }),
+      ],
+      fieldList: ['dept_id', 'dept_name'],
+      valueField: ['dept_id'],
+      labelField: ['dept_name'],
+    })
+  },
+  settings: { labelConfig: { label: '部门' }, mode: 'multiple', showLabel: true }
+})
+
+// 时间筛选器
+buildSchema.timeFilter({
+  dataSetModelMap: {
+    filterData: buildDataSetEntry({
+      cubeCode: 'your_cube_code',
+      cubeCodes: ['your_cube_code'],
+      fieldDefinitionList: [
+        buildFieldDefinition({ alias: 'create_date', aliasName: '创建日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+      ],
+      fieldList: ['create_date'],
+      valueField: ['create_date'],
+    })
+  },
+  settings: { labelConfig: { label: '日期范围' }, mode: 'range', dataConfig: { queryType: 'Between' } }
+})
+```
+
+### 完整报表页面 Schema 构建示例
+
+以下示例展示如何组合多个组件构建一个完整的报表页面：
+
+```javascript
+const {
+  buildSchema, buildDataSetEntry, buildFieldDefinition, buildOrderByItem,
+} = require('./build-yida-report-schema');
+
+const CUBE_CODE = 'your_cube_code_here';
+
+const reportPageSchema = buildSchema.pageHeader({
+  titleContent: '销售数据看板',
+  titleTip: '数据每日 08:00 更新',
+  children: [
+    buildSchema.topFilterContainer({
+      showTag: true,
+      children: [
+        buildSchema.timeFilter({ /* 时间筛选器配置 */ }),
+        buildSchema.selectFilter({ /* 下拉筛选器配置 */ }),
+      ],
+    }),
+    buildSchema.simpleIndicatorCard({ /* 指标卡配置 */ }),
+    buildSchema.lineChart({ /* 折线图配置 */ }),
+    buildSchema.table({ /* 明细表格配置 */ }),
+  ],
+});
+
+console.log(JSON.stringify(reportPageSchema, null, 2));
+```
+
+### 通用 settings 配置参考
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `titleConfig.label` | `string` | 组件标题 |
+| `height` | `number` | 组件高度（默认 300） |
+| `colorType` | `string` | 颜色类型，`default` 或 `CUSTOM_COLOR` |
+| `customColor` | `string` | 自定义颜色，逗号分隔 |
+| `drillDown` | `boolean` | 是否开启下钻（默认 false） |
+| `limit` | `number` | 数据条数限制（默认 1000） |
+
+### 各图表组件特有配置
+
+| 组件 | 特有配置 | 说明 |
+|------|---------|------|
+| **折线图** | `smooth`, `isStack`, `isPercent` | 平滑曲线、堆叠、百分比堆叠 |
+| **饼图** | `innerRadius` | 内半径（>0 为环形图） |
+| **条形图** | `isStack`, `isPercent` | 堆叠、百分比堆叠 |
+| **仪表盘** | `min`, `max`, `range` | 最小值、最大值、区间配置 |
+| **基础表格** | `fixedHeader`, `theme`, `pagination` | 固定表头、风格、分页 |
+
+---
+
+## 报表 Schema 构建关键规则（chart-builder.js）
+
+### 命令调用格式
+
+```bash
+openyida create-report <appType> "<报表名称>" <配置JSON文件路径>
+```
+
+**⚠️ 第二个参数是报表名称，必须使用业务含义的中文名称**（如"任务管理数据报表"），不要传 formUuid。
+
+### cubeCode 格式规则
+
+报表引擎的 `cubeCode` 使用**下划线**分隔，而 `formUuid` 使用**连字符**分隔。代码中 `normalizeCubeCode()` 会自动转换，但配置文件中建议直接使用下划线格式：
+
+```
+formUuid:  FORM-AB4ACB9DD12C470D82047E05CDC19166CJSU
+cubeCode:  FORM_AB4ACB9DD12C470D82047E05CDC19166CJSU  ← 连字符替换为下划线
+```
+
+### 配置文件字段格式
+
+推荐使用**结构化格式**（`xField`/`yField`），而非简化的 `fields` 数组格式：
+
+```json
+{
+  "reportName": "任务管理数据报表",
+  "formUuid": "FORM-xxx",
+  "charts": [
+    {
+      "title": "按优先级分布",
+      "type": "pie",
+      "cubeCode": "FORM_xxx",
+      "xField": {
+        "fieldCode": "selectField_xxx_value",
+        "aliasName": "优先级",
+        "dataType": "STRING",
+        "aggregateType": "NONE"
+      },
+      "yField": [
+        {
+          "fieldCode": "pid",
+          "aliasName": "数量",
+          "dataType": "STRING",
+          "aggregateType": "COUNT"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 各图表类型的字段配置
+
+| 图表类型 | 必填字段 | 说明 |
+|---------|---------|------|
+| `indicator` | `kpi`（数组） | 每个 kpi 字段需要 `fieldCode`、`aliasName`、`aggregateType` |
+| `pie` | `xField`（单个）+ `yField`（数组） | xField 为分类维度，yField 为数值度量 |
+| `bar`/`line`/`area` | `xField`（单个）+ `yField`（数组） | 可选 `groupField` 分组 |
+| `table` | `columnFields`（数组） | 每列一个字段对象 |
+| `combo` | `xField` + `leftYFields` + `rightYFields` | 柱线混合图 |
+| `gauge` | `valueField`（单个） | 可选 `assitValueField` |
+| `pivot` | `columnList`（数组） | 交叉透视表 |
+
+### fieldCode 后缀规则
+
+| 字段组件类型 | 报表中的 fieldCode | 示例 |
+|------------|-------------------|------|
+| `SelectField` | 加 `_value` 后缀 | `selectField_xxx` → `selectField_xxx_value` |
+| `EmployeeField` | 加 `_value` 后缀 | `employeeField_xxx` → `employeeField_xxx_value` |
+| `TextField` | 原样使用 | `textField_xxx` |
+| `NumberField` | 原样使用 | `numberField_xxx` |
+| `DateField` | 原样使用 | `dateField_xxx` |
+| 内置字段 `pid` | 原样使用 | `pid`（用于 COUNT 计数） |
+
+### dataSetModelMap 结构要点
+
+报表引擎要求 `dataSetModelMap` 中每个数据集包含**两层字段定义**：
+
+1. **`dataViewQueryModel.fieldDefinitionList`**：查询模型层，定义字段的 `alias`、`fieldCode`、`aggregateType` 等
+2. **外层字段数组**（`xField`/`yField`/`fieldList`/`columnFields` 等）：展示层，每个字段对象包含 20+ 属性（`visible`、`isDimension`、`fieldKey`、`cubeCode`、`title`、`format`、`link`、`drillList`、`orderBy`、`measureType` 等）
+
+两层都必须正确填充，否则报表图表会显示为空。
+
+### userConfig 格式
+
+报表引擎期望 `userConfig` 为**数组格式**（带 `ColumnFieldSetter` 配置器定义），而非简单对象格式：
+
+```json
+[
+  {
+    "name": "chartData",
+    "title": "配置数据",
+    "items": [
+      {
+        "setterName": "ColumnFieldSetter",
+        "name": "xField",
+        "title": "横轴",
+        "setterProps": { "single": true, "showFormatTab": true }
+      },
+      {
+        "setterName": "ColumnFieldSetter",
+        "name": "yField",
+        "title": "纵轴",
+        "setterProps": { "showFormatTab": true, "showDataLink": true }
+      }
+    ]
+  }
+]
+```
+
+指标卡（`indicator`）的 `userConfig` 也是数组格式，`name` 为 `youshuData`。

--- a/yida-skills/skills/yida-report/build-yida-report-schema.js
+++ b/yida-skills/skills/yida-report/build-yida-report-schema.js
@@ -1,0 +1,1284 @@
+/**
+ * vc-yida-report 图表组件 Schema 构建脚本
+ * 组件库：//g.alicdn.com/code/npm/@ali/vc-yida-report/1.0.101/pc.js
+ *
+ * 使用方式：
+ *   const { buildSchema } = require('./build-yida-report-schema');
+ *   const schema = buildSchema.lineChart({ cubeCode: 'xxx', fieldList: ['date', 'value'] });
+ *   console.log(JSON.stringify(schema, null, 2));
+ */
+
+// ─────────────────────────────────────────────
+// 工具函数
+// ─────────────────────────────────────────────
+
+/**
+ * 生成唯一组件 ID
+ * @param {string} prefix - 组件名前缀
+ */
+function generateComponentId(prefix) {
+  return prefix + '_' + Math.random().toString(36).substring(2, 10);
+}
+
+/**
+ * 构建 dataViewQueryModel（数据查询模型）
+ * @param {object} options
+ * @param {string}   options.cubeCode              - 数据集 cubeCode（必填）
+ * @param {Array}    options.fieldDefinitionList   - 字段定义列表
+ * @param {Array}    options.fieldList             - 查询字段别名列表
+ * @param {Array}    options.filterList            - 过滤条件列表
+ * @param {Array}    options.orderByList           - 排序列表
+ */
+function buildDataViewQueryModel({
+  cubeCode = '',
+  fieldDefinitionList = [],
+  fieldList = [],
+  filterList = [],
+  orderByList = [],
+} = {}) {
+  return {
+    cubeCode,
+    fieldDefinitionList,
+    fieldList,
+    filterList,
+    orderByList,
+  };
+}
+
+/**
+ * 构建单个字段定义（fieldDefinition）
+ * @param {object} options
+ * @param {string}  options.cubeCode             - 所属数据集 cubeCode
+ * @param {boolean} options.isDim                - 是否为维度字段（true=维度，false=度量）
+ * @param {string}  options.alias                - 字段别名（fieldKey）
+ * @param {string}  options.aliasName            - 字段显示名称
+ * @param {string}  options.classifiedCode       - 分类编码
+ * @param {string}  options.fieldCode            - 字段编码
+ * @param {string}  options.expression           - 字段表达式
+ * @param {string}  options.dataType             - 数据类型：STRING | NUMBER | DATE | BOOLEAN | ARRAY
+ * @param {string}  options.aggregateType        - 聚合类型：NONE | SUM | AVG | COUNT | MAX | MIN | COUNT_DISTINCT
+ * @param {string}  options.timeGranularityType  - 时间粒度：YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | null
+ */
+function buildFieldDefinition({
+  cubeCode = '',
+  isDim = true,
+  alias = '',
+  aliasName = '',
+  classifiedCode = '',
+  fieldCode = '',
+  expression = '',
+  dataType = 'STRING',
+  aggregateType = 'NONE',
+  timeGranularityType = null,
+} = {}) {
+  return {
+    cubeCode,
+    isDim,
+    alias,
+    aliasName: aliasName || alias,
+    classifiedCode,
+    fieldCode: fieldCode || alias,
+    expression,
+    dataType,
+    aggregateType,
+    timeGranularityType,
+  };
+}
+
+/**
+ * 构建过滤条件（filterItem）
+ * @param {object} options
+ * @param {string}  options.filterKey      - 过滤字段 key（通常等于 alias）
+ * @param {string}  options.alias          - 字段别名
+ * @param {string}  options.conditionType  - 条件类型：EqualTo | Like | InAny | Between | GreaterThan | LessThan
+ * @param {*}       options.value          - 过滤值
+ */
+function buildFilterItem({ filterKey = '', alias = '', conditionType = 'EqualTo', value = null } = {}) {
+  return { filterKey: filterKey || alias, alias, conditionType, value };
+}
+
+/**
+ * 构建排序项（orderByItem）
+ * @param {string} alias     - 字段别名
+ * @param {string} orderType - 排序方向：ASC | DESC
+ */
+function buildOrderByItem(alias, orderType = 'ASC') {
+  return { alias, orderType };
+}
+
+/**
+ * 构建 dataSetModelMap 中的单个数据集配置
+ * @param {object} options
+ * @param {string}   options.dataSetName         - 数据集名称（作为 key）
+ * @param {string}   options.cubeCode            - 数据集 cubeCode（必填）
+ * @param {Array}    options.fieldDefinitionList - 字段定义列表
+ * @param {Array}    options.fieldList           - 查询字段列表
+ * @param {Array}    options.filterList          - 过滤条件
+ * @param {Array}    options.orderByList         - 排序列表
+ * @param {number}   options.limit              - 数据条数限制
+ * @param {Array}    options.cubeCodes          - cubeCode 数组（筛选器使用）
+ * @param {Array}    options.valueField         - 值字段数组（筛选器使用）
+ * @param {Array}    options.labelField         - 显示字段数组（筛选器使用）
+ * @param {*}        options.defaultValue       - 默认值（筛选器使用）
+ */
+function buildDataSetEntry({
+  cubeCode = '',
+  fieldDefinitionList = [],
+  fieldList = [],
+  filterList = [],
+  orderByList = [],
+  limit = 1000,
+  cubeCodes,
+  valueField,
+  labelField,
+  defaultValue,
+} = {}) {
+  const entry = {
+    dataViewQueryModel: buildDataViewQueryModel({ cubeCode, fieldDefinitionList, fieldList, filterList, orderByList }),
+    limit,
+  };
+  if (cubeCodes !== undefined) entry.cubeCodes = cubeCodes;
+  if (valueField !== undefined) entry.valueField = valueField;
+  if (labelField !== undefined) entry.labelField = labelField;
+  if (defaultValue !== undefined) entry.defaultValue = defaultValue;
+  return entry;
+}
+
+// ─────────────────────────────────────────────
+// 各组件 Schema 构建函数
+// ─────────────────────────────────────────────
+
+const buildSchema = {
+
+  /**
+   * 指标卡 - YoushuSimpleIndicatorCard
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID（不填自动生成）
+   * @param {object}   options.dataSetModelMap   - 数据集配置 map，key 为数据集名，value 由 buildDataSetEntry 生成
+   * @param {object}   options.settings          - 组件配置
+   * @param {number}   options.settings.columnCount       - PC 端每行指标数量（默认 4）
+   * @param {number}   options.settings.columnCountForH5  - 移动端每行指标数量（默认 2）
+   * @param {string}   options.settings.colorType         - 颜色类型（CUSTOM_COLOR 时使用 customColor）
+   * @param {string}   options.settings.customColor       - 自定义颜色，逗号分隔
+   *
+   * @example
+   * buildSchema.simpleIndicatorCard({
+   *   dataSetModelMap: {
+   *     kpi_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *         buildFieldDefinition({ alias: 'order_count', aliasName: '订单数', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+   *       ],
+   *       fieldList: ['sales', 'order_count'],
+   *     })
+   *   },
+   *   settings: { columnCount: 4 }
+   * })
+   */
+  simpleIndicatorCard({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuSimpleIndicatorCard',
+      componentId: componentId || generateComponentId('simpleIndicatorCard'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          columnCount: 4,
+          columnCountForH5: 2,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 折线图 - YoushuLineChart
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {object}   options.dataSetModelMap   - 数据集配置
+   * @param {object}   options.settings          - 组件配置
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {boolean}  options.settings.smooth             - 是否平滑曲线（默认 false）
+   * @param {boolean}  options.settings.isStack            - 是否堆叠（默认 false）
+   * @param {boolean}  options.settings.isPercent          - 是否百分比堆叠（默认 false）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻（默认 false）
+   * @param {number}   options.settings.limit              - 数据条数限制（默认 1000）
+   * @param {string}   options.settings.colorType          - 颜色类型
+   * @param {string}   options.settings.customColor        - 自定义颜色，逗号分隔
+   * @param {number}   options.settings.lineWidth          - 线条宽度（默认 2）
+   * @param {object}   options.settings.labelConfig        - 标签配置 { showLabel: false }
+   *
+   * @example
+   * buildSchema.lineChart({
+   *   dataSetModelMap: {
+   *     line_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'date', aliasName: '日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+   *         buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['date', 'sales'],
+   *       orderByList: [buildOrderByItem('date', 'ASC')],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '销售趋势' }, height: 400, smooth: true }
+   * })
+   */
+  lineChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuLineChart',
+      componentId: componentId || generateComponentId('lineChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          smooth: false,
+          isStack: false,
+          isPercent: false,
+          drillDown: false,
+          limit: 1000,
+          colorType: 'default',
+          customColor: '',
+          lineWidth: 2,
+          labelConfig: { showLabel: false },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 饼图 - YoushuPieChart
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {number}   options.settings.innerRadius        - 内半径比例 0~1，>0 时为环形图（默认 0）
+   * @param {number}   options.settings.startAngle         - 起始角度（弧度，默认 -Math.PI/2）
+   * @param {number}   options.settings.endAngle           - 结束角度（弧度，默认 3*Math.PI/2）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   * @param {number}   options.settings.limit              - 数据条数限制
+   * @param {object}   options.settings.labelConfig        - 标签配置 { showLabel: true }
+   *
+   * @example
+   * buildSchema.pieChart({
+   *   dataSetModelMap: {
+   *     pie_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'category', aliasName: '类别', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'amount', aliasName: '金额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['category', 'amount'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '销售占比' }, innerRadius: 0.6 }  // innerRadius>0 为环形图
+   * })
+   */
+  pieChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuPieChart',
+      componentId: componentId || generateComponentId('pieChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          innerRadius: 0,
+          startAngle: -Math.PI / 2,
+          endAngle: (3 * Math.PI) / 2,
+          drillDown: false,
+          limit: 1000,
+          colorType: 'default',
+          customColor: '',
+          labelConfig: { showLabel: true },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 分组条形图 - YoushuGroupedBarChart
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {boolean}  options.settings.isStack            - 是否堆叠（默认 false）
+   * @param {boolean}  options.settings.isPercent          - 是否百分比堆叠（默认 false）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   * @param {number}   options.settings.limit              - 数据条数限制
+   * @param {object}   options.settings.labelConfig        - 标签配置 { showLabel: false }
+   *
+   * @example
+   * buildSchema.groupedBarChart({
+   *   dataSetModelMap: {
+   *     bar_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'region', aliasName: '地区', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'product', aliasName: '产品', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['region', 'product', 'sales'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '各地区产品销售对比' }, isStack: true }
+   * })
+   */
+  groupedBarChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuGroupedBarChart',
+      componentId: componentId || generateComponentId('groupedBarChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          isStack: false,
+          isPercent: false,
+          drillDown: false,
+          limit: 1000,
+          colorType: 'default',
+          customColor: '',
+          labelConfig: { showLabel: false },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 漏斗图 - YoushuFunnelChart
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   * @param {number}   options.settings.limit              - 数据条数限制
+   * @param {object}   options.settings.labelConfig        - 标签配置 { showLabel: true }
+   *
+   * @example
+   * buildSchema.funnelChart({
+   *   dataSetModelMap: {
+   *     funnel_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'stage', aliasName: '阶段', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'count', aliasName: '数量', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+   *       ],
+   *       fieldList: ['stage', 'count'],
+   *       orderByList: [buildOrderByItem('count', 'DESC')],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '销售漏斗' } }
+   * })
+   */
+  funnelChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuFunnelChart',
+      componentId: componentId || generateComponentId('funnelChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          drillDown: false,
+          limit: 1000,
+          colorType: 'default',
+          customColor: '',
+          labelConfig: { showLabel: true },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 仪表盘 - YoushuGauge
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {number}   options.settings.min                - 最小值（默认 0）
+   * @param {number}   options.settings.max                - 最大值（默认 100）
+   * @param {Array}    options.settings.range              - 区间配置，如 [0.3, 0.6, 1]
+   * @param {string}   options.settings.colorType          - 颜色类型
+   *
+   * @example
+   * buildSchema.gauge({
+   *   dataSetModelMap: {
+   *     gauge_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'completion_rate', aliasName: '完成率', isDim: false, dataType: 'NUMBER', aggregateType: 'AVG' }),
+   *       ],
+   *       fieldList: ['completion_rate'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: 'KPI 完成率' }, min: 0, max: 100, range: [0.3, 0.6, 1] }
+   * })
+   */
+  gauge({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuGauge',
+      componentId: componentId || generateComponentId('gauge'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          min: 0,
+          max: 100,
+          range: [0.3, 0.6, 1],
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 雷达图 - YoushuRadarChart
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {number}   options.settings.max                - 各维度最大值（默认 100）
+   * @param {number}   options.settings.opacity            - 填充透明度 0~1（默认 0.3）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   *
+   * @example
+   * buildSchema.radarChart({
+   *   dataSetModelMap: {
+   *     radar_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'dimension', aliasName: '维度', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'score', aliasName: '得分', isDim: false, dataType: 'NUMBER', aggregateType: 'AVG' }),
+   *       ],
+   *       fieldList: ['dimension', 'score'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '能力雷达图' }, max: 100, opacity: 0.4 }
+   * })
+   */
+  radarChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuRadarChart',
+      componentId: componentId || generateComponentId('radarChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          max: 100,
+          opacity: 0.3,
+          drillDown: false,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 热力图 - YoushuHeatmap
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   *
+   * @example
+   * buildSchema.heatmap({
+   *   dataSetModelMap: {
+   *     heatmap_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'x_dim', aliasName: 'X轴维度', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'y_dim', aliasName: 'Y轴维度', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'value', aliasName: '值', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['x_dim', 'y_dim', 'value'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '用户行为热力图' } }
+   * })
+   */
+  heatmap({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuHeatmap',
+      componentId: componentId || generateComponentId('heatmap'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          drillDown: false,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 日历热力图 - YoushuCalendarHeatmap
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 200）
+   *
+   * @example
+   * buildSchema.calendarHeatmap({
+   *   dataSetModelMap: {
+   *     calendar_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'date', aliasName: '日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+   *         buildFieldDefinition({ alias: 'count', aliasName: '数量', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+   *       ],
+   *       fieldList: ['date', 'count'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '提交日历' } }
+   * })
+   */
+  calendarHeatmap({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuCalendarHeatmap',
+      componentId: componentId || generateComponentId('calendarHeatmap'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 200,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 组合图 - YoushuComboChart（柱状图 + 折线图）
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   * @param {number}   options.settings.limit              - 数据条数限制
+   *
+   * @example
+   * buildSchema.comboChart({
+   *   dataSetModelMap: {
+   *     combo_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'month', aliasName: '月份', isDim: true, dataType: 'DATE', timeGranularityType: 'MONTH' }),
+   *         buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *         buildFieldDefinition({ alias: 'growth_rate', aliasName: '增长率', isDim: false, dataType: 'NUMBER', aggregateType: 'AVG' }),
+   *       ],
+   *       fieldList: ['month', 'sales', 'growth_rate'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '销售额与增长率' } }
+   * })
+   */
+  comboChart({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuComboChart',
+      componentId: componentId || generateComponentId('comboChart'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          drillDown: false,
+          limit: 1000,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 词云图 - YoushuWordCloud
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 300）
+   * @param {number}   options.settings.limit              - 显示词语数量（默认 100）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   *
+   * @example
+   * buildSchema.wordCloud({
+   *   dataSetModelMap: {
+   *     word_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'keyword', aliasName: '关键词', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'frequency', aliasName: '频次', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+   *       ],
+   *       fieldList: ['keyword', 'frequency'],
+   *       orderByList: [buildOrderByItem('frequency', 'DESC')],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '热门关键词' }, limit: 50 }
+   * })
+   */
+  wordCloud({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuWordCloud',
+      componentId: componentId || generateComponentId('wordCloud'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 300,
+          limit: 100,
+          drillDown: false,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 地图 - YoushuMap
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 图表标题
+   * @param {number}   options.settings.height             - 图表高度（默认 400）
+   * @param {boolean}  options.settings.drillDown          - 是否开启省市下钻
+   *
+   * @example
+   * buildSchema.map({
+   *   dataSetModelMap: {
+   *     map_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'province', aliasName: '省份', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['province', 'sales'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '全国销售分布' }, drillDown: true }
+   * })
+   */
+  map({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuMap',
+      componentId: componentId || generateComponentId('map'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 400,
+          drillDown: false,
+          colorType: 'default',
+          customColor: '',
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 交叉透视表 - YoushuCrossPivotTable
+   *
+   * @param {object} options
+   * @param {object}   options.settings
+   * @param {string}   options.settings.titleConfig.label  - 表格标题
+   * @param {number}   options.settings.height             - 表格高度（默认 400）
+   * @param {boolean}  options.settings.drillDown          - 是否开启下钻
+   *
+   * @example
+   * buildSchema.crossPivotTable({
+   *   dataSetModelMap: {
+   *     pivot_dataset: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'row_dim', aliasName: '行维度', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'col_dim', aliasName: '列维度', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'measure', aliasName: '度量', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+   *       ],
+   *       fieldList: ['row_dim', 'col_dim', 'measure'],
+   *     })
+   *   },
+   *   settings: { titleConfig: { label: '多维分析表' } }
+   * })
+   */
+  crossPivotTable({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuCrossPivotTable',
+      componentId: componentId || generateComponentId('crossPivotTable'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          titleConfig: { label: '' },
+          height: 400,
+          drillDown: false,
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 基础表格 - YoushuTable
+   * schema 来源：bundle 内嵌 JSON.parse 定义
+   *
+   * @param {object} options
+   * @param {object}   options.dataSetModelMap   - 数据集配置，key 固定为 "table"
+   * @param {object}   options.settings          - 组件配置
+   * @param {boolean}  options.settings.fixedHeader      - 是否固定表头（默认 false）
+   * @param {string}   options.settings.theme            - 表格风格：noBorder | zebra | split | border（默认 split）
+   * @param {number}   options.settings.maxBodyHeight    - 最大内容高度（默认 300）
+   * @param {object}   options.settings.pagination       - 分页配置
+   * @param {number}   options.settings.pagination.pageSize         - 每页条数（默认 10）
+   * @param {boolean}  options.settings.pagination.showPageSelect   - 是否显示每页条数选择
+   * @param {Array}    options.settings.pagination.pageSizeList     - 可选每页条数列表
+   *
+   * dataSetModelMap 中 table 数据集的 fieldsConfig：
+   *   - columnFields（STRING，必填）：表格列配置，包含字段 key 列表
+   *
+   * @example
+   * buildSchema.table({
+   *   dataSetModelMap: {
+   *     table: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'name', aliasName: '姓名', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'age', aliasName: '年龄', isDim: false, dataType: 'NUMBER', aggregateType: 'NONE' }),
+   *         buildFieldDefinition({ alias: 'dept', aliasName: '部门', isDim: true, dataType: 'STRING' }),
+   *       ],
+   *       fieldList: ['name', 'age', 'dept'],
+   *     })
+   *   },
+   *   settings: {
+   *     fixedHeader: true,
+   *     theme: 'border',
+   *     maxBodyHeight: 500,
+   *     pagination: { pageSize: 20, showPageSelect: true, pageSizeList: [10, 20, 50] }
+   *   }
+   * })
+   */
+  table({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuTable',
+      componentId: componentId || generateComponentId('table'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          fixedHeader: false,
+          theme: 'split',
+          maxBodyHeight: 300,
+          pagination: {
+            pageSize: 10,
+            showPageSelect: false,
+            pageSizeList: [10, 20, 50, 100],
+            shape: 'arrow-only',
+          },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 页面标题栏 - YoushuPageHeader
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {boolean}  options.tab               - 是否为 Tab 模式（默认 false）
+   * @param {string}   options.display           - 显示模式：normal | hidden（默认 normal）
+   * @param {boolean}  options.showTitle         - 是否显示标题（默认 true）
+   * @param {string}   options.titleContent      - 标题文字（默认空）
+   * @param {string}   options.titleTip          - 标题提示文字（默认空）
+   * @param {boolean}  options.waiter            - 是否显示加载状态（默认 false）
+   * @param {Array}    options.children          - 子组件 schema 列表
+   *
+   * @example
+   * buildSchema.pageHeader({
+   *   titleContent: '销售数据看板',
+   *   titleTip: '数据每日 08:00 更新',
+   *   showTitle: true,
+   *   children: [
+   *     buildSchema.lineChart({ ... })
+   *   ]
+   * })
+   */
+  pageHeader({
+    componentId,
+    tab = false,
+    display = 'normal',
+    showTitle = true,
+    titleContent = '',
+    titleTip = '',
+    waiter = false,
+    children = [],
+  } = {}) {
+    return {
+      componentName: 'YoushuPageHeader',
+      componentId: componentId || generateComponentId('pageHeader'),
+      props: {
+        tab,
+        display,
+        showTitle,
+        titleContent,
+        titleTip,
+        waiter,
+      },
+      children,
+    };
+  },
+
+  /**
+   * 顶部筛选容器 - YoushuTopFilterContainer
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {object}   options.style             - 容器样式
+   * @param {boolean}  options.showTag           - 是否显示已选标签（默认 false）
+   * @param {Array}    options.children          - 子筛选组件 schema 列表
+   *
+   * @example
+   * buildSchema.topFilterContainer({
+   *   showTag: true,
+   *   children: [
+   *     buildSchema.selectFilter({ ... }),
+   *     buildSchema.timeFilter({ ... }),
+   *   ]
+   * })
+   */
+  topFilterContainer({
+    componentId,
+    style = null,
+    showTag = false,
+    children = [],
+  } = {}) {
+    return {
+      componentName: 'YoushuTopFilterContainer',
+      componentId: componentId || generateComponentId('topFilterContainer'),
+      props: {
+        style,
+        showTag,
+        config: [],
+      },
+      children,
+    };
+  },
+
+  /**
+   * 下拉筛选器 - YoushuSelectFilter
+   * schema 来源：bundle 内嵌 JSON.parse 定义
+   *
+   * dataSetModelMap 中 selectFilter 数据集的 fieldsConfig：
+   *   - valueField（STRING|DATE，必填）：值字段
+   *   - labelField（STRING，可选）：显示字段
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {object}   options.dataSetModelMap   - 数据集配置，key 固定为 "selectFilter"
+   * @param {object}   options.settings          - 组件配置
+   * @param {boolean}  options.settings.showLabel  - 是否显示标签（默认 false）
+   * @param {number}   options.settings.height     - 下拉框高度（默认 300）
+   * @param {string}   options.settings.labelConfig.label  - 筛选器标签名
+   * @param {string}   options.settings.mode      - 选择模式：single | multiple（默认 single）
+   * @param {object}   options.settings.dataConfig - 数据配置
+   * @param {string}   options.settings.dataConfig.queryType  - 查询类型
+   * @param {boolean}  options.settings.dataConfig.required   - 是否必选
+   *
+   * @example
+   * buildSchema.selectFilter({
+   *   dataSetModelMap: {
+   *     selectFilter: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       cubeCodes: ['your_cube_code'],
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'dept_id', aliasName: '部门ID', isDim: true, dataType: 'STRING' }),
+   *         buildFieldDefinition({ alias: 'dept_name', aliasName: '部门名称', isDim: true, dataType: 'STRING' }),
+   *       ],
+   *       fieldList: ['dept_id', 'dept_name'],
+   *       valueField: ['dept_id'],
+   *       labelField: ['dept_name'],
+   *     })
+   *   },
+   *   settings: {
+   *     labelConfig: { label: '部门' },
+   *     mode: 'multiple',
+   *     showLabel: true,
+   *   }
+   * })
+   */
+  selectFilter({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuSelectFilter',
+      componentId: componentId || generateComponentId('selectFilter'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          showLabel: false,
+          height: 300,
+          mode: 'single',
+          labelConfig: { label: '' },
+          dataConfig: { queryType: 'EqualTo', required: false },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 时间筛选器 - YoushuTimeFilter
+   * schema 来源：bundle 内嵌 JSON.parse 定义
+   *
+   * dataSetModelMap 中 filterData 数据集的 fieldsConfig：
+   *   - valueField（STRING，必填）：查询字段
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {object}   options.dataSetModelMap   - 数据集配置，key 固定为 "filterData"
+   * @param {object}   options.settings          - 组件配置
+   * @param {string}   options.settings.labelConfig.label  - 筛选器标签名
+   * @param {string}   options.settings.mode      - 时间模式：single（单日）| range（范围）
+   * @param {string}   options.settings.dataConfig.queryType  - 查询类型：EqualTo | Between
+   * @param {*}        options.settings.defaultValue  - 默认时间值
+   *
+   * @example
+   * buildSchema.timeFilter({
+   *   dataSetModelMap: {
+   *     filterData: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       cubeCodes: ['your_cube_code'],
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'create_date', aliasName: '创建日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+   *       ],
+   *       fieldList: ['create_date'],
+   *       valueField: ['create_date'],
+   *     })
+   *   },
+   *   settings: {
+   *     labelConfig: { label: '日期范围' },
+   *     mode: 'range',
+   *     dataConfig: { queryType: 'Between' },
+   *   }
+   * })
+   */
+  timeFilter({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuTimeFilter',
+      componentId: componentId || generateComponentId('timeFilter'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          labelConfig: { label: '' },
+          mode: 'single',
+          dataConfig: { queryType: 'EqualTo', isRange: false, required: false },
+          ...settings,
+        },
+      },
+    };
+  },
+
+  /**
+   * 区间筛选器 - YoushuInputFilter
+   * schema 来源：bundle 内嵌 JSON.parse 定义
+   *
+   * dataSetModelMap 中 filterData 数据集的 fieldsConfig：
+   *   - valueField（STRING，必填）：查询字段
+   *
+   * @param {object} options
+   * @param {string}   options.componentId       - 组件 ID
+   * @param {object}   options.dataSetModelMap   - 数据集配置，key 固定为 "filterData"
+   * @param {object}   options.settings          - 组件配置
+   * @param {string}   options.settings.labelConfig.label  - 筛选器标签名
+   * @param {boolean}  options.settings.dataConfig.isRange  - 是否为区间输入（默认 false）
+   * @param {string}   options.settings.contentConfig.placeholder  - 输入框占位文字
+   *
+   * @example
+   * buildSchema.inputFilter({
+   *   dataSetModelMap: {
+   *     filterData: buildDataSetEntry({
+   *       cubeCode: 'your_cube_code',
+   *       cubeCodes: ['your_cube_code'],
+   *       fieldDefinitionList: [
+   *         buildFieldDefinition({ alias: 'amount', aliasName: '金额', isDim: false, dataType: 'NUMBER', aggregateType: 'NONE' }),
+   *       ],
+   *       fieldList: ['amount'],
+   *       valueField: ['amount'],
+   *     })
+   *   },
+   *   settings: {
+   *     labelConfig: { label: '金额区间' },
+   *     dataConfig: { isRange: true, queryType: 'Between' },
+   *     contentConfig: { placeholder: '请输入金额' },
+   *   }
+   * })
+   */
+  inputFilter({
+    componentId,
+    dataSetModelMap = {},
+    settings = {},
+  } = {}) {
+    return {
+      componentName: 'YoushuInputFilter',
+      componentId: componentId || generateComponentId('inputFilter'),
+      props: {
+        dataSetModelMap,
+        settings: {
+          labelConfig: { label: '' },
+          dataConfig: { isRange: false, queryType: 'Like', required: false },
+          contentConfig: { placeholder: '请输入' },
+          ...settings,
+        },
+      },
+    };
+  },
+};
+
+// ─────────────────────────────────────────────
+// 导出
+// ─────────────────────────────────────────────
+
+module.exports = {
+  buildSchema,
+  buildDataSetEntry,
+  buildFieldDefinition,
+  buildFilterItem,
+  buildOrderByItem,
+  buildDataViewQueryModel,
+  generateComponentId,
+};
+
+// ─────────────────────────────────────────────
+// 使用示例（直接运行此文件时输出示例）
+// ─────────────────────────────────────────────
+
+if (require.main === module) {
+  const CUBE_CODE = 'your_cube_code_here';
+
+  console.log('\n========== 示例 1：折线图 ==========');
+  const lineChartSchema = buildSchema.lineChart({
+    dataSetModelMap: {
+      line_dataset: buildDataSetEntry({
+        cubeCode: CUBE_CODE,
+        fieldDefinitionList: [
+          buildFieldDefinition({ alias: 'date', aliasName: '日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+          buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+        ],
+        fieldList: ['date', 'sales'],
+        orderByList: [buildOrderByItem('date', 'ASC')],
+      }),
+    },
+    settings: {
+      titleConfig: { label: '销售趋势' },
+      height: 400,
+      smooth: true,
+    },
+  });
+  console.log(JSON.stringify(lineChartSchema, null, 2));
+
+  console.log('\n========== 示例 2：饼图（环形） ==========');
+  const pieChartSchema = buildSchema.pieChart({
+    dataSetModelMap: {
+      pie_dataset: buildDataSetEntry({
+        cubeCode: CUBE_CODE,
+        fieldDefinitionList: [
+          buildFieldDefinition({ alias: 'category', aliasName: '类别', isDim: true, dataType: 'STRING' }),
+          buildFieldDefinition({ alias: 'amount', aliasName: '金额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+        ],
+        fieldList: ['category', 'amount'],
+      }),
+    },
+    settings: {
+      titleConfig: { label: '销售占比' },
+      innerRadius: 0.6,
+    },
+  });
+  console.log(JSON.stringify(pieChartSchema, null, 2));
+
+  console.log('\n========== 示例 3：基础表格 ==========');
+  const tableSchema = buildSchema.table({
+    dataSetModelMap: {
+      table: buildDataSetEntry({
+        cubeCode: CUBE_CODE,
+        fieldDefinitionList: [
+          buildFieldDefinition({ alias: 'name', aliasName: '姓名', isDim: true, dataType: 'STRING' }),
+          buildFieldDefinition({ alias: 'dept', aliasName: '部门', isDim: true, dataType: 'STRING' }),
+          buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+        ],
+        fieldList: ['name', 'dept', 'sales'],
+        orderByList: [buildOrderByItem('sales', 'DESC')],
+      }),
+    },
+    settings: {
+      fixedHeader: true,
+      theme: 'border',
+      maxBodyHeight: 500,
+      pagination: { pageSize: 20 },
+    },
+  });
+  console.log(JSON.stringify(tableSchema, null, 2));
+
+  console.log('\n========== 示例 4：带筛选器的完整页面 ==========');
+  const pageSchema = buildSchema.pageHeader({
+    titleContent: '销售数据看板',
+    titleTip: '数据每日 08:00 更新',
+    children: [
+      buildSchema.topFilterContainer({
+        showTag: true,
+        children: [
+          buildSchema.timeFilter({
+            dataSetModelMap: {
+              filterData: buildDataSetEntry({
+                cubeCode: CUBE_CODE,
+                cubeCodes: [CUBE_CODE],
+                fieldDefinitionList: [
+                  buildFieldDefinition({ alias: 'create_date', aliasName: '创建日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+                ],
+                fieldList: ['create_date'],
+                valueField: ['create_date'],
+              }),
+            },
+            settings: { labelConfig: { label: '日期范围' }, mode: 'range' },
+          }),
+          buildSchema.selectFilter({
+            dataSetModelMap: {
+              selectFilter: buildDataSetEntry({
+                cubeCode: CUBE_CODE,
+                cubeCodes: [CUBE_CODE],
+                fieldDefinitionList: [
+                  buildFieldDefinition({ alias: 'dept_id', aliasName: '部门ID', isDim: true, dataType: 'STRING' }),
+                  buildFieldDefinition({ alias: 'dept_name', aliasName: '部门名称', isDim: true, dataType: 'STRING' }),
+                ],
+                fieldList: ['dept_id', 'dept_name'],
+                valueField: ['dept_id'],
+                labelField: ['dept_name'],
+              }),
+            },
+            settings: { labelConfig: { label: '部门' }, mode: 'multiple', showLabel: true },
+          }),
+        ],
+      }),
+      buildSchema.lineChart({
+        dataSetModelMap: {
+          line_dataset: buildDataSetEntry({
+            cubeCode: CUBE_CODE,
+            fieldDefinitionList: [
+              buildFieldDefinition({ alias: 'date', aliasName: '日期', isDim: true, dataType: 'DATE', timeGranularityType: 'DAY' }),
+              buildFieldDefinition({ alias: 'sales', aliasName: '销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+            ],
+            fieldList: ['date', 'sales'],
+          }),
+        },
+        settings: { titleConfig: { label: '销售趋势' }, height: 350 },
+      }),
+      buildSchema.simpleIndicatorCard({
+        dataSetModelMap: {
+          kpi_dataset: buildDataSetEntry({
+            cubeCode: CUBE_CODE,
+            fieldDefinitionList: [
+              buildFieldDefinition({ alias: 'total_sales', aliasName: '总销售额', isDim: false, dataType: 'NUMBER', aggregateType: 'SUM' }),
+              buildFieldDefinition({ alias: 'order_count', aliasName: '订单数', isDim: false, dataType: 'NUMBER', aggregateType: 'COUNT' }),
+            ],
+            fieldList: ['total_sales', 'order_count'],
+          }),
+        },
+        settings: { columnCount: 2 },
+      }),
+    ],
+  });
+  console.log(JSON.stringify(pageSchema, null, 2));
+}


### PR DESCRIPTION
## 变更内容

### 新增技能
- **yida-chart**: ECharts 图表开发技能，包含筛选器局部刷新最佳实践、7 个示例文件
- **yida-report**: 宜搭原生报表创建技能，含 Schema 构建脚本

### 代码改动
- **lib/report/chart-builder.js**: 新增雷达图支持、fields 简化格式、normalizeCubeCode、userConfig 数组格式重构
- **lib/report/constants.js**: 新增 inferDataType、deriveFilterFieldCode、BASE_COMPONENTS
- **package.json**: @babel/standalone 升级到 ^7.29.2

### 文档改动
- **yida-custom-page/SKILL.md**: 补充 renderJsx 必须包含 timestamp 隐藏 div 的关键约束
- **reference/vc-yida-report-components-doc.md**: 新增报表组件参考文档

### 测试
- 14 个测试套件全部通过，324 个测试用例全部通过