### PR TITLE
fix: correct Claude Code environment detection

### DIFF
--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -29,7 +29,7 @@ function getInstalledTools() {
       dirName: process.platform === 'win32' ? path.join('.config', 'opencode') : '.opencode',
       displayName: 'OpenCode',
     },
-    { dirName: '.claudecode', displayName: 'Claude Code' },
+    { dirName: '.claude', displayName: 'Claude Code' },
     { dirName: '.aone_copilot', displayName: 'Aone Copilot' },
     { dirName: '.cursor', displayName: 'Cursor' },
     { dirName: '.qoder', displayName: 'Qoder' },

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -47,11 +47,11 @@ function detectActiveTool() {
   }
 
   // Claude Code
-  if (env.CLAUDE_CODE) {
+  if (env.CLAUDECODE) {
     return {
       tool: 'claude-code',
       displayName: 'Claude Code',
-      dirName: '.claudecode',
+      dirName: '.claude',
       workspaceRoot: path.join(cwd, 'project'),
     };
   }


### PR DESCRIPTION
## Summary

- Fix environment variable from `CLAUDE_CODE` to `CLAUDECODE`
- Fix config directory from `.claudecode` to `.claude`

## Problem

Claude Code was not being detected correctly because:
1. The environment variable check was looking for `CLAUDE_CODE` but Claude Code actually sets `CLAUDECODE=1`
2. The config directory check was looking for `~/.claudecode` but Claude Code actually uses `~/.claude/`

## Verification

Before fix:
```
❌ No active AI tool environment detected
```

After fix:
```
🟡 Claude Code        ← Active, but no project directory
🎯 Current Active Environment
  AI Tool:      Claude Code
```

## Test plan

- [x] Verified `openyida env` correctly detects Claude Code
- [x] Verified `openyida copy` works in Claude Code environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)