### PR TITLE
fix: add YAML Front Matter to yida-integration/SKILL.md

### DIFF
--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -1,3 +1,22 @@
+---
+name: yida-integration
+description: 宜搭集成&自动化（逻辑流）管理技能，用于创建表单事件触发的自动化逻辑流，支持钉钉工作通知、跨表数据操作、条件分支等多节点组合场景。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+metadata:
+  audience: developers
+  workflow: yida-integration-management
+  version: 1.0.0
+  tags:
+    - yida
+    - integration
+    - automation
+    - logicflow
+    - notification
+---
+
 # yida-integration — 宜搭集成&自动化（逻辑流）技能
 
 本技能用于在宜搭平台创建「集成&自动化」（逻辑流），支持场景：**表单事件触发 → 多节点组合处理 → 钉钉工作通知 / 数据操作**。


### PR DESCRIPTION
## 问题描述

修复 #224 中提到的高优先级问题：`yida-integration/SKILL.md` 是唯一一个没有 `---` YAML Front Matter 的技能文档，缺少 `name`、`description`、`version`、`compatibility` 等元数据字段，导致 Agent 在自动发现和加载该技能时无法正确识别其元信息，与其他 21 个技能规范不一致。

## 修改内容

在 `yida-skills/skills/yida-integration/SKILL.md` 文件顶部补充标准 YAML Front Matter，参考 `yida-connector/SKILL.md` 的格式，包含以下字段：
- `name`：技能名称
- `description`：技能描述
- `license`：MIT
- `compatibility`：支持的环境（opencode、claude-code）
- `metadata`：版本、标签等元数据

## 关联 Issue

Closes #224