### PR TITLE
fix: 修复 create-page --datasource 参数解析错误 (#226)

### DIFF
--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -22,9 +22,10 @@ const { t } = require('../core/i18n');
 const { buildDataSourceList, parseDatasourceArg, extractDatasourceArg } = require('./datasource-utils');
 
 async function run(args) {
-  // 从参数中提取 --datasource 选项（会原地修改 args 数组）
+  // 从参数中提取 --datasource 选项，解构返回值并更新 mutableArgs
   const mutableArgs = [...args];
-  const datasourceArg = extractDatasourceArg(mutableArgs);
+  const { datasourceValue, remainingArgs } = extractDatasourceArg(mutableArgs);
+  mutableArgs.splice(0, mutableArgs.length, ...remainingArgs);
 
   if (mutableArgs.length < 2) {
     console.error(t('create_page.usage'));
@@ -88,7 +89,7 @@ async function run(args) {
   const pageUrl = `${authRef.baseUrl}/${appType}/workbench/${pageId}`;
 
   // Step 3: 注入连接器数据源（如果提供了 --datasource 参数）
-  const datasourceDefinitions = parseDatasourceArg(datasourceArg);
+  const datasourceDefinitions = parseDatasourceArg(datasourceValue);
   if (datasourceDefinitions.length > 0) {
     console.error(`[datasource] 正在注入 ${datasourceDefinitions.length} 个连接器数据源...`);
 


### PR DESCRIPTION
## 问题

使用 `openyida create-page` 命令并传入 `--datasource` 参数时，抛出 `TypeError: value.trim is not a function` 错误。

## 根本原因

`extractDatasourceArg()` 返回 `{ datasourceValue, remainingArgs }` 对象，但原代码直接将整个对象赋给 `datasourceArg`，再传入 `parseDatasourceArg(datasourceArg)`，导致内部 `value.trim()` 调用失败。

此外，`mutableArgs` 也未被更新为 `remainingArgs`，导致后续 `appType`、`pageName` 的解析也会出错。

## 修复内容

```js
// 修复前
const datasourceArg = extractDatasourceArg(mutableArgs);
// ...
const datasourceDefinitions = parseDatasourceArg(datasourceArg);

// 修复后
const { datasourceValue, remainingArgs } = extractDatasourceArg(mutableArgs);
mutableArgs.splice(0, mutableArgs.length, ...remainingArgs);
// ...
const datasourceDefinitions = parseDatasourceArg(datasourceValue);
```

## 关联 Issue

Fixes #226