### PR TITLE
feat: support parallel process branches

### DIFF
--- a/lib/process/configure-process.js
+++ b/lib/process/configure-process.js
@@ -275,7 +275,7 @@ function buildNodeListRecursive(nodes, exitNodeId, nameToIdMap) {
     const node = nodes[i];
     const nextNodeId = i + 1 < nodes.length ? nodes[i + 1]._nodeId : exitNodeId;
 
-    if (node.type === 'route') {
+    if (node.type === 'route' || node.type === 'parallel') {
       const routeResult = buildRouteNode(node, nextNodeId, nameToIdMap);
       processNodes.push(routeResult.processNode);
       viewNodes.push(routeResult.viewNode);
@@ -431,6 +431,7 @@ function buildCarbonNode(node, nextNodeId) {
 function buildRouteNode(node, exitNodeId, nameToIdMap) {
   const routeNodeId = node._nodeId;
   const conditions = node.conditions || [];
+  const isParallel = node.type === 'parallel' || node.outgoingType === 'multiple';
 
   const conditionNodeIds = [];
   const conditionProcessNodes = [];
@@ -475,8 +476,11 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
         ruleId: condRules.ruleId || 'group-' + generateUuid(),
         conditionCode: condRules.conditionCode || '&&',
       };
-      conditionProps.calculate = 'condition';
+      if (isParallel) {
+        conditionProps.conditions.description = '所有数据均可进入';
+      }
     }
+    conditionProps.calculate = isParallel ? 'all' : 'condition';
 
     // 条件节点的 nextId：如果有子节点，指向第一个子节点；否则指向出口节点
     const condNextId = (childProcessNodes.length > 0)
@@ -500,13 +504,13 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
 
     // 构建 condition viewNode（带嵌套 conditions 包装）
     const condViewNode = {
-      componentName: 'ConditionNode',
+      componentName: isParallel ? 'ParallelNode' : 'ConditionNode',
       id: condNodeId,
       props: {
-        name: i18n(condDescription || '条件', 'Condition'),
+        name: i18n(condDescription || (isParallel ? '并行分支' : '条件'), isParallel ? 'Parallel' : 'Condition'),
         description: '',
         conditions: {
-          calculate: 'condition',
+          calculate: isParallel ? 'all' : 'condition',
           conditions: {
             condition: condRules.condition || 'AND',
             rules: condRules.rules || [],
@@ -548,7 +552,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
   conditionProcessNodes.push(defaultCondProcessNode);
 
   const defaultCondViewNode = {
-    componentName: 'ConditionNode',
+    componentName: isParallel ? 'ParallelNode' : 'ConditionNode',
     id: defaultCondNodeId,
     props: {
       isDefault: true,
@@ -562,13 +566,13 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
 
   // 构建 route processNode
   const routeProcessNode = {
-    name: { zh_CN: 'ConditionNode', en_US: '' },
+    name: { zh_CN: isParallel ? 'ParallelNode' : 'ConditionNode', en_US: '' },
     description: '',
     type: 'route',
     nodeId: routeNodeId,
     prevId: '',
     nextId: conditionNodeIds,
-    props: { outgoingType: 'priority' },
+    props: { outgoingType: isParallel ? 'multiple' : 'priority' },
     childNodes: conditionProcessNodes,
   };
 
@@ -576,8 +580,11 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
   const routeViewNode = {
     componentName: 'ConditionContainer',
     id: routeNodeId,
-    props: {},
-    title: '条件分支',
+    props: {
+      name: i18n(isParallel ? 'ParallelNode' : 'ConditionNode', ''),
+    },
+    type: isParallel ? 'parallel' : 'route',
+    title: isParallel ? '并行分支' : '条件分支',
     children: conditionViewNodes,
   };
 


### PR DESCRIPTION
## Summary
- add parallel branch support to the process builder
- allow `route` nodes to emit `outgoingType: \"multiple\"` and `ParallelNode` view nodes
- keep conditional routes unchanged for existing flows

## Notes
- This aligns the CLI-generated process structure with the manually configured v5 parallel branch shape.