### PR TITLE
fix: connector HTTP method should be uppercase

### DIFF
--- a/lib/connector/action-generator.js
+++ b/lib/connector/action-generator.js
@@ -206,7 +206,7 @@ function generateOperation(curlData, relevantHeaders) {
         summary: summary,
         description: description,
         url: cleanPath,
-        method: curlData.method.toLowerCase(),
+        method: curlData.method.toUpperCase(),
         inputs: inputs,
         parameters: parameters,
         responses: { type: 'object', properties: {} },

--- a/lib/connector/doc-parser.js
+++ b/lib/connector/doc-parser.js
@@ -356,7 +356,7 @@ function convertToOperationConfig(parseResult) {
         summary: parseResult.basicInfo.title || '未命名操作',
         description: parseResult.basicInfo.description || '',
         url: parseResult.serverInfo.path || '',
-        method: (parseResult.serverInfo.method || 'GET').toLowerCase(),
+        method: (parseResult.serverInfo.method || 'GET').toUpperCase(),
         inputs: [],
         parameters: {
             header: [],

--- a/src/connector/action-generator.ts
+++ b/src/connector/action-generator.ts
@@ -253,7 +253,7 @@ function generateOperation(curlData: CurlData, relevantHeaders: [string, string]
     summary: summary,
     description: description,
     url: cleanPath,
-    method: curlData.method.toLowerCase(),
+    method: curlData.method.toUpperCase(),
     inputs: inputs,
     parameters: parameters,
     responses: { type: 'object', properties: {} },

--- a/src/connector/doc-parser.ts
+++ b/src/connector/doc-parser.ts
@@ -452,7 +452,7 @@ function convertToOperationConfig(parseResult: ParseResult): Operation {
     summary: parseResult.basicInfo.title || '未命名操作',
     description: parseResult.basicInfo.description || '',
     url: parseResult.serverInfo.path || '',
-    method: (parseResult.serverInfo.method || 'GET').toLowerCase(),
+    method: (parseResult.serverInfo.method || 'GET').toUpperCase(),
     inputs: [],
     parameters: {
       header: [],

--- a/tests/connector.test.js
+++ b/tests/connector.test.js
@@ -377,7 +377,7 @@ describe("generateOperation", () => {
     };
     const result = generateOperation(curlData, []);
     expect(result.operationId).toBeDefined();
-    expect(result.method).toBe("get");
+    expect(result.method).toBe("GET");
     expect(result.url).toBe("users");
     expect(result.summary).toBeDefined();
     expect(result.inputs).toEqual([]);

--- a/tests/doc-parser.test.js
+++ b/tests/doc-parser.test.js
@@ -287,7 +287,7 @@ describe('convertToOperationConfig', () => {
     expect(config.operationId).toBe('查询用户');
     expect(config.summary).toBe('查询用户');
     expect(config.description).toBe('查询用户列表接口');
-    expect(config.method).toBe('get');
+    expect(config.method).toBe('GET');
     expect(config.url).toBe('/api/users');
     expect(config.origin).toBe(true);
   });


### PR DESCRIPTION
## Summary

Fixes #241 - HTTP methods in connector actions were incorrectly converted to lowercase, causing the Yida platform UI to display them as empty or unrecognized.

## Problem

When creating connectors using `openyida connector smart-create` or `openyida connector create`, the HTTP method field was being saved as lowercase values (e.g., `get`, `post`) instead of uppercase (e.g., `GET`, `POST`).

This caused the "Request Method" field to appear empty or unselected in the Yida platform connector UI.

## Root Cause

The `action-generator.ts` and `doc-parser.ts` files were converting the method to lowercase:

## Solution

Changed the method conversion from `toLowerCase()` to `toUpperCase()` in both files:

## Files Changed

- `src/connector/action-generator.ts` - line 256
- `src/connector/doc-parser.ts` - line 455
- `tests/connector.test.js` - updated test expectation
- `tests/doc-parser.test.js` - updated test expectation

## Test Results

All 526 tests pass ✅

Fixes #241