### PR TITLE
fix: 规范化连接器执行动作的请求方法字段

### DIFF
--- a/lib/connector/connector-add-action.js
+++ b/lib/connector/connector-add-action.js
@@ -63,6 +63,16 @@ function parseArgs(args) {
     }
     return options;
 }
+/**
+ * 规范化执行动作配置
+ * 确保 method 字段为小写，兼容宜搭平台要求
+ */
+function normalizeOperations(operations) {
+    return operations.map(op => ({
+        ...op,
+        method: op.method ? op.method.toLowerCase() : 'get',
+    }));
+}
 async function run(args) {
     if (!args || args.length === 0 || args[0] === '--help' || args[0] === '-h') {
         showUsage();
@@ -83,6 +93,8 @@ async function run(args) {
         if (!Array.isArray(newOperations)) {
             newOperations = [newOperations];
         }
+        // 规范化 operations，确保 method 字段为小写
+        newOperations = normalizeOperations(newOperations);
         console.log(`✓ 已加载 ${newOperations.length} 个执行动作`);
         newOperations.forEach((operation, index) => {
             console.log(`  [${index + 1}] ${operation.operationId}: ${operation.summary}`);

--- a/lib/connector/connector-create.js
+++ b/lib/connector/connector-create.js
@@ -194,6 +194,16 @@ function parseBaseUrl(url) {
 function generateConnectorName() {
     return 'Http_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 }
+/**
+ * 规范化执行动作配置
+ * 确保 method 字段为小写，兼容宜搭平台要求
+ */
+function normalizeOperations(operations) {
+    return operations.map(op => ({
+        ...op,
+        method: op.method ? op.method.toLowerCase() : 'get',
+    }));
+}
 async function run(args) {
     if (!args || args.length === 0 || args[0] === '--help' || args[0] === '-h') {
         showUsage();
@@ -254,6 +264,8 @@ async function run(args) {
             console.error('❌ 错误: operations 文件不能为空数组');
             process.exit(1);
         }
+        // 规范化 operations，确保 method 字段为小写
+        operations = normalizeOperations(operations);
         console.log(`✓ 已加载 ${operations.length} 个执行动作`);
     }
     catch (e) {

--- a/src/connector/connector-add-action.ts
+++ b/src/connector/connector-add-action.ts
@@ -78,6 +78,17 @@ function parseArgs(args: string[]): AddActionOptions {
   return options;
 }
 
+/**
+ * 规范化执行动作配置
+ * 确保 method 字段为小写，兼容宜搭平台要求
+ */
+function normalizeOperations(operations: any[]): any[] {
+  return operations.map(op => ({
+    ...op,
+    method: op.method ? op.method.toLowerCase() : 'get',
+  }));
+}
+
 async function run(args: string[]): Promise<void> {
   if (!args || args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     showUsage();
@@ -103,6 +114,8 @@ async function run(args: string[]): Promise<void> {
     if (!Array.isArray(newOperations)) {
       newOperations = [newOperations];
     }
+    // 规范化 operations，确保 method 字段为小写
+    newOperations = normalizeOperations(newOperations);
     console.log(`✓ 已加载 ${newOperations.length} 个执行动作`);
     newOperations.forEach((operation, index) => {
       console.log(`  [${index + 1}] ${operation.operationId}: ${operation.summary}`);

--- a/src/connector/connector-create.ts
+++ b/src/connector/connector-create.ts
@@ -223,6 +223,17 @@ function generateConnectorName(): string {
   return 'Http_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 }
 
+/**
+ * 规范化执行动作配置
+ * 确保 method 字段为小写，兼容宜搭平台要求
+ */
+function normalizeOperations(operations: any[]): any[] {
+  return operations.map(op => ({
+    ...op,
+    method: op.method ? op.method.toLowerCase() : 'get',
+  }));
+}
+
 async function run(args: string[]): Promise<void> {
   if (!args || args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     showUsage();
@@ -293,6 +304,8 @@ async function run(args: string[]): Promise<void> {
       console.error('❌ 错误: operations 文件不能为空数组');
       process.exit(1);
     }
+    // 规范化 operations，确保 method 字段为小写
+    operations = normalizeOperations(operations);
     console.log(`✓ 已加载 ${operations.length} 个执行动作`);
   } catch (e: any) {
     console.error(`❌ 读取执行动作配置文件失败: ${e.message}`);


### PR DESCRIPTION
## 问题描述

Fixes #241

使用 openyida 创建连接器时，无法正确设置执行动作的"请求方法"。多次通过命令行明确设置请求方法（如 POST、PUT），但在宜搭平台上查看连接器详情时，请求方法选项仍然是空的或未正确保存。

## 复现步骤

1. 使用 `openyida connector create` 或 `connector add-action` 创建连接器
2. 通过 `--operations` 参数传入包含 `method: "POST"` 的操作配置
3. 在宜搭平台查看连接器详情
4. 发现"请求方法"选项为空或未选中

## 根本原因

宜搭平台期望 `method` 字段为**小写格式**（如 `"post"`、`"get"`），但：

- `connector smart-create` 命令通过 `action-generator.ts` 生成配置，该函数会将 method 转换为小写 ✓
- `connector create --operations file.json` 和 `connector add-action --operations file.json` 命令直接读取用户提供的 JSON 文件，**没有对 method 字段进行规范化** ✗

## 修复内容

在以下两个文件中添加了 `normalizeOperations` 函数：

```typescript
/**
 * 规范化执行动作配置
 * 确保 method 字段为小写，兼容宜搭平台要求
 */
function normalizeOperations(operations: any[]): any[] {
  return operations.map(op => ({
    ...op,
    method: op.method ? op.method.toLowerCase() : 'get',
  }));
}
```

### 修改的文件

- `src/connector/connector-create.ts` - 添加规范化函数并在读取 operations 后调用
- `src/connector/connector-add-action.ts` - 同上

## 测试

- ✅ TypeScript 编译成功
- ✅ 所有 385 个测试用例通过