### PR TITLE
refactor(create-page): 优化类型安全和代码质量

### DIFF
--- a/src/app/create-page.ts
+++ b/src/app/create-page.ts
@@ -1,7 +1,7 @@
 /**
  * create-page.ts - 宜搭自定义页面创建命令
  *
- * 用法：yidacli create-page <appType> "<pageName>" [--datasource <jsonOrFile>]
+ * 用法：openyida create-page <appType> "<pageName>" [--datasource <jsonOrFile>]
  *
  * --datasource 参数（可选）：JSON 字符串或文件路径，用于在页面创建后注入连接器数据源。
  * 数据源定义格式：
@@ -18,6 +18,7 @@ import {
 } from '../core/utils';
 import { t } from '../core/i18n';
 import { buildDataSourceList, parseDatasourceArg, extractDatasourceArg } from './datasource-utils';
+import type { CookieData, AuthRef, YidaApiResponse } from '../types';
 
 export async function run(args: string[]): Promise<void> {
   // 从参数中提取 --datasource 选项，解构返回值并更新 mutableArgs
@@ -34,23 +35,23 @@ export async function run(args: string[]): Promise<void> {
   const appType = mutableArgs[0];
   const pageName = mutableArgs[1];
 
-  const SEP = '='.repeat(50);
-  console.error(SEP);
+  const SEPARATOR = '='.repeat(50);
+  console.error(SEPARATOR);
   console.error(t('create_page.title'));
-  console.error(SEP);
+  console.error(SEPARATOR);
   console.error(t('create_page.app_id', appType));
   console.error(t('create_page.page_name', pageName));
 
   // Step 1: 读取登录态
   console.error(t('common.step_login', '1'));
-  let cookieData: any = loadCookieData();
+  let cookieData: CookieData | null = loadCookieData();
   if (!cookieData) {
     console.error(t('common.login_no_cache'));
     cookieData = triggerLogin();
   }
 
-  const authRef = {
-    csrfToken: cookieData.csrf_token,
+  const authRef: AuthRef = {
+    csrfToken: cookieData.csrf_token ?? '',
     cookies: cookieData.cookies,
     baseUrl: resolveBaseUrl(cookieData),
     cookieData,
@@ -61,7 +62,7 @@ export async function run(args: string[]): Promise<void> {
   console.error(t('create_page.step_create'));
   console.error(t('create_page.sending'));
 
-  const response: any = await requestWithAutoLogin((auth) => {
+  const response: YidaApiResponse = await requestWithAutoLogin((auth) => {
     const postData = querystring.stringify({
       _csrf_token: auth.csrfToken,
       formType: 'display',
@@ -84,8 +85,8 @@ export async function run(args: string[]): Promise<void> {
   }
 
   const rawContent = response.content;
-  const pageId = (typeof rawContent === 'object' && rawContent !== null)
-    ? rawContent.formUuid || rawContent.pageId
+  const pageId: string | undefined = (typeof rawContent === 'object' && rawContent !== null)
+    ? ((rawContent as Record<string, unknown>).formUuid as string) || ((rawContent as Record<string, unknown>).pageId as string)
     : String(rawContent);
 
   if (!pageId) {
@@ -108,7 +109,7 @@ export async function run(args: string[]): Promise<void> {
       dataSourceList: dataSourceList,
     };
 
-    const saveSchemaResponse: any = await requestWithAutoLogin((auth) => {
+    const saveSchemaResponse: YidaApiResponse = await requestWithAutoLogin((auth) => {
       const postData = querystring.stringify({
         _csrf_token: auth.csrfToken,
         formUuid: pageId,
@@ -134,12 +135,11 @@ export async function run(args: string[]): Promise<void> {
   }
 
   // 输出结果
-  const SEP2 = '='.repeat(50);
-  console.error('\n' + SEP2);
+  console.error('\n' + SEPARATOR);
   console.error(t('create_page.success'));
   console.error(t('create_page.page_id_label', pageId));
   console.error(t('create_page.url_label', pageUrl));
-  console.error(SEP2);
+  console.error(SEPARATOR);
 
   console.log(JSON.stringify({ success: true, pageId, pageName, appType, url: pageUrl }));
 }

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -135,10 +135,15 @@ export function didUnmount() {
   // 清理逻辑
 }
 
+// ============================================================
+// 业务方法
+// ============================================================
+
 export function handleSubmit(e) {
   this.setCustomState({ submitted: true });
   this.utils.toast({ title: '提交成功', type: 'success' });
 }
+
 // ============================================================
 // 渲染
 // ============================================================
@@ -150,11 +155,12 @@ export function handleSubmit(e) {
  */
 // ⚠️ **关键约束：`renderJsx` 的每个 `return` 分支都必须包含 `<div style={{ display: 'none' }}>{this.state.timestamp}</div>`**，否则 `forceUpdate` 调用 `this.setState({ timestamp })` 后，React 无法检测到输出变化，`renderJsx` 不会被重新执行，页面将无法更新。这是宜搭渲染引擎触发重渲染的核心机制。
 export function renderJsx() {
+  // this.state 由宜搭运行时注入，包含 timestamp 等内置状态
   const { timestamp } = this.state;
 
   return (
     <div>
-      {/* 必须保留：用于触发重新渲染 */}
+      {/* 必须保留：timestamp 用于触发 React 重新渲染 */}
       <div style={{ display: "none" }}>{timestamp}</div>
 
       {/* 页面内容写在这里 */}
@@ -209,9 +215,9 @@ this.forceUpdate();
      this.utils.yida.searchFormDatas({ formUuid: 'FORM-XXX', pageSize: 10 });
    }
 
-   // ❌ 错误①：缺少 export，无法被宜搭运行时识别，this 丢失
+   // ❌ 错误①：普通函数无法访问外部 this，宜搭运行时无法为其绑定正确的 this 上下文
    export function didMount() {
-     loadStatistics();  // 直接调用，this 丢失
+     loadStatistics();  // 普通函数调用，内部的 this 为 undefined（严格模式）
    }
    function loadStatistics() {
      this.utils.yida.searchFormDatas(...);  // 报错：this is undefined
@@ -385,6 +391,31 @@ this.forceUpdate();
     1. 获取表单 Schema 后，**必须先在文件顶部定义 `FIELDS` 常量**，将所有用到的字段 ID 映射为语义化名称
     2. 后续所有代码中**禁止直接写字段 ID 字符串**，统一通过 `FIELDS.xxx` 引用
     3. `FIELDS` 的 key 使用 camelCase 命名，与字段的中文含义对应
+
+---
+
+## 页面管理
+
+### 创建自定义页面
+
+使用 `openyida create-page` 命令在指定应用中创建空白自定义页面：
+
+```bash
+openyida create-page <appType> "<pageName>" [--datasource <jsonOrFile>]
+```
+
+**参数说明**：
+
+| 参数 | 说明 | 示例 |
+| --- | --- | --- |
+| `appType` | 应用 ID | `APP_XXX` |
+| `pageName` | 页面名称 | `"数据大屏"` |
+| `--datasource` | 可选，连接器数据源定义 | JSON 字符串或文件路径 |
+
+**数据源定义格式**（用于页面创建后自动注入连接器数据源）：
+```json
+[{ "id": "myApi", "connectorId": "G-CONN-xxx", "actionId": "G-ACT-xxx" }]
+```
 
 ---
 


### PR DESCRIPTION
- 修复 CLI 名称注释 (yidacli -> openyida)
- 消除重复代码 (SEP/SEP2 -> SEPARATOR)
- 添加类型定义替代 any (CookieData, AuthRef, YidaApiResponse)
- 优化 SKILL.md 编码注意事项示例说明
- 为 handleSubmit 添加业务方法区域注释
- 补充 this.state 来源说明
- 新增页面管理章节，补充 create-page 命令说明

## 改动说明

<!-- 简要描述本 PR 做了什么、为什么这样做 -->

## 改动类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级

## 关联 Issue

<!-- 如有关联 Issue，请填写：Closes #123 -->

## 测试

- [ ] 本地运行 `npm test` 通过
- [ ] JS 语法检查通过：`node --check bin/yida.js`
- [ ] 已在真实宜搭环境测试过相关功能（如适用）

## 截图 / 录屏

<!-- 如有 UI 或行为变化，请附上截图或录屏 -->
