### PR TITLE
feat: add export-conversation command (#260)

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -119,6 +119,11 @@ openyida - 宜搭命令行工具
   connector gen-template [输出路径]                              生成接口文档模板
   create-report <appType> "<报表名称>" <图表定义JSON或文件路径>   创建宜搭报表
   append-chart <appType> <reportId> <图表定义JSON或文件路径>      向已有报表追加图表
+  export-conversation [选项]                                      导出 AI 对话记录
+    --output, -o <path>                                           指定输出文件路径
+    --input, -i <file>                                            指定输入对话文件
+    --latest                                                      只导出最新对话（默认）
+    --list                                                        列出可用的对话记录
 
 示例：
   openyida login
@@ -149,6 +154,9 @@ openyida - 宜搭命令行工具
   openyida doctor --create-ticket                 创建工单
   openyida doctor --create-voc                    创建 VOC
   openyida doctor --auto-submit                   自动判断并提交
+  openyida export-conversation                   导出当前对话记录
+  openyida export-conversation -o output.md     指定输出路径
+  openyida export-conversation --list            列出可用对话
 `);
   console.log(t('cli.help'));
 }
@@ -595,6 +603,25 @@ async function main() {
       }
       const { run: runQueryData } = require('../lib/core/query-data');
       await runQueryData(args);
+      break;
+    }
+
+    case 'export-conversation': {
+      const { exportConversation } = require('../lib/conversation/export-conversation');
+      // 解析选项
+      const options = {};
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--output' || args[i] === '-o') {
+          options.output = args[++i];
+        } else if (args[i] === '--input' || args[i] === '-i') {
+          options.input = args[++i];
+        } else if (args[i] === '--latest') {
+          options.latest = true;
+        } else if (args[i] === '--list') {
+          options.list = true;
+        }
+      }
+      await exportConversation(options);
       break;
     }
 

--- a/lib/conversation/collector.js
+++ b/lib/conversation/collector.js
@@ -1,0 +1,363 @@
+/**
+ * collector.js - 对话记录采集器
+ *
+ * 从不同 AI 工具环境采集对话数据，输出标准化格式。
+ *
+ * 支持的数据源：
+ *   - Claude Code JSONL 文件（~/.claude/projects/）
+ *   - 用户指定的 JSON/JSONL 文件（--input）
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { t } = require('../core/i18n');
+
+// ── Claude Code 对话文件定位 ─────────────────────────────
+
+/**
+ * 扫描 Claude Code 的 projects 目录，找到匹配当前项目的对话文件夹。
+ * Claude Code 将项目路径编码后作为文件夹名存储在 ~/.claude/projects/ 下。
+ *
+ * @returns {string|null} 项目对话目录的路径，未找到返回 null
+ */
+function findClaudeProjectDir() {
+  const home = os.homedir();
+  const claudeProjectsDir = path.join(home, '.claude', 'projects');
+
+  if (!fs.existsSync(claudeProjectsDir)) {
+    return null;
+  }
+
+  const cwd = process.cwd();
+  const entries = fs.readdirSync(claudeProjectsDir);
+
+  // Claude Code 使用 URL 编码的路径作为文件夹名，将 / 替换为 -
+  // 例如：/Users/js/workspace/openyida → -Users-js-workspace-openyida
+  const encodedCwd = cwd.replace(/\//g, '-');
+
+  for (const entry of entries) {
+    const entryPath = path.join(claudeProjectsDir, entry);
+    const stat = fs.statSync(entryPath);
+
+    if (stat.isDirectory()) {
+      // 检查编码后的路径是否匹配
+      if (entry === encodedCwd || entry.endsWith(encodedCwd)) {
+        return entryPath;
+      }
+      // 也尝试解码比较
+      const decodedEntry = entry.replace(/-/g, '/');
+      if (decodedEntry === cwd || cwd.startsWith(decodedEntry) || decodedEntry.endsWith(cwd)) {
+        return entryPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 获取 Claude Code 项目目录中的所有对话文件列表。
+ *
+ * @param {string} projectDir - 项目对话目录
+ * @returns {Array<{path: string, name: string, mtime: Date}>} 对话文件列表，按时间倒序
+ */
+function listClaudeConversations(projectDir) {
+  const files = fs.readdirSync(projectDir);
+  const jsonlFiles = files
+    .filter(f => f.endsWith('.jsonl'))
+    .map(f => {
+      const filePath = path.join(projectDir, f);
+      const stat = fs.statSync(filePath);
+      return {
+        path: filePath,
+        name: f,
+        mtime: stat.mtime,
+      };
+    })
+    .sort((a, b) => b.mtime.getTime() - a.mtime.getTime()); // 按修改时间倒序
+
+  return jsonlFiles;
+}
+
+// ── 对话文件解析 ─────────────────────────────────────────
+
+/**
+ * 解析 Claude Code 的 JSONL 对话文件。
+ *
+ * @param {string} filePath - JSONL 文件路径
+ * @returns {object} 标准化的对话数据
+ */
+function parseClaudeJsonl(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.trim().split('\n').filter(line => line.trim());
+  const messages = [];
+  let timestamp = null;
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      const entryTimestamp = entry.timestamp || null;
+
+      if (!timestamp && entryTimestamp) {
+        timestamp = entryTimestamp;
+      }
+
+      if (entry.type === 'human') {
+        const msg = parseClaudeMessage(entry, 'user');
+        if (msg) {
+          msg.timestamp = entryTimestamp;
+          messages.push(msg);
+        }
+      } else if (entry.type === 'assistant') {
+        const assistantMessages = parseClaudeAssistantMessage(entry);
+        for (const msg of assistantMessages) {
+          msg.timestamp = entryTimestamp;
+          messages.push(msg);
+        }
+      }
+    } catch {
+      // 跳过解析失败的行
+      continue;
+    }
+  }
+
+  return {
+    metadata: {
+      tool: 'claude-code',
+      timestamp: timestamp || new Date().toISOString(),
+      project: process.cwd(),
+    },
+    messages,
+  };
+}
+
+/**
+ * 解析 Claude 的消息内容（user 消息）。
+ *
+ * @param {object} entry - JSONL 条目
+ * @param {string} role - 角色
+ * @returns {object|null} 标准化消息
+ */
+function parseClaudeMessage(entry, role) {
+  const messageContent = entry.message?.content;
+  if (!messageContent) {
+    return null;
+  }
+
+  let textContent = '';
+
+  if (typeof messageContent === 'string') {
+    textContent = messageContent;
+  } else if (Array.isArray(messageContent)) {
+    // 提取所有文本内容
+    const textParts = messageContent
+      .filter(item => item.type === 'text')
+      .map(item => item.text);
+    textContent = textParts.join('\n');
+  }
+
+  if (!textContent.trim()) {
+    return null;
+  }
+
+  return {
+    role,
+    content: textContent,
+  };
+}
+
+/**
+ * 解析 Claude 的 assistant 消息（可能包含 tool_use 和 tool_result）。
+ *
+ * @param {object} entry - JSONL 条目
+ * @returns {Array<object>} 标准化消息数组
+ */
+function parseClaudeAssistantMessage(entry) {
+  const messageContent = entry.message?.content;
+  const messages = [];
+
+  if (!messageContent) {
+    return messages;
+  }
+
+  if (typeof messageContent === 'string') {
+    messages.push({
+      role: 'assistant',
+      content: messageContent,
+    });
+    return messages;
+  }
+
+  if (Array.isArray(messageContent)) {
+    let textParts = [];
+
+    for (const item of messageContent) {
+      if (item.type === 'text') {
+        textParts.push(item.text);
+      } else if (item.type === 'tool_use') {
+        // 先输出累积的文本内容
+        if (textParts.length > 0) {
+          messages.push({
+            role: 'assistant',
+            content: textParts.join('\n'),
+          });
+          textParts = [];
+        }
+        // 添加工具调用
+        messages.push({
+          role: 'tool_call',
+          name: item.name,
+          input: item.input || {},
+        });
+      } else if (item.type === 'tool_result') {
+        // 添加工具结果
+        const resultContent = typeof item.content === 'string'
+          ? item.content
+          : JSON.stringify(item.content);
+        messages.push({
+          role: 'tool_result',
+          content: resultContent,
+        });
+      }
+    }
+
+    // 处理剩余的文本内容
+    if (textParts.length > 0) {
+      messages.push({
+        role: 'assistant',
+        content: textParts.join('\n'),
+      });
+    }
+  }
+
+  return messages;
+}
+
+/**
+ * 解析用户提供的 JSON 文件。
+ *
+ * @param {string} filePath - JSON 文件路径
+ * @returns {object} 标准化的对话数据
+ */
+function parseJsonFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  // 尝试作为普通 JSON 解析
+  try {
+    const data = JSON.parse(content);
+    // 如果已经是标准格式，直接返回
+    if (data.metadata && data.messages) {
+      return data;
+    }
+    // 否则包装成标准格式
+    return {
+      metadata: {
+        tool: 'unknown',
+        timestamp: new Date().toISOString(),
+        project: process.cwd(),
+      },
+      messages: Array.isArray(data) ? data : [data],
+    };
+  } catch {
+    // 不是有效 JSON
+    throw new Error('Invalid JSON file: ' + filePath);
+  }
+}
+
+/**
+ * 解析用户提供的 JSONL 文件。
+ *
+ * @param {string} filePath - JSONL 文件路径
+ * @returns {object} 标准化的对话数据
+ */
+function parseJsonlFile(filePath) {
+  // 首先尝试作为 Claude Code JSONL 解析
+  return parseClaudeJsonl(filePath);
+}
+
+// ── 主函数 ───────────────────────────────────────────────
+
+/**
+ * 采集对话记录。
+ *
+ * @param {object} options - 采集选项
+ * @param {string} [options.input] - 用户指定的输入文件路径
+ * @param {boolean} [options.latest=true] - 是否只取最新对话
+ * @param {boolean} [options.list=false] - 是否列出可用对话
+ * @param {object} [options.env] - 环境信息
+ * @returns {object|null} 标准化的对话数据
+ */
+function collect(options = {}) {
+  const { input, latest = true, list = false, env } = options;
+
+  // 场景1：用户指定了输入文件
+  if (input) {
+    if (!fs.existsSync(input)) {
+      console.error(t('exportConv.inputNotFound') || `Input file not found: ${input}`);
+      process.exit(1);
+    }
+
+    if (input.endsWith('.jsonl')) {
+      return parseJsonlFile(input);
+    } else if (input.endsWith('.json')) {
+      return parseJsonFile(input);
+    } else {
+      console.error(t('exportConv.unsupportedFormat') || 'Unsupported file format. Please use .json or .jsonl');
+      process.exit(1);
+    }
+  }
+
+  // 场景2：自动检测对话文件
+  const toolName = env?.activeToolName || '';
+  const isClaudeCode = toolName.toLowerCase().includes('claude') ||
+                       process.env.CLAUDE_CODE ||
+                       fs.existsSync(path.join(os.homedir(), '.claude'));
+
+  if (isClaudeCode) {
+    const projectDir = findClaudeProjectDir();
+
+    if (!projectDir) {
+      console.error(t('exportConv.noClaudeProject') || 'No Claude Code project found for current directory.');
+      console.error(t('exportConv.useInputHint') || 'Please use --input to specify a conversation file manually.');
+      process.exit(1);
+    }
+
+    const conversations = listClaudeConversations(projectDir);
+
+    if (conversations.length === 0) {
+      console.error(t('exportConv.noConversations') || 'No conversation files found.');
+      process.exit(1);
+    }
+
+    // 场景2a：列出可用对话
+    if (list) {
+      console.log(t('exportConv.availableConversations') || 'Available conversations:');
+      conversations.forEach((conv, index) => {
+        const date = conv.mtime.toISOString().replace('T', ' ').substring(0, 19);
+        console.log(`  ${index + 1}. ${conv.name} (${date})`);
+      });
+      return null; // 返回 null 表示只是列出，不进行后续处理
+    }
+
+    // 场景2b：取最新对话
+    if (latest) {
+      const latestConv = conversations[0];
+      console.error(t('exportConv.usingLatest') || `Using latest conversation: ${latestConv.name}`);
+      return parseClaudeJsonl(latestConv.path);
+    }
+
+    // 默认取最新
+    const latestConv = conversations[0];
+    return parseClaudeJsonl(latestConv.path);
+  }
+
+  // 场景3：其他环境，提示用户手动指定
+  console.error(t('exportConv.envNotSupported') || 'Current environment does not support automatic conversation detection.');
+  console.error(t('exportConv.useInputHint') || 'Please use --input to specify a conversation file manually.');
+  process.exit(1);
+}
+
+module.exports = { collect };

--- a/lib/conversation/export-conversation.js
+++ b/lib/conversation/export-conversation.js
@@ -1,0 +1,146 @@
+/**
+ * export-conversation.js - 导出 AI 对话记录命令
+ *
+ * 采集当前 AI 工具的对话记录，格式化为 Markdown 文档导出。
+ *
+ * 用法：openyida export-conversation [options]
+ *   --output, -o    输出文件路径
+ *   --input, -i     输入对话文件（JSON/JSONL）
+ *   --latest        只导出最新对话（默认）
+ *   --list          列出可用的对话记录
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { t } = require('../core/i18n');
+const { detectEnvironment } = require('../core/env');
+const { findProjectRoot } = require('../core/utils');
+const { collect } = require('./collector');
+const { format } = require('./formatter');
+
+// ── 获取应用配置 ─────────────────────────────────────────
+
+/**
+ * 尝试获取应用配置。
+ *
+ * @returns {object|null} 应用配置或 null
+ */
+function tryGetConfig() {
+  try {
+    const projectRoot = findProjectRoot();
+    const configPath = path.join(projectRoot, 'config.json');
+
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      return JSON.parse(content);
+    }
+  } catch {
+    // 忽略错误，返回 null
+  }
+  return null;
+}
+
+// ── 获取项目目录 ─────────────────────────────────────────
+
+/**
+ * 获取项目目录（用于默认输出路径）。
+ *
+ * @returns {string} 项目目录路径
+ */
+function getProjectDir() {
+  return findProjectRoot();
+}
+
+// ── 主函数 ───────────────────────────────────────────────
+
+/**
+ * 导出对话记录。
+ *
+ * @param {object} options - 命令选项
+ * @param {string} [options.output] - 输出文件路径
+ * @param {string} [options.input] - 输入对话文件
+ * @param {boolean} [options.latest=true] - 只取最新对话
+ * @param {boolean} [options.list=false] - 列出可用对话
+ */
+async function exportConversation(options = {}) {
+  const { output, input, latest = true, list = false } = options;
+
+  try {
+    console.error('='.repeat(50));
+    console.error(t('exportConv.title') || '📝 导出 AI 对话记录');
+    console.error('='.repeat(50));
+
+    // Step 1: 检测环境
+    console.error(t('exportConv.detectEnv') || '🔍 检测当前环境...');
+    const env = detectEnvironment();
+    const toolName = env.activeToolName || 'Unknown';
+    console.error(t('exportConv.currentTool') || `  当前 AI 工具: ${toolName}`);
+
+    // Step 2: 采集对话记录
+    console.error(t('exportConv.collecting') || '📥 采集对话记录...');
+    const conversationData = collect({ input, latest, list, env });
+
+    // 如果是 --list 模式，collect 返回 null，直接退出
+    if (conversationData === null) {
+      return;
+    }
+
+    // 检查是否有消息
+    if (!conversationData.messages || conversationData.messages.length === 0) {
+      console.error(t('exportConv.noConversation') || '❌ 未找到对话记录');
+      process.exit(1);
+    }
+
+    console.error(t('exportConv.messagesFound') || `  找到 ${conversationData.messages.length} 条消息`);
+
+    // Step 3: 获取应用配置
+    console.error(t('exportConv.loadingConfig') || '⚙️  加载应用配置...');
+    const appConfig = tryGetConfig();
+    if (appConfig) {
+      console.error(t('exportConv.appName') || `  应用名: ${appConfig.appName || appConfig.name || '未命名'}`);
+    } else {
+      console.error(t('exportConv.noConfig') || '  未找到应用配置，使用默认值');
+    }
+
+    // Step 4: 格式化为 Markdown
+    console.error(t('exportConv.formatting') || '📄 格式化 Markdown...');
+    const markdown = format(conversationData, appConfig);
+
+    // Step 5: 确定输出路径
+    const outputPath = output || path.join(getProjectDir(), 'conversation-export.md');
+    const outputDir = path.dirname(outputPath);
+
+    // 确保输出目录存在
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Step 6: 写入文件
+    console.error(t('exportConv.writing') || '💾 写入文件...');
+    fs.writeFileSync(outputPath, markdown, 'utf-8');
+
+    // 输出成功信息
+    console.error('');
+    console.error('='.repeat(50));
+    console.error(t('exportConv.success') || '✅ 导出成功！');
+    console.error(t('exportConv.outputPath') || '📁 输出路径: ' + outputPath);
+    console.error('='.repeat(50));
+
+    // 输出 JSON 结果到 stdout（便于程序化使用）
+    console.log(JSON.stringify({
+      success: true,
+      path: outputPath,
+      messagesCount: conversationData.messages.length,
+      tool: conversationData.metadata.tool,
+    }));
+
+  } catch (error) {
+    console.error('');
+    console.error(t('exportConv.error') || '❌ 导出失败: ' + error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { exportConversation };

--- a/lib/conversation/formatter.js
+++ b/lib/conversation/formatter.js
@@ -1,0 +1,310 @@
+/**
+ * formatter.js - Markdown 格式化器
+ *
+ * 将标准化的对话数据转换为结构化的 Markdown 文档。
+ */
+
+'use strict';
+
+const { t } = require('../core/i18n');
+
+// ── 工具调用关键词识别 ───────────────────────────────────
+
+/**
+ * 判断工具调用是否为 Yida 相关操作。
+ *
+ * @param {string} toolName - 工具名称
+ * @returns {boolean}
+ */
+function isYidaOperation(toolName) {
+  const yidaKeywords = [
+    'create', 'publish', 'export', 'import', 'login', 'logout',
+    'form', 'page', 'app', 'schema', 'permission', 'process',
+    'connector', 'report', 'yida', 'openyida',
+  ];
+
+  const lowerName = toolName.toLowerCase();
+  return yidaKeywords.some(keyword => lowerName.includes(keyword));
+}
+
+/**
+ * 生成工具调用的简要描述。
+ *
+ * @param {object} toolCall - 工具调用消息
+ * @returns {string}
+ */
+function generateToolDescription(toolCall) {
+  const { name, input } = toolCall;
+
+  // 根据工具名称生成描述
+  if (name.includes('create') && name.includes('form')) {
+    return input.name ? `创建表单「${input.name}」` : '创建表单';
+  }
+  if (name.includes('create') && name.includes('page')) {
+    return input.name ? `创建页面「${input.name}」` : '创建页面';
+  }
+  if (name.includes('create') && name.includes('app')) {
+    return input.name ? `创建应用「${input.name}」` : '创建应用';
+  }
+  if (name.includes('publish')) {
+    return '发布页面';
+  }
+  if (name.includes('export')) {
+    return '导出应用';
+  }
+  if (name.includes('import')) {
+    return '导入应用';
+  }
+  if (name.includes('login')) {
+    return '登录宜搭';
+  }
+  if (name.includes('schema')) {
+    return '获取表单 Schema';
+  }
+  if (name.includes('permission')) {
+    return '配置权限';
+  }
+  if (name.includes('process')) {
+    return '配置流程';
+  }
+  if (name.includes('connector')) {
+    return '配置连接器';
+  }
+  if (name.includes('execute') || name.includes('command') || name.includes('terminal')) {
+    const cmd = input.command || input.cmd || '';
+    return cmd ? `执行命令: ${cmd.substring(0, 50)}${cmd.length > 50 ? '...' : ''}` : '执行命令';
+  }
+  if (name.includes('read') || name.includes('file')) {
+    const filePath = input.path || input.file || input.file_path || '';
+    return filePath ? `读取文件: ${filePath}` : '读取文件';
+  }
+  if (name.includes('write') || name.includes('edit')) {
+    const filePath = input.path || input.file || input.file_path || '';
+    return filePath ? `编辑文件: ${filePath}` : '编辑文件';
+  }
+  if (name.includes('search')) {
+    return '搜索代码';
+  }
+
+  // 默认描述
+  return name;
+}
+
+// ── 关键步骤提取 ─────────────────────────────────────────
+
+/**
+ * 从消息列表中提取关键步骤。
+ *
+ * @param {Array} messages - 消息列表
+ * @returns {Array<string>} 关键步骤描述列表
+ */
+function extractKeySteps(messages) {
+  const steps = [];
+  let stepIndex = 1;
+
+  for (const msg of messages) {
+    if (msg.role === 'tool_call') {
+      const isYida = isYidaOperation(msg.name);
+      const description = generateToolDescription(msg);
+      const prefix = isYida ? '🎯' : '🔧';
+      steps.push(`${stepIndex}. ${prefix} 执行 \`${msg.name}\`: ${description}`);
+      stepIndex++;
+    }
+  }
+
+  return steps;
+}
+
+// ── 统计信息计算 ─────────────────────────────────────────
+
+/**
+ * 计算对话统计信息。
+ *
+ * @param {Array} messages - 消息列表
+ * @returns {object} 统计信息
+ */
+function calculateStats(messages) {
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolCalls = 0;
+  let toolResults = 0;
+
+  for (const msg of messages) {
+    switch (msg.role) {
+      case 'user':
+        userMessages++;
+        break;
+      case 'assistant':
+        assistantMessages++;
+        break;
+      case 'tool_call':
+        toolCalls++;
+        break;
+      case 'tool_result':
+        toolResults++;
+        break;
+    }
+  }
+
+  // 对话轮次 = 用户消息数量
+  const conversationRounds = userMessages;
+
+  return {
+    conversationRounds,
+    toolCalls,
+    userMessages,
+    assistantMessages,
+    toolResults,
+  };
+}
+
+// ── Markdown 生成 ────────────────────────────────────────
+
+/**
+ * 转义 Markdown 特殊字符。
+ *
+ * @param {string} text - 原始文本
+ * @returns {string} 转义后的文本
+ */
+function escapeMarkdown(text) {
+  if (!text) {return '';}
+  // 仅转义可能破坏结构的字符，保留代码块内容
+  return text;
+}
+
+/**
+ * 截断长文本。
+ *
+ * @param {string} text - 原始文本
+ * @param {number} maxLength - 最大长度
+ * @returns {string} 截断后的文本
+ */
+function truncateText(text, maxLength = 500) {
+  if (!text || text.length <= maxLength) {
+    return text;
+  }
+  return text.substring(0, maxLength) + '... (已截断)';
+}
+
+/**
+ * 格式化消息内容为 Markdown。
+ *
+ * @param {object} message - 消息对象
+ * @returns {string} Markdown 格式的消息
+ */
+function formatMessage(message) {
+  const { role, content, name, input } = message;
+  const lines = [];
+
+  switch (role) {
+    case 'user':
+      lines.push('---');
+      lines.push('');
+      lines.push('### 👤 用户');
+      lines.push('');
+      lines.push('> ' + (content || '').split('\n').join('\n> '));
+      lines.push('');
+      break;
+
+    case 'assistant':
+      lines.push('---');
+      lines.push('');
+      lines.push('### 🤖 AI 助手');
+      lines.push('');
+      lines.push(escapeMarkdown(content || ''));
+      lines.push('');
+      break;
+
+    case 'tool_call':
+      lines.push('');
+      lines.push(`#### 🔧 执行操作：\`${name}\``);
+      lines.push('');
+      if (input && Object.keys(input).length > 0) {
+        lines.push('```json');
+        lines.push(JSON.stringify(input, null, 2));
+        lines.push('```');
+      }
+      lines.push('');
+      break;
+
+    case 'tool_result': {
+      lines.push('');
+      const truncatedContent = truncateText(content, 500);
+      const statusIcon = content && content.includes('error') ? '❌' : '✅';
+      lines.push(`> ${statusIcon} 执行结果：`);
+      lines.push('>');
+      lines.push('> ```');
+      lines.push('> ' + truncatedContent.split('\n').join('\n> '));
+      lines.push('> ```');
+      lines.push('');
+      break;
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── 主格式化函数 ─────────────────────────────────────────
+
+/**
+ * 将对话数据格式化为 Markdown 文档。
+ *
+ * @param {object} conversationData - 标准化的对话数据
+ * @param {object|null} appConfig - 应用配置（可能为 null）
+ * @returns {string} Markdown 文档内容
+ */
+function format(conversationData, appConfig) {
+  const { metadata, messages } = conversationData;
+  const appName = appConfig?.appName || appConfig?.name || 'OpenYida';
+  const stats = calculateStats(messages);
+  const keySteps = extractKeySteps(messages);
+
+  const lines = [];
+
+  // 标题
+  lines.push(`# ${appName} — AI 对话记录`);
+  lines.push('');
+
+  // 概要信息
+  lines.push('## 概要信息');
+  lines.push('');
+  lines.push('| 项目 | 值 |');
+  lines.push('|------|------|');
+  lines.push(`| 应用 | ${appName !== 'OpenYida' ? appName : '未配置'} |`);
+  lines.push(`| AI 工具 | ${metadata.tool || '未知'} |`);
+  lines.push(`| 导出时间 | ${new Date().toISOString()} |`);
+  lines.push(`| 对话时间 | ${metadata.timestamp || '未知'} |`);
+  lines.push(`| 对话轮次 | ${stats.conversationRounds} |`);
+  lines.push(`| 工具调用 | ${stats.toolCalls} 次 |`);
+  lines.push('');
+
+  // 关键步骤摘要
+  lines.push('## 关键步骤摘要');
+  lines.push('');
+  if (keySteps.length > 0) {
+    for (const step of keySteps) {
+      lines.push(step);
+    }
+  } else {
+    lines.push(t('exportConv.noKeySteps') || '无工具调用记录');
+  }
+  lines.push('');
+
+  // 完整对话记录
+  lines.push('## 完整对话记录');
+  lines.push('');
+
+  for (const message of messages) {
+    lines.push(formatMessage(message));
+  }
+
+  // 文档尾部
+  lines.push('---');
+  lines.push('');
+  lines.push('*本文档由 OpenYida 导出工具自动生成*');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+module.exports = { format };

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -740,6 +740,41 @@ Examples:
     footer2: '  💬 Community: Join OpenYida community on DingTalk',
   },
 
+  // ── lib/conversation/export-conversation.js ────────
+  exportConv: {
+    // CLI option descriptions
+    outputDesc: 'Specify output file path',
+    inputDesc: 'Specify conversation record file manually',
+    latestDesc: 'Export only the latest conversation',
+    listDesc: 'List available conversation records',
+    // Main flow messages
+    title: '📝 Export AI Conversation Records',
+    detectEnv: '🔍 Detecting environment...',
+    currentTool: '  Current AI tool: {0}',
+    collecting: '📥 Collecting conversation records...',
+    noConversation: '❌ No conversation records found',
+    messagesFound: '  Found {0} messages',
+    loadingConfig: '⚙️  Loading app config...',
+    appName: '  App name: {0}',
+    noConfig: '  No app config found, using defaults',
+    formatting: '📄 Formatting Markdown...',
+    writing: '💾 Writing file...',
+    success: '✅ Export successful!',
+    outputPath: '📁 Output path: {0}',
+    error: '❌ Export failed: {0}',
+    // collector.js messages
+    inputNotFound: '❌ Input file not found: {0}',
+    unsupportedFormat: '❌ Unsupported file format, please use .json or .jsonl',
+    noClaudeProject: '❌ No Claude Code project found for current directory',
+    useInputHint: '💡 Please use --input to specify a conversation file manually',
+    noConversations: '❌ No conversation records found',
+    availableConversations: '📋 Available conversations:',
+    usingLatest: '  Using latest conversation: {0}',
+    envNotSupported: '❌ Current environment does not support automatic conversation detection',
+    // formatter.js messages
+    noKeySteps: 'No tool calls recorded',
+  },
+
   // ── lib/cdn-*.js ───────────────────────────────────
   cdn: {
     // Configuration

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -701,6 +701,41 @@ openyida - 宜搭命令行工具
     footer2: '  💬 社区：钉钉扫码加入 OpenYida 社区',
   },
 
+  // ── lib/conversation/export-conversation.js ────────
+  exportConv: {
+    // CLI 选项描述
+    outputDesc: '指定输出文件路径',
+    inputDesc: '手动指定对话记录文件',
+    latestDesc: '仅导出最近一次对话',
+    listDesc: '列出可用的对话记录',
+    // 主流程消息
+    title: '📝 导出 AI 对话记录',
+    detectEnv: '🔍 检测当前环境...',
+    currentTool: '  当前 AI 工具: {0}',
+    collecting: '📥 采集对话记录...',
+    noConversation: '❌ 未找到对话记录',
+    messagesFound: '  找到 {0} 条消息',
+    loadingConfig: '⚙️  加载应用配置...',
+    appName: '  应用名: {0}',
+    noConfig: '  未找到应用配置，使用默认值',
+    formatting: '📄 格式化 Markdown...',
+    writing: '💾 写入文件...',
+    success: '✅ 导出成功！',
+    outputPath: '📁 输出路径: {0}',
+    error: '❌ 导出失败: {0}',
+    // collector.js 消息
+    inputNotFound: '❌ 输入文件不存在: {0}',
+    unsupportedFormat: '❌ 不支持的文件格式，请使用 .json 或 .jsonl',
+    noClaudeProject: '❌ 未找到当前目录对应的 Claude Code 项目',
+    useInputHint: '💡 请使用 --input 参数手动指定对话文件',
+    noConversations: '❌ 未找到任何对话记录',
+    availableConversations: '📋 可用的对话记录:',
+    usingLatest: '  使用最新对话: {0}',
+    envNotSupported: '❌ 当前环境不支持自动检测对话记录',
+    // formatter.js 消息
+    noKeySteps: '无工具调用记录',
+  },
+
   // ── lib/cdn-*.js ───────────────────────────────────
   cdn: {
     // 配置管理

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -97,6 +97,12 @@ openyida copy
 | **yida-logout** | [`skills/yida-logout/SKILL.md`](skills/yida-logout/SKILL.md) | 退出登录 / 切换账号 |
 | **yida-page-config** | [`skills/yida-page-config/SKILL.md`](skills/yida-page-config/SKILL.md) | 页面公开访问 / 组织内分享配置 |
 
+### 工具
+
+| 技能 | 路径 | 说明 |
+|------|------|------|
+| **yida-export-conversation** | [`skills/yida-export-conversation/SKILL.md`](skills/yida-export-conversation/SKILL.md) | 导出 AI 对话记录 |
+
 ### 共享参考文档
 
 | 文档 | 路径 | 说明 |

--- a/yida-skills/skills/yida-export-conversation/SKILL.md
+++ b/yida-skills/skills/yida-export-conversation/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: yida-export-conversation
+description: 导出 AI 对话记录，生成结构化的 Markdown 文档。支持 Claude Code 自动检测，其他环境通过 --input 手动指定。
+---
+
+# 导出 AI 对话记录
+
+> 将 AI 对话记录导出为结构化的 Markdown 文档，方便分享和存档。
+
+## 命令
+
+```bash
+openyida export-conversation [options]
+```
+
+| 选项 | 说明 |
+|------|------|
+| `--output <path>` | 指定输出文件路径（默认 `project/conversation-export.md`） |
+| `--input <file>` | 手动指定对话记录文件（覆盖自动检测） |
+| `--latest` | 仅导出最近一次对话（默认行为） |
+| `--list` | 列出可用的对话记录供选择 |
+
+## 支持的 AI 工具环境
+
+| 环境 | 支持方式 |
+|------|---------|
+| Claude Code | 自动检测并读取对话记录 |
+| 其他环境 | 通过 `--input` 手动指定对话文件 |
+
+## 输出格式
+
+生成的 Markdown 文档包含以下内容：
+
+1. **概要信息**
+   - 应用名称
+   - AI 工具环境
+   - 导出时间
+   - 对话轮次
+   - 工具调用次数
+
+2. **关键步骤摘要**
+   - 从工具调用中自动提取的操作步骤
+
+3. **完整对话记录**
+   - 用户消息
+   - AI 回复
+   - 工具调用及执行结果
+
+## 使用示例
+
+```bash
+# 导出最近一次对话（自动检测环境）
+openyida export-conversation
+
+# 导出到指定文件
+openyida export-conversation --output ./my-conversation.md
+
+# 从指定文件导入对话记录
+openyida export-conversation --input ./conversation.jsonl
+
+# 列出可用的对话记录
+openyida export-conversation --list
+```
+
+## 前置条件
+
+- 无需登录宜搭（对话导出是本地操作）
+- Node.js ≥ 18
+
+## 注意事项
+
+1. 目前 MVP 版本主要支持 Claude Code 的对话记录自动检测
+2. 其他 AI 工具环境请使用 `--input` 手动指定对话文件
+3. 后续版本将支持发布到宜搭社区和钉钉群


### PR DESCRIPTION
## 功能描述

实现 GitHub Issue #260 的核心功能：新增 `openyida export-conversation` CLI 命令，支持自动检测 AI 工具环境、采集对话记录、生成结构化 Markdown 文档。

## 变更内容

### 新增文件
- `lib/conversation/collector.js` — 对话记录采集器（支持 Claude Code 自动检测 + 手动指定文件）
- `lib/conversation/formatter.js` — Markdown 格式化器（生成结构化对话文档）
- `lib/conversation/export-conversation.js` — 命令主入口
- `yida-skills/skills/yida-export-conversation/SKILL.md` — 技能文档

### 修改文件
- `bin/yida.js` — 注册 export-conversation 命令 + 添加帮助信息
- `lib/core/locales/zh.js` — 添加中文翻译
- `lib/core/locales/en.js` — 添加英文翻译
- `yida-skills/SKILL.md` — 索引表添加新技能

## 命令用法

```bash
# 导出最近一次对话（自动检测环境）
openyida export-conversation

# 导出到指定文件
openyida export-conversation --output ./my-conversation.md

# 从指定文件导入对话记录
openyida export-conversation --input ./conversation.jsonl

# 列出可用的对话记录
openyida export-conversation --list
```

## 验证

- [x] `node --check` 所有文件语法通过
- [x] `npm test` 189 个测试全部通过
- [x] `--help` 正确显示新命令
- [x] ESLint 无错误
- [x] i18n 键完整（中英文）

## 后续迭代

- 发布到宜搭社区/钉钉群
- 模板系统（教程风格、案例风格等）
- 应用快照

Closes #260