### PR TITLE
feat: add large-file-write skill - 解决大文件写入截断问题

### DIFF
--- a/yida-skills/skills/large-file-write/SKILL.md
+++ b/yida-skills/skills/large-file-write/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: large-file-write
+description: Solves the problem of large file content being truncated when using heredoc or shell commands. Use this skill when you need to write large blocks of content (>100 lines) to a file reliably without truncation. Provides a Node.js script that accepts content via stdin or a temp file and writes it atomically.
+---
+
+# Large File Write Skill
+
+## 问题背景
+
+在 AI Agent 模式下，使用 heredoc（`<< 'EOF'`）或 shell 命令向文件写入大块内容时，经常出现：
+- 内容被截断（工具输出超过 token 限制）
+- heredoc 内容未生效（zsh 特殊字符转义问题）
+- 多次追加导致重复内容或语法错误
+
+## 解决方案
+
+使用 Node.js 脚本 `scripts/write.js`，将内容作为 JS 字符串变量传入，绕过 shell 截断限制。
+
+## 使用方式
+
+### 方式一：创建内容脚本后执行（推荐）
+
+**Step 1**：用 `create_file` 工具创建一个临时内容脚本：
+
+```js
+// /tmp/content-payload.js
+const fs = require('fs');
+const content = `
+// 这里放你要写入的大块内容
+// 支持任意长度，不受 heredoc 限制
+export function myFunction() {
+  // ...
+}
+`;
+fs.writeFileSync('/path/to/target.js', content, 'utf8');
+console.log('写入完成，行数：', content.split('\n').length);
+```
+
+**Step 2**：执行脚本：
+
+```bash
+node /tmp/content-payload.js
+```
+
+**Step 3**：验证写入结果：
+
+```bash
+wc -l /path/to/target.js
+tail -5 /path/to/target.js
+```
+
+### 方式二：追加内容到已有文件
+
+```js
+// /tmp/append-payload.js
+const fs = require('fs');
+const appendContent = `
+// 追加的内容
+export function additionalFunction() {
+  // ...
+}
+`;
+fs.appendFileSync('/path/to/target.js', appendContent, 'utf8');
+console.log('追加完成');
+```
+
+### 方式三：使用通用写入脚本
+
+```bash
+node ~/.agents/skills/large-file-write/scripts/write.js \
+  --file /path/to/target.js \
+  --mode write   # 或 append
+```
+
+然后通过 stdin 输入内容（Ctrl+D 结束）。
+
+## 核心原则
+
+1. **永远不要用 heredoc 写大文件** — 改用 `create_file` 工具创建临时 JS 脚本
+2. **内容放在 JS 模板字符串里** — 支持任意长度，不受 shell 限制
+3. **写完立即验证** — `wc -l` 检查行数，`tail` 检查末尾内容
+4. **分段写入大文件** — 超过 300 行的内容，拆分为多个 `create_file` + `node` 执行
+
+## 适用场景
+
+- 宜搭自定义页面代码（通常 500-1500 行）
+- Three.js 场景代码
+- 任何超过 100 行的代码文件写入

--- a/yida-skills/skills/large-file-write/scripts/write.js
+++ b/yida-skills/skills/large-file-write/scripts/write.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * large-file-write - Node.js 大文件可靠写入工具
+ *
+ * 解决 AI Agent 模式下 heredoc / shell 命令写入大文件时内容被截断的问题。
+ *
+ * 用法：
+ *   node write.js --file <目标文件路径> [--mode write|append] [--encoding utf8]
+ *
+ * 内容来源（三选一）：
+ *   1. stdin：echo "content" | node write.js --file out.js
+ *   2. --content-file <临时内容文件>：node write.js --file out.js --content-file /tmp/content.txt
+ *   3. --payload <JS文件>：node write.js --payload /tmp/payload.js（payload 文件自行调用 fs 写入）
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+// ─── 解析命令行参数 ───────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const key = argv[i];
+    if (key.startsWith('--')) {
+      const name = key.slice(2);
+      const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : true;
+      args[name] = value;
+    }
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv);
+
+// ─── 帮助信息 ─────────────────────────────────────────────────────────────────
+
+if (args.help || args.h) {
+  console.log(`
+large-file-write - 大文件可靠写入工具
+
+用法：
+  node write.js --file <目标路径> [选项]
+
+选项：
+  --file <path>          目标文件路径（必填，除非使用 --payload）
+  --mode <write|append>  写入模式，默认 write（覆盖）
+  --encoding <enc>       文件编码，默认 utf8
+  --content-file <path>  从指定文件读取内容后写入目标文件
+  --payload <path>       执行一个自包含的 JS 脚本（脚本内自行调用 fs 写入）
+  --verify               写入后输出行数和末尾5行进行验证
+  --help                 显示帮助
+
+示例：
+  # 从 stdin 写入
+  echo "hello world" | node write.js --file /tmp/out.txt
+
+  # 从内容文件写入
+  node write.js --file /tmp/out.js --content-file /tmp/content.txt --verify
+
+  # 执行自包含 payload 脚本
+  node write.js --payload /tmp/my-payload.js
+`);
+  process.exit(0);
+}
+
+// ─── 执行 payload 模式 ────────────────────────────────────────────────────────
+
+if (args.payload) {
+  const payloadPath = path.resolve(args.payload);
+  if (!fs.existsSync(payloadPath)) {
+    console.error(`❌ payload 文件不存在：${payloadPath}`);
+    process.exit(1);
+  }
+  console.log(`▶ 执行 payload：${payloadPath}`);
+  require(payloadPath);
+  process.exit(0);
+}
+
+// ─── 普通写入模式 ─────────────────────────────────────────────────────────────
+
+if (!args.file) {
+  console.error('❌ 缺少必填参数 --file <目标文件路径>');
+  console.error('   运行 node write.js --help 查看帮助');
+  process.exit(1);
+}
+
+const targetFile = path.resolve(args.file);
+const writeMode = args.mode === 'append' ? 'a' : 'w';
+const encoding = args.encoding || 'utf8';
+const shouldVerify = args.verify === true || args.verify === 'true';
+
+// 确保目标目录存在
+const targetDir = path.dirname(targetFile);
+if (!fs.existsSync(targetDir)) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  console.log(`📁 已创建目录：${targetDir}`);
+}
+
+function writeContent(content) {
+  const flag = writeMode;
+  fs.writeFileSync(targetFile, content, { encoding, flag });
+
+  const totalLines = content.split('\n').length;
+  const actualLines = fs.readFileSync(targetFile, 'utf8').split('\n').length;
+  const modeLabel = flag === 'a' ? '追加' : '写入';
+
+  console.log(`✅ ${modeLabel}成功：${targetFile}`);
+  console.log(`   本次内容：${totalLines} 行 | 文件总行数：${actualLines} 行`);
+
+  if (shouldVerify) {
+    const lines = fs.readFileSync(targetFile, 'utf8').split('\n');
+    const tail = lines.slice(-5).join('\n');
+    console.log('\n📋 文件末尾 5 行：');
+    console.log('─'.repeat(50));
+    console.log(tail);
+    console.log('─'.repeat(50));
+  }
+}
+
+// ─── 从 --content-file 读取内容 ───────────────────────────────────────────────
+
+if (args['content-file']) {
+  const contentFilePath = path.resolve(args['content-file']);
+  if (!fs.existsSync(contentFilePath)) {
+    console.error(`❌ 内容文件不存在：${contentFilePath}`);
+    process.exit(1);
+  }
+  const content = fs.readFileSync(contentFilePath, encoding);
+  writeContent(content);
+  process.exit(0);
+}
+
+// ─── 从 stdin 读取内容 ────────────────────────────────────────────────────────
+
+const isTTY = process.stdin.isTTY;
+
+if (isTTY) {
+  console.log('📝 请输入内容（输入完成后按 Ctrl+D 结束）：');
+}
+
+const chunks = [];
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+  chunks.push(line);
+});
+
+rl.on('close', () => {
+  const content = chunks.join('\n');
+  if (!content.trim()) {
+    console.error('❌ 未接收到任何内容，请通过 stdin 或 --content-file 提供内容');
+    process.exit(1);
+  }
+  writeContent(content);
+});


### PR DESCRIPTION
## 关联 Issue

Closes #265

## 变更内容

新增 `large-file-write` skill，解决 AI Agent 模式下使用 heredoc / shell 命令写入大文件时内容被截断的问题。

### 新增文件

```
yida-skills/skills/large-file-write/
├── SKILL.md          # skill 文档：问题背景、使用方式、核心原则
└── scripts/
    └── write.js      # Node.js 写入脚本（无需额外依赖，仅用 Node 内置模块）
```

## 问题背景

在使用 AI Agent 开发宜搭自定义页面时，页面代码通常 500-1500 行。当 AI 尝试用 heredoc 写入大文件时：

- zsh heredoc 在工具输出超过 token 限制时被截断
- 文件末尾缺失关键函数（如 `renderJsx`、`switchSceneMode` 等）
- 发布时 Babel 编译报错，需要手动定位修复

## 解决方案

**核心思路**：用 `create_file` 工具创建临时 payload 脚本，内容放在 JS 模板字符串里，再用 `node` 执行写入，完全绕过 shell 截断限制。

### 支持 3 种写入模式

| 模式 | 命令 | 适用场景 |
|------|------|---------|
| **stdin** | `echo "..." \| node write.js --file out.js` | 短内容快速写入 |
| **content-file** | `node write.js --file out.js --content-file /tmp/content.txt` | 从临时文件读取写入 |
| **payload** | `node write.js --payload /tmp/payload.js` | 自包含脚本（**推荐**） |

### 推荐工作流

```bash
# Step 1: AI 用 create_file 创建 payload（内容放在 JS 模板字符串，不受 shell 限制）
# /tmp/payload.js
const fs = require('fs');
const content = `
export function renderJsx() {
  // 任意长度内容...
}
`;
fs.writeFileSync('/path/to/target.js', content, 'utf8');

# Step 2: 执行写入
node ~/.agents/skills/large-file-write/scripts/write.js --payload /tmp/payload.js

# Step 3: 验证（--verify 参数自动输出行数和末尾5行）
node write.js --file out.js --content-file /tmp/content.txt --verify
```

## 测试验证

```bash
# stdin 模式
echo "// test" | node write.js --file /tmp/out.js --verify
# ✅ 写入成功：/tmp/out.js
#    本次内容：1 行 | 文件总行数：1 行

# content-file + append 模式
node write.js --file /tmp/out.js --content-file /tmp/content.txt --mode append --verify
# ✅ 追加成功：/tmp/out.js
```

## 无额外依赖

脚本仅使用 Node.js 内置模块（`fs`、`path`、`readline`），无需 `npm install`。