### PR TITLE
fix: 修复 PR #268 评审反馈中 w/h 默认值覆盖问题

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -618,6 +618,8 @@ async function main() {
     case 'dws': {
       const { run: runDws } = require('../lib/dws/dws-wrapper');
       await runDws(args);
+      break;
+    }
     case 'export-conversation': {
       const { exportConversation } = require('../lib/conversation/export-conversation');
       // 解析选项

--- a/lib/report/chart-builder.js
+++ b/lib/report/chart-builder.js
@@ -1501,8 +1501,8 @@ function buildReportSchema(reportTitle, charts, reportId, cubeTenantId) {
     const nodeId = genNodeId();
     const chartTitle = chart.title || (componentName + '_' + (index + 1));
     const defaultLayout = getDefaultLayout(chart.type);
-    const w = chart.w || defaultLayout.w;
-    const h = chart.h || defaultLayout.h;
+    const w = chart.w != null ? chart.w : defaultLayout.w;
+    const h = chart.h != null ? chart.h : defaultLayout.h;
 
     // 当前行放不下时换行
     if (currentX + w > 6) {

--- a/tests/dws-integration.test.js
+++ b/tests/dws-integration.test.js
@@ -6,59 +6,32 @@
 'use strict';
 
 const { execSync } = require('child_process');
-const assert = require('assert');
 
-console.log('开始测试钉钉 CLI 集成...\n');
+describe('钉钉 CLI 集成', () => {
+  // 测试 1: dws 命令帮助信息
+  test('dws --help 显示帮助信息', () => {
+    const output = execSync('node bin/yida.js dws --help', { encoding: 'utf8' });
+    expect(output).toContain('openyida dws - 钉钉 CLI 集成');
+    expect(output).toContain('常用命令');
+    expect(output).toContain('contact user search');
+  });
 
-// 测试 1: dws 命令帮助信息
-console.log('测试 1: dws --help');
-try {
-  const output = execSync('node bin/yida.js dws --help', { encoding: 'utf8' });
-  assert(output.includes('openyida dws - 钉钉 CLI 集成'), '帮助信息标题不正确');
-  assert(output.includes('常用命令'), '缺少常用命令列表');
-  assert(output.includes('contact user search'), '缺少联系人搜索命令');
-  console.log('✓ 通过\n');
-} catch (error) {
-  console.error('✗ 失败:', error.message);
-  process.exit(1);
-}
+  // 测试 2: 无参数显示帮助
+  test('dws (无参数) 显示帮助信息', () => {
+    const output = execSync('node bin/yida.js dws', { encoding: 'utf8' });
+    expect(output).toContain('openyida dws - 钉钉 CLI 集成');
+  });
 
-// 测试 2: 无参数显示帮助
-console.log('测试 2: dws (无参数)');
-try {
-  const output = execSync('node bin/yida.js dws', { encoding: 'utf8' });
-  assert(output.includes('openyida dws - 钉钉 CLI 集成'), '帮助信息标题不正确');
-  console.log('✓ 通过\n');
-} catch (error) {
-  console.error('✗ 失败:', error.message);
-  process.exit(1);
-}
+  // 测试 3: 主帮助包含 dws 命令
+  test('主帮助包含 dws 命令', () => {
+    const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
+    expect(output).toContain('dws');
+    expect(output).toContain('钉钉 CLI');
+  });
 
-// 测试 3: 主帮助包含 dws 命令
-console.log('测试 3: 主帮助包含 dws 命令');
-try {
-  const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
-  assert(output.includes('dws'), '主帮助缺少 dws 命令');
-  assert(output.includes('钉钉 CLI'), '缺少钉钉 CLI 说明');
-  console.log('✓ 通过\n');
-} catch (error) {
-  console.error('✗ 失败:', error.message);
-  process.exit(1);
-}
-
-// 测试 4: 示例命令在帮助中
-console.log('测试 4: 示例命令在帮助中');
-try {
-  const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
-  assert(output.includes('dws contact user search'), '缺少示例命令');
-  console.log('✓ 通过\n');
-} catch (error) {
-  console.error('✗ 失败:', error.message);
-  process.exit(1);
-}
-
-console.log('所有测试通过！✓');
-console.log('\n提示：钉钉 CLI (dws) 尚未安装，运行以下命令安装：');
-console.log('  openyida dws install');
-console.log('\n或手动执行：');
-console.log('  curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh');
+  // 测试 4: 示例命令在帮助中
+  test('示例命令在帮助中', () => {
+    const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
+    expect(output).toContain('dws contact user search');
+  });
+});


### PR DESCRIPTION
## 问题

PR #268 评审反馈中指出：`chart.w || defaultLayout.w` 会在 `chart.w = 0` 时错误地 fallback 到默认值。

## 修复内容

### 1. chart-builder.js - w/h 默认值问题
将 `||` 改为 `!= null` 判断，正确区分 `0` 和 `undefined/null`：

```javascript
// 修复前
const w = chart.w || defaultLayout.w;
const h = chart.h || defaultLayout.h;

// 修复后
const w = chart.w != null ? chart.w : defaultLayout.w;
const h = chart.h != null ? chart.h : defaultLayout.h;
```

### 2. bin/yida.js - dws case 缺少 break
修复 `case 'dws':` 块缺少 `break` 语句导致的 fall-through bug。

### 3. dws-integration.test.js - 重构为 Jest 格式
将独立脚本重构为标准 Jest 测试格式，解决 CI 测试失败问题。

## 关联

- PR #268 评审反馈修复
- @yize @alex-mm 感谢评审