### PR TITLE
fix: 增加通过命令检测claude环境

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -121,9 +121,9 @@ function detectActiveTool() {
   // 优先级3：Claude CLI - 通过命令检测（全局安装的 CLI 工具）
   if (commandExists('claude')) {
     return {
-      tool: 'claude',
+      tool: 'claude-code',
       displayName: 'Claude CLI',
-      dirName: '.claude',
+      dirName: '.claudecode',
       workspaceRoot: cwd,
     };
   }


### PR DESCRIPTION
## 改动说明

通过在utils.js里面增加通过命令检测的代码，来修复某些情况下，claude安装后无环境变量，但是无法过环境检测

## 改动类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级

## 关联 Issue



## 测试

- [ ] 本地运行 `npm test` 通过
- [ x ] JS 语法检查通过：`node --check bin/yida.js`
- [ x ] 已在真实宜搭环境测试过相关功能（如适用）

## 截图 / 录屏

<!-- 如有 UI 或行为变化，请附上截图或录屏 -->
