### PR TITLE
fix: buildFormSchema 添加缺失的 componentDidMount 生命周期配置

### DIFF
--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -1337,6 +1337,7 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
           compiled: constructorCode,
           source: constructorCode,
         },
+        componentDidMount: { name: 'didMount', id: 'didMount', params: {}, type: 'actionRef' },
       },
       hidden: false,
       title: '',

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -57,7 +57,21 @@ describe('generateFieldId uniqueness', () => {
   });
 });
 
-// ── Bug #3: buildFormSchema 不能有重复嵌套的 FormContainer ──
+// ── Bug #3: buildFormSchema 必须包含 componentDidMount 生命周期 ──
+
+describe('buildFormSchema lifeCycles', () => {
+  test('lifeCycles includes componentDidMount with actionRef to didMount', () => {
+    const formSchemaFunction = extractFunctionBody(sourceCode, 'buildFormSchema');
+    expect(formSchemaFunction).toBeDefined();
+
+    // 检查 lifeCycles 中包含 componentDidMount 配置
+    expect(formSchemaFunction).toContain('componentDidMount');
+    expect(formSchemaFunction).toContain("name: 'didMount'");
+    expect(formSchemaFunction).toContain("type: 'actionRef'");
+  });
+});
+
+// ── Bug #4: buildFormSchema 不能有重复嵌套的 FormContainer ──
 
 describe('buildFormSchema FormContainer structure', () => {
   test('FormContainer does not nest another FormContainer as direct child', () => {


### PR DESCRIPTION
## 问题描述

创建表单后测试提交时，部分组件显示未找到可能已卸载错误。

## 问题原因

`buildFormSchema` 函数中 Page 组件的 `lifeCycles` 配置缺少 `componentDidMount` 生命周期配置，导致页面加载时 `didMount` 函数无法正确绑定到页面组件。

## 修复方案

在 `buildFormSchema` 函数的 Page 组件 `lifeCycles` 配置中添加：

```javascript
componentDidMount: { name: 'didMount', id: 'didMount', params: {}, type: 'actionRef' },
```

此配置与 `buildEmptyFormSchema` 函数中的配置保持一致。

## 测试

- 新增测试用例验证 `buildFormSchema` 中包含 `componentDidMount` 配置
- 所有现有测试通过

Closes #238