### PR TITLE
fix(connector): add paramLocation to action generator inputs

### DIFF
--- a/lib/connector/action-generator.js
+++ b/lib/connector/action-generator.js
@@ -120,11 +120,17 @@ function generateOperation(curlData, relevantHeaders) {
   // Headers input
   if (relevantHeaders.length > 0) {
     const headersChildList = relevantHeaders.map(([key, value]) => ({
-      componentName: 'TextField',
-      desc: key,
+      _key: `${operationId}%${key}`,
       name: key,
+      paramType: 'String',
+      desc: key,
       required: false,
-      defaultValue: value.substring(0, 50) + (value.length > 50 ? '...' : '')
+      defaultValue: value.substring(0, 50) + (value.length > 50 ? '...' : ''),
+      children: [],
+      childList: [],
+      __level: 0,
+      hidden: false,
+      paramLocation: 'header'
     }));
 
     inputs.push({
@@ -132,7 +138,8 @@ function generateOperation(curlData, relevantHeaders) {
       desc: '请求头',
       name: 'Headers',
       paramType: 'Object',
-      required: false
+      required: false,
+      paramLocation: 'header'
     });
   }
 
@@ -145,10 +152,12 @@ function generateOperation(curlData, relevantHeaders) {
         name: key,
         paramType: typeof bodyObj[key] === 'number' ? 'Number' : 'String',
         desc: key,
+        required: false,
         children: [],
         childList: [],
         __level: 0,
-        hidden: false
+        hidden: false,
+        paramLocation: 'body'
       }));
 
       inputs.push({
@@ -157,7 +166,8 @@ function generateOperation(curlData, relevantHeaders) {
         name: 'Body',
         paramType: 'Object',
         required: false,
-        childList: bodyChildren
+        childList: bodyChildren,
+        paramLocation: 'body'
       });
     } catch {
       inputs.push({
@@ -165,7 +175,8 @@ function generateOperation(curlData, relevantHeaders) {
         desc: '请求体',
         name: 'Body',
         paramType: 'String',
-        required: false
+        required: false,
+        paramLocation: 'body'
       });
     }
   }
@@ -180,10 +191,12 @@ function generateOperation(curlData, relevantHeaders) {
         name: key,
         paramType: 'String',
         desc: key,
+        required: false,
         children: [],
         childList: [],
         __level: 0,
-        hidden: false
+        hidden: false,
+        paramLocation: 'query'
       });
     }
 
@@ -193,7 +206,8 @@ function generateOperation(curlData, relevantHeaders) {
         name: 'Query',
         paramType: 'Object',
         required: false,
-        childList: queryChildren
+        childList: queryChildren,
+        paramLocation: 'query'
       });
     }
   }


### PR DESCRIPTION
## Bug 修复

修复 HTTP 连接器创建后无法使用的问题（#284）。

### 问题描述
通过 openyida 创建的 HTTP 连接器执行动作，虽然创建成功但无法使用：
- 连接器执行动作编辑页面异常（点击其他执行动作时页面变空）
- 在表单编辑页面添加连接器选择执行动作后报错
- 调用连接器时报错：invoke http connector error，自定义连接器运行失败

### 根本原因
`lib/connector/action-generator.js` 生成的执行动作参数中，`inputs.childList` 子字段缺少 `paramLocation` 字段，导致宜搭平台无法识别参数应放在 header / query / body 哪个位置。

### 修复内容
为所有三类参数的子字段统一补充了 `paramLocation` 字段：

| 参数类型 | 修复内容 |
|---------|---------|
| Headers 子字段 | 补充 `paramLocation: 'header'` 及完整字段结构 |
| Body 子字段 | 补充 `paramLocation: 'body'`、`required: false` |
| Query 子字段 | 补充 `paramLocation: 'query'`、`required: false` |

Closes #284