### PR TITLE
feat: add update-app command to support updating app name

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -26,6 +26,7 @@
  *   openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]  保存公开访问/分享配置
  *   openyida get-page-config <appType> <formUuid>       查询页面公开访问/分享配置
  *   openyida update-form-config <appType> <formUuid> <isRenderNav> <title>  更新表单配置
+ *   openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]  更新应用信息
  *   openyida data <action> <resource> [args]            统一数据管理（表单/流程/任务/子表单）
  *   openyida task-center <type> [--page N] [--size N] [--keyword TEXT]  全局任务中心（待办/我创建的/我已处理/抄送/代提交）
  *   openyida doctor [选项]                              检查环境依赖，诊断应用问题
@@ -86,6 +87,7 @@ openyida - 宜搭命令行工具
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
   get-page-config <appType> <formUuid>                         查询页面公开访问/分享配置
   update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
+  update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] 更新应用信息
   data <action> <resource> [args]                              统一数据管理（表单/流程/任务/子表单）
   doctor [选项]                                                检查环境依赖，诊断应用问题
     --fix / --repair                                           诊断并自动修复
@@ -429,6 +431,17 @@ async function main() {
       }
       process.argv = [process.argv[0], process.argv[1], ...args];
       require('../lib/app/update-form-config');
+      break;
+    }
+
+    case 'update-app': {
+      if (args.length < 2) {
+        console.error(t('cli.update_app_usage'));
+        console.error(t('cli.update_app_example'));
+        process.exit(1);
+      }
+      const { run: runUpdateApp } = require('../lib/app/update-app');
+      await runUpdateApp(args);
       break;
     }
 

--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -1,0 +1,202 @@
+/**
+ * update-app.js - 更新宜搭应用信息
+ *
+ * 用法：openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]
+ */
+
+'use strict';
+
+const querystring = require('querystring');
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpPost,
+  requestWithAutoLogin,
+} = require('../core/utils');
+const { t } = require('../core/i18n');
+
+/**
+ * 解析命令行参数
+ * @param {string[]} args 命令行参数
+ * @returns {Object} 解析后的参数对象
+ */
+function parseArgs(args) {
+  const result = {
+    appType: null,
+    name: null,
+    desc: null,
+    icon: null,
+    iconColor: null,
+  };
+
+  // 第一个参数是 appType
+  if (args.length < 1) {
+    return result;
+  }
+  result.appType = args[0];
+
+  // 解析选项参数
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    switch (arg) {
+      case '--name':
+      case '-n':
+        if (nextArg) {
+          result.name = nextArg;
+          i++;
+        }
+        break;
+      case '--desc':
+      case '-d':
+        if (nextArg) {
+          result.desc = nextArg;
+          i++;
+        }
+        break;
+      case '--icon':
+        if (nextArg) {
+          result.icon = nextArg;
+          i++;
+        }
+        break;
+      case '--icon-color':
+        if (nextArg) {
+          result.iconColor = nextArg;
+          i++;
+        }
+        break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 打印使用帮助
+ */
+function printUsage() {
+  console.error(t('update_app.usage'));
+  console.error(t('update_app.example'));
+  console.error(t('update_app.options'));
+}
+
+async function run(args) {
+  const params = parseArgs(args);
+
+  // 验证必填参数
+  if (!params.appType) {
+    console.error(t('update_app.missing_app_type'));
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!params.name && !params.desc && !params.icon) {
+    console.error(t('update_app.missing_update_field'));
+    printUsage();
+    process.exit(1);
+  }
+
+  const SEP = '='.repeat(50);
+  console.error(SEP);
+  console.error(t('update_app.title'));
+  console.error(SEP);
+  console.error(t('update_app.app_type', params.appType));
+  if (params.name) {console.error(t('update_app.new_name', params.name));}
+  if (params.desc) {console.error(t('update_app.new_desc', params.desc));}
+  if (params.icon) {console.error(t('update_app.new_icon', params.icon, params.iconColor || '#0089FF'));}
+
+  // Step 1: 读取登录态
+  console.error(t('common.step_login', 1));
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error(t('common.login_no_cache'));
+    cookieData = triggerLogin();
+  }
+
+  const authRef = {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+  console.error(t('common.login_ready', authRef.baseUrl));
+
+  // Step 2: 更新应用
+  console.error(t('update_app.step_update'));
+
+  // 构建请求参数
+  const postDataObj = {
+    _csrf_token: authRef.csrfToken,
+    _locale_time_zone_offset: '28800000',
+    appType: params.appType,
+  };
+
+  // 应用名称（支持国际化）
+  if (params.name) {
+    postDataObj.appName = JSON.stringify({
+      zh_CN: params.name,
+      en_US: params.name,
+      type: 'i18n',
+      pureEn_US: params.name,
+    });
+  }
+
+  // 应用描述
+  if (params.desc) {
+    postDataObj.description = JSON.stringify({
+      zh_CN: params.desc,
+      en_US: params.desc,
+      type: 'i18n',
+    });
+  }
+
+  // 图标
+  if (params.icon) {
+    const iconColor = params.iconColor || '#0089FF';
+    const iconValue = `${params.icon}%%${iconColor}`;
+    postDataObj.icon = iconValue;
+    postDataObj.iconUrl = iconValue;
+  }
+
+  const postData = querystring.stringify(postDataObj);
+
+  const response = await requestWithAutoLogin((auth) => {
+    return httpPost(
+      auth.baseUrl,
+      `/query/app/updateAppName.json?_api=Form.updateAppName&_mock=false&_stamp=${Date.now()}`,
+      postData,
+      auth.cookies
+    );
+  }, authRef);
+
+  // 输出结果
+  const SEP2 = '='.repeat(50);
+  console.error('\n' + SEP2);
+  if (response && response.success) {
+    console.error(t('update_app.success'));
+    console.error(t('update_app.app_type_label', params.appType));
+    if (params.name) {console.error(t('update_app.name_label', params.name));}
+    console.error(SEP2);
+
+    console.log(JSON.stringify({
+      success: true,
+      appType: params.appType,
+      updatedFields: {
+        name: params.name || undefined,
+        desc: params.desc || undefined,
+        icon: params.icon || undefined,
+      },
+    }));
+  } else {
+    const errorMsg = response ? response.errorMsg || t('common.unknown_error') : t('common.request_failed');
+    console.error(t('update_app.failed', errorMsg));
+    console.error(SEP2);
+    console.log(JSON.stringify({ success: false, error: errorMsg }));
+    process.exit(1);
+  }
+}
+
+module.exports = { run };

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -64,6 +64,8 @@ Examples:
     page_config_example: 'Example: openyida get-page-config APP_XXX FORM-XXX',
     form_config_usage: 'Usage: openyida update-form-config <appType> <formUuid> <isRenderNav> <title>',
     form_config_example: 'Example: openyida update-form-config APP_XXX FORM-XXX false "Page Title"',
+    update_app_usage: 'Usage: openyida update-app <appType> --name "New Name" [--desc "Description"] [--icon "icon-name"]',
+    update_app_example: 'Example: openyida update-app APP_XXX --name "New App Name" --desc "New Description"',
     export_usage: 'Usage: openyida export <appType> [output]',
     export_example1: 'Example: openyida export APP_XXX',
     export_example2: '        openyida export APP_XXX ./my-app-backup.json',
@@ -110,7 +112,7 @@ Examples:
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - Environment Detection',
+    title: '  openyida env - Environment Detection',
     system_info: '\n📋 System Info',
     os: '  OS:           {0} ({1})',
     node: '  Node.js:      {0}',
@@ -134,17 +136,17 @@ Examples:
     corp_id_label: '  Org ID:       {0}',
     user_id_label: '  User ID:      {0}',
     csrf_label: '  csrf_token:   {0}...',
-    not_logged_in: '  Status:       ❌ Not logged in (run yidacli login to authenticate)',
+    not_logged_in: '  Status:       ❌ Not logged in (run openyida login to authenticate)',
     unknown: '(unknown)',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - Yida Login Tool',
-    logout_title: '  yidacli logout - Yida Logout Tool',
+    title: '  openyida login - Yida Login Tool',
+    logout_title: '  openyida logout - Yida Logout Tool',
     cookie_file_label: '\n  Cookie file: {0}',
     logout_success: '  ✅ Cookie cleared, login session invalidated.',
-    logout_hint: '  Next time you run yidacli login, a QR scan will be triggered.',
+    logout_hint: '  Next time you run openyida login, a QR scan will be triggered.',
     logout_no_file: '  ℹ️  Cookie file does not exist, nothing to clear.',
     using_cache: '🔍 Local Cookie found, using it directly...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -167,7 +169,7 @@ Examples:
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - Login Status Query',
+    status_title: '  openyida auth status - Login Status Query',
     not_logged_in: '  Status:       ❌ Not logged in',
     login_hint: '  Hint:         Run openyida auth login to authenticate',
     no_csrf_token: '  Status:       ❌ Invalid login (no csrf_token)',
@@ -192,12 +194,12 @@ Examples:
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - Organization List',
+    list_title: '  openyida org list - Organization List',
     no_corp_id: '  ❌ Cannot get current org ID, please login first',
     current_org: 'Current organization',
     current: 'current',
     no_organizations: '  ⚠️  No organization info available',
-    switch_title: '  yidacli org switch - Organization Switch',
+    switch_title: '  openyida org switch - Organization Switch',
     switch_from: '  Current org: {0}',
     switch_to: '  Target org:  {0}',
     already_in_org: '  ✅ Already in target organization',
@@ -220,9 +222,9 @@ Examples:
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - Yida App Creation Tool',
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: 'Example: yidacli create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - Yida App Creation Tool',
+    usage: 'Usage: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: 'Example: openyida create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853" "red"',
     available_icons: '\nAvailable icons:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\nAvailable colors:',
@@ -247,9 +249,9 @@ Examples:
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - Yida Custom Page Creation Tool',
-    usage: 'Usage: yidacli create-page <appType> "<pageName>"',
-    example: 'Example: yidacli create-page "APP_XXX" "Game Home"',
+    title: '  openyida create-page - Yida Custom Page Creation Tool',
+    usage: 'Usage: openyida create-page <appType> "<pageName>"',
+    example: 'Example: openyida create-page "APP_XXX" "Game Home"',
     app_id: '  App ID:    {0}',
     page_name: '  Page name: {0}',
     step_create: '\n📄 Step 2: Create Custom Page\n',
@@ -262,9 +264,9 @@ Examples:
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - Yida Form Schema Tool',
-    usage: 'Usage: yidacli get-schema <appType> <formUuid>',
-    example: 'Example: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - Yida Form Schema Tool',
+    usage: 'Usage: openyida get-schema <appType> <formUuid>',
+    example: 'Example: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  App ID:    {0}',
     form_uuid: '  Form UUID: {0}',
     step_get: '\n📄 Step 2: Get Form Schema',
@@ -478,8 +480,8 @@ Examples:
 
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: 'Usage: yidacli get-page-config <appType> <formUuid>',
-    example: 'Example: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: 'Usage: openyida get-page-config <appType> <formUuid>',
+    example: 'Example: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - Yida Page Config Query Tool',
     app_id: '\n  App ID:    {0}',
     form_uuid: '  Form UUID: {0}',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -62,6 +62,8 @@ openyida - Yida CLI ツール
     page_config_example: '例: openyida get-page-config APP_XXX FORM-XXX',
     form_config_usage: '使用方法: openyida update-form-config <appType> <formUuid> <isRenderNav> <title>',
     form_config_example: '例: openyida update-form-config APP_XXX FORM-XXX false "ページタイトル"',
+    update_app_usage: '使用方法: openyida update-app <appType> --name "新しい名前" [--desc "説明"] [--icon "アイコン"]',
+    update_app_example: '例: openyida update-app APP_XXX --name "新しいアプリ名" --desc "新しい説明"',
     export_usage: '使用方法: openyida export <appType> [output]',
     export_example1: '例: openyida export APP_XXX',
     export_example2: '    openyida export APP_XXX ./my-app-backup.json',
@@ -95,7 +97,7 @@ openyida - Yida CLI ツール
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - 環境検出',
+    title: '  openyida env - 環境検出',
     system_info: '\n📋 システム情報',
     os: '  OS:           {0} ({1})',
     node: '  Node.js:      {0}',
@@ -119,17 +121,17 @@ openyida - Yida CLI ツール
     corp_id_label: '  組織 ID:    {0}',
     user_id_label: '  ユーザー ID: {0}',
     csrf_label: '  csrf_token: {0}...',
-    not_logged_in: '  状態:       ❌ 未ログイン（yidacli login を実行してログインしてください）',
+    not_logged_in: '  状態:       ❌ 未ログイン（openyida login を実行してログインしてください）',
     unknown: '（不明）',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - Yida ログインツール',
-    logout_title: '  yidacli logout - Yida ログアウトツール',
+    title: '  openyida login - Yida ログインツール',
+    logout_title: '  openyida logout - Yida ログアウトツール',
     cookie_file_label: '\n  Cookie ファイル: {0}',
     logout_success: '  ✅ Cookie をクリアしました。ログインセッションが無効になりました。',
-    logout_hint: '  次回 yidacli login を実行すると QR コードスキャンが開始されます。',
+    logout_hint: '  次回 openyida login を実行すると QR コードスキャンが開始されます。',
     logout_no_file: '  ℹ️  Cookie ファイルが存在しません。クリア不要です。',
     using_cache: '🔍 ローカルの Cookie が見つかりました。直接使用します...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -152,7 +154,7 @@ openyida - Yida CLI ツール
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - ログイン状態照会',
+    status_title: '  openyida auth status - ログイン状態照会',
     not_logged_in: '  状態:       ❌ 未ログイン',
     login_hint: '  ヒント:     openyida auth login を実行してログインしてください',
     no_csrf_token: '  状態:       ❌ ログイン状態が無効（csrf_token なし）',
@@ -177,12 +179,12 @@ openyida - Yida CLI ツール
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - 組織一覧',
+    list_title: '  openyida org list - 組織一覧',
     no_corp_id: '  ❌ 現在の組織 ID を取得できません、先にログインしてください',
     current_org: '現在の組織',
     current: '現在',
     no_organizations: '  ⚠️  組織情報がありません',
-    switch_title: '  yidacli org switch - 組織切り替え',
+    switch_title: '  openyida org switch - 組織切り替え',
     switch_from: '  現在の組織: {0}',
     switch_to: '  切り替え先: {0}',
     already_in_org: '  ✅ 既にターゲット組織にいます',
@@ -205,9 +207,9 @@ openyida - Yida CLI ツール
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - Yida アプリ作成ツール',
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: '例: yidacli create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - Yida アプリ作成ツール',
+    usage: 'Usage: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '例: openyida create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853" "red"',
     available_icons: '\n利用可能なアイコン:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\n利用可能な色:',
@@ -232,9 +234,9 @@ openyida - Yida CLI ツール
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - Yida カスタムページ作成ツール',
-    usage: 'Usage: yidacli create-page <appType> "<pageName>"',
-    example: '例: yidacli create-page "APP_XXX" "ゲームホーム"',
+    title: '  openyida create-page - Yida カスタムページ作成ツール',
+    usage: 'Usage: openyida create-page <appType> "<pageName>"',
+    example: '例: openyida create-page "APP_XXX" "ゲームホーム"',
     app_id: '  アプリ ID:   {0}',
     page_name: '  ページ名:   {0}',
     step_create: '\n📄 Step 2: カスタムページを作成\n',
@@ -247,9 +249,9 @@ openyida - Yida CLI ツール
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - Yida フォーム Schema 取得ツール',
-    usage: 'Usage: yidacli get-schema <appType> <formUuid>',
-    example: '例: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - Yida フォーム Schema 取得ツール',
+    usage: 'Usage: openyida get-schema <appType> <formUuid>',
+    example: '例: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  アプリ ID:    {0}',
     form_uuid: '  フォーム UUID: {0}',
     step_get: '\n📄 Step 2: フォーム Schema を取得',
@@ -463,8 +465,8 @@ openyida - Yida CLI ツール
 
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: '使用方法: yidacli get-page-config <appType> <formUuid>',
-    example: '例: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: '使用方法: openyida get-page-config <appType> <formUuid>',
+    example: '例: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - Yida ページ設定照会ツール',
     app_id: '\n  アプリ ID:    {0}',
     form_uuid: '  フォーム UUID: {0}',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -65,6 +65,8 @@ openyida - 宜搭命令行工具
     page_config_example: '示例: openyida get-page-config APP_XXX FORM-XXX',
     form_config_usage: '用法: openyida update-form-config <appType> <formUuid> <isRenderNav> <title>',
     form_config_example: '示例: openyida update-form-config APP_XXX FORM-XXX false "页面标题"',
+    update_app_usage: '用法: openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]',
+    update_app_example: '示例: openyida update-app APP_XXX --name "新应用名称" --desc "新描述"',
     export_usage: '用法: openyida export <appType> [output]',
     export_example1: '示例: openyida export APP_XXX',
     export_example2: '      openyida export APP_XXX ./my-app-backup.json',
@@ -102,7 +104,7 @@ openyida - 宜搭命令行工具
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - 环境检测',
+    title: '  openyida env - 环境检测',
     system_info: '\n📋 系统信息',
     os: '  操作系统:   {0} ({1})',
     node: '  Node.js:    {0}',
@@ -126,17 +128,17 @@ openyida - 宜搭命令行工具
     corp_id_label: '  组织 ID:    {0}',
     user_id_label: '  用户 ID:    {0}',
     csrf_label: '  csrf_token: {0}...',
-    not_logged_in: '  状态:       ❌ 未登录（运行 yidacli login 进行登录）',
+    not_logged_in: '  状态:       ❌ 未登录（运行 openyida login 进行登录）',
     unknown: '(未知)',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - 宜搭登录工具',
-    logout_title: '  yidacli logout - 宜搭退出登录工具',
+    title: '  openyida login - 宜搭登录工具',
+    logout_title: '  openyida logout - 宜搭退出登录工具',
     cookie_file_label: '\n  Cookie 文件: {0}',
     logout_success: '  ✅ 已清空 Cookie，登录态已失效。',
-    logout_hint: '  下次调用 yidacli login 时将重新触发扫码登录。',
+    logout_hint: '  下次调用 openyida login 时将重新触发扫码登录。',
     logout_no_file: '  ℹ️  Cookie 文件不存在，无需清空。',
     using_cache: '🔍 检测到本地 Cookie，直接使用...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -159,7 +161,7 @@ openyida - 宜搭命令行工具
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - 登录状态查询',
+    status_title: '  openyida auth status - 登录状态查询',
     not_logged_in: '  状态:       ❌ 未登录',
     login_hint: '  提示:       运行 openyida auth login 进行登录',
     no_csrf_token: '  状态:       ❌ 登录态无效（无 csrf_token）',
@@ -184,12 +186,12 @@ openyida - 宜搭命令行工具
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - 组织列表',
+    list_title: '  openyida org list - 组织列表',
     no_corp_id: '  ❌ 无法获取当前组织 ID，请先登录',
     current_org: '当前组织',
     current: '当前',
     no_organizations: '  ⚠️  暂无组织信息',
-    switch_title: '  yidacli org switch - 组织切换',
+    switch_title: '  openyida org switch - 组织切换',
     switch_from: '  当前组织: {0}',
     switch_to: '  目标组织: {0}',
     already_in_org: '  ✅ 已在目标组织中，无需切换',
@@ -212,9 +214,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - 宜搭应用创建工具',
-    usage: '用法: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: '示例: yidacli create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - 宜搭应用创建工具',
+    usage: '用法: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '示例: openyida create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"',
     available_icons: '\n可用图标:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\n可用颜色:',
@@ -239,9 +241,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - 宜搭自定义页面创建工具',
-    usage: '用法: yidacli create-page <appType> "<pageName>"',
-    example: '示例: yidacli create-page "APP_XXX" "游戏主页"',
+    title: '  openyida create-page - 宜搭自定义页面创建工具',
+    usage: '用法: openyida create-page <appType> "<pageName>"',
+    example: '示例: openyida create-page "APP_XXX" "游戏主页"',
     app_id: '  应用 ID:  {0}',
     page_name: '  页面名称: {0}',
     step_create: '\n📄 Step 2: 创建自定义页面\n',
@@ -254,9 +256,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - 宜搭表单 Schema 获取工具',
-    usage: '用法: yidacli get-schema <appType> <formUuid>',
-    example: '示例: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - 宜搭表单 Schema 获取工具',
+    usage: '用法: openyida get-schema <appType> <formUuid>',
+    example: '示例: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  应用 ID:    {0}',
     form_uuid: '  表单 UUID:  {0}',
     step_get: '\n📄 Step 2: 获取表单 Schema',
@@ -435,8 +437,8 @@ openyida - 宜搭命令行工具
   title: '  openyida import - 宜搭应用导入工具',
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: '用法: yidacli get-page-config <appType> <formUuid>',
-    example: '示例: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: '用法: openyida get-page-config <appType> <formUuid>',
+    example: '示例: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - 宜搭页面配置查询工具',
     app_id: '\n  应用 ID:    {0}',
     form_uuid: '  表单 UUID:  {0}',
@@ -475,6 +477,25 @@ openyida - 宜搭命令行工具
     err_open_url_required: '开启公开访问时，openUrl 不能为空',
     err_open_url_prefix: 'openUrl 必须以 /o/ 开头，当前值: {0}',
     err_open_url_chars: 'openUrl 路径部分只支持 a-z A-Z 0-9 _ -，当前值: {0}',
+  },
+
+  // ── lib/update-app.js ─────────────────────────────
+  update_app: {
+    usage: '用法: openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] [--icon-color "颜色"]',
+    example: '示例: openyida update-app APP_XXX --name "新应用名称" --desc "新描述"',
+    options: '选项:\n  --name, -n      应用名称（必填或至少一个更新字段）\n  --desc, -d      应用描述\n  --icon          图标名称（如: xian-yingyong）\n  --icon-color    图标颜色（默认: #0089FF）',
+    missing_app_type: '错误: 缺少 appType 参数',
+    missing_update_field: '错误: 至少需要指定一个更新字段（--name, --desc, --icon）',
+    title: '  update-app - 宜搭应用信息更新工具',
+    app_type: '\n  应用 ID:      {0}',
+    new_name: '  新名称:       {0}',
+    new_desc: '  新描述:       {0}',
+    new_icon: '  新图标:       {0} ({1})',
+    step_update: '\n💾 Step 2: 更新应用信息',
+    success: '  ✅ 应用信息更新成功！',
+    app_type_label: '  appType: {0}',
+    name_label: '  应用名称: {0}',
+    failed: '  ❌ 更新失败: {0}',
   },
 
   // ── lib/update-form-config.js ──────────────────────


### PR DESCRIPTION
## 功能描述

实现 "更新应用名称" 功能，支持通过 CLI 更新已创建应用的名称、描述和图标。

## 实现内容

### 新增命令

```bash
# 更新应用名称
openyida update-app APP_XXX --name "新应用名称"

# 同时更新名称和描述
openyida update-app APP_XXX --name "CRM系统" --desc "客户关系管理系统"

# 更新图标
openyida update-app APP_XXX --icon "xian-yingyong" --icon-color "#0089FF"
```

### 支持的参数

| 参数 | 简写 | 说明 |
|------|------|------|
| `--name` | `-n` | 应用名称 |
| `--desc` | `-d` | 应用描述 |
| `--icon` | - | 图标名称 |
| `--icon-color` | - | 图标颜色（默认 #0089FF） |

### 修改的文件

- `lib/app/update-app.js` - 新增命令实现
- `bin/yida.js` - 注册命令路由
- `lib/core/locales/zh.js` - 中文国际化
- `lib/core/locales/en.js` - 英文国际化
- `lib/core/locales/ja.js` - 日文国际化

### API 信息

使用宜搭 API: `POST /query/app/updateAppName.json`

请求参数支持国际化格式（zh_CN/en_US）。

## 关联 Issue

Closes #298