### PR TITLE
refactor: 统一 CLI 命令名称从 yidacli 改为 openyida

### DIFF
--- a/lib/app/create-app.js
+++ b/lib/app/create-app.js
@@ -1,7 +1,7 @@
 /**
  * create-app.js - 宜搭应用创建命令
  *
- * 用法：yidacli create-app "<appName>" [description] [icon] [iconColor] [colour] [navTheme] [layoutDirection]
+ * 用法：openyida create-app "<appName>" [description] [icon] [iconColor] [colour] [navTheme] [layoutDirection]
  */
 
 'use strict';

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -1,7 +1,7 @@
 /**
  * create-page.js - 宜搭自定义页面创建命令
  *
- * 用法：yidacli create-page <appType> "<pageName>"
+ * 用法：openyida create-page <appType> "<pageName>"
  */
 
 'use strict';

--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -1,7 +1,7 @@
 /**
  * get-schema.js - 宜搭表单 Schema 获取命令
  *
- * 用法：yidacli get-schema <appType> <formUuid>
+ * 用法：openyida get-schema <appType> <formUuid>
  */
 
 'use strict';

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -165,14 +165,14 @@ function ensureLogin() {
  * 获取 playwright 模块的绝对路径，用于临时脚本中 require。
  *
  * 查找策略（按优先级）：
- *   1. yidacli 包自身的 node_modules/playwright（最可靠）
+ *   1. openyida 包自身的 node_modules/playwright（最可靠）
  *   2. require.resolve 标准解析
  *   3. 全局 npm root 路径
  *
  * @returns {string|null} playwright index.js 的绝对路径
  */
 function getPlaywrightPath() {
-  // 策略1：从 __dirname 向上找到 yidacli 包根目录下的 node_modules/playwright
+  // 策略1：从 __dirname 向上找到 openyida 包根目录下的 node_modules/playwright
   // __dirname 是 dist/ 或 src/，向上一级是包根目录
   const candidates = [
     path.join(__dirname, '..', 'node_modules', 'playwright', 'index.js'),
@@ -287,7 +287,7 @@ const { URL } = require('url');
 })();
 `;
 
-  const tmpScript = path.join(os.tmpdir(), `yidacli-login-${Date.now()}.js`);
+  const tmpScript = path.join(os.tmpdir(), `openyida-login-${Date.now()}.js`);
   fs.writeFileSync(tmpScript, scriptContent, 'utf-8');
 
   try {

--- a/lib/core/i18n.js
+++ b/lib/core/i18n.js
@@ -23,7 +23,7 @@
  * 用法：
  *   const { t } = require('./i18n');
  *   console.log(t('login.success'));
- *   console.log(t('create_app.usage', 'yidacli'));
+ *   console.log(t('create_app.usage', 'openyida'));
  */
 
 'use strict';

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -110,7 +110,7 @@ Examples:
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - Environment Detection',
+    title: '  openyida env - Environment Detection',
     system_info: '\n📋 System Info',
     os: '  OS:           {0} ({1})',
     node: '  Node.js:      {0}',
@@ -134,17 +134,17 @@ Examples:
     corp_id_label: '  Org ID:       {0}',
     user_id_label: '  User ID:      {0}',
     csrf_label: '  csrf_token:   {0}...',
-    not_logged_in: '  Status:       ❌ Not logged in (run yidacli login to authenticate)',
+    not_logged_in: '  Status:       ❌ Not logged in (run openyida login to authenticate)',
     unknown: '(unknown)',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - Yida Login Tool',
-    logout_title: '  yidacli logout - Yida Logout Tool',
+    title: '  openyida login - Yida Login Tool',
+    logout_title: '  openyida logout - Yida Logout Tool',
     cookie_file_label: '\n  Cookie file: {0}',
     logout_success: '  ✅ Cookie cleared, login session invalidated.',
-    logout_hint: '  Next time you run yidacli login, a QR scan will be triggered.',
+    logout_hint: '  Next time you run openyida login, a QR scan will be triggered.',
     logout_no_file: '  ℹ️  Cookie file does not exist, nothing to clear.',
     using_cache: '🔍 Local Cookie found, using it directly...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -167,7 +167,7 @@ Examples:
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - Login Status Query',
+    status_title: '  openyida auth status - Login Status Query',
     not_logged_in: '  Status:       ❌ Not logged in',
     login_hint: '  Hint:         Run openyida auth login to authenticate',
     no_csrf_token: '  Status:       ❌ Invalid login (no csrf_token)',
@@ -192,12 +192,12 @@ Examples:
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - Organization List',
+    list_title: '  openyida org list - Organization List',
     no_corp_id: '  ❌ Cannot get current org ID, please login first',
     current_org: 'Current organization',
     current: 'current',
     no_organizations: '  ⚠️  No organization info available',
-    switch_title: '  yidacli org switch - Organization Switch',
+    switch_title: '  openyida org switch - Organization Switch',
     switch_from: '  Current org: {0}',
     switch_to: '  Target org:  {0}',
     already_in_org: '  ✅ Already in target organization',
@@ -220,9 +220,9 @@ Examples:
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - Yida App Creation Tool',
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: 'Example: yidacli create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - Yida App Creation Tool',
+    usage: 'Usage: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: 'Example: openyida create-app "Attendance" "Employee attendance system" "xian-daka" "#00B853" "red"',
     available_icons: '\nAvailable icons:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\nAvailable colors:',
@@ -247,9 +247,9 @@ Examples:
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - Yida Custom Page Creation Tool',
-    usage: 'Usage: yidacli create-page <appType> "<pageName>"',
-    example: 'Example: yidacli create-page "APP_XXX" "Game Home"',
+    title: '  openyida create-page - Yida Custom Page Creation Tool',
+    usage: 'Usage: openyida create-page <appType> "<pageName>"',
+    example: 'Example: openyida create-page "APP_XXX" "Game Home"',
     app_id: '  App ID:    {0}',
     page_name: '  Page name: {0}',
     step_create: '\n📄 Step 2: Create Custom Page\n',
@@ -262,9 +262,9 @@ Examples:
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - Yida Form Schema Tool',
-    usage: 'Usage: yidacli get-schema <appType> <formUuid>',
-    example: 'Example: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - Yida Form Schema Tool',
+    usage: 'Usage: openyida get-schema <appType> <formUuid>',
+    example: 'Example: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  App ID:    {0}',
     form_uuid: '  Form UUID: {0}',
     step_get: '\n📄 Step 2: Get Form Schema',
@@ -478,8 +478,8 @@ Examples:
 
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: 'Usage: yidacli get-page-config <appType> <formUuid>',
-    example: 'Example: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: 'Usage: openyida get-page-config <appType> <formUuid>',
+    example: 'Example: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - Yida Page Config Query Tool',
     app_id: '\n  App ID:    {0}',
     form_uuid: '  Form UUID: {0}',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -95,7 +95,7 @@ openyida - Yida CLI ツール
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - 環境検出',
+    title: '  openyida env - 環境検出',
     system_info: '\n📋 システム情報',
     os: '  OS:           {0} ({1})',
     node: '  Node.js:      {0}',
@@ -119,17 +119,17 @@ openyida - Yida CLI ツール
     corp_id_label: '  組織 ID:    {0}',
     user_id_label: '  ユーザー ID: {0}',
     csrf_label: '  csrf_token: {0}...',
-    not_logged_in: '  状態:       ❌ 未ログイン（yidacli login を実行してログインしてください）',
+    not_logged_in: '  状態:       ❌ 未ログイン（openyida login を実行してログインしてください）',
     unknown: '（不明）',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - Yida ログインツール',
-    logout_title: '  yidacli logout - Yida ログアウトツール',
+    title: '  openyida login - Yida ログインツール',
+    logout_title: '  openyida logout - Yida ログアウトツール',
     cookie_file_label: '\n  Cookie ファイル: {0}',
     logout_success: '  ✅ Cookie をクリアしました。ログインセッションが無効になりました。',
-    logout_hint: '  次回 yidacli login を実行すると QR コードスキャンが開始されます。',
+    logout_hint: '  次回 openyida login を実行すると QR コードスキャンが開始されます。',
     logout_no_file: '  ℹ️  Cookie ファイルが存在しません。クリア不要です。',
     using_cache: '🔍 ローカルの Cookie が見つかりました。直接使用します...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -152,7 +152,7 @@ openyida - Yida CLI ツール
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - ログイン状態照会',
+    status_title: '  openyida auth status - ログイン状態照会',
     not_logged_in: '  状態:       ❌ 未ログイン',
     login_hint: '  ヒント:     openyida auth login を実行してログインしてください',
     no_csrf_token: '  状態:       ❌ ログイン状態が無効（csrf_token なし）',
@@ -177,12 +177,12 @@ openyida - Yida CLI ツール
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - 組織一覧',
+    list_title: '  openyida org list - 組織一覧',
     no_corp_id: '  ❌ 現在の組織 ID を取得できません、先にログインしてください',
     current_org: '現在の組織',
     current: '現在',
     no_organizations: '  ⚠️  組織情報がありません',
-    switch_title: '  yidacli org switch - 組織切り替え',
+    switch_title: '  openyida org switch - 組織切り替え',
     switch_from: '  現在の組織: {0}',
     switch_to: '  切り替え先: {0}',
     already_in_org: '  ✅ 既にターゲット組織にいます',
@@ -205,9 +205,9 @@ openyida - Yida CLI ツール
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - Yida アプリ作成ツール',
-    usage: 'Usage: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: '例: yidacli create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - Yida アプリ作成ツール',
+    usage: 'Usage: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '例: openyida create-app "勤怠管理" "従業員勤怠システム" "xian-daka" "#00B853" "red"',
     available_icons: '\n利用可能なアイコン:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\n利用可能な色:',
@@ -232,9 +232,9 @@ openyida - Yida CLI ツール
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - Yida カスタムページ作成ツール',
-    usage: 'Usage: yidacli create-page <appType> "<pageName>"',
-    example: '例: yidacli create-page "APP_XXX" "ゲームホーム"',
+    title: '  openyida create-page - Yida カスタムページ作成ツール',
+    usage: 'Usage: openyida create-page <appType> "<pageName>"',
+    example: '例: openyida create-page "APP_XXX" "ゲームホーム"',
     app_id: '  アプリ ID:   {0}',
     page_name: '  ページ名:   {0}',
     step_create: '\n📄 Step 2: カスタムページを作成\n',
@@ -247,9 +247,9 @@ openyida - Yida CLI ツール
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - Yida フォーム Schema 取得ツール',
-    usage: 'Usage: yidacli get-schema <appType> <formUuid>',
-    example: '例: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - Yida フォーム Schema 取得ツール',
+    usage: 'Usage: openyida get-schema <appType> <formUuid>',
+    example: '例: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  アプリ ID:    {0}',
     form_uuid: '  フォーム UUID: {0}',
     step_get: '\n📄 Step 2: フォーム Schema を取得',
@@ -463,8 +463,8 @@ openyida - Yida CLI ツール
 
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: '使用方法: yidacli get-page-config <appType> <formUuid>',
-    example: '例: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: '使用方法: openyida get-page-config <appType> <formUuid>',
+    example: '例: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - Yida ページ設定照会ツール',
     app_id: '\n  アプリ ID:    {0}',
     form_uuid: '  フォーム UUID: {0}',

--- a/lib/core/locales/zh-TW.js
+++ b/lib/core/locales/zh-TW.js
@@ -102,7 +102,7 @@ openyida - 宜搭命令列工具
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - 環境偵測',
+    title: '  openyida env - 環境偵測',
     system_info: '\n📋 系統資訊',
     os: '  作業系統：   {0} ({1})',
     node: '  Node.js：    {0}',
@@ -126,17 +126,17 @@ openyida - 宜搭命令列工具
     corp_id_label: '  組織 ID：    {0}',
     user_id_label: '  使用者 ID：  {0}',
     csrf_label: '  csrf_token：{0}...',
-    not_logged_in: '  狀態：       ❌ 未登入（執行 yidacli login 進行登入）',
+    not_logged_in: '  狀態：       ❌ 未登入（執行 openyida login 進行登入）',
     unknown: '(未知)',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - 宜搭登入工具',
-    logout_title: '  yidacli logout - 宜搭登出工具',
+    title: '  openyida login - 宜搭登入工具',
+    logout_title: '  openyida logout - 宜搭登出工具',
     cookie_file_label: '\n  Cookie 檔案：{0}',
     logout_success: '  ✅ 已清空 Cookie，登入態已失效。',
-    logout_hint: '  下次呼叫 yidacli login 時將重新觸發掃碼登入。',
+    logout_hint: '  下次呼叫 openyida login 時將重新觸發掃碼登入。',
     logout_no_file: '  ℹ️  Cookie 檔案不存在，無需清空。',
     using_cache: '🔍 偵測到本機 Cookie，直接使用...',
     csrf_ok: '  ✅ csrf_token：{0}...',
@@ -159,7 +159,7 @@ openyida - 宜搭命令列工具
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - 登入狀態查詢',
+    status_title: '  openyida auth status - 登入狀態查詢',
     not_logged_in: '  狀態：       ❌ 未登入',
     login_hint: '  提示：       執行 openyida auth login 進行登入',
     no_csrf_token: '  狀態：       ❌ 登入態無效（無 csrf_token）',
@@ -184,12 +184,12 @@ openyida - 宜搭命令列工具
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - 組織清單',
+    list_title: '  openyida org list - 組織清單',
     no_corp_id: '  ❌ 無法取得目前組織 ID，請先登入',
     current_org: '目前組織',
     current: '目前',
     no_organizations: '  ⚠️  暫無組織資訊',
-    switch_title: '  yidacli org switch - 組織切換',
+    switch_title: '  openyida org switch - 組織切換',
     switch_from: '  目前組織：{0}',
     switch_to: '  目標組織：{0}',
     already_in_org: '  ✅ 已在目標組織中，無需切換',
@@ -212,9 +212,9 @@ openyida - 宜搭命令列工具
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - 宜搭應用建立工具',
-    usage: '用法：yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: '範例：yidacli create-app "考勤管理" "員工考勤打卡系統" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - 宜搭應用建立工具',
+    usage: '用法：openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '範例：openyida create-app "考勤管理" "員工考勤打卡系統" "xian-daka" "#00B853" "red"',
     available_icons: '\n可用圖示：',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\n可用顏色：',
@@ -239,9 +239,9 @@ openyida - 宜搭命令列工具
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - 宜搭自訂頁面建立工具',
-    usage: '用法：yidacli create-page <appType> "<pageName>"',
-    example: '範例：yidacli create-page "APP_XXX" "遊戲主頁"',
+    title: '  openyida create-page - 宜搭自訂頁面建立工具',
+    usage: '用法：openyida create-page <appType> "<pageName>"',
+    example: '範例：openyida create-page "APP_XXX" "遊戲主頁"',
     app_id: '  應用 ID：  {0}',
     page_name: '  頁面名稱：{0}',
     step_create: '\n📄 Step 2：建立自訂頁面\n',
@@ -254,9 +254,9 @@ openyida - 宜搭命令列工具
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - 宜搭表單 Schema 取得工具',
-    usage: '用法：yidacli get-schema <appType> <formUuid>',
-    example: '範例：yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - 宜搭表單 Schema 取得工具',
+    usage: '用法：openyida get-schema <appType> <formUuid>',
+    example: '範例：openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  應用 ID：    {0}',
     form_uuid: '  表單 UUID：  {0}',
     step_get: '\n📄 Step 2：取得表單 Schema',
@@ -373,8 +373,8 @@ openyida - 宜搭命令列工具
   title: '  openyida import - 宜搭應用匯入工具',
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: '用法：yidacli get-page-config <appType> <formUuid>',
-    example: '範例：yidacli get-page-config APP_XXX FORM-XXX',
+    usage: '用法：openyida get-page-config <appType> <formUuid>',
+    example: '範例：openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - 宜搭頁面設定查詢工具',
     app_id: '\n  應用 ID：    {0}',
     form_uuid: '  表單 UUID：  {0}',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -102,7 +102,7 @@ openyida - 宜搭命令行工具
 
   // ── lib/env.js ─────────────────────────────────────
   env: {
-    title: '  yidacli env - 环境检测',
+    title: '  openyida env - 环境检测',
     system_info: '\n📋 系统信息',
     os: '  操作系统:   {0} ({1})',
     node: '  Node.js:    {0}',
@@ -126,17 +126,17 @@ openyida - 宜搭命令行工具
     corp_id_label: '  组织 ID:    {0}',
     user_id_label: '  用户 ID:    {0}',
     csrf_label: '  csrf_token: {0}...',
-    not_logged_in: '  状态:       ❌ 未登录（运行 yidacli login 进行登录）',
+    not_logged_in: '  状态:       ❌ 未登录（运行 openyida login 进行登录）',
     unknown: '(未知)',
   },
 
   // ── lib/login.js ───────────────────────────────────
   login: {
-    title: '  yidacli login - 宜搭登录工具',
-    logout_title: '  yidacli logout - 宜搭退出登录工具',
+    title: '  openyida login - 宜搭登录工具',
+    logout_title: '  openyida logout - 宜搭退出登录工具',
     cookie_file_label: '\n  Cookie 文件: {0}',
     logout_success: '  ✅ 已清空 Cookie，登录态已失效。',
-    logout_hint: '  下次调用 yidacli login 时将重新触发扫码登录。',
+    logout_hint: '  下次调用 openyida login 时将重新触发扫码登录。',
     logout_no_file: '  ℹ️  Cookie 文件不存在，无需清空。',
     using_cache: '🔍 检测到本地 Cookie，直接使用...',
     csrf_ok: '  ✅ csrf_token: {0}...',
@@ -159,7 +159,7 @@ openyida - 宜搭命令行工具
 
   // ── lib/auth.js ────────────────────────────────────
   auth: {
-    status_title: '  yidacli auth status - 登录状态查询',
+    status_title: '  openyida auth status - 登录状态查询',
     not_logged_in: '  状态:       ❌ 未登录',
     login_hint: '  提示:       运行 openyida auth login 进行登录',
     no_csrf_token: '  状态:       ❌ 登录态无效（无 csrf_token）',
@@ -184,12 +184,12 @@ openyida - 宜搭命令行工具
 
   // ── lib/org.js ─────────────────────────────────────
   org: {
-    list_title: '  yidacli org list - 组织列表',
+    list_title: '  openyida org list - 组织列表',
     no_corp_id: '  ❌ 无法获取当前组织 ID，请先登录',
     current_org: '当前组织',
     current: '当前',
     no_organizations: '  ⚠️  暂无组织信息',
-    switch_title: '  yidacli org switch - 组织切换',
+    switch_title: '  openyida org switch - 组织切换',
     switch_from: '  当前组织: {0}',
     switch_to: '  目标组织: {0}',
     already_in_org: '  ✅ 已在目标组织中，无需切换',
@@ -212,9 +212,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/create-app.js ──────────────────────────────
   create_app: {
-    title: '  yidacli create-app - 宜搭应用创建工具',
-    usage: '用法: yidacli create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
-    example: '示例: yidacli create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"',
+    title: '  openyida create-app - 宜搭应用创建工具',
+    usage: '用法: openyida create-app "<appName>" [description] [icon] [iconColor] [themeColor]',
+    example: '示例: openyida create-app "考勤管理" "员工考勤打卡系统" "xian-daka" "#00B853" "red"',
     available_icons: '\n可用图标:',
     icons_list: '  xian-xinwen, xian-zhengfu, xian-yingyong, xian-xueshimao, xian-qiye,\n  xian-danju, xian-shichang, xian-jingli, xian-falv, xian-baogao,\n  huoche, xian-shenbao, xian-diqiu, xian-qiche, xian-feiji,\n  xian-diannao, xian-gongzuozheng, xian-gouwuche, xian-xinyongka,\n  xian-huodong, xian-jiangbei, xian-liucheng, xian-chaxun, xian-daka',
     available_colors: '\n可用颜色:',
@@ -239,9 +239,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/create-page.js ─────────────────────────────
   create_page: {
-    title: '  yidacli create-page - 宜搭自定义页面创建工具',
-    usage: '用法: yidacli create-page <appType> "<pageName>"',
-    example: '示例: yidacli create-page "APP_XXX" "游戏主页"',
+    title: '  openyida create-page - 宜搭自定义页面创建工具',
+    usage: '用法: openyida create-page <appType> "<pageName>"',
+    example: '示例: openyida create-page "APP_XXX" "游戏主页"',
     app_id: '  应用 ID:  {0}',
     page_name: '  页面名称: {0}',
     step_create: '\n📄 Step 2: 创建自定义页面\n',
@@ -254,9 +254,9 @@ openyida - 宜搭命令行工具
 
   // ── lib/get-schema.js ──────────────────────────────
   get_schema: {
-    title: '  yidacli get-schema - 宜搭表单 Schema 获取工具',
-    usage: '用法: yidacli get-schema <appType> <formUuid>',
-    example: '示例: yidacli get-schema "APP_XXX" "FORM-XXX"',
+    title: '  openyida get-schema - 宜搭表单 Schema 获取工具',
+    usage: '用法: openyida get-schema <appType> <formUuid>',
+    example: '示例: openyida get-schema "APP_XXX" "FORM-XXX"',
     app_id: '  应用 ID:    {0}',
     form_uuid: '  表单 UUID:  {0}',
     step_get: '\n📄 Step 2: 获取表单 Schema',
@@ -435,8 +435,8 @@ openyida - 宜搭命令行工具
   title: '  openyida import - 宜搭应用导入工具',
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {
-    usage: '用法: yidacli get-page-config <appType> <formUuid>',
-    example: '示例: yidacli get-page-config APP_XXX FORM-XXX',
+    usage: '用法: openyida get-page-config <appType> <formUuid>',
+    example: '示例: openyida get-page-config APP_XXX FORM-XXX',
     title: '  get-page-config - 宜搭页面配置查询工具',
     app_id: '\n  应用 ID:    {0}',
     form_uuid: '  表单 UUID:  {0}',

--- a/lib/page-config/get-page-config.js
+++ b/lib/page-config/get-page-config.js
@@ -1,7 +1,7 @@
 /**
  * get-page-config.js - 宜搭页面公开访问/分享配置查询命令
  *
- * 用法：yidacli get-page-config <appType> <formUuid>
+ * 用法：openyida get-page-config <appType> <formUuid>
  */
 
 'use strict';

--- a/lib/page-config/save-share-config.js
+++ b/lib/page-config/save-share-config.js
@@ -1,7 +1,7 @@
 /**
  * save-share-config.js - 宜搭页面公开访问/分享配置保存命令
  *
- * 用法：yidacli save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]
+ * 用法：openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]
  */
 
 'use strict';

--- a/lib/page-config/verify-short-url.js
+++ b/lib/page-config/verify-short-url.js
@@ -1,7 +1,7 @@
 /**
  * verify-short-url.js - 宜搭公开访问/分享 URL 验证命令
  *
- * 用法：yidacli verify-short-url <appType> <formUuid> <url>
+ * 用法：openyida verify-short-url <appType> <formUuid> <url>
  *
  * 参数：
  *   appType  - 应用 ID（必填），如 APP_XXX
@@ -14,7 +14,7 @@
  *   - 路径部分只支持英文、数字、- 和 _
  *
  * 示例：
- *   yidacli verify-short-url APP_XXX FORM-XXX /o/myapp
+ *   openyida verify-short-url APP_XXX FORM-XXX /o/myapp
  */
 
 'use strict';


### PR DESCRIPTION
## 变更概述

将项目中所有 `yidacli` 命令名称统一重命名为 `openyida`，与项目名称保持一致。

## 变更范围

- **文件注释**: 更新 JS 文件头部用法说明中的命令名
- **国际化文案**: 更新 `lib/core/locales/` 下所有语言包中的命令示例
  - zh.js (简体中文)
  - en.js (英文)
  - ja.js (日文)
  - zh-TW.js (繁体中文)

## 变更文件清单

| 文件 | 变更内容 |
|------|----------|
| lib/app/create-app.js | 用法注释 |
| lib/app/create-page.js | 用法注释 |
| lib/app/get-schema.js | 用法注释 |
| lib/auth/login.js | 注释 + 日志输出 |
| lib/core/i18n.js | 标题输出 |
| lib/core/locales/*.js | 所有语言包中的命令示例 |
| lib/page-config/*.js | 用法注释 |

## 影响范围

仅涉及文档注释和用户提示文案，不影响代码逻辑功能。

## 测试验证

- [x] 所有变更为纯文本替换
- [x] 无代码逻辑变更