### PR TITLE
fix(i18n): add missing update_app locale section to English translations

### DIFF
--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -522,6 +522,25 @@ Examples:
     err_open_url_chars: 'openUrl path only supports a-z A-Z 0-9 _ -, current value: {0}',
   },
 
+  // ── lib/update-app.js ─────────────────────────────
+  update_app: {
+    usage: 'Usage: openyida update-app <appType> --name "New Name" [--desc "Description"] [--icon "icon-name"] [--icon-color "color"]',
+    example: 'Example: openyida update-app APP_XXX --name "New App Name" --desc "New Description"',
+    options: 'Options:\n  --name, -n      App name (required or at least one update field)\n  --desc, -d      App description\n  --icon          Icon name (e.g. xian-yingyong)\n  --icon-color    Icon color (default: #0089FF)',
+    missing_app_type: 'Error: missing appType argument',
+    missing_update_field: 'Error: at least one update field must be specified (--name, --desc, --icon)',
+    title: '  update-app - Yida App Info Update Tool',
+    app_type: '\n  App ID:       {0}',
+    new_name: '  New name:     {0}',
+    new_desc: '  New desc:     {0}',
+    new_icon: '  New icon:     {0} ({1})',
+    step_update: '\n💾 Step 2: Update app info',
+    success: '  ✅ App info updated successfully!',
+    app_type_label: '  appType: {0}',
+    name_label: '  App name: {0}',
+    failed: '  ❌ Update failed: {0}',
+  },
+
   // ── lib/update-form-config.js ──────────────────────
   update_form_config: {
     usage: 'Usage: openyida update-form-config <appType> <formUuid> <isRenderNav> <title>',


### PR DESCRIPTION
## Problem

The `update-app` command was added recently but its locale strings were never added to `lib/core/locales/en.js`. When users run `openyida update-app` in an English environment (`OPENYIDA_LANG=en` or `LANG=en_US`), every message falls back to the raw key name (e.g. `update_app.title`, `update_app.failed`) instead of a proper English string.

## Fix

Adds the complete `update_app` section to the English locale file, covering all 16 keys consumed by `lib/app/update-app.js`:

- `usage`, `example`, `options`
- `missing_app_type`, `missing_update_field`
- `title`, `app_type`, `new_name`, `new_desc`, `new_icon`
- `step_update`, `success`, `app_type_label`, `name_label`, `failed`

The new section is placed between `update_form_config` and `verify_short_url`, matching the order in `zh.js`.

## Test plan

- [x] All 299 existing tests pass (`npx jest`)
- [x] `node --check lib/core/locales/en.js` passes
- [ ] Manual: set `OPENYIDA_LANG=en` and run `openyida update-app` — messages should display in English