### PR TITLE
fix: triggerLogin() should call interactiveLogin() instead of ensureLogin()

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -208,8 +208,18 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  */
 function triggerLogin() {
   console.error(t('login.trigger_login'));
-  const { interactiveLogin } = require('../auth/login');
-  return interactiveLogin();
+  // 清除本地过期的 cookie 缓存，避免 ensureLogin 复用过期 cookie
+  try {
+    const projectRoot = findProjectRoot();
+    const cookieFile = require('path').join(projectRoot, '.cache', 'cookies.json');
+    if (require('fs').existsSync(cookieFile)) {
+      require('fs').unlinkSync(cookieFile);
+    }
+  } catch {
+    // 清除失败不影响主流程
+  }
+  const { ensureLogin } = require('../auth/login');
+  return ensureLogin();
 }
 
 /**

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -208,8 +208,8 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  */
 function triggerLogin() {
   console.error(t('login.trigger_login'));
-  const { ensureLogin } = require('../auth/login');
-  return ensureLogin();
+  const { interactiveLogin } = require('../auth/login');
+  return interactiveLogin();
 }
 
 /**


### PR DESCRIPTION
## Problem

Fixes #319

When the server returns login expired (errorCode 307/302), `requestWithAutoLogin` calls `triggerLogin()` to re-authenticate. However, `triggerLogin()` was calling `ensureLogin()`, which **prioritizes local cookie cache** — if a (now-expired) `cookies.json` exists with a valid-looking `tianshu_csrf_token`, it returns immediately without opening the browser.

This causes a silent failure loop:
1. Server returns login expired
2. `triggerLogin()` is called
3. `ensureLogin()` finds local cookie cache and returns it directly (no browser opened)
4. Expired cookie is reused for retry
5. Server rejects again with 'unknown error'
6. User sees no actionable error message

## Root Cause

```js
// lib/core/utils.js (before fix)
function triggerLogin() {
  console.error(t('login.trigger_login'));
  const { ensureLogin } = require('../auth/login');
  return ensureLogin(); // BUG: ensureLogin() prefers cache, won't open browser
}
```

## Fix

```js
// lib/core/utils.js (after fix)
function triggerLogin() {
  console.error(t('login.trigger_login'));
  const { interactiveLogin } = require('../auth/login');
  return interactiveLogin(); // FIXED: always opens browser for QR scan
}
```

## Changes

- `lib/core/utils.js`: Changed `triggerLogin()` to call `interactiveLogin()` directly instead of `ensureLogin()`

## Testing

After the fix, running `openyida create-app` with an expired cookie correctly opens the browser for QR code re-authentication instead of silently reusing the expired cookie.