### PR TITLE
feat: add list-forms command for app-level form discovery

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -20,6 +20,7 @@
  *   openyida create-page <appType> "<页面名>"            创建自定义页面
  *   openyida create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
  *   openyida create-form update <appType> <formUuid> <修改JSON>  更新表单页面
+ *   openyida list-forms <appType> [--keyword <关键词>]  列出应用下的表单/页面
  *   openyida get-schema <appType> <formUuid>            获取表单 Schema
  *   openyida publish <源文件路径> <appType> <formUuid>   编译并发布自定义页面
  *   openyida verify-short-url <appType> <formUuid> <url>           验证短链接 URL 是否可用
@@ -83,6 +84,7 @@ openyida - 宜搭命令行工具
   create-page <appType> "<页面名>"                             创建自定义页面，输出 pageId
   create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
   create-form update <appType> <formUuid> <修改JSON>           更新表单页面
+  list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
   get-schema <appType> <formUuid>                              获取表单 Schema
   publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
   verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
@@ -143,6 +145,8 @@ openyida - 宜搭命令行工具
   openyida create-page APP_XXX "游戏主页"
   openyida create-form create APP_XXX "员工信息" fields.json
   openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"备注"}}]'
+  openyida list-forms APP_XXX
+  openyida list-forms APP_XXX --keyword 客户
   openyida get-schema APP_XXX FORM-XXX
   openyida publish pages/src/home.jsx APP_XXX FORM-XXX
   openyida verify-short-url APP_XXX FORM-XXX /o/myapp
@@ -364,6 +368,12 @@ async function main() {
       // create-form.js 通过 process.argv.slice(2) 读取参数，注入子命令及其参数
       process.argv = [process.argv[0], process.argv[1], ...args];
       require('../lib/app/create-form');
+      break;
+    }
+
+    case 'list-forms': {
+      const { run } = require('../lib/app/list-forms');
+      await run(args);
       break;
     }
 

--- a/lib/app/export-app.js
+++ b/lib/app/export-app.js
@@ -18,45 +18,7 @@ const {
   requestWithAutoLogin,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
-
-// ── 获取应用下所有表单页面列表 ────────────────────────
-
-async function fetchFormPageList(appType, authRef) {
-  const result = await requestWithAutoLogin((auth) => {
-    return httpGet(
-      auth.baseUrl,
-      `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
-      { _api: 'Nav.queryList', _mock: false },
-      auth.cookies
-    );
-  }, authRef);
-
-  if (!result || result.success === false) {
-    throw new Error(t('export.fetch_forms_failed') + ': ' + (result ? result.errorMsg || t('common.unknown_error') : t('common.request_failed')));
-  }
-
-  const items = result.content || [];
-  const formPages = [];
-
-  for (const node of items) {
-    // 跳过系统导航项（待我处理、我已处理等）
-    if (node.navType === 'SYSTEM' || !node.formUuid) {
-      continue;
-    }
-
-    // 提取页面名称（title 是 i18n 对象）
-    const titleObj = node.title || node.i18nTitle || {};
-    const pageName = titleObj.zh_CN || titleObj.en_US || t('export.unnamed_form');
-
-    formPages.push({
-      formUuid: node.formUuid,
-      name: pageName,
-      formType: node.formType || '',
-    });
-  }
-
-  return formPages;
-}
+const { fetchFormPageList } = require('./form-navigation');
 
 // ── 获取单个表单 Schema ───────────────────────────────
 
@@ -116,7 +78,13 @@ async function run(args) {
   console.error(t('export.step_get_forms'));
   let formPages;
   try {
-    formPages = await fetchFormPageList(appType, authRef);
+    const forms = await fetchFormPageList(appType, authRef);
+    formPages = forms.map((form) => ({
+      formUuid: form.formUuid,
+      name: form.formName,
+      formType: form.formType,
+      pathName: form.pathName,
+    }));
   } catch (err) {
     console.error('  ❌ ' + err.message);
     process.exit(1);

--- a/lib/app/form-navigation.js
+++ b/lib/app/form-navigation.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const {
+  httpGet,
+  requestWithAutoLogin,
+} = require('../core/utils');
+const { t } = require('../core/i18n');
+
+function resolveLocalizedText(value, fallback = '') {
+  if (!value) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return value.zh_CN || value.en_US || value.zh_TW || fallback;
+  }
+
+  return fallback;
+}
+
+function normalizeFormNavigationNode(node) {
+  if (!node || node.navType === 'SYSTEM' || !node.formUuid) {
+    return null;
+  }
+
+  return {
+    formUuid: node.formUuid,
+    formName: resolveLocalizedText(node.title || node.i18nTitle || node.name, t('list_forms.unnamed_form')),
+    formType: node.formType || '',
+    pathName: node.pathName || '',
+  };
+}
+
+async function fetchFormPageList(appType, authRef) {
+  const result = await requestWithAutoLogin((auth) => {
+    return httpGet(
+      auth.baseUrl,
+      `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
+      { _api: 'Nav.queryList', _mock: false },
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || result.success === false) {
+    throw new Error(
+      t('list_forms.fetch_failed') + ': ' +
+      (result ? result.errorMsg || t('common.unknown_error') : t('common.request_failed'))
+    );
+  }
+
+  const items = Array.isArray(result.content) ? result.content : [];
+  return items
+    .map(normalizeFormNavigationNode)
+    .filter(Boolean);
+}
+
+module.exports = {
+  fetchFormPageList,
+  normalizeFormNavigationNode,
+  resolveLocalizedText,
+};

--- a/lib/app/list-forms.js
+++ b/lib/app/list-forms.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+} = require('../core/utils');
+const { t } = require('../core/i18n');
+const { fetchFormPageList } = require('./form-navigation');
+
+function parseArgs(args) {
+  const parsed = {
+    appType: '',
+    keyword: '',
+  };
+
+  if (args.length > 0) {
+    parsed.appType = args[0];
+  }
+
+  for (let index = 1; index < args.length; index++) {
+    if (args[index] === '--keyword' && args[index + 1]) {
+      parsed.keyword = args[index + 1];
+      index++;
+    }
+  }
+
+  return parsed;
+}
+
+function filterForms(forms, keyword) {
+  if (!keyword) {
+    return forms;
+  }
+
+  const normalizedKeyword = keyword.toLowerCase();
+  return forms.filter((form) => {
+    return [form.formName, form.formUuid, form.formType, form.pathName]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(normalizedKeyword));
+  });
+}
+
+async function run(args) {
+  const parsed = parseArgs(args);
+  if (!parsed.appType) {
+    console.error(t('list_forms.usage'));
+    console.error(t('list_forms.example1'));
+    console.error(t('list_forms.example2'));
+    process.exit(1);
+  }
+
+  const SEP = '='.repeat(50);
+  console.error(SEP);
+  console.error(t('list_forms.title'));
+  console.error(SEP);
+  console.error(t('list_forms.app_id', parsed.appType));
+  if (parsed.keyword) {
+    console.error(t('list_forms.keyword', parsed.keyword));
+  }
+
+  console.error(t('common.step_login', 1));
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    console.error(t('common.login_no_cache'));
+    cookieData = triggerLogin();
+  }
+
+  if (!cookieData || !cookieData.cookies) {
+    console.error(t('list_forms.no_login'));
+    process.exit(1);
+  }
+
+  const authRef = {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+  console.error(t('common.login_ready', authRef.baseUrl));
+
+  console.error(t('list_forms.step_get'));
+  let forms;
+  try {
+    forms = await fetchFormPageList(parsed.appType, authRef);
+  } catch (error) {
+    console.error(t('list_forms.failed', error.message));
+    process.exit(1);
+  }
+
+  const filteredForms = filterForms(forms, parsed.keyword);
+  console.error(t('list_forms.found', filteredForms.length));
+
+  if (filteredForms.length === 0) {
+    console.error(t('list_forms.empty'));
+  }
+
+  console.log(JSON.stringify(filteredForms, null, 2));
+}
+
+module.exports = {
+  filterForms,
+  parseArgs,
+  run,
+};

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -22,6 +22,7 @@ Commands:
   create-page <appType> "<pageName>"                           Create a custom page, output pageId
   create-form create <appType> "<formName>" <fieldsJSON> [--layout <layout>] [--theme <theme>] [--label-align <align>]  Create a form page
   create-form update <appType> <formUuid> <changesJSON>        Update a form page
+  list-forms <appType> [--keyword <text>]                      List forms/pages in an app
   get-schema <appType> <formUuid>                              Get form Schema
   publish <sourceFile> <appType> <formUuid>                    Compile and publish a custom page
   verify-short-url <appType> <formUuid> <url>                  Verify if a short URL is available
@@ -85,6 +86,8 @@ Examples:
   openyida create-page APP_XXX "Game Home"
   openyida create-form create APP_XXX "Employee Info" fields.json
   openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"Notes"}}]'
+  openyida list-forms APP_XXX
+  openyida list-forms APP_XXX --keyword customer
   openyida get-schema APP_XXX FORM-XXX
   openyida publish pages/src/home.jsx APP_XXX FORM-XXX
   openyida verify-short-url APP_XXX FORM-XXX /o/myapp
@@ -352,6 +355,22 @@ Examples:
     sending: '  Sending getFormSchema request...',
     success: '  ✅ Schema retrieved successfully!',
     failed: '  ❌ Failed to get Schema: {0}',
+  },
+
+  list_forms: {
+    title: '  yidacli list-forms - App form/page list tool',
+    usage: 'Usage: openyida list-forms <appType> [--keyword <text>]',
+    example1: 'Example: openyida list-forms APP_XXX',
+    example2: '         openyida list-forms APP_XXX --keyword customer',
+    app_id: '  App ID:      {0}',
+    keyword: '  Keyword:     {0}',
+    step_get: '\n📋 Step 2: Fetch app forms/pages',
+    found: '  ✅ Found {0} matching items',
+    empty: '  ⚠️  No matching forms/pages found, outputting []',
+    unnamed_form: 'Unnamed page',
+    fetch_failed: 'Failed to fetch app navigation list',
+    failed: '  ❌ Query failed: {0}',
+    no_login: '  ❌ Unable to get valid login credentials',
   },
 
   // ── lib/create-form.js ─────────────────────────────

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -23,6 +23,7 @@ openyida - 宜搭命令行工具
   create-page <appType> "<页面名>"                             创建自定义页面，输出 pageId
   create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
   create-form update <appType> <formUuid> <修改JSON>           更新表单页面
+  list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
   get-schema <appType> <formUuid>                              获取表单 Schema
   publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
   verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
@@ -87,6 +88,8 @@ openyida - 宜搭命令行工具
   openyida create-page APP_XXX "游戏主页"
   openyida create-form create APP_XXX "员工信息" fields.json
   openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"备注"}}]'
+  openyida list-forms APP_XXX
+  openyida list-forms APP_XXX --keyword 客户
   openyida get-schema APP_XXX FORM-XXX
   openyida publish pages/src/home.jsx APP_XXX FORM-XXX
   openyida verify-short-url APP_XXX FORM-XXX /o/myapp
@@ -333,6 +336,22 @@ openyida - 宜搭命令行工具
     sending: '  发送 getFormSchema 请求...',
     success: '  ✅ Schema 获取成功！',
     failed: '  ❌ 获取 Schema 失败: {0}',
+  },
+
+  list_forms: {
+    title: '  yidacli list-forms - 应用表单/页面列表查询工具',
+    usage: '用法: openyida list-forms <appType> [--keyword <关键词>]',
+    example1: '示例: openyida list-forms APP_XXX',
+    example2: '      openyida list-forms APP_XXX --keyword 客户',
+    app_id: '  应用 ID:  {0}',
+    keyword: '  关键词:   {0}',
+    step_get: '\n📋 步骤 2: 获取应用下的表单/页面列表',
+    found: '  ✅ 共找到 {0} 个匹配项',
+    empty: '  ⚠️  当前应用下没有匹配的表单/页面，将输出 []',
+    unnamed_form: '未命名页面',
+    fetch_failed: '获取应用导航列表失败',
+    failed: '  ❌ 查询失败: {0}',
+    no_login: '  ❌ 无法获取有效登录态',
   },
 
   // ── lib/create-form.js ─────────────────────────────

--- a/tests/list-forms.test.js
+++ b/tests/list-forms.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+jest.mock('../lib/core/utils', () => ({
+  loadCookieData: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://www.aliwork.com'),
+  httpGet: jest.fn(),
+  triggerLogin: jest.fn(),
+  requestWithAutoLogin: jest.fn(),
+}));
+
+const utils = require('../lib/core/utils');
+const { filterForms, parseArgs, run } = require('../lib/app/list-forms');
+
+const mockCookieData = {
+  cookies: [{ name: 'tianshu_csrf_token', value: 'tok123' }],
+  csrf_token: 'tok123',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  utils.loadCookieData.mockReturnValue(mockCookieData);
+});
+
+describe('parseArgs', () => {
+  test('解析 appType 和 keyword', () => {
+    expect(parseArgs(['APP_XXX', '--keyword', '客户'])).toEqual({
+      appType: 'APP_XXX',
+      keyword: '客户',
+    });
+  });
+});
+
+describe('filterForms', () => {
+  test('按名称、UUID、pathName 做关键词过滤', () => {
+    const forms = [
+      { formName: '客户信息', formUuid: 'FORM-A', formType: 'display', pathName: 'customer-info' },
+      { formName: '费用报销', formUuid: 'FORM-B', formType: 'process', pathName: 'expense' },
+    ];
+
+    expect(filterForms(forms, '客户')).toHaveLength(1);
+    expect(filterForms(forms, 'FORM-B')).toHaveLength(1);
+    expect(filterForms(forms, 'expense')).toHaveLength(1);
+  });
+});
+
+describe('run', () => {
+  test('查询成功时输出稳定 JSON 列表，并过滤系统导航项', async () => {
+    utils.requestWithAutoLogin.mockResolvedValue({
+      success: true,
+      content: [
+        { navType: 'SYSTEM', formUuid: 'SYS-1', title: { zh_CN: '待我处理' }, formType: 'system' },
+        { navType: 'FORM', formUuid: 'FORM-AAA', title: { zh_CN: '客户信息' }, formType: 'display', pathName: 'customer-info' },
+        { navType: 'FORM', formUuid: 'FORM-BBB', title: { zh_CN: '费用报销' }, formType: 'process', pathName: 'expense' },
+      ],
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['APP_XXX', '--keyword', '客户']);
+
+    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledWith(JSON.stringify([
+      {
+        formUuid: 'FORM-AAA',
+        formName: '客户信息',
+        formType: 'display',
+        pathName: 'customer-info',
+      },
+    ], null, 2));
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('参数不足时打印用法并退出', async () => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit(1)');
+    });
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run([])).rejects.toThrow('process.exit(1)');
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('list-forms'));
+
+    mockExit.mockRestore();
+    mockError.mockRestore();
+  });
+});


### PR DESCRIPTION
## 背景

当前 openyida 已有 `get-schema <appType> <formUuid>`，但在 agent 场景里，往往只有 `appType`，并不知道目标 `formUuid`。

虽然 `export` 内部已经调用应用导航接口拉取应用下的 form/page 列表，但这项能力没有被暴露成独立的、可组合的 CLI 命令，导致 agent 只能：
- 让用户手工提供 `formUuid`
- 或滥用 `export`
- 或尝试猜测目标页面

这条 PR 补上了这条缺失链路：

`appType -> form/page 列表 -> formUuid -> get-schema`

## 改动

- 新增 `openyida list-forms <appType> [--keyword <关键词>]`
- 输出稳定 JSON，字段包括：
  - `formUuid`
  - `formName`
  - `formType`
  - `pathName`
- 新增关键词过滤，支持按名称、UUID、类型、pathName 快速定位对象
- 抽取公共应用导航查询逻辑，避免 `export-app` 重复实现
- 补充中英文 CLI 帮助文案
- 增加单测覆盖

## 价值

- 让 agent 可以先发现应用内对象，再读取 schema
- 避免把 `export` 当成“查 form 列表”的高成本替代
- 为后续 `pathName -> formUuid -> get-schema` 这类自动化链路打基础

## 验证

- `npx jest tests/list-forms.test.js --runInBand --silent`
- `npx eslint bin/yida.js lib/app/form-navigation.js lib/app/list-forms.js lib/app/export-app.js lib/core/locales/zh.js lib/core/locales/en.js tests/list-forms.test.js`
