### PR TITLE
fix: resolve ReferenceError 'warn is not defined' in login scripts

### DIFF
--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -243,7 +243,7 @@ const { URL } = require('url');
   const page = await context.newPage();
   await page.goto(${JSON.stringify(loginUrl)}, { timeout: 120000 });
 
-  warn('  Waiting for login (up to 10 minutes)...');
+  console.error('  Waiting for login (up to 10 minutes)...');
   // 轮询 tianshu_csrf_token cookie 出现来判断登录成功
   // 兼容专属域名（your-company.aliwork.com）登录后跳转路径不固定的情况
   let loginSuccess = false;
@@ -257,12 +257,12 @@ const { URL } = require('url');
     }
   }
   if (!loginSuccess) {
-    warn('  ⏰ Login timed out (10 minutes). Please try again.');
+    console.error('  ⏰ Login timed out (10 minutes). Please try again.');
     await browser.close();
     process.exit(1);
   }
   await page.waitForLoadState('networkidle').catch(() => {});
-  warn('  ✅ Login successful!');
+  console.error('  ✅ Login successful!');
 
   const currentUrl = page.url();
   const cookies = await context.cookies();

--- a/lib/auth/qr-login.js
+++ b/lib/auth/qr-login.js
@@ -22,6 +22,7 @@ const readline = require('readline');
 const { extractInfoFromCookies } = require('../core/utils');
 const { saveCookieCache } = require('./login');
 const { t } = require('../core/i18n');
+const { warn } = require('../core/chalk');
 
 const { resolveLoginUrl, resolveEndpoint } = require('../core/env-manager');
 const DEFAULT_BASE_URL = 'https://www.aliwork.com';


### PR DESCRIPTION
修复：解决登录脚本中的 ReferenceError: warn is not defined 问题
问题描述
自 v2026.4.15 版本发布后，用户无法完成扫码登录流程。登录过程会立即崩溃并报错：
根本原因
v2026.4.15 版本在进行 chalk 美化输出重构时，将代码中的 console.error() 批量替换为 warn()（来自 lib/core/chalk.js 模块），但遗漏了两个关键场景：

lib/auth/login.js — interactiveLogin() 函数中通过模板字符串生成了一段 Playwright 临时脚本，该脚本通过 execSync('node ...') 在独立的子进程中运行。子进程无法访问主模块中定义的 warn() 函数，导致运行时抛出 ReferenceError，直接阻断了整个扫码登录流程。

lib/auth/qr-login.js — renderQrCodeInTerminal() 函数中使用了 warn()，但该文件顶部缺少相应的 import 语句。
修复方案

文件 | 修改内容
-- | --
lib/auth/login.js | 将 Playwright 临时脚本模板中的 3 处 warn() 调用恢复为 console.error()（子进程中必须使用原生 API）
lib/auth/qr-login.js | 添加缺失的 const { warn } = require('../core/chalk'); 导入语句

验证
✅ 确认 login.js 中不再存在裸调用的 warn()
✅ 确认 qr-login.js 已正确导入 warn 函数
✅ 基于 Playwright 的登录流程（interactiveLogin）和终端二维码登录流程（qrLogin）均已修复
## 改动说明

<!-- 简要描述本 PR 做了什么、为什么这样做 -->

## 改动类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级
- [ ] 🌐 国际化（i18n）
- [ ] 🎨 UI / 终端输出优化

## 关联 Issue

<!-- 如有关联 Issue，请填写：Closes #123 -->

## 测试

- [ ] 本地运行 `npm test` 通过
- [ ] JS 语法检查通过：`node --check bin/yida.js && find lib -name "*.js" | xargs -I{} node --check {}`
- [ ] 已在真实宜搭环境测试过相关功能（如适用）
- [ ] 新增 CLI 命令已在 `bin/yida.js` 注册，并更新了 `README.md` 命令一览表
- [ ] 新增 i18n key 已同步到所有语言包（`lib/core/locales/`）
- [ ] 私有化部署场景已验证（如适用）

## 截图 / 录屏

<!-- 如有 UI 或行为变化，请附上截图或录屏 -->
