### PR TITLE
feat: add nav-group command for form navigation grouping

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -5,59 +5,7 @@
  * 安装：npm install -g openyida
  * 用法：openyida <命令> [参数]（别名：yida）
  *
-<<<<<<< HEAD
  * 命令清单维护在 lib/core/command-manifest.js，供 help 和 agent JSON 共用。
-=======
- * 命令列表：
- *   openyida env                                        检测当前 AI 工具环境和登录态
- *   openyida copy [--force]                             复制 project 工作目录到当前 AI 工具环境
- *   openyida login [--qr]                               登录态管理（--qr 使用终端二维码扫码）
- *   openyida logout                                     退出登录
- *   openyida auth status                                查看当前登录状态
- *   openyida auth login                                 执行登录
- *   openyida auth refresh                               刷新登录态
- *   openyida auth logout                                退出登录
- *   openyida org list                                   列出可访问的组织
- *   openyida org switch --corp-id <corpId>              切换组织（无需重新登录）
- *   openyida create-app "<名称>" [desc] [icon] [color] [colour] [navTheme] [layout]  创建应用
- *   openyida create-page <appType> "<页面名>"            创建自定义页面
- *   openyida create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
- *   openyida create-form update <appType> <formUuid> <修改JSON>  更新表单页面
- *   openyida list-forms <appType> [--keyword <关键词>]  列出应用下的表单/页面
- *   openyida get-schema <appType> <formUuid>            获取表单 Schema
- *   openyida publish <源文件路径> <appType> <formUuid>   编译并发布自定义页面
- *   openyida verify-short-url <appType> <formUuid> <url>           验证短链接 URL 是否可用
- *   openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]  保存公开访问/分享配置
- *   openyida get-page-config <appType> <formUuid>       查询页面公开访问/分享配置
- *   openyida update-form-config <appType> <formUuid> <isRenderNav> <title>  更新表单配置
- *   openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]  更新应用信息
- *   openyida data <action> <resource> [args]            统一数据管理（表单/流程/任务/子表单）
- *   openyida task-center <type> [--page N] [--size N] [--keyword TEXT]  全局任务中心（待办/我创建的/我已处理/抄送/代提交）
- *   openyida doctor [选项]                              检查环境依赖，诊断应用问题
- *   openyida export <appType> [output]                  导出应用所有表单 Schema（生成迁移包）
- *   openyida import <file> [name]                       导入迁移包，在目标环境重建应用
- *   openyida get-permission <appType> <formUuid>        查询表单权限配置
- *   openyida save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]  保存表单权限配置
- *   openyida process preview <appType> <processInstanceId> [--output <path>]  预览流程实例（生成可视化流程图）
- *   openyida connector list [选项]                       列出 HTTP 连接器
- *   openyida connector create "名称" "域名" --operations <file> [选项]  创建连接器
- *   openyida connector detail <connector-id>             查看连接器详情
- *   openyida connector delete <connector-id> [--force]  删除连接器
- *   openyida connector add-action --operations <file> --connector-id <id> [--confirm]  添加执行动作
- *   openyida connector list-actions <connector-id>       列出执行动作
- *   openyida connector delete-action <connector-id> <operation-id> [--force]  删除执行动作
- *   openyida connector test --connector-id <id> --action <actionId> [选项]  测试执行动作
- *   openyida connector list-connections <connector-id>   列出鉴权账号
- *   openyida connector create-connection <connector-id> <name> [选项]  创建鉴权账号
- *   openyida connector smart-create --curl "curl命令" [选项]  智能创建连接器
- *   openyida connector parse-api [选项]                  解析接口信息
- *   openyida connector gen-template [输出路径]            生成接口文档模板
- *   openyida integration create <appType> <formUuid> <flowName> [选项]  创建集成&自动化逻辑流
- *   openyida create-report <appType> "<报表名称>" <图表定义JSON或文件路径>  创建宜搭报表
- *   openyida append-chart <appType> <reportId> <图表定义JSON或文件路径>    向已有报表追加图表
- *   openyida dws <command> [args]                        钉钉 CLI（通讯录/日历/待办/审批等）
- *   openyida update                                       检查并更新 openyida 到最新版本
->>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
  */
 
 'use strict';
@@ -134,7 +82,6 @@ function printHelp() {
 
   const SEP = `${DIM}${'─'.repeat(60)}${RESET}`;
 
-<<<<<<< HEAD
   /**
    * 渲染一组命令列表。
    * @param {string} groupTitle - 分组标题
@@ -181,108 +128,6 @@ function printHelp() {
   console.log('');
   console.log(`  ${DIM}${t('help.docs')} https://openyida.ai  ·  https://github.com/openyida/openyida${RESET}`);
   console.log('');
-=======
-命令：
-  env                                                          检测当前 AI 工具环境和登录态
-  copy [--force]                                               复制 project 工作目录到当前 AI 工具环境
-  login                                                        登录态管理（优先缓存，否则扫码）
-  logout                                                       退出登录 / 切换账号
-  create-app "<名称>" [描述] [图标] [颜色] [主题色] [导航风格] [布局]   创建应用，输出 appType
-  create-page <appType> "<页面名>"                             创建自定义页面，输出 pageId
-  create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
-  create-form update <appType> <formUuid> <修改JSON>           更新表单页面
-  list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
-  get-schema <appType> <formUuid>                              获取表单 Schema
-  publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
-  verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
-  save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
-  get-page-config <appType> <formUuid>                         查询页面公开访问/分享配置
-  update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
-  update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] 更新应用信息
-  data <action> <resource> [args]                              统一数据管理（表单/流程/任务/子表单）
-  doctor [选项]                                                检查环境依赖，诊断应用问题
-    --fix / --repair                                           诊断并自动修复
-    --production --app <appId>                                 线上应用诊断
-    --monitor                                                  启动实时健康度监控
-    --report <format>                                          生成诊断报告（json | markdown | html）
-    --create-ticket                                            根据诊断结果创建工单
-    --create-voc                                               创建 VOC（需求反馈）
-    --auto-submit                                              自动判断并提交工单或 VOC
-  auth status                                                  查看当前登录状态
-  auth login                                                   执行登录
-  auth refresh                                                 刷新登录态
-  auth logout                                                  退出登录
-  org list                                                     列出可访问的组织
-  org switch --corp-id <corpId>                                切换组织（无需重新登录）
-  get-permission <appType> <formUuid>                          查询表单权限配置
-  save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]  保存表单权限配置
-  configure-process <appType> <formUuid> <processDefinitionFile> [processCode]  配置并发布流程
-  create-process <appType> <formTitle> <fieldsJsonFile> <processDefinitionFile>  创建流程表单（一体化）
-  create-process <appType> --formUuid <formUuid> <processDefinitionFile>         复用已有表单创建流程
-  process preview <appType> <processInstanceId> [--output <path>]                预览流程实例（生成可视化流程图）
-  connector list [选项]                                          列出 HTTP 连接器
-  connector create "名称" "域名" --operations <file> [选项]      创建连接器
-  connector detail <connector-id>                               查看连接器详情
-  connector delete <connector-id> [--force]                     删除连接器
-  connector add-action --operations <file> --connector-id <id>  添加执行动作到连接器
-  connector list-actions <connector-id>                         列出执行动作
-  connector delete-action <connector-id> <operation-id>         删除执行动作
-  connector test --connector-id <id> --action <actionId>        测试执行动作
-  connector list-connections <connector-id>                     列出鉴权账号
-  connector create-connection <connector-id> <name> [选项]      创建鉴权账号
-  connector smart-create --curl "curl命令" [选项]               智能创建连接器
-  connector parse-api [选项]                                    解析接口信息
-  connector gen-template [输出路径]                              生成接口文档模板
-  dws <command> [args]                                          钉钉 CLI（通讯录/日历/待办/审批等）
-  update                                                       检查并更新 openyida 到最新版本
-  create-report <appType> "<报表名称>" <图表定义 JSON 或文件路径>   创建宜搭报表
-  append-chart <appType> <reportId> <图表定义 JSON 或文件路径>      向已有报表追加图表
-  export-conversation [选项]                                      导出 AI 对话记录
-    --output, -o <path>                                           指定输出文件路径
-    --input, -i <file>                                            指定输入对话文件
-    --latest                                                      只导出最新对话（默认）
-    --list                                                        列出可用的对话记录
-
-示例：
-  openyida login
-  openyida logout
-  openyida create-app "考勤管理"
-  openyida create-app "考勤管理" "员工考勤系统" "xian-daka" "#00B853" "deepBlue" "dark" "slide"
-  openyida create-app "党建管理" "党员管理系统" "xian-zhengfu" "#FF4D4F" "red" "light" "ver"
-  openyida create-page APP_XXX "游戏主页"
-  openyida create-form create APP_XXX "员工信息" fields.json
-  openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"备注"}}]'
-  openyida list-forms APP_XXX
-  openyida list-forms APP_XXX --keyword 客户
-  openyida get-schema APP_XXX FORM-XXX
-  openyida publish pages/src/home.jsx APP_XXX FORM-XXX
-  openyida verify-short-url APP_XXX FORM-XXX /o/myapp
-  openyida save-share-config APP_XXX FORM-XXX /o/myapp y n
-  openyida get-page-config APP_XXX FORM-XXX
-  openyida update-form-config APP_XXX FORM-XXX false "页面标题"
-  openyida data query form APP_XXX FORM-XXX --page 1 --size 20
-  openyida dws contact user search --keyword "悟空"
-  openyida dws calendar event list
-  openyida dws todo task create --title "任务"
-  openyida create-report APP_XXX "销售报表" charts.json
-  openyida append-chart APP_XXX REPORT-XXX charts.json
-  openyida configure-process APP_XXX FORM-YYY process-def.json
-  openyida create-process APP_XXX "订单处理表" fields.json process-def.json
-  openyida create-process APP_XXX --formUuid FORM-YYY process-def.json
-  openyida doctor                                 完整诊断
-  openyida doctor --fix                           诊断并自动修复
-  openyida doctor --production --app APP_XXX      线上应用诊断
-  openyida doctor --monitor                       实时监控
-  openyida doctor --report markdown               生成 Markdown 报告
-  openyida doctor --create-ticket                 创建工单
-  openyida doctor --create-voc                    创建 VOC
-  openyida doctor --auto-submit                   自动判断并提交
-  openyida export-conversation                   导出当前对话记录
-  openyida export-conversation -o output.md     指定输出路径
-  openyida export-conversation --list            列出可用对话
-`);
-  console.log(t('cli.help'));
->>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
 }
 
 /**
@@ -568,6 +413,12 @@ async function main() {
 
     case 'list-forms': {
       const { run } = require('../lib/app/list-forms');
+      await run(args);
+      break;
+    }
+
+    case 'nav-group': {
+      const { run } = require('../lib/app/nav-group');
       await run(args);
       break;
     }

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -5,7 +5,59 @@
  * 安装：npm install -g openyida
  * 用法：openyida <命令> [参数]（别名：yida）
  *
+<<<<<<< HEAD
  * 命令清单维护在 lib/core/command-manifest.js，供 help 和 agent JSON 共用。
+=======
+ * 命令列表：
+ *   openyida env                                        检测当前 AI 工具环境和登录态
+ *   openyida copy [--force]                             复制 project 工作目录到当前 AI 工具环境
+ *   openyida login [--qr]                               登录态管理（--qr 使用终端二维码扫码）
+ *   openyida logout                                     退出登录
+ *   openyida auth status                                查看当前登录状态
+ *   openyida auth login                                 执行登录
+ *   openyida auth refresh                               刷新登录态
+ *   openyida auth logout                                退出登录
+ *   openyida org list                                   列出可访问的组织
+ *   openyida org switch --corp-id <corpId>              切换组织（无需重新登录）
+ *   openyida create-app "<名称>" [desc] [icon] [color] [colour] [navTheme] [layout]  创建应用
+ *   openyida create-page <appType> "<页面名>"            创建自定义页面
+ *   openyida create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
+ *   openyida create-form update <appType> <formUuid> <修改JSON>  更新表单页面
+ *   openyida list-forms <appType> [--keyword <关键词>]  列出应用下的表单/页面
+ *   openyida get-schema <appType> <formUuid>            获取表单 Schema
+ *   openyida publish <源文件路径> <appType> <formUuid>   编译并发布自定义页面
+ *   openyida verify-short-url <appType> <formUuid> <url>           验证短链接 URL 是否可用
+ *   openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]  保存公开访问/分享配置
+ *   openyida get-page-config <appType> <formUuid>       查询页面公开访问/分享配置
+ *   openyida update-form-config <appType> <formUuid> <isRenderNav> <title>  更新表单配置
+ *   openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]  更新应用信息
+ *   openyida data <action> <resource> [args]            统一数据管理（表单/流程/任务/子表单）
+ *   openyida task-center <type> [--page N] [--size N] [--keyword TEXT]  全局任务中心（待办/我创建的/我已处理/抄送/代提交）
+ *   openyida doctor [选项]                              检查环境依赖，诊断应用问题
+ *   openyida export <appType> [output]                  导出应用所有表单 Schema（生成迁移包）
+ *   openyida import <file> [name]                       导入迁移包，在目标环境重建应用
+ *   openyida get-permission <appType> <formUuid>        查询表单权限配置
+ *   openyida save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]  保存表单权限配置
+ *   openyida process preview <appType> <processInstanceId> [--output <path>]  预览流程实例（生成可视化流程图）
+ *   openyida connector list [选项]                       列出 HTTP 连接器
+ *   openyida connector create "名称" "域名" --operations <file> [选项]  创建连接器
+ *   openyida connector detail <connector-id>             查看连接器详情
+ *   openyida connector delete <connector-id> [--force]  删除连接器
+ *   openyida connector add-action --operations <file> --connector-id <id> [--confirm]  添加执行动作
+ *   openyida connector list-actions <connector-id>       列出执行动作
+ *   openyida connector delete-action <connector-id> <operation-id> [--force]  删除执行动作
+ *   openyida connector test --connector-id <id> --action <actionId> [选项]  测试执行动作
+ *   openyida connector list-connections <connector-id>   列出鉴权账号
+ *   openyida connector create-connection <connector-id> <name> [选项]  创建鉴权账号
+ *   openyida connector smart-create --curl "curl命令" [选项]  智能创建连接器
+ *   openyida connector parse-api [选项]                  解析接口信息
+ *   openyida connector gen-template [输出路径]            生成接口文档模板
+ *   openyida integration create <appType> <formUuid> <flowName> [选项]  创建集成&自动化逻辑流
+ *   openyida create-report <appType> "<报表名称>" <图表定义JSON或文件路径>  创建宜搭报表
+ *   openyida append-chart <appType> <reportId> <图表定义JSON或文件路径>    向已有报表追加图表
+ *   openyida dws <command> [args]                        钉钉 CLI（通讯录/日历/待办/审批等）
+ *   openyida update                                       检查并更新 openyida 到最新版本
+>>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
  */
 
 'use strict';
@@ -82,6 +134,7 @@ function printHelp() {
 
   const SEP = `${DIM}${'─'.repeat(60)}${RESET}`;
 
+<<<<<<< HEAD
   /**
    * 渲染一组命令列表。
    * @param {string} groupTitle - 分组标题
@@ -128,6 +181,108 @@ function printHelp() {
   console.log('');
   console.log(`  ${DIM}${t('help.docs')} https://openyida.ai  ·  https://github.com/openyida/openyida${RESET}`);
   console.log('');
+=======
+命令：
+  env                                                          检测当前 AI 工具环境和登录态
+  copy [--force]                                               复制 project 工作目录到当前 AI 工具环境
+  login                                                        登录态管理（优先缓存，否则扫码）
+  logout                                                       退出登录 / 切换账号
+  create-app "<名称>" [描述] [图标] [颜色] [主题色] [导航风格] [布局]   创建应用，输出 appType
+  create-page <appType> "<页面名>"                             创建自定义页面，输出 pageId
+  create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
+  create-form update <appType> <formUuid> <修改JSON>           更新表单页面
+  list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
+  get-schema <appType> <formUuid>                              获取表单 Schema
+  publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
+  verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
+  save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
+  get-page-config <appType> <formUuid>                         查询页面公开访问/分享配置
+  update-form-config <appType> <formUuid> <isRenderNav> <title> 更新表单配置
+  update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] 更新应用信息
+  data <action> <resource> [args]                              统一数据管理（表单/流程/任务/子表单）
+  doctor [选项]                                                检查环境依赖，诊断应用问题
+    --fix / --repair                                           诊断并自动修复
+    --production --app <appId>                                 线上应用诊断
+    --monitor                                                  启动实时健康度监控
+    --report <format>                                          生成诊断报告（json | markdown | html）
+    --create-ticket                                            根据诊断结果创建工单
+    --create-voc                                               创建 VOC（需求反馈）
+    --auto-submit                                              自动判断并提交工单或 VOC
+  auth status                                                  查看当前登录状态
+  auth login                                                   执行登录
+  auth refresh                                                 刷新登录态
+  auth logout                                                  退出登录
+  org list                                                     列出可访问的组织
+  org switch --corp-id <corpId>                                切换组织（无需重新登录）
+  get-permission <appType> <formUuid>                          查询表单权限配置
+  save-permission <appType> <formUuid> [--data-permission <json>] [--action-permission <json>]  保存表单权限配置
+  configure-process <appType> <formUuid> <processDefinitionFile> [processCode]  配置并发布流程
+  create-process <appType> <formTitle> <fieldsJsonFile> <processDefinitionFile>  创建流程表单（一体化）
+  create-process <appType> --formUuid <formUuid> <processDefinitionFile>         复用已有表单创建流程
+  process preview <appType> <processInstanceId> [--output <path>]                预览流程实例（生成可视化流程图）
+  connector list [选项]                                          列出 HTTP 连接器
+  connector create "名称" "域名" --operations <file> [选项]      创建连接器
+  connector detail <connector-id>                               查看连接器详情
+  connector delete <connector-id> [--force]                     删除连接器
+  connector add-action --operations <file> --connector-id <id>  添加执行动作到连接器
+  connector list-actions <connector-id>                         列出执行动作
+  connector delete-action <connector-id> <operation-id>         删除执行动作
+  connector test --connector-id <id> --action <actionId>        测试执行动作
+  connector list-connections <connector-id>                     列出鉴权账号
+  connector create-connection <connector-id> <name> [选项]      创建鉴权账号
+  connector smart-create --curl "curl命令" [选项]               智能创建连接器
+  connector parse-api [选项]                                    解析接口信息
+  connector gen-template [输出路径]                              生成接口文档模板
+  dws <command> [args]                                          钉钉 CLI（通讯录/日历/待办/审批等）
+  update                                                       检查并更新 openyida 到最新版本
+  create-report <appType> "<报表名称>" <图表定义 JSON 或文件路径>   创建宜搭报表
+  append-chart <appType> <reportId> <图表定义 JSON 或文件路径>      向已有报表追加图表
+  export-conversation [选项]                                      导出 AI 对话记录
+    --output, -o <path>                                           指定输出文件路径
+    --input, -i <file>                                            指定输入对话文件
+    --latest                                                      只导出最新对话（默认）
+    --list                                                        列出可用的对话记录
+
+示例：
+  openyida login
+  openyida logout
+  openyida create-app "考勤管理"
+  openyida create-app "考勤管理" "员工考勤系统" "xian-daka" "#00B853" "deepBlue" "dark" "slide"
+  openyida create-app "党建管理" "党员管理系统" "xian-zhengfu" "#FF4D4F" "red" "light" "ver"
+  openyida create-page APP_XXX "游戏主页"
+  openyida create-form create APP_XXX "员工信息" fields.json
+  openyida create-form update APP_XXX FORM-XXX '[{"action":"add","field":{"type":"TextField","label":"备注"}}]'
+  openyida list-forms APP_XXX
+  openyida list-forms APP_XXX --keyword 客户
+  openyida get-schema APP_XXX FORM-XXX
+  openyida publish pages/src/home.jsx APP_XXX FORM-XXX
+  openyida verify-short-url APP_XXX FORM-XXX /o/myapp
+  openyida save-share-config APP_XXX FORM-XXX /o/myapp y n
+  openyida get-page-config APP_XXX FORM-XXX
+  openyida update-form-config APP_XXX FORM-XXX false "页面标题"
+  openyida data query form APP_XXX FORM-XXX --page 1 --size 20
+  openyida dws contact user search --keyword "悟空"
+  openyida dws calendar event list
+  openyida dws todo task create --title "任务"
+  openyida create-report APP_XXX "销售报表" charts.json
+  openyida append-chart APP_XXX REPORT-XXX charts.json
+  openyida configure-process APP_XXX FORM-YYY process-def.json
+  openyida create-process APP_XXX "订单处理表" fields.json process-def.json
+  openyida create-process APP_XXX --formUuid FORM-YYY process-def.json
+  openyida doctor                                 完整诊断
+  openyida doctor --fix                           诊断并自动修复
+  openyida doctor --production --app APP_XXX      线上应用诊断
+  openyida doctor --monitor                       实时监控
+  openyida doctor --report markdown               生成 Markdown 报告
+  openyida doctor --create-ticket                 创建工单
+  openyida doctor --create-voc                    创建 VOC
+  openyida doctor --auto-submit                   自动判断并提交
+  openyida export-conversation                   导出当前对话记录
+  openyida export-conversation -o output.md     指定输出路径
+  openyida export-conversation --list            列出可用对话
+`);
+  console.log(t('cli.help'));
+>>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
 }
 
 /**

--- a/lib/app/nav-group.js
+++ b/lib/app/nav-group.js
@@ -1,0 +1,662 @@
+'use strict';
+
+const querystring = require('querystring');
+
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpGet,
+  httpPost,
+  requestWithAutoLogin,
+} = require('../core/utils');
+const { t } = require('../core/i18n');
+
+const ROOT_NAV_UUID = 'NAV-SYSTEM-PARENT-UUID';
+
+function parseArgs(args) {
+  const parsed = {
+    subCommand: args[0] || '',
+    appType: args[1] || '',
+    name: '',
+    group: '',
+    page: '',
+    to: '',
+    order: '',
+    position: null,
+    force: false,
+  };
+
+  for (let index = 2; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--name' && args[index + 1]) {
+      parsed.name = args[index + 1];
+      index++;
+    } else if (arg === '--group' && args[index + 1]) {
+      parsed.group = args[index + 1];
+      index++;
+    } else if (arg === '--page' && args[index + 1]) {
+      parsed.page = args[index + 1];
+      index++;
+    } else if (arg === '--to' && args[index + 1]) {
+      parsed.to = args[index + 1];
+      index++;
+    } else if (arg === '--order' && args[index + 1]) {
+      parsed.order = args[index + 1];
+      index++;
+    } else if (arg === '--position' && args[index + 1]) {
+      parsed.position = Number(args[index + 1]);
+      index++;
+    } else if (arg === '--force') {
+      parsed.force = true;
+    }
+  }
+
+  return parsed;
+}
+
+function ensurePosition(position, maxLength) {
+  if (position == null || Number.isNaN(position)) {
+    return null;
+  }
+  return Math.max(0, Math.min(position, maxLength));
+}
+
+function resolveLocalizedText(value, fallback = '') {
+  if (!value) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return value.zh_CN || value.en_US || value.zh_TW || fallback;
+  }
+
+  return fallback;
+}
+
+function toI18nTitle(name) {
+  return JSON.stringify({
+    pureEn_US: name,
+    en_US: name,
+    zh_CN: name,
+    envLocale: null,
+    type: 'i18n',
+    ja_JP: null,
+    key: null,
+  });
+}
+
+function normalizeNode(node) {
+  if (!node) {
+    return null;
+  }
+
+  return {
+    id: node.id,
+    navUuid: node.navUuid,
+    title: resolveLocalizedText(node.title || node.i18nTitle || node.name, ''),
+    navType: node.navType || '',
+    formUuid: node.formUuid || '',
+    parentNavUuid: node.parentNavUuid || ROOT_NAV_UUID,
+    parentId: node.parentId == null ? 0 : node.parentId,
+    listOrder: typeof node.listOrder === 'number' ? node.listOrder : 0,
+    hidden: node.hidden || 'n',
+    mobileHidden: node.mobileHidden == null ? 'n' : node.mobileHidden,
+    raw: node,
+  };
+}
+
+function filterVisibleNodes(nodes) {
+  return nodes.filter((node) => node.hidden !== 'y' && node.navType !== 'SYSTEM');
+}
+
+function sortByListOrder(nodes) {
+  return [...nodes].sort((left, right) => {
+    if (left.listOrder !== right.listOrder) {
+      return left.listOrder - right.listOrder;
+    }
+    return left.id - right.id;
+  });
+}
+
+function buildTree(nodes) {
+  const visibleNodes = sortByListOrder(filterVisibleNodes(nodes));
+  const nodeMap = new Map();
+  visibleNodes.forEach((node) => {
+    nodeMap.set(node.navUuid, { ...node, children: [] });
+  });
+
+  const groups = [];
+  const ungrouped = [];
+
+  visibleNodes.forEach((node) => {
+    const current = nodeMap.get(node.navUuid);
+    if (current.parentNavUuid !== ROOT_NAV_UUID) {
+      const parent = nodeMap.get(current.parentNavUuid);
+      if (parent) {
+        parent.children.push(current);
+        return;
+      }
+    }
+
+    if (current.navType === 'NAV') {
+      groups.push(current);
+    } else {
+      ungrouped.push(current);
+    }
+  });
+
+  return { groups, ungrouped };
+}
+
+function findNode(nodes, identifier, predicate) {
+  if (!identifier) {
+    return null;
+  }
+
+  const normalized = String(identifier).trim();
+  return nodes.find((node) => {
+    if (predicate && !predicate(node)) {
+      return false;
+    }
+
+    return [
+      String(node.id),
+      node.navUuid,
+      node.formUuid,
+      node.title,
+    ].filter(Boolean).includes(normalized);
+  }) || null;
+}
+
+function requireSubCommand(parsed) {
+  const supported = ['list', 'create', 'move', 'sort', 'rename', 'delete'];
+  if (!supported.includes(parsed.subCommand)) {
+    throw new Error(t('nav_group.invalid_subcommand'));
+  }
+}
+
+function getAuthRef() {
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    cookieData = triggerLogin();
+  }
+
+  if (!cookieData || !cookieData.cookies) {
+    throw new Error(t('nav_group.no_login'));
+  }
+
+  return {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+}
+
+async function requestNavGet(authRef, appType, path, params) {
+  const result = await requestWithAutoLogin((auth) => {
+    return httpGet(
+      auth.baseUrl,
+      `/dingtalk/web/${appType}${path}`,
+      { ...params, _mock: false, _api: params._api, _csrf_token: auth.csrfToken },
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || result.success === false) {
+    throw new Error(result ? (result.errorMsg || t('common.unknown_error')) : t('common.request_failed'));
+  }
+
+  return result;
+}
+
+async function requestNavPost(authRef, appType, path, params) {
+  const result = await requestWithAutoLogin((auth) => {
+    return httpPost(
+      auth.baseUrl,
+      `/dingtalk/web/${appType}${path}`,
+      querystring.stringify({ ...params, _mock: false, _api: params._api, _csrf_token: auth.csrfToken }),
+      auth.cookies
+    );
+  }, authRef);
+
+  if (!result || result.success === false) {
+    throw new Error(result ? (result.errorMsg || t('common.unknown_error')) : t('common.request_failed'));
+  }
+
+  return result;
+}
+
+async function fetchNavigationList(appType, authRef) {
+  const result = await requestNavGet(
+    authRef,
+    appType,
+    '/query/formnav/getFormNavigationListByOrder.json',
+    { _api: 'Nav.queryList' }
+  );
+
+  return Array.isArray(result.content) ? result.content.map(normalizeNode).filter(Boolean) : [];
+}
+
+async function fetchNavigationDetail(appType, authRef, navUuid) {
+  const result = await requestNavGet(
+    authRef,
+    appType,
+    '/query/formnav/getNavigationByKey.json',
+    { _api: 'Nav.getDetail', navUuid }
+  );
+
+  return normalizeNode(result.content);
+}
+
+async function createGroup(appType, authRef, name) {
+  const result = await requestNavPost(
+    authRef,
+    appType,
+    '/query/formnav/saveFormNavigation.json',
+    {
+      _api: 'Nav.save',
+      _locale_time_zone_offset: '28800000',
+      title: toI18nTitle(name),
+      navType: 'NAV',
+      parentId: 0,
+      hidden: 'n',
+      mobileHidden: 'n',
+    }
+  );
+
+  return result.content;
+}
+
+async function renameGroup(appType, authRef, node, name) {
+  await requestNavPost(
+    authRef,
+    appType,
+    '/query/formnav/updateNavigationTitle.json',
+    {
+      _api: 'Nav.updateTitle',
+      navUuid: node.navUuid,
+      title: toI18nTitle(name),
+    }
+  );
+}
+
+async function updateNavigationNode(appType, authRef, node, overrides) {
+  const raw = node.raw || {};
+  await requestNavPost(
+    authRef,
+    appType,
+    '/query/formnav/updateFormNavigation.json',
+    {
+      _api: 'Nav.update',
+      id: node.id,
+      navUuid: node.navUuid,
+      navType: node.navType,
+      parentId: overrides.parentId == null ? node.parentId : overrides.parentId,
+      parentNavUuid: overrides.parentNavUuid || node.parentNavUuid || ROOT_NAV_UUID,
+      hidden: overrides.hidden || node.hidden,
+      mobileHidden: overrides.mobileHidden == null ? node.mobileHidden : overrides.mobileHidden,
+      title: toI18nTitle(overrides.title || node.title),
+      icon: raw.icon || '',
+      i18nTitle: raw.i18nTitle || '',
+      isNewReport: raw.isNewReport || '',
+      isNewForm: raw.isNewForm || '',
+      slug: raw.slug || '',
+      formType: raw.formType || '',
+      formUuid: node.formUuid || '',
+      url: raw.url || '',
+      topicId: raw.topicId || '',
+      displayType: raw.displayType || '',
+      relateFormUuid: raw.relateFormUuid || node.formUuid || '',
+      processCode: raw.processCode || '',
+      listOrder: raw.listOrder == null ? node.listOrder : raw.listOrder,
+      formStatus: raw.formStatus || '',
+      relateFormType: raw.relateFormType || '',
+    }
+  );
+}
+
+async function deleteGroup(appType, authRef, node) {
+  await requestNavPost(
+    authRef,
+    appType,
+    '/query/formnav/deleteFormNavigation.json',
+    {
+      _api: 'Nav.delete',
+      navUuid: node.navUuid,
+    }
+  );
+}
+
+async function reorderVisibleNodes(appType, authRef, orderedNodes) {
+  const visibleNodes = filterVisibleNodes(orderedNodes);
+  await requestNavPost(
+    authRef,
+    appType,
+    '/query/formnav/updateFormNavigationOrder.json',
+    {
+      _api: 'Nav.updateOrder',
+      ids: visibleNodes.map((node) => node.id).join(','),
+      listOrders: visibleNodes.map((_, index) => index).join(','),
+    }
+  );
+}
+
+function moveNodeInArray(nodes, navUuid, targetIndex) {
+  const list = [...nodes];
+  const fromIndex = list.findIndex((node) => node.navUuid === navUuid);
+  if (fromIndex === -1) {
+    return list;
+  }
+  const [item] = list.splice(fromIndex, 1);
+  const nextIndex = Math.max(0, Math.min(targetIndex, list.length));
+  list.splice(nextIndex, 0, item);
+  return list;
+}
+
+function computeGroupTailIndex(nodes, groupNavUuid) {
+  const groupIndex = nodes.findIndex((node) => node.navUuid === groupNavUuid);
+  if (groupIndex === -1) {
+    return nodes.length;
+  }
+
+  let tailIndex = groupIndex + 1;
+  while (
+    tailIndex < nodes.length &&
+    nodes[tailIndex].parentNavUuid === groupNavUuid &&
+    nodes[tailIndex].navType !== 'NAV'
+  ) {
+    tailIndex++;
+  }
+
+  return tailIndex;
+}
+
+function parseOrderIdentifiers(orderValue) {
+  if (!orderValue) {
+    throw new Error(t('nav_group.order_required'));
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(orderValue);
+  } catch (error) {
+    throw new Error(t('nav_group.order_invalid_json'));
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(t('nav_group.order_invalid_json'));
+  }
+
+  return parsed.map((value) => String(value));
+}
+
+function buildListOutput(appType, nodes) {
+  const tree = buildTree(nodes);
+  return {
+    appType,
+    groups: tree.groups.map((group) => ({
+      id: group.id,
+      navUuid: group.navUuid,
+      title: group.title,
+      listOrder: group.listOrder,
+      children: sortByListOrder(group.children).map((child) => ({
+        id: child.id,
+        navUuid: child.navUuid,
+        formUuid: child.formUuid,
+        title: child.title,
+        navType: child.navType,
+        listOrder: child.listOrder,
+      })),
+    })),
+    ungrouped: tree.ungrouped.map((node) => ({
+      id: node.id,
+      navUuid: node.navUuid,
+      formUuid: node.formUuid,
+      title: node.title,
+      navType: node.navType,
+      listOrder: node.listOrder,
+    })),
+  };
+}
+
+async function handleList(appType, authRef) {
+  const nodes = await fetchNavigationList(appType, authRef);
+  console.log(JSON.stringify(buildListOutput(appType, nodes), null, 2));
+}
+
+async function handleCreate(parsed, authRef) {
+  if (!parsed.name) {
+    throw new Error(t('nav_group.name_required'));
+  }
+
+  const nodesBefore = await fetchNavigationList(parsed.appType, authRef);
+  const createdId = await createGroup(parsed.appType, authRef, parsed.name);
+  const nodesAfter = await fetchNavigationList(parsed.appType, authRef);
+  const createdNode = findNode(nodesAfter, String(createdId), (node) => node.navType === 'NAV');
+
+  if (!createdNode) {
+    throw new Error(t('nav_group.create_failed'));
+  }
+
+  const position = ensurePosition(parsed.position, filterVisibleNodes(nodesAfter).length - 1);
+  if (position != null) {
+    const visibleNodes = sortByListOrder(filterVisibleNodes(nodesAfter));
+    const reordered = moveNodeInArray(visibleNodes, createdNode.navUuid, position);
+    await reorderVisibleNodes(parsed.appType, authRef, reordered);
+  }
+
+  const finalNodes = await fetchNavigationList(parsed.appType, authRef);
+  const finalNode = findNode(finalNodes, createdNode.navUuid, (node) => node.navType === 'NAV');
+  console.log(JSON.stringify({
+    action: 'create',
+    appType: parsed.appType,
+    group: {
+      id: finalNode.id,
+      navUuid: finalNode.navUuid,
+      title: finalNode.title,
+      listOrder: finalNode.listOrder,
+    },
+    previousVisibleCount: filterVisibleNodes(nodesBefore).length,
+  }, null, 2));
+}
+
+async function handleRename(parsed, authRef) {
+  if (!parsed.group || !parsed.name) {
+    throw new Error(t('nav_group.rename_usage'));
+  }
+
+  const nodes = await fetchNavigationList(parsed.appType, authRef);
+  const group = findNode(nodes, parsed.group, (node) => node.navType === 'NAV');
+  if (!group) {
+    throw new Error(t('nav_group.group_not_found', parsed.group));
+  }
+
+  await renameGroup(parsed.appType, authRef, group, parsed.name);
+  const renamed = await fetchNavigationDetail(parsed.appType, authRef, group.navUuid);
+  console.log(JSON.stringify({
+    action: 'rename',
+    appType: parsed.appType,
+    group: {
+      id: renamed.id,
+      navUuid: renamed.navUuid,
+      title: renamed.title,
+    },
+  }, null, 2));
+}
+
+async function handleDelete(parsed, authRef) {
+  if (!parsed.group) {
+    throw new Error(t('nav_group.group_required'));
+  }
+
+  const nodes = await fetchNavigationList(parsed.appType, authRef);
+  const group = findNode(nodes, parsed.group, (node) => node.navType === 'NAV');
+  if (!group) {
+    throw new Error(t('nav_group.group_not_found', parsed.group));
+  }
+
+  const children = sortByListOrder(nodes.filter((node) => node.parentNavUuid === group.navUuid));
+  if (children.length > 0 && !parsed.force) {
+    throw new Error(t('nav_group.group_not_empty', group.title));
+  }
+
+  for (const child of children) {
+    await updateNavigationNode(parsed.appType, authRef, child, {
+      parentNavUuid: ROOT_NAV_UUID,
+    });
+  }
+
+  await deleteGroup(parsed.appType, authRef, group);
+  const finalNodes = await fetchNavigationList(parsed.appType, authRef);
+  console.log(JSON.stringify({
+    action: 'delete',
+    appType: parsed.appType,
+    group: {
+      id: group.id,
+      navUuid: group.navUuid,
+      title: group.title,
+    },
+    releasedChildren: children.map((child) => ({
+      id: child.id,
+      navUuid: child.navUuid,
+      title: child.title,
+    })),
+    remainingVisibleCount: filterVisibleNodes(finalNodes).length,
+  }, null, 2));
+}
+
+async function handleMove(parsed, authRef) {
+  if (!parsed.page || !parsed.to) {
+    throw new Error(t('nav_group.move_usage'));
+  }
+
+  const nodes = await fetchNavigationList(parsed.appType, authRef);
+  const page = findNode(nodes, parsed.page, (node) => node.navType !== 'NAV' && node.navType !== 'SYSTEM');
+  if (!page) {
+    throw new Error(t('nav_group.page_not_found', parsed.page));
+  }
+
+  const group = findNode(nodes, parsed.to, (node) => node.navType === 'NAV');
+  if (!group) {
+    throw new Error(t('nav_group.group_not_found', parsed.to));
+  }
+
+  await updateNavigationNode(parsed.appType, authRef, page, {
+    parentNavUuid: group.navUuid,
+  });
+
+  const updatedNodes = await fetchNavigationList(parsed.appType, authRef);
+  const updatedPage = findNode(updatedNodes, page.navUuid);
+  const visibleNodes = sortByListOrder(filterVisibleNodes(updatedNodes));
+  const position = ensurePosition(parsed.position, visibleNodes.length - 1);
+  const targetIndex = position != null ? position : computeGroupTailIndex(visibleNodes, group.navUuid);
+  const reordered = moveNodeInArray(visibleNodes, updatedPage.navUuid, targetIndex);
+  await reorderVisibleNodes(parsed.appType, authRef, reordered);
+
+  const finalPage = await fetchNavigationDetail(parsed.appType, authRef, page.navUuid);
+  console.log(JSON.stringify({
+    action: 'move',
+    appType: parsed.appType,
+    page: {
+      id: finalPage.id,
+      navUuid: finalPage.navUuid,
+      formUuid: finalPage.formUuid,
+      title: finalPage.title,
+      parentNavUuid: finalPage.parentNavUuid,
+    },
+    group: {
+      id: group.id,
+      navUuid: group.navUuid,
+      title: group.title,
+    },
+  }, null, 2));
+}
+
+async function handleSort(parsed, authRef) {
+  const identifiers = parseOrderIdentifiers(parsed.order);
+  const nodes = sortByListOrder(filterVisibleNodes(await fetchNavigationList(parsed.appType, authRef)));
+  const orderedNodes = [];
+  const used = new Set();
+
+  identifiers.forEach((identifier) => {
+    const node = findNode(nodes, identifier);
+    if (!node) {
+      throw new Error(t('nav_group.node_not_found', identifier));
+    }
+    if (!used.has(node.navUuid)) {
+      used.add(node.navUuid);
+      orderedNodes.push(node);
+    }
+  });
+
+  nodes.forEach((node) => {
+    if (!used.has(node.navUuid)) {
+      orderedNodes.push(node);
+    }
+  });
+
+  await reorderVisibleNodes(parsed.appType, authRef, orderedNodes);
+  const finalNodes = sortByListOrder(filterVisibleNodes(await fetchNavigationList(parsed.appType, authRef)));
+  console.log(JSON.stringify({
+    action: 'sort',
+    appType: parsed.appType,
+    orderedNavUuids: finalNodes.map((node) => node.navUuid),
+  }, null, 2));
+}
+
+async function run(args) {
+  const parsed = parseArgs(args);
+  requireSubCommand(parsed);
+
+  if (!parsed.appType) {
+    console.error(t('nav_group.usage'));
+    process.exit(1);
+  }
+
+  const authRef = getAuthRef();
+
+  switch (parsed.subCommand) {
+    case 'list':
+      await handleList(parsed.appType, authRef);
+      break;
+    case 'create':
+      await handleCreate(parsed, authRef);
+      break;
+    case 'rename':
+      await handleRename(parsed, authRef);
+      break;
+    case 'delete':
+      await handleDelete(parsed, authRef);
+      break;
+    case 'move':
+      await handleMove(parsed, authRef);
+      break;
+    case 'sort':
+      await handleSort(parsed, authRef);
+      break;
+    default:
+      throw new Error(t('nav_group.invalid_subcommand'));
+  }
+}
+
+module.exports = {
+  ROOT_NAV_UUID,
+  parseArgs,
+  resolveLocalizedText,
+  normalizeNode,
+  filterVisibleNodes,
+  sortByListOrder,
+  buildTree,
+  findNode,
+  moveNodeInArray,
+  computeGroupTailIndex,
+  parseOrderIdentifiers,
+  buildListOutput,
+  run,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -54,6 +54,7 @@ const COMMAND_GROUPS = [
       command('create-form.create', ['create-form', 'create'], 'create-form create <appType> ...', 'help.cmd_create_form'),
       command('create-form.update', ['create-form', 'update'], 'create-form update <appType> ...', 'help.cmd_update_form'),
       command('list-forms', ['list-forms'], 'list-forms <appType> [--keyword <text>]', 'help.cmd_list_forms'),
+      command('nav-group', ['nav-group'], 'nav-group <sub-command> <appType> ...', 'help.cmd_nav_group'),
       command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all>', 'help.cmd_get_schema'),
       command('create-page', ['create-page'], 'create-page <appType> "<name>"', 'help.cmd_create_page'),
       command('generate-page', ['generate-page'], 'generate-page <template>', 'help.cmd_generate_page'),

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'إنشاء صفحة نموذج',
     cmd_update_form: 'تحديث صفحة نموذج',
     cmd_list_forms: 'List forms/pages in an app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'الحصول على Schema النموذج',
     cmd_create_page: 'إنشاء صفحة عرض مخصصة',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ فشل الإنشاء: {0}',
     error: '\n❌ خطأ في الإنشاء: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'Formularseite erstellen',
     cmd_update_form: 'Formularseite aktualisieren',
     cmd_list_forms: 'Formulare/Seiten einer App auflisten',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Formular-Schema abrufen',
     cmd_create_page: 'Benutzerdefinierte Anzeigeseite erstellen',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ Erstellung fehlgeschlagen: {0}',
     error: '\n❌ Erstellungsfehler: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -28,6 +28,7 @@ module.exports = {
     cmd_create_form: 'Create a form page',
     cmd_update_form: 'Update a form page',
     cmd_list_forms: 'List forms/pages in an app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Get one form Schema or all form Schemas',
     cmd_create_page: 'Create a custom display page',
     cmd_generate_page: 'Generate page from curated template',
@@ -106,12 +107,8 @@ Commands:
   create-form create <appType> "<formName>" <fieldsJSON> [--layout <layout>] [--theme <theme>] [--label-align <align>]  Create a form page
   create-form update <appType> <formUuid> <changesJSON>        Update a form page
   list-forms <appType> [--keyword <text>]                      List forms/pages in an app
-<<<<<<< HEAD
   get-schema <appType> <formUuid|--all>                        Get one form Schema or all form Schemas
   formula evaluate <formula|file> [--schema <schema.json>]      Static-check Yida formulas
-=======
-  get-schema <appType> <formUuid>                              Get form Schema
->>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
   publish <sourceFile> <appType> <formUuid>                    Compile and publish a custom page
   verify-short-url <appType> <formUuid> <url>                  Verify if a short URL is available
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] Save public access / share config
@@ -480,6 +477,23 @@ Examples:
     fetch_failed: 'Failed to fetch app navigation list',
     failed: '  ❌ Query failed: {0}',
     no_login: '  ❌ Unable to get valid login credentials',
+  },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
   },
 
   // ── lib/create-form.js ─────────────────────────────

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -106,8 +106,12 @@ Commands:
   create-form create <appType> "<formName>" <fieldsJSON> [--layout <layout>] [--theme <theme>] [--label-align <align>]  Create a form page
   create-form update <appType> <formUuid> <changesJSON>        Update a form page
   list-forms <appType> [--keyword <text>]                      List forms/pages in an app
+<<<<<<< HEAD
   get-schema <appType> <formUuid|--all>                        Get one form Schema or all form Schemas
   formula evaluate <formula|file> [--schema <schema.json>]      Static-check Yida formulas
+=======
+  get-schema <appType> <formUuid>                              Get form Schema
+>>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
   publish <sourceFile> <appType> <formUuid>                    Compile and publish a custom page
   verify-short-url <appType> <formUuid> <url>                  Verify if a short URL is available
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] Save public access / share config

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'Crear página de formulario',
     cmd_update_form: 'Actualizar página de formulario',
     cmd_list_forms: 'Listar formularios/páginas de una app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Obtener Schema del formulario',
     cmd_create_page: 'Crear página de visualización personalizada',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ Error al crear: {0}',
     error: '\n❌ Error de creación: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'Créer une page de formulaire',
     cmd_update_form: 'Mettre à jour une page de formulaire',
     cmd_list_forms: 'Lister les formulaires/pages d\'une app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Obtenir le Schema du formulaire',
     cmd_create_page: 'Créer une page d\'affichage personnalisée',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ Échec de la création : {0}',
     error: '\n❌ Erreur de création : {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'फॉर्म पेज बनाएं',
     cmd_update_form: 'फॉर्म पेज अपडेट करें',
     cmd_list_forms: 'List forms/pages in an app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'फॉर्म Schema प्राप्त करें',
     cmd_create_page: 'कस्टम डिस्प्ले पेज बनाएं',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ निर्माण विफल: {0}',
     error: '\n❌ निर्माण त्रुटि: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -28,6 +28,7 @@ module.exports = {
     cmd_create_form: 'フォームページを作成',
     cmd_update_form: 'フォームページを更新',
     cmd_list_forms: 'アプリ内のフォーム/ページを一覧表示',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'フォーム Schema を取得',
     cmd_create_page: 'カスタム表示ページを作成',
     cmd_generate_page: 'Generate page from curated template',
@@ -429,6 +430,24 @@ openyida - Yida CLI ツール
     success: '  ✅ Schema の取得に成功しました！',
     failed: '  ❌ Schema の取得に失敗しました: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ─────────────────────────────
   create_form: {

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: '양식 페이지 생성',
     cmd_update_form: '양식 페이지 업데이트',
     cmd_list_forms: 'List forms/pages in an app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: '양식 Schema 가져오기',
     cmd_create_page: '사용자 정의 표시 페이지 생성',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ 앱 생성 실패: {0}',
     error: '\n❌ 앱 생성 오류: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'Criar página de formulário',
     cmd_update_form: 'Atualizar página de formulário',
     cmd_list_forms: 'Listar formulários/páginas de um app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Obter Schema do formulário',
     cmd_create_page: 'Criar página de exibição personalizada',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ Falha na criação: {0}',
     error: '\n❌ Erro de criação: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -26,6 +26,7 @@ module.exports = {
     cmd_create_form: 'Tạo trang biểu mẫu',
     cmd_update_form: 'Cập nhật trang biểu mẫu',
     cmd_list_forms: 'List forms/pages in an app',
+    cmd_nav_group: 'Manage app navigation groups',
     cmd_get_schema: 'Lấy Schema biểu mẫu',
     cmd_create_page: 'Tạo trang hiển thị tùy chỉnh',
     cmd_generate_page: 'Generate page from curated template',
@@ -146,6 +147,24 @@ module.exports = {
     failed: '  ❌ Tạo thất bại: {0}',
     error: '\n❌ Lỗi tạo ứng dụng: {0}',
   },
+
+  nav_group: {
+    usage: 'Usage: openyida nav-group <list|create|move|sort|rename|delete> <appType> [options]',
+    no_login: '  ❌ Unable to get valid login credentials',
+    invalid_subcommand: 'Unknown sub-command, supported: list/create/move/sort/rename/delete',
+    name_required: 'create requires --name <groupName>',
+    group_required: 'Missing --group <groupIdentifier>',
+    rename_usage: 'rename requires --group <groupIdentifier> --name <newName>',
+    move_usage: 'move requires --page <pageIdentifier> --to <groupIdentifier>',
+    order_required: 'sort requires --order <jsonArray>',
+    order_invalid_json: '--order must be a JSON array, e.g. ["NAV-XXX","FORM-YYY"]',
+    group_not_found: 'Navigation group not found: {0}',
+    page_not_found: 'Page not found: {0}',
+    node_not_found: 'Navigation node not found: {0}',
+    group_not_empty: 'Group "{0}" still contains pages. Move them first or use --force to release children before deletion',
+    create_failed: 'Created group could not be read back from navigation list',
+  },
+
 
   // ── lib/create-form.js ──────────────────────────────
   create_form: {

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -28,6 +28,7 @@ module.exports = {
     cmd_create_form: '建立表單頁面',
     cmd_update_form: '更新表單頁面',
     cmd_list_forms: '列出應用程式下的表單/頁面',
+    cmd_nav_group: '管理應用導航分組',
     cmd_get_schema: '取得表單 Schema',
     cmd_create_page: '建立自訂展示頁面',
     cmd_generate_page: '基於高質素模板生成頁面',
@@ -413,6 +414,24 @@ openyida - 宜搭命令列工具
     success: '  ✅ Schema 取得成功！',
     failed: '  ❌ 取得 Schema 失敗：{0}',
   },
+
+  nav_group: {
+    usage: '用法: openyida nav-group <list|create|move|sort|rename|delete> <appType> [選項]',
+    no_login: '  ❌ 無法獲取有效登錄態',
+    invalid_subcommand: '未知子命令，支持 list/create/move/sort/rename/delete',
+    name_required: 'create 需要 --name <分組名>',
+    group_required: '需要 --group <分組標識>',
+    rename_usage: 'rename 需要 --group <分組標識> --name <新名稱>',
+    move_usage: 'move 需要 --page <頁面標識> --to <分組標識>',
+    order_required: 'sort 需要 --order <JSON數組>',
+    order_invalid_json: '--order 必須是 JSON 數組，例如 ["NAV-XXX","FORM-YYY"]',
+    group_not_found: '未找到分組: {0}',
+    page_not_found: '未找到頁面: {0}',
+    node_not_found: '未找到導航節點: {0}',
+    group_not_empty: '分組「{0}」下還有頁面，刪除前請先移動，或加 --force 釋放子頁面後再刪',
+    create_failed: '創建分組後無法回讀到新節點',
+  },
+
 
   // ── lib/create-form.js ─────────────────────────────
   create_form: {

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -28,6 +28,7 @@ module.exports = {
     cmd_create_form: '创建表单页面',
     cmd_update_form: '更新表单页面',
     cmd_list_forms: '列出应用下的表单/页面',
+    cmd_nav_group: '管理应用导航分组',
     cmd_get_schema: '获取单个或全部表单 Schema',
     cmd_create_page: '创建自定义展示页面',
     cmd_generate_page: '基于高质量模板生成页面',
@@ -106,12 +107,8 @@ openyida - 宜搭命令行工具
   create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
   create-form update <appType> <formUuid> <修改JSON>           更新表单页面
   list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
-<<<<<<< HEAD
   get-schema <appType> <formUuid|--all>                        获取单个或全部表单 Schema
   formula evaluate <公式或文件> [--schema <schema.json>]        静态检查宜搭公式
-=======
-  get-schema <appType> <formUuid>                              获取表单 Schema
->>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
   publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
   verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置
@@ -452,6 +449,23 @@ openyida - 宜搭命令行工具
     fetch_failed: '获取应用导航列表失败',
     failed: '  ❌ 查询失败: {0}',
     no_login: '  ❌ 无法获取有效登录态',
+  },
+
+  nav_group: {
+    usage: '用法: openyida nav-group <list|create|move|sort|rename|delete> <appType> [选项]',
+    no_login: '  ❌ 无法获取有效登录态',
+    invalid_subcommand: '未知子命令，支持 list/create/move/sort/rename/delete',
+    name_required: 'create 需要 --name <分组名>',
+    group_required: '需要 --group <分组标识>',
+    rename_usage: 'rename 需要 --group <分组标识> --name <新名称>',
+    move_usage: 'move 需要 --page <页面标识> --to <分组标识>',
+    order_required: 'sort 需要 --order <JSON数组>',
+    order_invalid_json: '--order 必须是 JSON 数组，例如 ["NAV-XXX","FORM-YYY"]',
+    group_not_found: '未找到分组: {0}',
+    page_not_found: '未找到页面: {0}',
+    node_not_found: '未找到导航节点: {0}',
+    group_not_empty: '分组“{0}”下还有页面，删除前请先移动，或加 --force 释放子页面后再删',
+    create_failed: '创建分组后无法回读到新节点',
   },
 
   // ── lib/create-form.js ─────────────────────────────

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -106,8 +106,12 @@ openyida - 宜搭命令行工具
   create-form create <appType> "<表单名>" <字段JSON> [--layout <布局>] [--theme <主题>] [--label-align <对齐>]  创建表单页面
   create-form update <appType> <formUuid> <修改JSON>           更新表单页面
   list-forms <appType> [--keyword <关键词>]                    列出应用下的表单/页面
+<<<<<<< HEAD
   get-schema <appType> <formUuid|--all>                        获取单个或全部表单 Schema
   formula evaluate <公式或文件> [--schema <schema.json>]        静态检查宜搭公式
+=======
+  get-schema <appType> <formUuid>                              获取表单 Schema
+>>>>>>> cae018b (新增 list-forms 命令支持按应用查询表单页面)
   publish <源文件路径> <appType> <formUuid>                    编译并发布自定义页面
   verify-short-url <appType> <formUuid> <url>                  验证短链接 URL 是否可用
   save-share-config <appType> <formUuid> <url> <isOpen> [auth] 保存公开访问/分享配置

--- a/tests/nav-group.test.js
+++ b/tests/nav-group.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+jest.mock('../lib/core/utils', () => ({
+  loadCookieData: jest.fn(),
+  triggerLogin: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://lvsumd.aliwork.com'),
+  httpGet: jest.fn(),
+  httpPost: jest.fn(),
+  requestWithAutoLogin: jest.fn(),
+}));
+
+const utils = require('../lib/core/utils');
+const {
+  parseArgs,
+  buildTree,
+  buildListOutput,
+  moveNodeInArray,
+  computeGroupTailIndex,
+  parseOrderIdentifiers,
+  filterVisibleNodes,
+} = require('../lib/app/nav-group');
+
+const mockCookieData = {
+  cookies: [{ name: 'tianshu_csrf_token', value: 'tok123' }],
+  csrf_token: 'tok123',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  utils.loadCookieData.mockReturnValue(mockCookieData);
+});
+
+describe('parseArgs', () => {
+  test('解析 create 参数', () => {
+    expect(parseArgs(['create', 'APP_XXX', '--name', '员工奖励', '--position', '3'])).toEqual({
+      subCommand: 'create',
+      appType: 'APP_XXX',
+      name: '员工奖励',
+      group: '',
+      page: '',
+      to: '',
+      order: '',
+      position: 3,
+      force: false,
+    });
+  });
+
+  test('解析 delete force 参数', () => {
+    expect(parseArgs(['delete', 'APP_XXX', '--group', 'NAV-123', '--force'])).toEqual({
+      subCommand: 'delete',
+      appType: 'APP_XXX',
+      name: '',
+      group: 'NAV-123',
+      page: '',
+      to: '',
+      order: '',
+      position: null,
+      force: true,
+    });
+  });
+});
+
+describe('tree helpers', () => {
+  const nodes = [
+    { id: 1, navUuid: 'NAV-A', title: '工作台', navType: 'NAV', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', listOrder: 0, hidden: 'n' },
+    { id: 2, navUuid: 'FORM-A', formUuid: 'FORM-A', title: 'HR 管理门户', navType: 'PAGE', parentNavUuid: 'NAV-A', listOrder: 1, hidden: 'n' },
+    { id: 3, navUuid: 'NAV-B', title: '测试', navType: 'NAV', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', listOrder: 2, hidden: 'n' },
+    { id: 4, navUuid: 'FORM-B', formUuid: 'FORM-B', title: '孤立页', navType: 'PAGE', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', listOrder: 3, hidden: 'n' },
+    { id: 5, navUuid: 'SYS-1', title: '待我处理', navType: 'SYSTEM', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', listOrder: 4, hidden: 'n' },
+    { id: 6, navUuid: 'FORM-C', formUuid: 'FORM-C', title: '隐藏页', navType: 'PAGE', parentNavUuid: 'NAV-B', listOrder: 5, hidden: 'y' },
+  ];
+
+  test('buildTree 只保留可见节点并按 parentNavUuid 组装', () => {
+    const tree = buildTree(nodes);
+    expect(tree.groups).toHaveLength(2);
+    expect(tree.groups[0].title).toBe('工作台');
+    expect(tree.groups[0].children).toHaveLength(1);
+    expect(tree.groups[0].children[0].title).toBe('HR 管理门户');
+    expect(tree.ungrouped).toHaveLength(1);
+    expect(tree.ungrouped[0].title).toBe('孤立页');
+  });
+
+  test('buildListOutput 返回稳定 JSON 结构', () => {
+    expect(buildListOutput('APP_XXX', nodes)).toEqual({
+      appType: 'APP_XXX',
+      groups: [
+        {
+          id: 1,
+          navUuid: 'NAV-A',
+          title: '工作台',
+          listOrder: 0,
+          children: [
+            {
+              id: 2,
+              navUuid: 'FORM-A',
+              formUuid: 'FORM-A',
+              title: 'HR 管理门户',
+              navType: 'PAGE',
+              listOrder: 1,
+            },
+          ],
+        },
+        {
+          id: 3,
+          navUuid: 'NAV-B',
+          title: '测试',
+          listOrder: 2,
+          children: [],
+        },
+      ],
+      ungrouped: [
+        {
+          id: 4,
+          navUuid: 'FORM-B',
+          formUuid: 'FORM-B',
+          title: '孤立页',
+          navType: 'PAGE',
+          listOrder: 3,
+        },
+      ],
+    });
+  });
+
+  test('filterVisibleNodes 过滤 hidden 和 SYSTEM', () => {
+    expect(filterVisibleNodes(nodes).map((node) => node.navUuid)).toEqual(['NAV-A', 'FORM-A', 'NAV-B', 'FORM-B']);
+  });
+});
+
+describe('ordering helpers', () => {
+  const nodes = [
+    { navUuid: 'NAV-A', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', navType: 'NAV' },
+    { navUuid: 'FORM-A1', parentNavUuid: 'NAV-A', navType: 'PAGE' },
+    { navUuid: 'FORM-A2', parentNavUuid: 'NAV-A', navType: 'PAGE' },
+    { navUuid: 'NAV-B', parentNavUuid: 'NAV-SYSTEM-PARENT-UUID', navType: 'NAV' },
+    { navUuid: 'FORM-B1', parentNavUuid: 'NAV-B', navType: 'PAGE' },
+  ];
+
+  test('computeGroupTailIndex 找到分组尾部位置', () => {
+    expect(computeGroupTailIndex(nodes, 'NAV-A')).toBe(3);
+    expect(computeGroupTailIndex(nodes, 'NAV-B')).toBe(5);
+  });
+
+  test('moveNodeInArray 按目标位置移动节点', () => {
+    expect(moveNodeInArray(nodes, 'FORM-B1', 1).map((node) => node.navUuid)).toEqual([
+      'NAV-A', 'FORM-B1', 'FORM-A1', 'FORM-A2', 'NAV-B',
+    ]);
+  });
+
+  test('parseOrderIdentifiers 解析排序 JSON', () => {
+    expect(parseOrderIdentifiers('["NAV-A","FORM-B1"]')).toEqual(['NAV-A', 'FORM-B1']);
+  });
+});


### PR DESCRIPTION
Closes #323

## 变更内容
- 新增 `openyida nav-group` 命令，支持 `list/create/move/sort/rename/delete`
- 复用真实 `formnav` 接口实现导航分组管理
- 补充 CLI 帮助和中英文文案
- 增加 `nav-group` 单测

## 实现要点
- 分组节点使用 `navType = NAV`
- 页面归组通过 `parentNavUuid` 更新，不依赖 `parentId`
- 排序使用 `updateFormNavigationOrder.json` 的 `ids + listOrders`
- 重命名使用 `updateNavigationTitle.json`
- 删除使用 `deleteFormNavigation.json`

## 验证
- `node --check bin/yida.js lib/app/nav-group.js`
- `npx jest tests/nav-group.test.js tests/list-forms.test.js --runInBand`
- 在真实应用 `APP_GEQ9EJW4EUXKVX3Q7KT5` 上验证了 `list/create/rename/move/sort/delete`
