### PR TITLE
fix: 修复 LOGIN FAILED 后的重登录与发布链路

### DIFF
--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -304,7 +304,7 @@ function buildSchemaContent(sourceCode, compiledCode, formUuid) {
 
 function sendSaveRequest(csrfToken, cookies, schemaContent, baseUrl, appType, formUuid) {
   return new Promise((resolve, reject) => {
-    const saveSchemaPath = `/alibaba/web/${appType}/${PREFIX}/query/formdesign/saveFormSchema.json?_stamp=${Date.now()}`;
+    const saveSchemaPath = `/dingtalk/web/${appType}/${PREFIX}/query/formdesign/saveFormSchema.json?_stamp=${Date.now()}`;
 
     const postData = querystring.stringify({
       _csrf_token: csrfToken,

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -30,7 +30,18 @@ const DEFAULT_LOGIN_URL = 'https://www.aliwork.com/workPlatform';
 
 function loadConfig() {
   const { resolveLoginUrl } = require('../core/env-manager');
-  const loginUrl = resolveLoginUrl();
+  let loginUrl = resolveLoginUrl();
+  const cookieData = loadCookieData();
+  const baseUrl = resolveBaseUrl(cookieData);
+  if (
+    cookieData &&
+    cookieData.base_url &&
+    loginUrl === DEFAULT_LOGIN_URL &&
+    baseUrl &&
+    baseUrl !== DEFAULT_BASE_URL
+  ) {
+    loginUrl = baseUrl.replace(/\/+$/, '') + '/workPlatform';
+  }
   return {
     loginUrl,
     defaultBaseUrl: DEFAULT_BASE_URL,
@@ -290,7 +301,7 @@ const { URL } = require('url');
     // 本地未安装 Chrome，降级为 Playwright 内置 Chromium
     browser = await chromium.launch({ headless: false });
   }
-  const context = await browser.newContext();
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
   await page.goto(${JSON.stringify(loginUrl)}, { timeout: 120000 });
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -334,8 +334,8 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  */
 function triggerLogin() {
   warn(t('login.trigger_login'));
-  const { ensureLogin } = require('../auth/login');
-  return ensureLogin();
+  const { interactiveLogin } = require('../auth/login');
+  return interactiveLogin();
 }
 
 /**

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -13,6 +13,7 @@ const {
   loadCookieData,
   detectActiveTool,
   resolveWukongWorkspaceRoot,
+  triggerLogin,
 } = require('../lib/core/utils');
 
 // ── extractInfoFromCookies ────────────────────────────────────────────
@@ -200,6 +201,31 @@ describe('loadCookieData', () => {
     fs.writeFileSync(cookieFile, 'not-json', 'utf-8');
     const result = loadCookieData(tmpDir);
     expect(result).toBeNull();
+  });
+});
+
+// ── triggerLogin ─────────────────────────────────────────────────────
+
+describe('triggerLogin', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('强制调用 interactiveLogin，而不是复用 ensureLogin 缓存逻辑', () => {
+    const loginModule = require('../lib/auth/login');
+    const interactiveResult = { csrf_token: 'fresh-token' };
+    const interactiveSpy = jest.spyOn(loginModule, 'interactiveLogin').mockReturnValue(interactiveResult);
+    const ensureSpy = jest.spyOn(loginModule, 'ensureLogin').mockImplementation(() => {
+      throw new Error('ensureLogin should not be called');
+    });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = triggerLogin();
+
+    expect(result).toBe(interactiveResult);
+    expect(interactiveSpy).toHaveBeenCalledTimes(1);
+    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## 背景

在自定义页发布等场景中，如果服务端已经返回 `LOGIN FAILED` / `302` / `307`，当前 CLI 的重登录链路仍然可能继续复用本地失效 Cookie，导致：

- 命令检测到登录失效
- 进入“重新登录”
- 实际上又拿回同一份旧缓存
- 再次请求仍然失败
- 最终表现为持续 `LOGIN FAILED` 或未知错误

这个问题和 PR #320 描述的是同一类根因：登录失效后没有进入真正的交互登录。

## 本次修改

### 1. `triggerLogin()` 改为直接走交互登录

文件：
- `lib/core/utils.js`

修改前：
- `triggerLogin()` 调用 `ensureLogin()`

问题：
- `ensureLogin()` 会优先使用本地缓存
- 当缓存仍存在但服务端已不认时，会重复使用同一份失效会话

修改后：
- `triggerLogin()` 直接调用 `interactiveLogin()`

效果：
- 一旦服务端明确返回登录失效，就强制进入真实交互登录，而不是继续信任缓存

### 2. 交互登录优先跟随当前专属域名

文件：
- `lib/auth/login.js`

问题：
- 当前默认登录页是 `https://www.aliwork.com/workPlatform`
- 但专属域名环境下，实际工作域名可能是 `https://<corp>.aliwork.com`
- 发布接口和 Cookie 都运行在专属域名时，继续打开公有云登录页不够稳定

修改后：
- 如果当前 `cookieData.base_url` 已经是专属域名
- 且没有显式配置其他登录地址
- 则优先使用 `{base_url}/workPlatform` 作为交互登录页

### 3. Playwright 登录上下文忽略 HTTPS 证书错误

文件：
- `lib/auth/login.js`

问题：
- 在部分环境下，打开登录页会遇到 `net::ERR_CERT_AUTHORITY_INVALID`
- 导致扫码登录页根本无法打开

修改后：
- `browser.newContext({ ignoreHTTPSErrors: true })`

效果：
- 避免登录页被证书错误直接阻断

### 4. 修复交互登录临时脚本中的运行时错误

文件：
- `lib/auth/login.js`

问题：
- 临时脚本里调用了未定义的 `warn(...)`
- 会在等待扫码阶段直接抛出 `ReferenceError`

修改后：
- 改为使用 `console.error(...)` 输出提示信息

效果：
- 登录脚本可正常进入扫码等待流程

### 5. `logout()` 删除当前环境真实使用的 Cookie 文件

文件：
- `lib/auth/login.js`

问题：
- 多环境支持引入后，当前环境优先使用 `cookies-public.json` 或环境配置指定文件
- 但 `logout()` 仍然只删除旧版 `.cache/cookies.json`

修改后：
- `logout()` 改为删除 `env-manager` 解析出的当前环境 Cookie 文件

效果：
- 退出登录行为与多环境 Cookie 读取逻辑保持一致

### 6. 自定义页发布保存 Schema 的接口改为 `dingtalk/web`

文件：
- `lib/app/publish.js`

问题：
- 当前自定义页发布使用 `/alibaba/web/.../saveFormSchema.json`
- 但在实际环境中，这条链路会稳定返回 `LOGIN FAILED`
- 而 `create-form` / `update-form-config` 等主链路使用的是 `/dingtalk/web/...`

修改后：
- 自定义页发布保存 Schema 改为走 `/dingtalk/web/${appType}/_view/query/formdesign/saveFormSchema.json`

效果：
- 与现有表单更新主链路保持一致
- 避免发布接口在同一登录态下仍报 `LOGIN FAILED`

## 复现路径

1. 本地仍有 Cookie 缓存
2. 服务端实际已不再接受该登录态
3. 执行 `openyida publish ...`
4. 服务端返回 `LOGIN FAILED`
5. CLI 进入重登录逻辑
6. 旧实现通过 `ensureLogin()` 又拿回本地失效缓存
7. 重试请求继续失败

## 修复后行为

- 服务端一旦明确返回登录失效，CLI 会真正进入交互登录
- 交互登录会优先打开当前专属域名登录页
- 登录流程不会被 HTTPS 证书错误或临时脚本运行时错误中断
- 自定义页发布使用更稳定的 `dingtalk/web` Schema 保存路径

## 本地验证

已完成：
- 语法校验通过
- 自定义页发布链路已从“假重登死循环”修复为“真实打开登录页等待扫码”
- 登录页已能正确打开到当前专属域名

未完成：
- 最终发布成功验证仍需人工扫码完成
