### PR TITLE
fix: 补全单实例查询中的完整子表数据

### DIFF
--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -179,6 +179,69 @@ function normalizeFormDatasResult(result) {
   return result;
 }
 
+function parseInstValueFields(instValue) {
+  if (!instValue) {return [];}
+  if (Array.isArray(instValue)) {return instValue;}
+  if (typeof instValue !== 'string') {return [];}
+
+  try {
+    const parsed = JSON.parse(instValue);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function convertTableFieldRowsFromInstValue(tableValue) {
+  if (!Array.isArray(tableValue)) {return [];}
+
+  return tableValue.map((rowCells) => {
+    const row = {};
+    (Array.isArray(rowCells) ? rowCells : []).forEach((cell) => {
+      if (!cell || !cell.fieldId) {return;}
+      const fieldData = cell.fieldData || {};
+      row[cell.fieldId] = fieldData.value;
+    });
+    return row;
+  }).filter((row) => Object.keys(row).length > 0);
+}
+
+/**
+ * getFormDataById / searchFormDatas 在 formData 中内联的子表最多只有 50 条，
+ * 但 instValue 里仍然保留完整子表。这里优先用 instValue 回填完整子表。
+ */
+function hydrateTableFieldsFromInstValue(result) {
+  if (!result || !result.success || !result.content) {return result;}
+
+  const content = result.content;
+  const instValueFields = parseInstValueFields(content.instValue);
+  if (!instValueFields.length) {return result;}
+
+  const formData = content.formData && typeof content.formData === 'object'
+    ? content.formData
+    : {};
+
+  instValueFields.forEach((field) => {
+    if (!field || field.componentName !== 'TableField' || !field.fieldId) {
+      return;
+    }
+
+    const tableValue = field.fieldData && field.fieldData.value;
+    const fullRows = convertTableFieldRowsFromInstValue(tableValue);
+    if (!fullRows.length) {
+      return;
+    }
+
+    const currentRows = Array.isArray(formData[field.fieldId]) ? formData[field.fieldId] : [];
+    if (!currentRows.length || fullRows.length > currentRows.length) {
+      formData[field.fieldId] = fullRows;
+    }
+  });
+
+  content.formData = formData;
+  return result;
+}
+
 function printResult(result) {
   const errorCode = result && result.errorCode;
   const hasErrorCode = errorCode !== undefined && errorCode !== null && errorCode !== '' && errorCode !== 0 && errorCode !== '0';
@@ -206,6 +269,7 @@ async function queryForm(positionals, options, session) {
     result = await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
       formInstId: options.inst_id,
     });
+    result = hydrateTableFieldsFromInstValue(result);
   } else {
     const params = {
       formUuid,
@@ -238,9 +302,10 @@ async function getForm(positionals, options, session) {
   requirePositionals(positionals, 1, ['appType']);
   requireOption(options, 'inst_id');
   const [appType] = positionals;
-  printResult(await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
+  const result = await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
     formInstId: options.inst_id,
-  }));
+  });
+  printResult(hydrateTableFieldsFromInstValue(result));
 }
 
 async function createForm(positionals, options, session) {

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -211,6 +211,162 @@ describe('run() query form', () => {
     mockExit.mockRestore();
     mockError.mockRestore();
   });
+
+  test('query form --inst-id 时，instValue 为 JSON 字符串可回填完整 TableField', async () => {
+    utils.requestWithAutoLogin.mockResolvedValue({
+      success: true,
+      content: {
+        formInstId: 'INST-001',
+        formData: {
+          tableField_1: [
+            { textField_1: '第1行' },
+          ],
+        },
+        instValue: JSON.stringify([
+          {
+            componentName: 'TableField',
+            fieldId: 'tableField_1',
+            fieldData: {
+              value: [
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第1行' } },
+                ],
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第2行' } },
+                ],
+              ],
+            },
+          },
+        ]),
+      },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--inst-id', 'INST-001']);
+
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output.content.formData.tableField_1).toEqual([
+      { textField_1: '第1行' },
+      { textField_1: '第2行' },
+    ]);
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('query form --inst-id 时，instValue 为数组也可回填，且不会把已有完整数据写短', async () => {
+    utils.requestWithAutoLogin.mockResolvedValue({
+      success: true,
+      content: {
+        formInstId: 'INST-002',
+        formData: {
+          tableField_1: [
+            { textField_1: '第1行' },
+            { textField_1: '第2行' },
+            { textField_1: '第3行' },
+          ],
+        },
+        instValue: [
+          {
+            componentName: 'TableField',
+            fieldId: 'tableField_1',
+            fieldData: {
+              value: [
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第1行' } },
+                ],
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第2行' } },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--inst-id', 'INST-002']);
+
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output.content.formData.tableField_1).toEqual([
+      { textField_1: '第1行' },
+      { textField_1: '第2行' },
+      { textField_1: '第3行' },
+    ]);
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('query form --inst-id 时，非法 JSON 或非 TableField 保持原结果不变', async () => {
+    utils.requestWithAutoLogin.mockResolvedValue({
+      success: true,
+      content: {
+        formInstId: 'INST-003',
+        formData: {
+          tableField_1: [
+            { textField_1: '保留原值' },
+          ],
+        },
+        instValue: '[not-valid-json',
+      },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--inst-id', 'INST-003']);
+
+    let output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output.content.formData.tableField_1).toEqual([
+      { textField_1: '保留原值' },
+    ]);
+
+    mockLog.mockClear();
+    utils.requestWithAutoLogin.mockResolvedValueOnce({
+      success: true,
+      content: {
+        formInstId: 'INST-004',
+        formData: {
+          tableField_1: [
+            { textField_1: '仍然保留' },
+          ],
+        },
+        instValue: JSON.stringify([
+          {
+            componentName: 'TextField',
+            fieldId: 'textField_1',
+            fieldData: { value: '不会回填到子表' },
+          },
+          {
+            componentName: 'TableField',
+            fieldData: {
+              value: [
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '缺少 fieldId 的子表' } },
+                ],
+              ],
+            },
+          },
+        ]),
+      },
+    });
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--inst-id', 'INST-004']);
+
+    output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output.content.formData.tableField_1).toEqual([
+      { textField_1: '仍然保留' },
+    ]);
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
 });
 
 // ── get form（--inst-id）场景 ─────────────────────────────────────────
@@ -263,6 +419,54 @@ describe('run() get form', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
 
     mockExit.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('get form --inst-id 时，仅在 instValue 行数更多时覆盖 formData 子表', async () => {
+    utils.requestWithAutoLogin.mockResolvedValue({
+      success: true,
+      content: {
+        formInstId: 'INST-005',
+        formData: {
+          tableField_1: [
+            { textField_1: '第1行' },
+          ],
+        },
+        instValue: JSON.stringify([
+          {
+            componentName: 'TableField',
+            fieldId: 'tableField_1',
+            fieldData: {
+              value: [
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第1行' } },
+                ],
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第2行' } },
+                ],
+                [
+                  { fieldId: 'textField_1', fieldData: { value: '第3行' } },
+                ],
+              ],
+            },
+          },
+        ]),
+      },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['get', 'form', 'APP_XXX', '--inst-id', 'INST-005']);
+
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output.content.formData.tableField_1).toEqual([
+      { textField_1: '第1行' },
+      { textField_1: '第2行' },
+      { textField_1: '第3行' },
+    ]);
+
+    mockLog.mockRestore();
     mockError.mockRestore();
   });
 });


### PR DESCRIPTION
## 背景

`openyida data get form` 和 `openyida data query form --inst-id ...` 在返回单条表单实例时，会直接使用接口返回的 `formData`。

但实际验证发现，`formData` 中内联的子表字段最多只保留前 50 条；超过 50 条的部分并没有真正丢失，而是仍然存在于同一响应里的 `instValue`，也可以通过 `data query subform` 分页查到。

这会导致用户误以为明细数据丢失。

Fixes #330

## 本次修改

- 为单实例查询新增 `instValue` 子表回填逻辑
- 当 `instValue` 中的子表行数多于 `formData` 中当前的子表行数时，用完整结果覆盖截断结果
- 作用范围仅限：
  - `openyida data get form`
  - `openyida data query form --inst-id ...`

## 为什么这样修

- 不改底层保存逻辑，因为数据本身并没有丢
- 不直接对普通列表查询做全量补子表，避免引入性能回归
- 优先利用同一响应中的 `instValue`，避免额外发起多次子表分页请求

## 本地验证

在应用 `APP_XGY8CM48VQTR23W6SY38` 中创建了测试表单和测试实例：

- 测试表单：`FORM-C4EAD33DD93A4D07B01D6F9014FFF407V2OR`
- 测试实例：`FINST-FYD66291LYX4HD1GJSWI8A7ZTMPR3DVWA71OMFW`
- 子表实际写入：60 行

修复前：
- `data get form` 返回 50 行
- `data query form --inst-id` 返回 50 行

修复后：
- `data get form` 返回 60 行
- `data query form --inst-id` 返回 60 行
- 第 60 行数据可正确读取

## 备注

这次是最小修复，只覆盖单实例查询。
如果后续需要，也可以再为列表查询增加显式参数，例如 `--expand-subforms`，按需补全所有子表。
