### PR TITLE
feat(ppt-skill): 新增 yida-ppt 技能文档

### DIFF
--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -1,234 +1,298 @@
 ---
-name: yida-skills
-description: "宜搭低代码平台 AI 开发助手。适用于一切业务数字化需求：创建登记表/申请表/信息收集表、设计审批流程、搭建数据报表/数据大屏、开发自定义页面、管理表单数据、闪记转PRD/会议纪要提取需求/需求文档生成、导出对话记录、编写公式/计算字段、配置连接器/外部API接入、设置权限/公开分享、集成自动化。当用户想要创建任何形式的表单、系统、页面、流程、报表，或提到员工管理、客户管理、费用报销、考勤打卡、项目管理等业务场景时触发。也适用于「宜搭」「yida」「低代码」「创建应用」「发布页面」「搭建系统」「PRD」「闪记」「会议记录」「对话导出」「公式」「连接器」「权限」「分享」「集成自动化」等关键词场景。"
+name: Yida
+description: >
+  宜搭 AI 应用开发总入口技能。通过有 AI Coding 能力的智能体（悟空/Claude/Open Code 等）+ 宜搭低代码平台，实现一句话生成完整应用。
+  包含应用创建、表单设计、自定义页面开发、页面发布、登录态管理等完整开发流程。
+  当用户提到"宜搭"、"yida"、"低代码"、"创建应用"、"创建表单"、"发布页面"、"搭建"、"系统"、等关键词时，使用此技能。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+  - qoder
+  - wukong
 metadata:
-  version: 2026.04.02
+  audience: developers
+  workflow: yida-development
+  version: 3.0.0
+  tags:
+    - yida
+    - low-code
+    - app
+    - form
+    - custom-page
 ---
 
 # 宜搭 AI 应用开发指南
 
-通过 `openyida` CLI 驱动宜搭低代码平台，一句话生成完整应用。
+## 概述
 
-## 严格禁止 (NEVER DO)
+本技能通过有 AI Coding 能力的智能体（悟空/Claude/Open Code 等） + 宜搭低代码平台，实现一句话生成完整应用。涵盖从应用创建、表单设计、自定义页面开发到页面发布的完整链路。
 
-- 不要编造 appType、formUuid、fieldId 等标识符，必须从命令返回或 Schema 中提取
-- 不要在未读取子技能 SKILL.md 的情况下执行操作，参数格式必须以文档为准
-- 不要在 corpId 不一致时强行创建应用，必须先询问用户
-- 不要将临时文件写在项目根目录，统一写入 `.cache/` 文件夹
+所有操作通过 **`openyida`** 命令行工具统一执行，无需关心脚本路径或运行环境差异。
 
-## 严格要求 (MUST DO)
-
-- 执行任何操作前，必须先运行 `openyida env` 检测环境和登录态
-- 每个子技能执行前，必须完整读取其 SKILL.md，不得凭记忆猜测参数
-- 业务语义信息写入 `prd/<项目名>.md`，Schema ID 写入 `.cache/<项目名>-schema.json`
-- 超过 100 行的大文件写入，使用 `large-file-write` 技能，禁止用 heredoc
-- 在悟空环境中（`AGENT_WORK_ROOT` 包含 `.real`），执行任何 npm/node/npx 命令前，必须先设置 `export PATH="$HOME/.real/.bin/node/bin:$PATH"`，确保使用悟空自带的 node 环境
+**登录态说明**：所有命令自动读取 `.cache/cookies.json`，首次运行或 Cookie 失效时自动触发登录流程，无需手动执行登录命令。
 
 ---
 
-## ⚡ 首要步骤（每次必须先执行）
+## 环境依赖
 
-**macOS / Linux：**
+| 依赖 | 版本 | 用途 |
+|------|------|------|
+| Node.js | ≥ 16 | 运行 openyida |
 
 ```bash
-# 0. 悟空环境：确保使用悟空自带的 node/npm（避免权限问题）
-if [ -n "$AGENT_WORK_ROOT" ] && echo "$AGENT_WORK_ROOT" | grep -q '.real'; then
-  export PATH="$HOME/.real/.bin/node/bin:$PATH"
-fi
+# 安装 openyida（首次使用前执行）
+npm install -g openyida
 
-# 1. 确保 openyida 已安装（未安装则自动安装，已安装则跳过）
-openyida -v 2>/dev/null || npm install -g openyida@latest
-
-# 2. 一键诊断并自动修复：环境检测 + project 目录初始化
-openyida doctor --fix
-```
-
-**Windows (PowerShell)：**
-
-```powershell
-# 0. 悟空环境：确保使用悟空自带的 node/npm（避免权限问题）
-if ($env:AGENT_WORK_ROOT -and $env:AGENT_WORK_ROOT -match '\.real') {
-  $env:PATH = "$env:USERPROFILE\.real\.bin\node\bin;$env:PATH"
-}
-
-# 1. 确保 openyida 已安装（未安装则自动安装，已安装则跳过）
-try { openyida -v } catch { npm install -g openyida@latest }
-
-# 2. 一键诊断并自动修复：环境检测 + project 目录初始化
-openyida doctor --fix
+# 更新 openyida 到最新版本
+npm install -g openyida@latest
 ```
 
 ---
 
-## 意图判断决策树
+## 更新 openyida
 
-根据用户描述，快速定位应使用的子技能：
+**手动更新**：
+```bash
+npm install -g openyida@latest
+```
 
-用户提到"查询应用列表/我的应用/有哪些应用" → `openyida yida-app-list`（直接执行，无需子技能）
-用户提到"创建应用/新建系统/搭建平台" → 先读 `yida-app` 了解全流程，再用 `yida-create-app`
-用户提到"创建表单/新增字段/更新表单" → `yida-create-form-page`
-用户提到"自定义页面/JSX/React/可视化大屏" → `yida-custom-page` + `yida-publish-page`
-用户提到"审批流程/流程表单/审批节点" → `yida-create-process` 或 `yida-process-rule`
-用户提到"流程预览/流程图/审批进度/流程可视化" → `openyida process preview`（直接执行）
-用户提到"数据查询/数据管理/表单实例" → `yida-data-management`
-用户提到"报表/图表/ECharts/数据大屏" → `yida-report`（原生报表）或 `yida-chart`（ECharts 高级）
-用户提到"连接器/外部接口/HTTP 接入" → `yida-connector`
-用户提到"权限/字段权限/数据权限" → `yida-form-permission`
-用户提到"公开访问/分享链接/外部访问" → `yida-page-config`
-用户提到"集成/自动化/触发通知" → `yida-integration`
-用户提到"登录/Cookie 失效/切换账号" → `yida-login` 或 `yida-logout`
-用户提到"公式/计算字段/函数" → `yida-formula`
-用户提到"闪记/会议纪要/PRD" → `yida-flash-note-to-prd`
-用户提到"Sequence/主键冲突/自增ID错误" → `yida-db-seq-fix`
+**让 AI 帮你更新**：
 
-**关键区分**：
-- `yida-report`（宜搭原生报表页面，16 种内置图表）vs `yida-chart`（ECharts 自定义大屏，依赖 yida-report 作数据源）
-- `yida-create-process`（从零创建流程表单一体化）vs `yida-process-rule`（为已有表单配置审批规则）
-- `yida-create-form-page`（创建/更新表单结构）vs `yida-data-management`（操作表单中的数据记录）
+执行 `openyida` 命令出现报错时，直接告诉 AI：
 
-> 易混淆场景详见各子技能 SKILL.md 的"注意事项"章节。
+> "openyida 命令出错了，请帮我更新 openyida"
+
+AI 会自动执行以下命令完成更新：
+```bash
+npm install -g openyida@latest
+```
+
+更新完成后重新执行出错的命令即可。
 
 ---
 
-## 危险操作确认
+## ⚡ 首要步骤：检测运行环境（必须先执行）
 
-以下操作不可逆，执行前**必须向用户展示操作摘要并获得明确同意**：
+**在执行任何宜搭操作前，必须先运行环境检测命令**，确认当前 AI 工具环境和登录态：
 
-| 操作 | 说明 |
+```bash
+openyida env
+```
+
+**输出解读**：
+
+| 字段 | 说明 |
 |------|------|
-| 删除应用 | 含全部表单、页面、数据，不可恢复 |
-| 覆盖表单 Schema | 可能导致已有数据字段丢失 |
-| 批量删除数据记录 | 数据不可恢复 |
-| 切换组织（logout/login） | 会清除当前登录态 |
+| AI 工具检测 | 显示当前活跃的 AI 工具（悟空/OpenCode/Aone Copilot 等） |
+| 当前生效环境 | 显示项目根目录路径 |
+| 登录态检测 | 显示是否已登录、域名、组织 ID |
 
-确认流程：
-1. 展示操作摘要（操作类型 + 目标对象 + 影响范围）
-2. 等待用户明确回复确认
-3. 执行操作
+> **若显示"未登录"，自动执行 `openyida login`，无需手动操作。**。
 
 ---
 
-## 错误处理
+## 🔧 初始化 project 工作目录
 
-1. 登录失效（401/Cookie 过期）→ 执行 `openyida login` 重新登录
-2. corpId 不匹配 → 询问用户是否切换组织，执行 `openyida logout && openyida login`
-3. 命令执行失败 → 检查参数格式是否与子技能 SKILL.md 一致，不要猜测参数
-4. 发布失败 → 确认 `openyida env` 环境检测通过，检查 Babel 编译产物
-5. **技能检索失败（search_skills 未返回预期技能）→ 不得直接输出执行结果或编造执行过程**。必须先查阅上方「意图判断决策树」手动定位子技能路径，再通过 `use_skill` 激活对应技能后执行。若仍无法确定技能，停止执行并向用户说明，询问补充信息。
+**如果当前工程目录下没有 `project/` 目录**（例如切换了 AI 工具、或在新工程中首次使用），需要手动执行初始化：
 
----
+```bash
+openyida copy
+```
 
-## 子技能索引
+### 复制目标说明
 
-> 执行前必须完整读取对应 SKILL.md，不得凭记忆猜测参数格式。
+| AI 工具 | project 目录位置 | 说明 |
+|---------|-----------------|------|
+| **悟空（Wukong）** | `~/.real/workspace/project` | 悟空有专属 workspace，与工程目录无关 |
+| **其他工具**（Aone Copilot、Cursor、Claude Code、OpenCode 等） | `<当前工程目录>/project` | 以项目为单位，需在工程根目录下执行 |
 
-### 应用生命周期
+### AI 执行规则
 
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-app** | [`skills/yida-app/SKILL.md`](skills/yida-app/SKILL.md) | 完整应用开发全流程编排（从零到一，创建应用前必读） |
-| **app-list** | `openyida yida-app-list [--size N]` | 查询我的应用列表，返回 appName / appType / systemLink（直接执行，无需子技能） |
-| **sample** | `openyida sample <skill> <name>` | 输出代码示例/模板到 `.cache/samples/<name>.js`，再用 `read_file` 读取（`--list` 查看所有可用示例） |
-| **yida-create-app** | [`skills/yida-create-app/SKILL.md`](skills/yida-create-app/SKILL.md) | 创建应用，获取 appType |
-| **yida-create-page** | [`skills/yida-create-page/SKILL.md`](skills/yida-create-page/SKILL.md) | 创建自定义展示页面，获取 formUuid |
-| **yida-publish-page** | [`skills/yida-publish-page/SKILL.md`](skills/yida-publish-page/SKILL.md) | 编译并发布自定义页面 |
+**在执行任何宜搭操作前，先检查 project 目录是否存在**：
 
-### 表单与数据
+- **悟空**：检查 `~/.real/workspace/project` 是否存在
+- **其他工具**：检查当前工程目录下的 `project/` 是否存在
 
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-create-form-page** | [`skills/yida-create-form-page/SKILL.md`](skills/yida-create-form-page/SKILL.md) | 创建/更新表单（19 种字段类型） |
-| **yida-get-schema** | [`skills/yida-get-schema/SKILL.md`](skills/yida-get-schema/SKILL.md) | 获取表单 Schema，确认字段 ID |
-| **yida-data-management** | [`skills/yida-data-management/SKILL.md`](skills/yida-data-management/SKILL.md) | 表单/流程实例的查询、新增、更新 |
-| **yida-form-permission** | [`skills/yida-form-permission/SKILL.md`](skills/yida-form-permission/SKILL.md) | 表单权限配置（字段/数据/操作权限） |
-| **yida-formula** | [`skills/yida-formula/SKILL.md`](skills/yida-formula/SKILL.md) | 公式字段编写规范（函数速查、18 个常见场景示例） |
+若不存在，执行初始化：
+```bash
+openyida copy
+```
 
-### 流程
-
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-create-process** | [`skills/yida-create-process/SKILL.md`](skills/yida-create-process/SKILL.md) | 一键创建流程表单（创建+转流程+配置） |
-| **yida-process-rule** | [`skills/yida-process-rule/SKILL.md`](skills/yida-process-rule/SKILL.md) | 为已有表单配置审批规则（条件分支/审批节点/字段权限） |
-| **process-preview** | `openyida process preview <appType> <processInstanceId> [--output <path>]` | 预览流程实例，生成可视化流程图 HTML（高亮当前审批节点，直接执行，无需子技能） |
-| **yida-integration** | [`skills/yida-integration/SKILL.md`](skills/yida-integration/SKILL.md) | 创建集成&自动化逻辑流（触发事件/通知/数据操作） |
-
-### 自定义页面开发
-
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-custom-page** | [`skills/yida-custom-page/SKILL.md`](skills/yida-custom-page/SKILL.md) | JSX 编码规范、API 调用、状态管理（必须完整学习） |
-| **yida-density** | [`skills/yida-density/SKILL.md`](skills/yida-density/SKILL.md) | 信息密度设计规范（紧凑/舒适/宽松） |
-| **yida-table-form** | [`skills/yida-table-form/SKILL.md`](skills/yida-table-form/SKILL.md) | 表格形式批量表单提交 |
-| **yida-ppt-slider** | [`skills/yida-ppt-slider/SKILL.md`](skills/yida-ppt-slider/SKILL.md) | PPT 幻灯片页面开发（演讲/路演/培训） |
-
-### 连接器与报表
-
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-connector** | [`skills/yida-connector/SKILL.md`](skills/yida-connector/SKILL.md) | HTTP 连接器管理（创建/测试/智能生成） |
-| **yida-report** | [`skills/yida-report/SKILL.md`](skills/yida-report/SKILL.md) | 创建宜搭原生报表（16 种图表/表格/筛选器，可作为 yida-chart 数据源） |
-| **yida-chart** | [`skills/yida-chart/SKILL.md`](skills/yida-chart/SKILL.md) | ECharts 高级报表（定制化数据大屏） |
-
-### 配置与认证
-
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-login** | [`skills/yida-login/SKILL.md`](skills/yida-login/SKILL.md) | 登录态管理（通常自动触发） |
-| **yida-logout** | [`skills/yida-logout/SKILL.md`](skills/yida-logout/SKILL.md) | 退出登录 / 切换账号 |
-| **yida-page-config** | [`skills/yida-page-config/SKILL.md`](skills/yida-page-config/SKILL.md) | 页面公开访问 / 组织内分享配置 |
-
-### 工具
-
-| 技能 | 路径 | 说明 |
-|------|------|------|
-| **yida-flash-note-to-prd** | [`skills/yida-flash-note-to-prd/SKILL.md`](skills/yida-flash-note-to-prd/SKILL.md) | 钉钉闪记转高质量 Prompt |
-| **yida-export-conversation** | [`skills/yida-export-conversation/SKILL.md`](skills/yida-export-conversation/SKILL.md) | 导出 AI 对话记录 |
-| **yida-db-seq-fix** | [`skills/yida-db-seq-fix/SKILL.md`](skills/yida-db-seq-fix/SKILL.md) | PostgreSQL Sequence 自动修复（检测并修复主键冲突问题） |
-| **large-file-write** | [`skills/large-file-write/SKILL.md`](skills/large-file-write/SKILL.md) | 大文件写入（解决 heredoc 截断问题） |
-
-### 共享参考文档
-
-| 文档 | 路径 | 说明 |
-|------|------|------|
-| 宜搭 JS API | [`references/yida-api.md`](references/yida-api.md) | 31 个 API（表单操作/流程操作/设计/工具类） |
-| 大模型 AI 接口 | [`references/model-api.md`](references/model-api.md) | AI 文本生成接口参数与示例 |
-| 查询条件指南 | [`references/query-condition-guide.md`](references/query-condition-guide.md) | searchFieldJson 条件构造规范 |
+> ⚠️ 对于非悟空工具，必须先 `cd` 到工程根目录再执行 `openyida copy`。
 
 ---
 
-## URL 规则
+## 何时使用
+
+当用户提出以下需求时，使用本技能并按照完整开发流程执行：
+- 创建宜搭应用、表单、自定义页面
+- 发布或更新宜搭页面
+- 配置页面公开访问/组织内分享
+- 查询表单 Schema 或字段 ID
+- 管理宜搭登录态（登录/退出）
+
+---
+
+## 完整开发流程
+
+```
+[Step 1] 创建应用 → openyida create-app          → 获得 appType
+              ↓
+[Step 2] 需求分析 → 写入 prd/<项目名>.md
+              ↓
+[Step 3] 创建自定义页面 → openyida create-page    → 获得 formUuid（自定义页面）
+              ↓
+[Step 4]（按需）创建/更新表单 → openyida create-form → 获得 formUuid（表单）
+              ↓
+[Step 5] 编写自定义页面代码 → yida-custom-page 规范 → pages/src/<项目名>.js
+              ↓
+[Step 6] 发布页面 → openyida publish
+              ↓
+[Step 7]（按需）配置公开访问 → openyida verify-short-url / save-share-config
+              ↓
+[Step 8] 输出访问链接，用系统浏览器打开
+```
+
+---
+
+## 子技能速查
+
+> 每个子技能均有独立的 SKILL.md，执行前请读取对应文档获取详细参数说明。
+
+| 技能 | SKILL.md 路径 | 用途 | 典型命令 |
+|------|--------------|------|---------|
+| `yida-login` | `skills/yida-login/SKILL.md` | 登录态管理（通常自动触发） | `openyida login` |
+| `yida-logout` | `skills/yida-logout/SKILL.md` | 退出登录 / 切换账号 | `openyida logout` |
+| `yida-create-app` | `skills/yida-create-app/SKILL.md` | 创建应用，获取 appType | `openyida create-app "<名称>"` |
+| `yida-create-page` | `skills/yida-create-page/SKILL.md` | 创建自定义页面，获取 formUuid | `openyida create-page <appType> "<页面名>"` |
+| `yida-create-form-page` | `skills/yida-create-form-page/SKILL.md` | 创建/更新表单页面 | `openyida create-form create <appType> "<表单名>" <字段JSON>` |
+| `yida-get-schema` | `skills/yida-get-schema/SKILL.md` | 获取表单 Schema，确认字段 ID | `openyida get-schema <appType> <formUuid>` |
+| `yida-custom-page` | `skills/yida-custom-page/SKILL.md` | 编写自定义页面 JSX 代码规范 | 详见 SKILL.md |
+| `yida-publish-page` | `skills/yida-publish-page/SKILL.md` | 编译并发布自定义页面 | `openyida publish <源文件路径> <appType> <formUuid>` |
+| `yida-page-config` | `skills/yida-page-config/SKILL.md` | 页面公开访问/组织内分享配置 | `openyida verify-short-url <appType> <formUuid> <url>` |
+| `yida-chart` | `skills/yida-chart/SKILL.md` | 报表可视化（ECharts 图表 + 数据聚合） | 详见 SKILL.md |
+| `yida-report` | `skills/yida-report/SKILL.md` | 宜搭原生报表创建（标准报表） | `openyida create-report <appType> "<名称>" <配置>` |
+| `yida-ppt` | `skills/yida-ppt/SKILL.md` | PPT/演示文稿开发（深色科技风+Canvas粒子+电影级转场+玻璃态卡片） | 详见 SKILL.md |
+
+---
+
+## 关键规则
+
+### 1. 执行子技能前必须读取其 SKILL.md
+
+每个子技能的详细参数、注意事项、示例均在其 SKILL.md 中。**执行任何子技能前，必须先读取对应的 SKILL.md**，不要凭记忆猜测参数格式。
+
+### 2. corpId 一致性检查（必须遵守）
+
+在创建页面前，**必须对比 prd 文档中的 corpId 与 `.cache/cookies.json` 中的 corpId 是否一致**：
+
+- **一致** → 继续执行
+- **不一致** → 询问用户：重新登录到正确组织，还是在当前组织新建应用？
+
+### 3. 配置信息分两处存储
+
+| 信息类型 | 存储位置 | 内容示例 |
+|---------|---------|---------|
+| 业务语义信息 | `prd/<项目名>.md` | 字段名称、字段类型、字段说明 |
+| Schema ID | `.cache/<项目名>-schema.json` | `appType`、`formUuid`、`fieldId` |
+
+> **prd 文档不记录 `formUuid`、`fieldId` 等 ID**，这些写入 `.cache/` 临时文件。
+
+### 4. 临时文件规范
+
+所有临时文件（cookies、schema 缓存等）**必须写在项目根目录的 `.cache/` 文件夹中**，不要写在系统其他位置。
+
+### 5. 报表优化/美化提示规则（必须遵守）
+
+当用户提到"优化"、"美化"、"更好看"、"不够漂亮"等与报表视觉效果相关的关键词时，**必须先询问用户**选择以下哪种方案：
+
+| 方案 | 说明 | 适用场景 |
+|------|------|---------|
+| **方案 A：优化宜搭原生报表** | 调整图表类型、布局、筛选器等，仍使用宜搭原生报表组件 | 快速优化，无需编写代码 |
+| **方案 B：创建 ECharts 高级报表** | 使用 ECharts + 自定义页面 JSX，实现高度定制化、更美观的数据可视化 | 需要更精美的视觉效果、复杂交互、数据大屏 |
+
+**提示话术示例**：
+
+> 我可以通过两种方式帮你优化报表：
+> 1. **优化原生报表**：调整图表类型组合、布局排列、添加筛选器，快速提升效果
+> 2. **创建 ECharts 高级报表**：使用 ECharts 自定义页面，实现更精美的视觉效果和交互体验（如渐变色、动画、自定义主题等）
+>
+> 你想选择哪种方案？
+
+- 用户选择方案 A → 使用 `yida-report` 技能（`openyida create-report`）
+- 用户选择方案 B → 读取 `skills/yida-chart/SKILL.md`，使用 `yida-chart` 技能
+
+---
+
+## 表单字段类型速查
+
+| 类型 | 说明 | 特殊属性 |
+|------|------|---------|
+| `TextField` | 单行文本 | — |
+| `TextareaField` | 多行文本 | — |
+| `NumberField` | 数字 | `precision`（小数位）、`innerAfter`（单位） |
+| `RadioField` | 单选 | `options` |
+| `CheckboxField` | 多选 | `options` |
+| `SelectField` | 下拉单选 | `options` |
+| `MultiSelectField` | 下拉多选 | `options` |
+| `DateField` | 日期 | `format`（如 `"YYYY-MM-DD"`） |
+| `CascadeDateField` | 级联日期（范围） | `format` |
+| `EmployeeField` | 成员选择 | `multiple` |
+| `DepartmentSelectField` | 部门选择 | `multiple` |
+| `AddressField` | 地址 | — |
+| `AttachmentField` | 附件上传 | — |
+| `ImageField` | 图片上传 | — |
+| `TableField` | 子表格 | `children`（子字段列表） |
+| `AssociationFormField` | 关联表单 | `associationForm` |
+| `SerialNumberField` | 流水号 | `serialNumberRule` |
+| `RateField` | 评分 | `count`（星级数） |
+| `CountrySelectField` | 国家选择 | `multiple` |
+
+---
+
+## 宜搭应用 URL 规则
 
 | 页面类型 | URL 格式 |
 |---------|---------|
 | 应用首页 | `{base_url}/{appType}/workbench` |
 | 表单提交页 | `{base_url}/{appType}/submission/{formUuid}` |
 | 自定义页面 | `{base_url}/{appType}/custom/{formUuid}` |
+| 自定义页面（隐藏导航） | `{base_url}/{appType}/custom/{formUuid}?isRenderNav=false` |
 | 表单详情页 | `{base_url}/{appType}/formDetail/{formUuid}?formInstId={formInstId}` |
+| 表单详情页（编辑模式） | `{base_url}/{appType}/formDetail/{formUuid}?formInstId={formInstId}&mode=edit` |
 
-> 拼接 `&corpid={corpId}` 切换组织，拼接 `&isRenderNav=false` 隐藏导航。
+> 所有地址拼接 `&corpid={corpId}` 可自动切换到对应组织。
 
 ---
 
 ## 常见问题
-
 **Q：发布时提示登录失效？**
-执行 `openyida login` 重新登录后再发布。
+
+重新登录后再发布：
+```bash
+openyida login
+openyida publish <源文件路径> <appType> <formUuid>
+```
 
 **Q：如何查看已有表单的字段 ID？**
-使用 `openyida get-schema <appType> <formUuid>` 获取 Schema，详见 `yida-get-schema` 技能。
+
+使用 `yida-get-schema` 技能获取表单 Schema，从中读取各字段的 `fieldId`：
+```bash
+openyida get-schema <appType> <formUuid>
+```
 
 **Q：如何更新已有表单字段？**
-使用 `yida-create-form-page` 的 update 模式：
+
+使用 `yida-create-form-page` 的 update 模式，详见 `skills/yida-create-form-page/SKILL.md`：
 ```bash
 openyida create-form update <appType> <formUuid> '[{"action":"add","field":{"type":"TextField","label":"新字段"}}]'
 ```
 
 **Q：发布时提示 corpId 不匹配？**
-询问用户是否在当前组织创建新应用，或重新登录到正确组织：
+
+询问用户是否在当前组织创建新应用发布，或重新登录到正确组织：
 ```bash
 openyida logout
 openyida login
 ```
-
-**Q：如何在表单/页面中调用外部接口？**
-参考 `references/connector-datasource.md`，通过 `--datasource` 参数注入连接器数据源，在 JS 中通过 `this.dataSourceMap.<名称>.load()` 调用。

--- a/yida-skills/skills/yida-ppt/SKILL.md
+++ b/yida-skills/skills/yida-ppt/SKILL.md
@@ -1,0 +1,697 @@
+---
+name: yida-ppt
+description: >
+  宜搭自定义页面 PPT / 演示文稿开发技能。
+  设计体系：深色科技风 + Canvas粒子 + 电影级转场 + 玻璃态卡片。
+  适用于企业培训、产品发布、战略汇报等场景的全屏幻灯片应用。
+  【重要】当用户提到"PPT"、"幻灯片"、"演示文稿"、"培训课件"、"演讲稿"等关键词时，
+  必须先向用户展示两种方案供选择，再执行对应技能，不要直接开始生成。
+license: MIT
+compatibility:
+  - opencode
+  - claude-code
+  - qoder
+  - wukong
+metadata:
+  audience: developers
+  workflow: yida-development
+  version: 1.0.0
+  tags:
+    - yida
+    - ppt
+    - slides
+    - presentation
+    - canvas
+    - animation
+---
+
+# 宜搭 PPT / 演示文稿开发技能
+
+## ⚡ 首要步骤：先询问用户选择方案
+
+**当用户提到"PPT"、"幻灯片"、"演示文稿"等关键词时，必须先展示以下两种方案，让用户选择后再执行，不要直接开始生成。**
+
+向用户说：
+
+> 我可以用两种方式帮你做 PPT，请选择：
+>
+> **方案 A · 宜搭 PPT**（本技能）
+> 部署到宜搭平台，深色科技风 + Canvas粒子 + 电影级转场，可调用宜搭实时数据，适合嵌入钉钉生态
+> 需要：宜搭账号 + `openyida publish` 发布
+>
+> **方案 B · 独立 HTML 演示文稿**（report-slides 技能）
+> 生成一个 HTML 文件，浏览器直接打开，11 种企业级风格可选（Apple / Google / Fluent / Ant Design 等），适合直接发送分享
+> 需要：无，生成即用
+
+用户选择 A → 继续执行本技能（yida-ppt）
+用户选择 B → 切换到 report-slides 技能
+
+---
+
+## 两种方案对比
+
+| 维度 | 方案 A · 宜搭 PPT | 方案 B · 独立 HTML |
+|------|------------------|-------------------|
+| **产出物** | 宜搭自定义页面（需发布） | 单个 `.html` 文件 |
+| **运行环境** | 宜搭/钉钉平台 | 浏览器直接打开 |
+| **设计风格** | 深色科技风（固定） | 11 种风格自选 |
+| **数据集成** | ✅ 可调用宜搭实时数据 | ❌ 静态内容 |
+| **分享方式** | 宜搭链接 | 发送 HTML 文件 |
+| **前提条件** | 需要宜搭账号 | 无 |
+| **适合场景** | 企业培训、产品发布、钉钉生态 | 汇报、复盘、直接分享 |
+
+---
+
+## 概述
+
+本技能用于在宜搭自定义页面上开发**全屏幻灯片演示应用**，设计体系来源于 `wukong-openyida-training-v2.js` 实战案例。
+
+**设计体系：深色科技风 + Canvas粒子 + 电影级转场 + 玻璃态卡片**
+
+---
+
+## 文件结构
+
+```
+project/pages/src/<页面名>.js   ← JSX 源码（本技能的产出物）
+```
+
+编译发布使用 `yida-publish-page` 技能：
+```bash
+openyida publish project/pages/src/<页面名>.js <appType> <pageId>
+```
+
+---
+
+## 设计体系速查
+
+### 颜色主题（深色科技风）
+
+| 角色 | 颜色值 | 用途 |
+|------|--------|------|
+| 主色蓝 | `#3b82f6` / `rgba(59,130,246,x)` | 主要强调、粒子、进度条 |
+| 主色紫 | `#a855f7` / `rgba(139,92,246,x)` | 章节高亮、光晕 |
+| 主色绿 | `#10b981` / `rgba(16,185,129,x)` | 正向指标、成功状态 |
+| 主色粉 | `#ec4899` / `rgba(236,72,153,x)` | 渐变点缀 |
+| 背景色 | `#0B0F19` | 全局背景（最深黑） |
+| 文字主色 | `#fff` / `#e5e7eb` | 标题 / 正文 |
+| 文字次色 | `#9ca3af` | 副标题、描述 |
+| 文字弱色 | `#6b7280` | 时间、标签 |
+
+### 字体
+
+```css
+font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+```
+
+引入方式：`@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700;900&display=swap");`
+
+---
+
+## 核心代码模板
+
+### 1. CSS 动画（必须完整复制）
+
+```jsx
+var CSS_ANIMATIONS = [
+  '@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700;900&display=swap");',
+  '*{font-family:"Noto Sans SC","PingFang SC","Microsoft YaHei",sans-serif;box-sizing:border-box}',
+  '#__lowcode_devtool_switch__,[id="__lowcode_devtool_switch__"]{display:none!important;visibility:hidden!important}',
+  '@keyframes fadeIn{from{opacity:0;transform:scale(1.02)}to{opacity:1;transform:scale(1)}}',
+  '@keyframes gridMove{0%{transform:translate(0,0)}100%{transform:translate(60px,60px)}}',
+  '@keyframes glowPulse{0%,100%{opacity:.5;transform:scale(1)}50%{opacity:.8;transform:scale(1.1)}}',
+  '@keyframes ip{0%{opacity:0;transform:scale(.85) translateY(8px)}100%{opacity:1;transform:scale(1) translateY(0)}}',
+  '@keyframes fu{0%{opacity:0;transform:translateY(20px)}100%{opacity:1;transform:translateY(0)}}',
+  '@keyframes df{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}',
+  '@keyframes cineZoom{0%{opacity:0;transform:scale(1.4);filter:blur(30px) brightness(1.8)}40%{opacity:.7;transform:scale(1.08);filter:blur(8px) brightness(1.2)}100%{opacity:1;transform:scale(1);filter:blur(0) brightness(1)}}',
+  '@keyframes cineParallax{0%{opacity:0;transform:translateX(-120px) scale(1.05);filter:blur(12px)}60%{opacity:.8;transform:translateX(10px) scale(1.01);filter:blur(2px)}100%{opacity:1;transform:translateX(0) scale(1);filter:blur(0)}}',
+  '@keyframes cineRise{0%{opacity:0;transform:translateY(100px);filter:blur(10px)}60%{opacity:.85;transform:translateY(-5px);filter:blur(1px)}100%{opacity:1;transform:translateY(0);filter:blur(0)}}',
+  '@keyframes cineGlitch{0%{opacity:0;transform:scale(1.06);filter:hue-rotate(90deg) saturate(3) blur(15px)}20%{transform:translate(-6px,3px) scale(1.02);filter:hue-rotate(-20deg) blur(2px)}50%{opacity:1;transform:translate(0) scale(1);filter:hue-rotate(0) saturate(1)}100%{opacity:1;transform:translate(0) scale(1);filter:none}}',
+  '@keyframes cineIris{0%{opacity:0;clip-path:circle(0% at 50% 50%);filter:brightness(2)}60%{opacity:1;clip-path:circle(70% at 50% 50%);filter:brightness(1.1)}100%{opacity:1;clip-path:circle(100% at 50% 50%);filter:brightness(1)}}',
+  '@keyframes cineGrand{0%{opacity:0;transform:scale(.7);filter:blur(20px) brightness(2)}50%{opacity:.8;transform:scale(1.02);filter:blur(3px) brightness(1.1)}100%{opacity:1;transform:scale(1);filter:blur(0) brightness(1)}}',
+  '@keyframes chapterGlow{0%,100%{opacity:.4;transform:scale(1)}30%{opacity:.85;transform:scale(1.25)}60%{opacity:.5;transform:scale(1.1)}}',
+  '@keyframes titleCinematic{0%{opacity:0;transform:translateY(50px);filter:blur(10px);letter-spacing:12px}60%{letter-spacing:-1px}100%{opacity:1;transform:translateY(0);filter:blur(0);letter-spacing:-2px}}',
+  '@keyframes subtitleCinematic{0%{opacity:0;transform:translateY(35px);filter:blur(6px)}100%{opacity:1;transform:translateY(0);filter:blur(0)}}',
+  '@keyframes glow{0%,100%{box-shadow:0 0 20px rgba(139,92,246,.4)}50%{box-shadow:0 0 40px rgba(139,92,246,.8)}}',
+  '@keyframes floatUp{0%{opacity:0;transform:translateY(40px)}100%{opacity:1;transform:translateY(0)}}',
+  '@keyframes tagSlideIn{0%{opacity:0;transform:translateY(-25px) scale(.8);filter:blur(6px)}100%{opacity:1;transform:translateY(0) scale(1);filter:blur(0)}}',
+  ':-webkit-full-screen{width:100vw!important;height:100vh!important}',
+  ':fullscreen{width:100vw!important;height:100vh!important}'
+].join('\n');
+```
+
+### 2. 转场配置
+
+```jsx
+// 每张幻灯片的转场动画（key=幻灯片编号，value=动画名）
+var slideTransitions = {
+  1: 'cineZoom',      // 封面：缩放模糊入场
+  2: 'cineParallax',  // 内容页：横向视差
+  3: 'fadeIn',        // 普通淡入
+  // 章节页推荐：cineGlitch / cineIris / cineRise / cineGrand
+};
+
+// 章节页编号（会额外渲染网格动画和光晕）
+var chapterSlides = [1, 5, 10];
+
+// 章节页背景图（Unsplash 科技风图片，可替换）
+var chapterImages = {
+  1: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?q=80&w=1280&auto=format&fit=crop',
+  5: 'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?q=80&w=1280&auto=format&fit=crop',
+};
+```
+
+**转场动画说明：**
+
+| 动画名 | 效果 | 适用场景 |
+|--------|------|----------|
+| `cineZoom` | 缩放 + 模糊 + 亮度 | 封面、重要开场 |
+| `cineParallax` | 横向视差滑入 | 内容页 |
+| `cineRise` | 从下方升起 | 总结、结尾 |
+| `cineGlitch` | 故障艺术 + 色相旋转 | 技术页、震撼转场 |
+| `cineIris` | 圆形光圈展开 | 章节切换 |
+| `cineGrand` | 宏大缩放 | 高潮页、大数据 |
+| `fadeIn` | 普通淡入缩放 | 普通内容页 |
+
+### 3. 公共样式预设（S 对象）
+
+```jsx
+var S = {
+  // 大标题（封面用）
+  st: { fontSize: '72px', fontWeight: 900, color: '#fff', marginBottom: '36px', letterSpacing: '-2px', lineHeight: 1.15, textShadow: '0 0 40px rgba(59,130,246,.5)' },
+  // 章节标题
+  stSts: { fontSize: '52px', fontWeight: 900, color: '#fff', marginBottom: '28px', letterSpacing: '-1px', lineHeight: 1.2, textShadow: '0 0 30px rgba(59,130,246,.4)' },
+  // 副标题
+  ss: { fontSize: '28px', fontWeight: 300, color: '#9ca3af', marginBottom: '44px', letterSpacing: '2px' },
+  // 标签徽章（蓝色边框）
+  tg: { display: 'inline-block', background: 'rgba(59,130,246,.15)', border: '1px solid rgba(59,130,246,.3)', borderRadius: '20px', padding: '8px 24px', fontSize: '18px', color: '#60a5fa', marginBottom: '28px', letterSpacing: '2px', fontWeight: 500 },
+  // 渐变流动文字（彩虹标题）
+  gt: { background: 'linear-gradient(90deg,#3b82f6,#a855f7,#10b981,#3b82f6)', backgroundSize: '300% 300%', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', animation: 'df 6s ease infinite' },
+  // 玻璃态卡片（核心组件）
+  cd: { background: 'rgba(255,255,255,.04)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,.08)', borderRadius: '16px', padding: '32px', textAlign: 'left' },
+  // 卡片标题
+  ct: { fontSize: '28px', fontWeight: 700, color: '#fff', marginBottom: '10px' },
+  // 卡片正文
+  cx: { fontSize: '22px', color: '#9ca3af', lineHeight: 1.6 },
+  // 高亮色（蓝/绿/紫/橙/粉）
+  hl: { color: '#3b82f6', fontWeight: 700 },
+  hs: { color: '#10b981', fontWeight: 700 },
+  hp: { color: '#a855f7', fontWeight: 700 },
+  hw: { color: '#f59e0b', fontWeight: 700 },
+  hr: { color: '#ec4899', fontWeight: 700 },
+};
+```
+
+### 4. Canvas 粒子系统
+
+```jsx
+export function initParticles() {
+  var canvas = document.getElementById('ppt-particles');
+  if (!canvas) return;
+  var ctx = canvas.getContext('2d');
+  var particles = [];
+  var COUNT = 50;
+  var DIST = 130;
+  var colors = ['59,130,246', '147,51,234', '16,185,129'];
+
+  function resize() { canvas.width = window.innerWidth; canvas.height = window.innerHeight; }
+
+  function init() {
+    resize();
+    particles = [];
+    for (var i = 0; i < COUNT; i++) {
+      particles.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.4,
+        vy: (Math.random() - 0.5) * 0.4,
+        r: Math.random() * 1.5 + 0.5,
+        c: colors[Math.floor(Math.random() * colors.length)]
+      });
+    }
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (var i = 0; i < particles.length; i++) {
+      var p = particles[i];
+      p.x += p.vx; p.y += p.vy;
+      if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+      if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(' + p.c + ',.6)';
+      ctx.fill();
+    }
+    for (var i = 0; i < particles.length; i++) {
+      for (var j = i + 1; j < particles.length; j++) {
+        var dx = particles[i].x - particles[j].x;
+        var dy = particles[i].y - particles[j].y;
+        var d = Math.sqrt(dx * dx + dy * dy);
+        if (d < DIST) {
+          ctx.beginPath();
+          ctx.moveTo(particles[i].x, particles[i].y);
+          ctx.lineTo(particles[j].x, particles[j].y);
+          ctx.strokeStyle = 'rgba(59,130,246,' + (0.08 * (1 - d / DIST)).toFixed(3) + ')';
+          ctx.lineWidth = 0.5;
+          ctx.stroke();
+        }
+      }
+    }
+    _customState._animFrame = requestAnimationFrame(draw);
+  }
+
+  window.addEventListener('resize', function() { resize(); init(); });
+  document.addEventListener('fullscreenchange', function() { setTimeout(function() { resize(); init(); }, 50); });
+  document.addEventListener('webkitfullscreenchange', function() { setTimeout(function() { resize(); init(); }, 50); });
+  init();
+  draw();
+}
+```
+
+### 5. 背景层渲染
+
+```jsx
+export function renderBgLayers(isChapter) {
+  return (
+    <div>
+      <div style={{
+        position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none',
+        background: 'radial-gradient(ellipse at 20% 30%,rgba(59,130,246,.15) 0%,transparent 50%),' +
+                    'radial-gradient(ellipse at 80% 70%,rgba(139,92,246,.12) 0%,transparent 50%),' +
+                    'radial-gradient(ellipse at 50% 50%,rgba(11,15,25,.8) 0%,rgba(0,0,0,1) 100%)'
+      }} />
+      {isChapter && <div style={{
+        position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none',
+        backgroundImage: 'linear-gradient(rgba(59,130,246,.03) 1px,transparent 1px),linear-gradient(90deg,rgba(59,130,246,.03) 1px,transparent 1px)',
+        backgroundSize: '60px 60px', animation: 'gridMove 20s linear infinite'
+      }} />}
+      {isChapter && <div style={{
+        position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none',
+        background: 'radial-gradient(circle at 50% 50%,rgba(59,130,246,.08) 0%,transparent 70%)',
+        animation: 'chapterGlow 6s ease-in-out infinite'
+      }} />}
+    </div>
+  );
+}
+```
+
+### 6. 幻灯片包装器（转场 + 布局）
+
+```jsx
+export function renderSlideWrapper(slideNum, content) {
+  var cur = _customState.currentSlide;
+  if (cur !== slideNum) return null;
+  var isChapter = chapterSlides.indexOf(slideNum) >= 0;
+  var tr = slideTransitions[slideNum] || 'fadeIn';
+  var trStyle = { animation: tr + ' 1.2s cubic-bezier(.25,.46,.45,.94) both' };
+  var bgImg = chapterImages[slideNum];
+  return (
+    <div style={Object.assign({
+      width: '100vw', height: '100vh', position: 'absolute', top: 0, left: 0,
+      overflow: 'hidden', display: 'flex', flexDirection: 'column',
+      justifyContent: 'center', alignItems: 'center'
+    }, trStyle)}>
+      {this.renderBgLayers(isChapter)}
+      {bgImg && <div style={{
+        position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
+        backgroundImage: 'url(' + bgImg + ')', backgroundSize: 'cover', backgroundPosition: 'center',
+        opacity: isChapter ? 0.15 : 0.1, zIndex: 0
+      }} />}
+      <div style={{
+        position: 'relative', zIndex: 10, margin: 'auto', padding: '36px 56px',
+        display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center',
+        textAlign: 'center', width: '100%', height: '100%', boxSizing: 'border-box'
+      }}>
+        {content}
+      </div>
+    </div>
+  );
+}
+```
+
+### 7. 通用内容页（带标签 + 标题 + 副标题 + 正文）
+
+```jsx
+export function renderGenericSlide(num, partTag, title, subtitle, bodyJsx) {
+  return this.renderSlideWrapper(num,
+    <div style={{ width: '100%' }}>
+      {partTag && <div style={S.tg}>{partTag}</div>}
+      <div style={S.stSts}>{title}</div>
+      {subtitle && <div style={S.ss}>{subtitle}</div>}
+      <div style={{ width: '100%', animation: 'fu 1.2s ease-out .8s both' }}>{bodyJsx}</div>
+    </div>
+  );
+}
+```
+
+### 8. 状态管理
+
+```jsx
+var _customState = {
+  currentSlide: 1,
+  totalSlides: 10,  // 修改为实际幻灯片总数
+  isFullscreen: false,
+};
+
+export function getCustomState(key) {
+  if (key) return _customState[key];
+  return Object.assign({}, _customState);
+}
+
+export function setCustomState(newState) {
+  Object.keys(newState).forEach(function(key) { _customState[key] = newState[key]; });
+  this.forceUpdate();
+}
+
+export function forceUpdate() {
+  this.setState({ timestamp: new Date().getTime() });
+}
+```
+
+### 9. 生命周期（didMount / didUnmount）
+
+```jsx
+export function didMount() {
+  var self = this;
+  _customState.totalSlides = 10; // 修改为实际总数
+
+  // 隐藏宜搭顶部导航栏（全屏沉浸式）
+  var hideNavStyle = document.createElement('style');
+  hideNavStyle.textContent = [
+    '.china-area-header { display: none !important; }',
+    '.yida-china-area-header { display: none !important; }',
+    '.header-area { display: none !important; }',
+    '.aliwork-header { display: none !important; }',
+    '.next-shell-header { display: none !important; }',
+    '#china-area-header { display: none !important; }',
+    '.yida-header { display: none !important; }',
+    '.china-area-content { padding-top: 0 !important; }',
+    '.yida-china-area-content { padding-top: 0 !important; }',
+  ].join(' ');
+  document.head.appendChild(hideNavStyle);
+
+  // 键盘导航
+  self._handleKeyDown = function(e) {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === ' ' || e.key === 'PageDown') {
+      e.preventDefault(); self.changeSlide(1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') {
+      e.preventDefault(); self.changeSlide(-1);
+    } else if (e.key === 'Home') {
+      e.preventDefault(); self.goToSlide(1);
+    } else if (e.key === 'End') {
+      e.preventDefault(); self.goToSlide(_customState.totalSlides);
+    } else if (e.key === 'f' || e.key === 'F') {
+      e.preventDefault(); self.toggleFullscreen();
+    }
+  };
+  document.addEventListener('keydown', self._handleKeyDown);
+
+  // 全屏状态同步
+  self._handleFullscreenChange = function() {
+    _customState.isFullscreen = !!(document.fullscreenElement || document.webkitFullscreenElement);
+    self.forceUpdate();
+  };
+  document.addEventListener('fullscreenchange', self._handleFullscreenChange);
+  document.addEventListener('webkitfullscreenchange', self._handleFullscreenChange);
+
+  // 触摸滑动
+  self._touchStartX = 0;
+  self._handleTouchStart = function(e) { self._touchStartX = e.changedTouches[0].screenX; };
+  self._handleTouchEnd = function(e) {
+    var diff = self._touchStartX - e.changedTouches[0].screenX;
+    if (Math.abs(diff) > 50) { self.changeSlide(diff > 0 ? 1 : -1); }
+  };
+  document.addEventListener('touchstart', self._handleTouchStart);
+  document.addEventListener('touchend', self._handleTouchEnd);
+
+  // 初始化粒子（延迟确保 DOM 就绪）
+  setTimeout(function() { self.initParticles(); }, 500);
+}
+
+export function didUnmount() {
+  document.removeEventListener('keydown', this._handleKeyDown);
+  document.removeEventListener('touchstart', this._handleTouchStart);
+  document.removeEventListener('touchend', this._handleTouchEnd);
+  document.removeEventListener('fullscreenchange', this._handleFullscreenChange);
+  document.removeEventListener('webkitfullscreenchange', this._handleFullscreenChange);
+  if (_customState._animFrame) cancelAnimationFrame(_customState._animFrame);
+}
+```
+
+### 10. 导航函数
+
+```jsx
+export function goToSlide(n) {
+  if (n < 1 || n > _customState.totalSlides) return;
+  _customState.currentSlide = n;
+  this.forceUpdate();
+}
+
+export function changeSlide(dir) {
+  var next = _customState.currentSlide + dir;
+  if (next < 1) next = 1;
+  if (next > _customState.totalSlides) next = _customState.totalSlides;
+  this.goToSlide(next);
+}
+
+export function toggleFullscreen() {
+  if (!document.fullscreenElement && !document.webkitFullscreenElement) {
+    var el = document.documentElement;
+    if (el.requestFullscreen) { el.requestFullscreen(); }
+    else if (el.webkitRequestFullscreen) { el.webkitRequestFullscreen(); }
+  } else {
+    if (document.exitFullscreen) { document.exitFullscreen(); }
+    else if (document.webkitExitFullscreen) { document.webkitExitFullscreen(); }
+  }
+  var self = this;
+  setTimeout(function() { self.forceUpdate(); }, 100);
+}
+```
+
+### 11. 主渲染函数（renderJsx）
+
+```jsx
+export function renderJsx() {
+  var self = this;
+  var cur = _customState.currentSlide;
+  var total = _customState.totalSlides;
+  var isFull = _customState.isFullscreen;
+  return (
+    <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: '#0B0F19', overflow: 'hidden', margin: 0, padding: 0, borderRadius: 0 }}>
+      <div style={{ display: 'none' }}>{this.state.timestamp}</div>
+      <style dangerouslySetInnerHTML={{ __html: CSS_ANIMATIONS }} />
+      <canvas id="ppt-particles" style={{ position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh', zIndex: 1, pointerEvents: 'none', opacity: 0.35 }} />
+      <div style={{ position: 'relative', zIndex: 2, width: '100vw', height: '100vh' }}>
+        {this.renderSlide1()}
+        {this.renderSlide2()}
+        {/* 按需添加更多幻灯片 */}
+      </div>
+      {/* 全屏按钮（右上角） */}
+      <div style={{ position: 'fixed', top: '20px', right: '20px', zIndex: 102, opacity: 0.3, transition: 'opacity .3s ease', cursor: 'pointer', width: '40px', height: '40px', borderRadius: '10px', background: 'rgba(0,0,0,.5)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', border: '1px solid rgba(255,255,255,.1)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        onClick={function() { self.toggleFullscreen(); }}
+        onMouseEnter={function(e) { e.currentTarget.style.opacity = '1'; }}
+        onMouseLeave={function(e) { e.currentTarget.style.opacity = '0.3'; }}
+        title={isFull ? '退出全屏 (F)' : '全屏 (F)'}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="#fff"><path d={isFull ? 'M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z' : 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z'} /></svg>
+      </div>
+      {/* 底部导航栏 */}
+      <div style={{ position: 'fixed', bottom: '30px', left: '50%', transform: 'translateX(-50%)', zIndex: 100, display: 'flex', alignItems: 'center', gap: '15px', background: 'rgba(0,0,0,.7)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,.1)', borderRadius: '50px', padding: '10px 25px' }}>
+        <div style={{ width: '40px', height: '40px', borderRadius: '50%', border: '1px solid rgba(255,255,255,.2)', background: 'rgba(255,255,255,.05)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={function() { self.goToSlide(1); }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="#fff"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z" /></svg>
+        </div>
+        <div style={{ width: '40px', height: '40px', borderRadius: '50%', border: '1px solid rgba(255,255,255,.2)', background: 'rgba(255,255,255,.05)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={function() { self.changeSlide(-1); }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="#fff"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" /></svg>
+        </div>
+        <div style={{ width: '120px', height: '3px', background: 'rgba(255,255,255,.1)', borderRadius: '2px', overflow: 'hidden' }}>
+          <div style={{ height: '100%', background: 'linear-gradient(90deg,#3b82f6,#8b5cf6,#ec4899)', borderRadius: '2px', width: (cur / total * 100) + '%', transition: 'width .5s ease' }} />
+        </div>
+        <div style={{ color: '#9ca3af', fontSize: '18px', minWidth: '60px', textAlign: 'center' }}>{cur} / {total}</div>
+        <div style={{ width: '40px', height: '40px', borderRadius: '50%', border: '1px solid rgba(255,255,255,.2)', background: 'rgba(255,255,255,.05)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={function() { self.changeSlide(1); }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="#fff"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" /></svg>
+        </div>
+        <div style={{ width: '40px', height: '40px', borderRadius: '50%', border: '1px solid rgba(255,255,255,.2)', background: 'rgba(255,255,255,.05)', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={function() { self.goToSlide(total); }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="#fff"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" /></svg>
+        </div>
+      </div>
+      {/* 顶部全宽进度条 */}
+      <div style={{ position: 'absolute', top: 0, left: 0, width: (cur / total * 100) + '%', height: '3px', background: 'linear-gradient(90deg,#3b82f6,#8b5cf6,#ec4899)', transition: 'width 0.3s ease', boxShadow: '0 0 10px rgba(139,92,246,.5), 0 0 20px rgba(139,92,246,.3)', zIndex: 101 }} />
+    </div>
+  );
+}
+```
+
+---
+
+## 常用 UI 组件片段
+
+### 玻璃态卡片
+
+```jsx
+// 基础玻璃态卡片
+<div style={{ background: 'rgba(255,255,255,.04)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,.08)', borderRadius: '16px', padding: '32px' }}>
+  {/* 内容 */}
+</div>
+
+// 高亮玻璃态卡片（带顶部渐变边 + 光晕）
+<div style={{ background: 'rgba(139,92,246,.08)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', border: '1px solid rgba(139,92,246,.3)', borderRadius: '16px', padding: '32px', position: 'relative', overflow: 'hidden' }}>
+  <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '3px', background: 'linear-gradient(90deg, #a855f7, #ec4899, #3b82f6)', borderRadius: '16px 16px 0 0' }} />
+  <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '40px', background: 'linear-gradient(180deg, rgba(168,85,247,.1), transparent)', pointerEvents: 'none' }} />
+  {/* 内容 */}
+</div>
+```
+
+### 渐变分隔线
+
+```jsx
+<div style={{ height: '1px', background: 'linear-gradient(90deg, transparent, rgba(139,92,246,.3), rgba(59,130,246,.3), transparent)', margin: '20px 0' }} />
+```
+
+### 光晕分割线（标题下方）
+
+```jsx
+<div style={{ width: '80px', height: '3px', background: 'linear-gradient(90deg,#3b82f6,#a855f7,#ec4899)', borderRadius: '2px', margin: '0 auto 40px', boxShadow: '0 0 20px rgba(139,92,246,.4)', animation: 'glow 3s ease-in-out infinite' }} />
+```
+
+### 标签徽章
+
+```jsx
+// 蓝色标签
+<div style={{ display: 'inline-block', background: 'rgba(59,130,246,.15)', border: '1px solid rgba(59,130,246,.3)', borderRadius: '20px', padding: '8px 24px', fontSize: '18px', color: '#60a5fa', letterSpacing: '2px', fontWeight: 500 }}>PART 01</div>
+
+// 绿色标签
+<div style={{ display: 'inline-block', background: 'rgba(16,185,129,.15)', border: '1px solid rgba(16,185,129,.3)', borderRadius: '20px', padding: '6px 18px', fontSize: '16px', color: '#34d399' }}>已完成</div>
+```
+
+### 渐变流动文字（彩虹标题）
+
+```jsx
+<span style={{ background: 'linear-gradient(90deg,#3b82f6,#a855f7,#10b981,#3b82f6)', backgroundSize: '300% 300%', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', animation: 'df 6s ease infinite' }}>
+  标题文字
+</span>
+```
+
+### 玻璃态图标按钮
+
+```jsx
+<a href="https://example.com" target="_blank" style={{ color: '#9ca3af', fontSize: '18px', textDecoration: 'none', background: 'rgba(255,255,255,.06)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', border: '1px solid rgba(255,255,255,.1)', borderRadius: '24px', padding: '8px 20px', display: 'flex', alignItems: 'center', gap: '5px' }}>
+  链接文字
+</a>
+```
+
+### 金句高亮条（左边框）
+
+```jsx
+<div style={{ background: 'rgba(139,92,246,.08)', border: '1px solid rgba(139,92,246,.25)', borderLeft: '3px solid #a855f7', borderRadius: '0 10px 10px 0', padding: '12px 20px' }}>
+  <div style={{ fontSize: '16px', color: '#e2e8f0', lineHeight: 1.6 }}>金句内容</div>
+</div>
+```
+
+### 数据指标卡
+
+```jsx
+<div style={{ textAlign: 'center', padding: '20px' }}>
+  <div style={{ fontSize: '56px', fontWeight: 900, color: '#3b82f6', lineHeight: 1, marginBottom: '8px' }}>4000万+</div>
+  <div style={{ fontSize: '18px', color: '#9ca3af' }}>指标说明</div>
+</div>
+```
+
+### 三列网格卡片
+
+```jsx
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: '16px', width: '100%' }}>
+  {items.map(function(item, i) {
+    return (
+      <div key={i} style={{ background: 'rgba(255,255,255,.04)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', border: '1px solid rgba(255,255,255,.08)', borderRadius: '14px', padding: '24px 20px' }}>
+        <div style={{ fontSize: '22px', fontWeight: 700, color: '#fff', marginBottom: '10px' }}>{item.title}</div>
+        <div style={{ fontSize: '16px', color: '#9ca3af', lineHeight: 1.6 }}>{item.desc}</div>
+      </div>
+    );
+  })}
+</div>
+```
+
+### 时间轴
+
+```jsx
+<div style={{ display: 'flex', flexDirection: 'column', gap: '16px', textAlign: 'left' }}>
+  {timeline.map(function(t, i) {
+    return (
+      <div key={i} style={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
+        <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: '#3b82f6', marginTop: '6px', flexShrink: 0, boxShadow: '0 0 10px rgba(59,130,246,.5)' }} />
+        <div>
+          <div style={{ fontSize: '14px', color: '#6b7280', marginBottom: '4px' }}>{t.period}</div>
+          <div style={{ fontSize: '20px', fontWeight: 700, color: '#fff' }}>{t.title}</div>
+        </div>
+      </div>
+    );
+  })}
+</div>
+```
+
+---
+
+## 封面页模板（renderSlide1）
+
+```jsx
+export function renderSlide1() {
+  return this.renderSlideWrapper(1,
+    <div>
+      <div style={{ fontSize: '18px', color: '#60a5fa', letterSpacing: '8px', marginBottom: '36px', fontWeight: 500 }}>YOUR BRAND · SUBTITLE</div>
+      <div style={{ fontSize: '72px', fontWeight: 900, color: '#fff', marginBottom: '28px', letterSpacing: '-2px', lineHeight: 1.15, textShadow: '0 0 40px rgba(59,130,246,.5)', animation: 'titleCinematic 1.1s cubic-bezier(.25,.46,.45,.94) .35s both' }}>
+        <span style={S.gt}>主标题</span>
+      </div>
+      <div style={{ fontSize: '36px', fontWeight: 300, color: '#e5e7eb', marginBottom: '16px', animation: 'subtitleCinematic 1s cubic-bezier(.25,.46,.45,.94) .55s both' }}>副标题</div>
+      <div style={{ fontSize: '24px', fontWeight: 300, color: '#9ca3af', marginBottom: '48px', letterSpacing: '2px', animation: 'subtitleCinematic 1s cubic-bezier(.25,.46,.45,.94) .65s both' }}>描述文字</div>
+      <div style={{ width: '80px', height: '3px', background: 'linear-gradient(90deg,#3b82f6,#a855f7,#ec4899)', borderRadius: '2px', margin: '0 auto 40px', boxShadow: '0 0 20px rgba(139,92,246,.4)', animation: 'glow 3s ease-in-out infinite' }} />
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', animation: 'fu 1.2s ease-out 1s both' }}>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ color: '#fff', fontSize: '26px', fontWeight: 700 }}>讲师姓名</div>
+          <div style={{ color: '#6b7280', fontSize: '20px', marginTop: '12px' }}>职位 / 单位</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## 动画入场时序规范
+
+内容元素按层级依次入场，使用 `animation: 'fu 1.2s ease-out Xs both'` 控制延迟：
+
+| 元素 | 延迟 | 说明 |
+|------|------|------|
+| 标签徽章 | `0s` | 最先出现 |
+| 主标题 | `0.2s` | 使用 `titleCinematic` |
+| 副标题 | `0.4s` | 使用 `subtitleCinematic` |
+| 分割线 | `0.5s` | 使用 `fu` |
+| 第一行卡片 | `0.6s` | 使用 `fu` |
+| 第二行卡片 | `0.8s` | 使用 `fu` |
+| 底部金句 | `1.0s` | 使用 `fu` |
+
+---
+
+## 注意事项
+
+1. **🚨 禁止 import/require**：文件顶部不能有任何 `import` 或 `require` 语句（包括 `import { Component } from 'react'`），宜搭沙箱不支持，会导致 `require is not defined` 报错页面崩溃
+2. **Canvas ID 唯一性**：`id="ppt-particles"` 在整个页面中必须唯一
+3. **宜搭 JSX 限制**：使用 React 16 语法，不支持 hooks，状态通过 `_customState` 对象管理
+4. **事件绑定用箭头函数**：JSX 中事件绑定必须用箭头函数 `onClick={() => { self.xxx(); }}`，不能用 `onClick={function() { self.xxx(); }}`
+5. **禁止 ES6 计算属性名**：`{ [key]: value }` 宜搭 JS 引擎不支持，改用 `var obj = {}; obj[key] = value;`
+6. **样式写法**：所有样式用 React 内联对象，`camelCase` 属性名（如 `backgroundColor`、`backdropFilter`）
+7. **`WebkitBackdropFilter`**：Safari 兼容，必须与 `backdropFilter` 同时写
+8. **`dangerouslySetInnerHTML`**：CSS 动画通过 `<style dangerouslySetInnerHTML={{ __html: CSS_ANIMATIONS }} />` 注入
+9. **全屏适配**：`position: 'fixed'` + `top/left/right/bottom: 0` 确保全屏覆盖
+10. **粒子初始化延迟**：`setTimeout(initParticles, 500)` 确保 Canvas DOM 已挂载
+11. **编译发布**：源码编写完成后用 `openyida publish` 命令编译并发布到宜搭
+
+---
+
+## 参考案例
+
+- **完整实现**：`project/pages/src/wukong-openyida-training-v2.js`（25页企业培训PPT，706KB）
+  - 包含：Canvas粒子、6种电影级转场、玻璃态卡片、讲师备注面板、全屏支持、键盘/触摸导航
+  - 设计体系：深色科技风，主色 #3b82f6 / #a855f7 / #10b981


### PR DESCRIPTION
## 本次变更

### 🎨 新增 yida-ppt 技能文档
- 路径：`yida-skills/skills/yida-ppt/SKILL.md`
- 设计体系：深色科技风 + Canvas粒子 + 电影级转场 + 玻璃态卡片
- 学习来源：`wukong-openyida-training-v2.js` 实战案例

### 📋 技能文档包含
- 完整 CSS 动画库（7种电影级转场：cineZoom / cineParallax / cineRise / cineGlitch / cineIris / cineGrand / fadeIn）
- Canvas 粒子系统（50粒子 + 连线 + 蓝紫绿三色）
- 玻璃态卡片（backdropFilter blur(20px)）
- 完整导航系统（键盘 / 触摸 / 全屏 / 进度条）
- 常用 UI 组件片段（卡片 / 分隔线 / 徽章 / 金句条 / 数据指标 / 时间轴）

### ⚡ 方案选择引导
用户触发 PPT 关键词时，AI 必须先展示两种方案供选择：
- **方案 A**：宜搭 PPT（本技能，部署到宜搭平台，深色科技风）
- **方案 B**：独立 HTML（report-slides 技能，浏览器直接打开，11种风格）

### 🐛 踩坑记录（已补充到技能文档）
- 🚨 禁止 `import`/`require`，宜搭沙箱不支持，会导致 `require is not defined` 崩溃
- 事件绑定必须用箭头函数 `() => {}`，不能用 `function() {}`
- 禁止 ES6 计算属性名 `{ [key]: value }`

### 🗂️ 更新主技能列表
- 在 `yida-skills/SKILL.md` 注册 `yida-ppt` 技能条目