### PR TITLE
[codex] Fix triggerLogin re-login flow

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -273,8 +273,8 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  */
 function triggerLogin() {
   warn(t('login.trigger_login'));
-  const { ensureLogin } = require('../auth/login');
-  return ensureLogin();
+  const { interactiveLogin } = require('../auth/login');
+  return interactiveLogin();
 }
 
 /**

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -12,6 +12,7 @@ const {
   isCsrfTokenExpired,
   loadCookieData,
   detectActiveTool,
+  triggerLogin,
 } = require('../lib/core/utils');
 
 // ── extractInfoFromCookies ────────────────────────────────────────────
@@ -199,6 +200,31 @@ describe('loadCookieData', () => {
     fs.writeFileSync(cookieFile, 'not-json', 'utf-8');
     const result = loadCookieData(tmpDir);
     expect(result).toBeNull();
+  });
+});
+
+// ── triggerLogin ─────────────────────────────────────────────────────
+
+describe('triggerLogin', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('强制调用 interactiveLogin，而不是复用 ensureLogin 缓存逻辑', () => {
+    const loginModule = require('../lib/auth/login');
+    const interactiveResult = { csrf_token: 'fresh-token' };
+    const interactiveSpy = jest.spyOn(loginModule, 'interactiveLogin').mockReturnValue(interactiveResult);
+    const ensureSpy = jest.spyOn(loginModule, 'ensureLogin').mockImplementation(() => {
+      throw new Error('ensureLogin should not be called');
+    });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = triggerLogin();
+
+    expect(result).toBe(interactiveResult);
+    expect(interactiveSpy).toHaveBeenCalledTimes(1);
+    expect(ensureSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

This PR fixes the re-login path used after the server reports an expired login session.

## What Changed

- updated `lib/core/utils.js` so `triggerLogin()` calls `interactiveLogin()` directly
- added a regression test in `tests/utils.test.js` to ensure the re-login path does not fall back to `ensureLogin()`

## Root Cause

When `requestWithAutoLogin()` detected an expired session, it called `triggerLogin()`. That function delegated to `ensureLogin()`, which prefers cached cookies when `tianshu_csrf_token` is present. In the expired-cookie case, this caused the retry path to silently reuse stale credentials instead of forcing a fresh browser login.

## Impact

Commands that rely on automatic re-login now correctly force an interactive login instead of reusing expired cookies. This makes failures after `302` / `307` responses recoverable and easier to understand for users.

Closes #319.

## Validation

- `npx jest tests/utils.test.js tests/login.test.js --runInBand`
