### PR TITLE
fix: hoist warn import to file scope

### DIFF
--- a/lib/core/copy.js
+++ b/lib/core/copy.js
@@ -28,6 +28,7 @@ const path = require('path');
 const os = require('os');
 const { detectEnvironment } = require('./env');
 const { t } = require('./i18n');
+const { warn } = require('./chalk');
 
 /**
  * 查找 npm 全局安装包根目录。


### PR DESCRIPTION
## Bug 分析

`openyida copy` 执行时报错：`warn is not defined`

### 根因

`warn()` 仅在 `run()` 函数内部导入（第 224 行），但 `removeSkillsLink()` 和 `createSymlink()` 在定义时就需要在 catch 块中调用它。这两个函数在 `run()` 被调用前就已定义，导致 `warn` 为 `undefined`。

### 修复

文件顶层添加：
```js
const { warn } = require('./chalk');
```

### 测试

```
node --check lib/core/copy.js  # 语法检查通过
```
