### PR TITLE
fix: correct Claude Code detection

### DIFF
--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -29,7 +29,7 @@ function getInstalledTools() {
       dirName: process.platform === 'win32' ? path.join('.config', 'opencode') : '.opencode',
       displayName: 'OpenCode',
     },
-    { dirName: '.claudecode', displayName: 'Claude Code' },
+    { dirName: '.claude', displayName: 'Claude Code' },
     { dirName: '.aone_copilot', displayName: 'Aone Copilot' },
     { dirName: '.cursor', displayName: 'Cursor' },
     { dirName: '.qoder', displayName: 'Qoder' },

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -48,11 +48,11 @@ function detectActiveTool() {
   }
 
   // Claude Code
-  if (env.CLAUDE_CODE) {
+  if (env.CLAUDE_CODE_ENTRYPOINT || env.CLAUDE_CODE) {
     return {
       tool: 'claude-code',
       displayName: 'Claude Code',
-      dirName: '.claudecode',
+      dirName: '.claude',
       workspaceRoot: path.join(cwd, 'project'),
     };
   }


### PR DESCRIPTION
- Change directory name from .claudecode to .claude
- Add CLAUDE_CODE_ENTRYPOINT environment variable check
- Fix both installation detection (env.js) and active tool detection (utils.js)

Fixes the issue where Claude Code was not properly detected when running openyida commands.

## 改动说明

<!-- 简要描述本 PR 做了什么、为什么这样做 -->

## 改动类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级
- [ ] 🌐 国际化（i18n）
- [ ] 🎨 UI / 终端输出优化

## 关联 Issue

<!-- 如有关联 Issue，请填写：Closes #123 -->

## 测试

- [ ] 本地运行 `npm test` 通过
- [ ] JS 语法检查通过：`node --check bin/yida.js && find lib -name "*.js" | xargs -I{} node --check {}`
- [ ] 已在真实宜搭环境测试过相关功能（如适用）
- [ ] 新增 CLI 命令已在 `bin/yida.js` 注册，并更新了 `README.md` 命令一览表
- [ ] 新增 i18n key 已同步到所有语言包（`lib/core/locales/`）
- [ ] 私有化部署场景已验证（如适用）

## 截图 / 录屏

<!-- 如有 UI 或行为变化，请附上截图或录屏 -->
