### PR TITLE
feat(auth): 统一内置浏览器登录为 --browser，支持 Qoder/Codex 自动 handoff

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -9,7 +9,7 @@
  *   openyida env                                        检测当前 AI 工具环境和登录态
  *   openyida copy [--force]                             复制 project 工作目录到当前 AI 工具环境
  *   openyida sample [--list]                             输出代码示例/模板
- *   openyida login [--qr|--codex] [--corp-id <corpId>]  登录态管理（--qr 使用终端二维码，--codex 使用 Codex 内置浏览器）
+ *   openyida login [--qr|--browser] [--corp-id <corpId>]  登录态管理（--qr 使用终端二维码，--browser 使用内置浏览器）
  *   openyida logout                                     退出登录
  *   openyida auth status                                查看当前登录状态
  *   openyida auth login                                 执行登录
@@ -110,7 +110,7 @@ function printHelp() {
 
   // ── 环境 & 认证 ──
   renderGroup(t('help.group_auth'), [
-    ['login [--qr|--codex] [--corp-id <corpId>]', t('help.cmd_login')],
+    ['login [--qr|--browser] [--corp-id <corpId>]', t('help.cmd_login')],
     ['logout',                                 t('help.cmd_logout')],
     ['auth <status|login|refresh|logout>',     t('help.cmd_auth')],
     ['org <list|switch>',                      t('help.cmd_org')],
@@ -300,16 +300,16 @@ function printLoginResult(result) {
   console.log(JSON.stringify(summary));
 }
 
-function isCodexEnvironment() {
+function isBrowserHandoffEnvironment() {
   const { detectActiveTool } = require('../lib/core/utils');
   const activeTool = detectActiveTool();
-  return !!activeTool && activeTool.tool === 'codex';
+  return !!activeTool && (activeTool.tool === 'codex' || activeTool.tool === 'qoder');
 }
 
-function shouldUseCodexLogin(cliArgs) {
+function shouldUseBrowserHandoffLogin(cliArgs) {
   if (cliArgs.includes('--qr')) {return false;}
-  if (cliArgs.includes('--codex')) {return true;}
-  return isCodexEnvironment();
+  if (cliArgs.includes('--browser') || cliArgs.includes('--codex') || cliArgs.includes('--qoder')) {return true;}
+  return isBrowserHandoffEnvironment();
 }
 
 function getArgValue(cliArgs, name) {
@@ -356,7 +356,7 @@ async function main() {
       if (args[0] === '--check-only') {
         const result = checkLoginOnly({ includeSecrets: args.includes('--with-cookies') });
         console.log(JSON.stringify(result, null, 2));
-      } else if (args.includes('--codex')) {
+      } else if (args.includes('--browser') || args.includes('--codex') || args.includes('--qoder')) {
         const { codexLogin } = require('../lib/auth/codex-login');
         const result = await codexLogin();
         printLoginResult(result);
@@ -364,7 +364,7 @@ async function main() {
         const { qrLogin } = require('../lib/auth/qr-login');
         const result = await qrLogin({ corpId: getArgValue(args, '--corp-id') });
         console.log(JSON.stringify(result));
-      } else if (shouldUseCodexLogin(args)) {
+      } else if (shouldUseBrowserHandoffLogin(args)) {
         const cachedResult = checkLoginOnly({ includeSecrets: true });
         if (cachedResult.status === 'ok') {
           printLoginResult(cachedResult);
@@ -393,7 +393,7 @@ async function main() {
       if (subCommand === 'status') {
         authStatus();
       } else if (subCommand === 'login') {
-        const loginType = shouldUseCodexLogin(args) ? 'codex' : 'qrcode';
+        const loginType = shouldUseBrowserHandoffLogin(args) ? 'browser' : 'qrcode';
         await authLogin({ type: loginType });
       } else if (subCommand === 'refresh') {
         authRefresh();

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -130,7 +130,7 @@ function authStatus() {
 /**
  * 执行登录
  * @param {object} options - 登录选项
- * @param {string} options.type - 登录类型：'qrcode' | 'dingtalk' | 'codex'
+ * @param {string} options.type - 登录类型：'qrcode' | 'dingtalk' | 'browser' | 'codex' | 'qoder'
  * @returns {Promise<object>|object} 登录结果
  */
 async function authLogin(options = {}) {
@@ -141,7 +141,7 @@ async function authLogin(options = {}) {
 
   // 调用现有的登录逻辑
   let result;
-  if (type === 'codex') {
+  if (type === 'browser' || type === 'codex' || type === 'qoder') {
     const cachedResult = checkLoginOnly({ includeSecrets: true });
     result = cachedResult.status === 'ok'
       ? cachedResult

--- a/lib/auth/codex-login.js
+++ b/lib/auth/codex-login.js
@@ -1,8 +1,8 @@
 /**
- * codex-login.js - Codex 登录模式
+ * codex-login.js - 内置浏览器登录模式（Codex / Qoder）
  *
- * Codex 自带 in-app browser。CLI 进程不能直接调用 Codex 的浏览器工具，
- * 因此这里返回一个明确的浏览器登录 handoff，由 Codex agent 打开 URL 让用户扫码。
+ * Codex 和 Qoder 自带 in-app browser。CLI 进程不能直接调用其内置浏览器工具，
+ * 因此这里返回一个明确的浏览器登录 handoff，由 Agent 打开 URL 让用户扫码。
  */
 
 'use strict';
@@ -11,8 +11,12 @@ const { detectActiveTool } = require('../core/utils');
 const { resolveLoginUrl } = require('../core/env-manager');
 const { t } = require('../core/i18n');
 
+/** 支持内置浏览器 handoff 的工具列表 */
+const BROWSER_HANDOFF_TOOLS = ['codex', 'qoder'];
+
 /**
- * Codex 专用登录入口：不依赖 Playwright，也不走终端二维码接口。
+ * 内置浏览器登录入口：不依赖 Playwright，也不走终端二维码接口。
+ * 支持 Codex 和 Qoder 环境。
  * @param {object} [options]
  * @returns {Promise<object>} loginResult
  */
@@ -22,7 +26,8 @@ async function codexLogin(options = {}) {
 
   banner(t('codex_login.title'));
 
-  if (!activeTool || activeTool.tool !== 'codex') {
+  const toolName = activeTool ? activeTool.tool : null;
+  if (!toolName || !BROWSER_HANDOFF_TOOLS.includes(toolName)) {
     warn(t('codex_login.not_codex'));
   }
 
@@ -33,11 +38,13 @@ async function codexLogin(options = {}) {
   label('URL', loginUrl);
   hint(t('codex_login.browser_handoff_hint'));
 
+  const browserName = toolName && BROWSER_HANDOFF_TOOLS.includes(toolName) ? toolName : 'codex';
+
   return {
     status: 'need_codex_browser_login',
     can_auto_use: false,
     login_url: loginUrl,
-    browser: 'codex',
+    browser: browserName,
     message: t('codex_login.handoff_message'),
   };
 }

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -26,6 +26,9 @@ function cliEnv() {
     USERPROFILE: tempHome,
     OPENYIDA_LANG: 'zh',
     CI: '1',
+    // 清除可能从父进程继承的 AI 工具环境变量，避免干扰测试
+    QODER_IDE: '',
+    QODER_AGENT: '',
   };
 }
 
@@ -76,7 +79,7 @@ describe('CLI offline smoke', () => {
   test('--help renders top-level command groups', () => {
     const output = runOk(['--help']);
     expect(output).toContain('OpenYida');
-    expect(output).toContain('login [--qr|--codex] [--corp-id <corpId>]');
+    expect(output).toContain('login [--qr|--browser] [--corp-id <corpId>]');
     expect(output).toContain('create-form');
     expect(output).toContain('connector');
     expect(output).toContain('dws');

--- a/tests/codex-login.test.js
+++ b/tests/codex-login.test.js
@@ -68,4 +68,22 @@ describe('codexLogin', () => {
     expect(chalk.warn).toHaveBeenCalledTimes(1);
     expect(result.status).toBe('need_codex_browser_login');
   });
+
+  test('Qoder 环境下返回内置浏览器登录 handoff，browser 为 qoder', async () => {
+    delete process.env.CODEX_SHELL;
+    delete process.env.CODEX_CI;
+    delete process.env.CODEX_THREAD_ID;
+    delete process.env.CODEX_HOME;
+    process.env.QODER_IDE = '1';
+
+    const result = await codexLogin();
+
+    expect(result).toMatchObject({
+      status: 'need_codex_browser_login',
+      browser: 'qoder',
+      login_url: 'https://www.aliwork.com/workPlatform',
+      can_auto_use: false,
+    });
+    expect(chalk.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 背景

Codex 和 Qoder 都自带内置浏览器，登录时应走相同的 browser handoff 机制。之前只支持 Codex，且 CLI 参数使用了工具特化的 `--codex` 命名。

## 改动

- **统一 CLI 参数**: 新增 `--browser` 通用参数，替代工具特化的 `--codex`
- **Qoder 自动检测**: 检测到 `QODER_IDE`/`QODER_AGENT` 环境变量时，自动使用内置浏览器 handoff
- **动态 browser 字段**: `codex-login.js` 根据实际环境返回 `browser: 'codex'` 或 `browser: 'qoder'`
- **向后兼容**: 保留 `--codex`/`--qoder` 作为别名

## 用法

```bash
# 通用方式（推荐）
openyida login --browser

# 向后兼容
openyida login --codex
openyida login --qoder

# Qoder/Codex 环境下无需参数，自动检测
openyida login
```

## 测试

- [x] `tests/codex-login.test.js` - 新增 Qoder handoff 测试
- [x] `tests/cli-smoke.test.js` - 所有 8 个用例通过