### PR TITLE
[codex] Add Codex plugin auto-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm install -g openyida
 
 OpenYida requires Node.js 18 or later. The package exposes both `openyida` and `yida` commands.
 
+If Codex is already installed, OpenYida also imports a local Codex plugin during postinstall. Restart Codex after installation, then type `@宜搭` or `@openyida` in the composer to attach the OpenYida context.
+
 ### 2. Check Your Environment
 
 Run this from the AI coding workspace where you want OpenYida to operate:
@@ -285,6 +287,8 @@ The `yida-skills/` directory contains agent-facing instructions and references f
 | `yida-skills/references/` | Shared Yida API, model API, and query-condition references |
 
 When OpenYida is used inside a supported AI coding environment, these skills help the agent choose the right command sequence and file conventions.
+
+For Codex, `npm install -g openyida` additionally creates a local plugin marketplace under `~/.openyida/codex-plugin` and enables `openyida@openyida` in `~/.codex/config.toml` when Codex is detected. This makes OpenYida show up in Codex's `@` plugin menu as **宜搭** after Codex reloads.
 
 ## Examples
 

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -206,6 +206,7 @@ function printLoginResult(result) {
   if (result && result.status === 'need_codex_browser_login') {
     console.log(JSON.stringify({
       status: result.status,
+      handoff_type: result.handoff_type || 'browser',
       can_auto_use: false,
       browser: result.browser,
       login_url: result.login_url,

--- a/lib/app/app-list.js
+++ b/lib/app/app-list.js
@@ -45,12 +45,12 @@ function fetchAppListPage(auth, pageIndex, pageSize) {
 async function fetchAllApps(auth, pageSize) {
   const firstResult = await fetchAppListPage(auth, 1, pageSize);
 
-  if (firstResult.__needLogin) {
-    throw new Error('登录态已失效，请重新登录');
+  // 如果首次请求就提示需要登录或 CSRF 过期，直接返回原始结果
+  // 让外层 requestWithAutoLogin 处理自动重试
+  if (firstResult.__needLogin || firstResult.__csrfExpired) {
+    return firstResult;
   }
-  if (firstResult.__csrfExpired) {
-    throw new Error('CSRF Token 已过期，请重新登录');
-  }
+
   if (!firstResult.success) {
     throw new Error(firstResult.errorMsg || '查询应用列表失败');
   }
@@ -67,6 +67,10 @@ async function fetchAllApps(auth, pageSize) {
 
   const remainingResults = await Promise.all(remainingFetches);
   for (const result of remainingResults) {
+    // 如果后续翻页也出现登录态问题，同样返回标记对象
+    if (result.__needLogin || result.__csrfExpired) {
+      return result;
+    }
     if (result.success && result.content && result.content.data) {
       allApps.push(...result.content.data);
     }
@@ -116,6 +120,12 @@ async function run(args) {
     );
   } catch (err) {
     console.error(`查询应用列表失败：${err.message}`);
+    process.exit(1);
+  }
+
+  // 如果重试后仍然返回登录失效标记，说明登录态确实不可用
+  if (apps && (apps.__needLogin || apps.__csrfExpired)) {
+    console.error('登录态已失效，请重新登录');
     process.exit(1);
   }
 

--- a/lib/auth/codex-login.js
+++ b/lib/auth/codex-login.js
@@ -42,6 +42,7 @@ async function codexLogin(options = {}) {
 
   return {
     status: 'need_codex_browser_login',
+    handoff_type: 'browser',
     can_auto_use: false,
     login_url: loginUrl,
     browser: browserName,

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
-const { findProjectRoot, extractInfoFromCookies, loadCookieData, resolveBaseUrl } = require('../core/utils');
+const { findProjectRoot, extractInfoFromCookies, loadCookieData, resolveBaseUrl, detectActiveTool } = require('../core/utils');
 const { t } = require('../core/i18n');
 
 const DEFAULT_BASE_URL = 'https://www.aliwork.com';
@@ -63,27 +63,68 @@ function saveCookieCache(cookies, baseUrl) {
  */
 function checkLoginOnly(options = {}) {
   const includeSecrets = !!options.includeSecrets;
-  const cookieData = loadCookieData();
+  const projectRoot = findProjectRoot();
+  const { getCurrentEnvConfig, getCookieFilePath } = require('../core/env-manager');
+  const activeTool = detectActiveTool();
+  const currentEnv = getCurrentEnvConfig(projectRoot);
+  const cookieFile = getCookieFilePath(projectRoot);
+  const legacyCookieFile = path.join(projectRoot, '.cache', 'cookies.json');
+  const cookieData = loadCookieData(projectRoot);
+  const cookies = cookieData && Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
+  const baseDiagnostics = {
+    activeTool: activeTool ? activeTool.tool : null,
+    isWukong: !!(activeTool && activeTool.tool === 'wukong'),
+    projectRoot,
+    projectRootExists: fs.existsSync(projectRoot),
+    hasConfig: fs.existsSync(path.join(projectRoot, 'config.json')),
+    currentEnv: currentEnv.name,
+    cookieFile,
+    legacyCookieFile,
+    cookieFileFound: fs.existsSync(cookieFile) || fs.existsSync(legacyCookieFile),
+    usedLegacyCookieFile: !fs.existsSync(cookieFile) && fs.existsSync(legacyCookieFile),
+  };
 
   if (!cookieData || !cookieData.cookies) {
     return {
       status: 'not_logged_in',
       can_auto_use: false,
+      diagnostics: {
+        ...baseDiagnostics,
+        cache_readable: false,
+        cookies_array_found: false,
+        csrf_token_found: false,
+        corp_id_found: false,
+        user_id_found: false,
+        base_url_found: false,
+        failure_reason: baseDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing',
+      },
       message: 'No local Cookie cache, QR scan login required',
     };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
+  const baseUrl = resolveBaseUrl(cookieData);
+  const diagnostics = {
+    ...baseDiagnostics,
+    cache_readable: true,
+    cookies_array_found: Array.isArray(cookieData.cookies),
+    csrf_token_found: !!csrfToken,
+    corp_id_found: !!corpId,
+    user_id_found: !!userId,
+    base_url_found: !!baseUrl,
+    cookies_count: cookies.length,
+    failure_reason: csrfToken ? null : 'csrf_token_missing',
+  };
 
   if (!csrfToken) {
     return {
       status: 'not_logged_in',
       can_auto_use: false,
+      diagnostics,
       message: 'No tianshu_csrf_token in Cookie, re-login required',
     };
   }
 
-  const baseUrl = resolveBaseUrl(cookieData);
   const result = {
     status: 'ok',
     can_auto_use: true,
@@ -91,11 +132,12 @@ function checkLoginOnly(options = {}) {
     corp_id: corpId,
     user_id: userId,
     base_url: baseUrl,
-    cookies_count: cookieData.cookies.length,
+    cookies_count: cookies.length,
+    diagnostics,
     message: `✅ Valid login credentials found\n  Org: ${corpId}\n  User: ${userId}\n  Domain: ${baseUrl}`,
   };
   if (includeSecrets) {
-    result.cookies = cookieData.cookies;
+    result.cookies = cookies;
   }
   return result;
 }

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -82,19 +82,78 @@ function detectEnvironment() {
 
   return { activeToolName, activeProjectRoot, results };
 }
+function getCookieDiagnostics(projectRoot) {
+  const { getCurrentEnvConfig, getCookieFilePath } = require('./env-manager');
+  const currentEnv = getCurrentEnvConfig(projectRoot);
+  const envCookieFile = getCookieFilePath(projectRoot);
+  const legacyCookieFile = path.join(projectRoot, '.cache', 'cookies.json');
+  const envCookieFileFound = fs.existsSync(envCookieFile);
+  const legacyCookieFileFound = fs.existsSync(legacyCookieFile);
+  const selectedCookieFile = envCookieFileFound ? envCookieFile : legacyCookieFile;
+
+  return {
+    currentEnv: currentEnv.name,
+    configuredCookieFile: envCookieFile,
+    legacyCookieFile,
+    cookieFile: selectedCookieFile,
+    cookieFileFound: envCookieFileFound || legacyCookieFileFound,
+    usedLegacyCookieFile: !envCookieFileFound && legacyCookieFileFound,
+  };
+}
+
 /**
  * 检测登录态信息。
  */
 function detectLoginStatus(projectRoot) {
+  const cookieDiagnostics = getCookieDiagnostics(projectRoot);
   const cookieData = loadCookieData(projectRoot);
+  const cookies = cookieData && Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
+
   if (!cookieData || !cookieData.cookies) {
-    return { loggedIn: false, csrfToken: null, corpId: null, userId: null, baseUrl: null };
+    return {
+      loggedIn: false,
+      canAutoUse: false,
+      csrfToken: null,
+      corpId: null,
+      userId: null,
+      baseUrl: null,
+      cookiesCount: 0,
+      diagnostics: {
+        ...cookieDiagnostics,
+        cacheReadable: false,
+        cookiesArrayFound: false,
+        csrfTokenFound: false,
+        corpIdFound: false,
+        userIdFound: false,
+        baseUrlFound: false,
+        failureReason: cookieDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing',
+      },
+    };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
   const baseUrl = resolveBaseUrl(cookieData);
+  const loggedIn = !!csrfToken;
 
-  return { loggedIn: !!csrfToken, csrfToken, corpId, userId, baseUrl };
+  return {
+    loggedIn,
+    canAutoUse: loggedIn,
+    csrfToken,
+    corpId,
+    userId,
+    baseUrl,
+    cookiesCount: cookies.length,
+    diagnostics: {
+      ...cookieDiagnostics,
+      cacheReadable: true,
+      cookiesArrayFound: Array.isArray(cookieData.cookies),
+      csrfTokenFound: !!csrfToken,
+      corpIdFound: !!corpId,
+      userIdFound: !!userId,
+      baseUrlFound: !!baseUrl,
+      failureReason: loggedIn ? null : 'csrf_token_missing',
+    },
+  };
 }
 
 function maskSecret(value) {
@@ -123,16 +182,22 @@ function buildEnvironmentSnapshot() {
     },
     active: {
       tool: environment.activeToolName,
+      toolKey: environment.results.find((item) => item.isActive)?.dirName || null,
+      isWukong: environment.results.some((item) => item.isActive && item.dirName === '.real'),
       projectRoot,
+      projectRootExists: fs.existsSync(projectRoot),
+      hasConfig: fs.existsSync(path.join(projectRoot, 'config.json')),
     },
     tools: environment.results,
     login: {
       loggedIn: loginStatus.loggedIn,
-      canAutoUse: loginStatus.loggedIn,
+      canAutoUse: loginStatus.canAutoUse,
       baseUrl: loginStatus.baseUrl,
       corpId: loginStatus.corpId,
       userId: loginStatus.userId,
       csrfToken: maskSecret(loginStatus.csrfToken),
+      cookiesCount: loginStatus.cookiesCount,
+      diagnostics: loginStatus.diagnostics,
     },
   };
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /**
- * postinstall hook: skills installation + welcome guide after `npm install -g openyida`
+ * postinstall hook: skills installation + Codex plugin import + welcome guide after `npm install -g openyida`
  *
  * 职责：
  *   1. 清理旧版本遗留的错误安装（~/.xxx/yida-skills/，缺少 skills/ 中间层级）
  *   2. 将 yida-skills/ 安装到各 AI 工具的正确 skills 目录
- *   3. 首次安装欢迎引导
+ *   3. Codex 已安装时，导入本地 Codex 插件，让用户可在 @ 菜单中选择「宜搭」
+ *   4. 首次安装欢迎引导
  *
  * 正确的 skills 安装路径（所有工具统一使用 skills/ 子目录）：
  *   ~/.claude/skills/yida-skills/          ← <package>/yida-skills (copy)
@@ -25,8 +26,12 @@ const fs = require('fs');
 const os = require('os');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const PACKAGE_JSON = require(path.join(PACKAGE_ROOT, 'package.json'));
 const SKILLS_DIR = path.join(PACKAGE_ROOT, 'yida-skills');
 const HOME_DIR = os.homedir();
+const CODEX_MARKETPLACE_NAME = 'openyida';
+const CODEX_PLUGIN_NAME = 'openyida';
+const CODEX_PLUGIN_LOGO_SVG = '<svg height="200" viewBox="0 0 1024 1024" width="200" xmlns="http://www.w3.org/2000/svg"><g fill="#0089ff"><path d="M966.743 0H57.498A57.197 57.197 0 0 0 .06 57.077v218.07a61.772 61.772 0 0 1 12.042 4.936L348.538 473.83l336.196-193.987a64.421 64.421 0 0 1 87.902 23.36l34.92 60.208a63.94 63.94 0 0 1-23.24 87.54L449.084 643.613v379.905h517.78a57.197 57.197 0 0 0 56.714-56.594V57.077A57.197 57.197 0 0 0 966.743 0z"/><path d="M.663 501.163v465.76a56.715 56.715 0 0 0 16.255 40.34 57.558 57.558 0 0 0 40.58 16.255H252.93V646.141z"/></g></svg>\n';
 
 /**
  * Run fn silently — never throws.
@@ -55,6 +60,28 @@ function copyDirRecursive(src, dest) {
       fs.copyFileSync(srcPath, destPath);
     }
   }
+}
+
+/**
+ * Write a JSON file with stable formatting.
+ */
+function writeJsonFile(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+/**
+ * Escape a string for TOML output.
+ */
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+/**
+ * Return an ISO timestamp without milliseconds for compact config churn.
+ */
+function nowIsoSeconds() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
 /**
@@ -96,18 +123,242 @@ function installSkillsToTool(toolConfigDir) {
   copyDirRecursive(SKILLS_DIR, destPath);
 }
 
+/**
+ * 构建 Codex 插件 manifest。
+ */
+function createCodexPluginManifest() {
+  return {
+    name: CODEX_PLUGIN_NAME,
+    version: PACKAGE_JSON.version,
+    description: 'OpenYida CLI plugin for building and managing Yida low-code apps from Codex.',
+    author: {
+      name: 'OpenYida Contributors',
+      email: 'yize.shc@gmail.com',
+      url: 'https://github.com/openyida/openyida',
+    },
+    homepage: 'https://github.com/openyida/openyida',
+    repository: 'https://github.com/openyida/openyida',
+    license: PACKAGE_JSON.license || 'MIT',
+    keywords: ['openyida', 'yida', 'low-code', 'aliyun', 'codex'],
+    skills: './skills/',
+    interface: {
+      displayName: '宜搭',
+      shortDescription: '通过 OpenYida CLI 创建和管理宜搭应用、表单、页面与数据',
+      longDescription: 'Use OpenYida from Codex to log in to Yida, create low-code apps, manage forms, publish custom pages, configure permissions, build reports, and query data through the openyida command line.',
+      developerName: 'OpenYida Contributors',
+      category: 'Productivity',
+      capabilities: ['Interactive', 'Write'],
+      websiteURL: 'https://github.com/openyida/openyida',
+      privacyPolicyURL: 'https://github.com/openyida/openyida',
+      termsOfServiceURL: 'https://github.com/openyida/openyida',
+      defaultPrompt: [
+        '帮我检查宜搭登录态并初始化项目',
+        '帮我创建一个宜搭应用和表单',
+        '帮我发布一个宜搭自定义页面',
+      ],
+      brandColor: '#FF6A00',
+      composerIcon: './assets/logo.svg',
+      logo: './assets/logo.svg',
+    },
+  };
+}
+
+/**
+ * 构建 Codex 插件总入口技能。
+ */
+function createCodexPluginSkill() {
+  return `---
+name: openyida
+description: >
+  OpenYida / 宜搭总入口技能。用户提到宜搭、OpenYida、Yida、低代码应用、创建应用、创建表单、自定义页面、
+  页面发布、权限、报表、连接器、流程、数据查询或登录态管理时使用。通过 openyida CLI 在 Codex 中操作宜搭平台。
+---
+
+# OpenYida 宜搭开发总入口
+
+## 目标
+
+使用 \`openyida\` CLI 帮用户在 Codex 中完成宜搭低代码平台操作，包括登录态检查、应用创建、表单管理、自定义页面开发、页面发布、权限配置、报表、连接器、流程和数据查询。
+
+## 首要步骤
+
+在执行任何会创建、修改或发布真实宜搭资源的操作前，先运行只读检查：
+
+\`\`\`bash
+openyida env --json
+openyida login --check-only --json
+\`\`\`
+
+如果 \`openyida\` 不存在，先提醒用户需要安装，或在用户同意后执行：
+
+\`\`\`bash
+npm install -g openyida@latest
+\`\`\`
+
+若登录态无效，执行：
+
+\`\`\`bash
+openyida login
+\`\`\`
+
+登录完成后再次运行 \`openyida login --check-only --json\` 验证缓存写入，再继续真实资源操作。
+
+## 工作目录
+
+执行宜搭开发前检查当前工作区是否已有 \`project/\` 目录。没有时运行：
+
+\`\`\`bash
+openyida copy
+\`\`\`
+
+## 子技能索引
+
+根据用户意图选择最匹配的子技能，并在执行前读取对应 \`SKILL.md\`：
+
+| 意图 | 子技能 |
+| --- | --- |
+| 完整应用开发编排 | \`../yida-app/SKILL.md\` |
+| 登录态管理 | \`../yida-login/SKILL.md\` |
+| 退出登录 / 切换账号 | \`../yida-logout/SKILL.md\` |
+| 创建应用 | \`../yida-create-app/SKILL.md\` |
+| 创建自定义页面 | \`../yida-create-page/SKILL.md\` |
+| 创建 / 更新表单页面 | \`../yida-create-form-page/SKILL.md\` |
+| 创建流程表单 | \`../yida-create-process/SKILL.md\` |
+| 获取表单 Schema | \`../yida-get-schema/SKILL.md\` |
+| 自定义页面 JSX 开发 | \`../yida-custom-page/SKILL.md\` |
+| 发布自定义页面 | \`../yida-publish-page/SKILL.md\` |
+| 页面公开访问 / 分享配置 | \`../yida-page-config/SKILL.md\` |
+| 表单权限 | \`../yida-form-permission/SKILL.md\` |
+| 数据查询与管理 | \`../yida-data-management/SKILL.md\` |
+| 流程规则 | \`../yida-process-rule/SKILL.md\` |
+| 集成自动化 | \`../yida-integration/SKILL.md\` |
+| HTTP 连接器 | \`../yida-connector/SKILL.md\` |
+| 图表页面 | \`../yida-chart/SKILL.md\` |
+| 原生报表 | \`../yida-report/SKILL.md\` |
+| 公式字段 | \`../yida-formula/SKILL.md\` |
+| 闪记 / 会议纪要转 PRD | \`../yida-flash-note-to-prd/SKILL.md\` |
+
+## 执行规则
+
+- 不要编造 \`appType\`、\`formUuid\`、\`fieldId\`、\`reportId\`；必须从命令输出、缓存或 schema 中读取。
+- 同一命令失败后，根据错误信息检查登录态、组织、参数和字段 ID；不要无修改地连续重试。
+- 自定义页面发布前先运行 \`openyida check-page\` 和 \`openyida compile\`。
+- JSON 配置写入文件后先解析校验，再调用会修改平台资源的命令。
+- 新增用户可见文案或 CLI 行为时，遵循当前 OpenYida 仓库的 \`AGENTS.md\` 开发规范。
+`;
+}
+
+/**
+ * 写入 Codex 本地 marketplace。
+ */
+function writeCodexMarketplace(marketplaceRoot) {
+  writeJsonFile(path.join(marketplaceRoot, '.agents', 'plugins', 'marketplace.json'), {
+    name: CODEX_MARKETPLACE_NAME,
+    interface: {
+      displayName: 'OpenYida',
+    },
+    plugins: [
+      {
+        name: CODEX_PLUGIN_NAME,
+        source: {
+          source: 'local',
+          path: `./plugins/${CODEX_PLUGIN_NAME}`,
+        },
+        policy: {
+          installation: 'INSTALLED_BY_DEFAULT',
+          authentication: 'ON_INSTALL',
+        },
+        category: 'Productivity',
+      },
+    ],
+  });
+}
+
+/**
+ * 确保 Codex 配置中启用了 OpenYida marketplace 和插件。
+ * 保守策略：只追加缺失 section；如果用户已经手动配置或禁用，不覆盖。
+ */
+function ensureCodexConfig(codexDir, marketplaceRoot) {
+  const configPath = path.join(codexDir, 'config.toml');
+  let config = '';
+
+  if (fs.existsSync(configPath)) {
+    config = fs.readFileSync(configPath, 'utf8');
+  }
+
+  const chunks = [];
+  const pluginSection = `[plugins."${CODEX_PLUGIN_NAME}@${CODEX_MARKETPLACE_NAME}"]`;
+  const marketplaceSection = `[marketplaces.${CODEX_MARKETPLACE_NAME}]`;
+
+  if (!config.includes(pluginSection)) {
+    chunks.push(`${pluginSection}\nenabled = true`);
+  }
+
+  if (!config.includes(marketplaceSection)) {
+    chunks.push(
+      `${marketplaceSection}\nlast_updated = ${tomlString(nowIsoSeconds())}\nsource_type = "local"\nsource = ${tomlString(marketplaceRoot)}`,
+    );
+  }
+
+  if (chunks.length === 0) {return;}
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const prefix = config ? (config.endsWith('\n') ? '\n' : '\n\n') : '';
+  fs.writeFileSync(configPath, `${config}${prefix}${chunks.join('\n\n')}\n`, 'utf8');
+}
+
+/**
+ * 将 OpenYida 导入为 Codex 本地插件。
+ */
+function installCodexPlugin() {
+  const codexDir = path.join(HOME_DIR, '.codex');
+  if (!fs.existsSync(codexDir)) {return false;}
+
+  const marketplaceRoot = path.join(HOME_DIR, '.openyida', 'codex-plugin');
+  const pluginRoot = path.join(marketplaceRoot, 'plugins', CODEX_PLUGIN_NAME);
+
+  cleanupLegacy(pluginRoot);
+  fs.mkdirSync(path.join(pluginRoot, '.codex-plugin'), { recursive: true });
+
+  writeJsonFile(
+    path.join(pluginRoot, '.codex-plugin', 'plugin.json'),
+    createCodexPluginManifest(),
+  );
+
+  fs.mkdirSync(path.join(pluginRoot, 'assets'), { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, 'assets', 'logo.svg'), CODEX_PLUGIN_LOGO_SVG, 'utf8');
+
+  copyDirRecursive(path.join(SKILLS_DIR, 'skills'), path.join(pluginRoot, 'skills'));
+  copyDirRecursive(path.join(SKILLS_DIR, 'references'), path.join(pluginRoot, 'references'));
+
+  fs.mkdirSync(path.join(pluginRoot, 'skills', CODEX_PLUGIN_NAME), { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginRoot, 'skills', CODEX_PLUGIN_NAME, 'SKILL.md'),
+    createCodexPluginSkill(),
+    'utf8',
+  );
+
+  writeCodexMarketplace(marketplaceRoot);
+  ensureCodexConfig(codexDir, marketplaceRoot);
+
+  return true;
+}
+
 // ── 1. Skills 安装 ───────────────────────────────────────────────────
 // 安装到各 AI 工具的正确 skills 目录（悟空跳过，悟空通过手动上传技能）
+
+let codexPluginInstalled = false;
 
 // Claude Code — 始终安装（Claude Code 是主要目标用户）
 safeExec(() => {
   installSkillsToTool(path.join(HOME_DIR, '.claude'));
 });
 
-// Codex — 仅在已安装时安装
+// Codex — 仅在已安装时安装 skills，并导入本地插件
 safeExec(() => {
   if (fs.existsSync(path.join(HOME_DIR, '.codex'))) {
     installSkillsToTool(path.join(HOME_DIR, '.codex'));
+    codexPluginInstalled = installCodexPlugin();
   }
 });
 
@@ -155,14 +406,15 @@ safeExec(() => {
     fs.writeFileSync(FIRST_INSTALL_FLAG, new Date().toISOString(), 'utf8');
   }
 
-  printWelcomeGuide(isFirstInstall);
+  printWelcomeGuide(isFirstInstall, codexPluginInstalled);
 });
 
 /**
  * 打印欢迎引导信息
  * @param {boolean} isFirstInstall - 是否首次安装
+ * @param {boolean} hasCodexPlugin - 是否已导入 Codex 插件
  */
-function printWelcomeGuide(isFirstInstall) {
+function printWelcomeGuide(isFirstInstall, hasCodexPlugin) {
   const RESET = '\x1b[0m';
   const BOLD = '\x1b[1m';
   const DIM = '\x1b[2m';
@@ -223,6 +475,12 @@ function printWelcomeGuide(isFirstInstall) {
     `  ${BOLD}Step 3${RESET}  AI 自动调用 openyida 命令完成创建和发布`,
   );
   console.log(`  ${BOLD}Step 4${RESET}  获得可访问的宜搭应用链接 🎉`);
+  if (hasCodexPlugin) {
+    console.log('');
+    console.log(
+      `  ${BOLD}${GREEN}Codex 已导入宜搭插件：${RESET}重启 Codex 后可在输入框输入 ${CYAN}@宜搭${RESET}`,
+    );
+  }
   console.log('');
   console.log(SEP);
   console.log(`${BOLD}${MAGENTA}  ⚡ 快捷命令${RESET}`);

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -141,7 +141,13 @@ describe('CLI offline smoke', () => {
     expect(parsed).toHaveProperty('ok', true);
     expect(parsed).toHaveProperty('system.node');
     expect(parsed).toHaveProperty('active.projectRoot');
+    expect(parsed).toHaveProperty('active.projectRootExists');
+    expect(parsed).toHaveProperty('active.hasConfig');
     expect(parsed).toHaveProperty('login.loggedIn');
+    expect(parsed).toHaveProperty('login.diagnostics.cookieFileFound');
+    expect(parsed).toHaveProperty('login.diagnostics.csrfTokenFound');
+    expect(parsed).toHaveProperty('login.diagnostics.corpIdFound');
+    expect(parsed).toHaveProperty('login.diagnostics.baseUrlFound');
   });
 
   test('env list routes to multi-environment management command', () => {
@@ -237,6 +243,7 @@ describe('CLI offline smoke', () => {
       const parsed = JSON.parse(output.trim());
       expect(parsed).toMatchObject({
         status: 'need_codex_browser_login',
+        handoff_type: 'browser',
         browser: 'wukong',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
@@ -287,10 +294,44 @@ describe('CLI offline smoke', () => {
       const parsed = JSON.parse(output.trim());
       expect(parsed).toMatchObject({
         status: 'need_codex_browser_login',
+        handoff_type: 'browser',
         browser: 'wukong',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
       });
+    } finally {
+      fs.rmSync(wukong.base, { recursive: true, force: true });
+    }
+  });
+
+  test('login --check-only exposes Wukong read-only diagnostics', () => {
+    const wukong = createWukongWorkRoot();
+    const cacheDir = path.join(wukong.projectDir, '.cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'cookies-public.json'), JSON.stringify({
+      cookies: [
+        { name: 'tianshu_csrf_token', value: 'wukong-check-token-1234567890' },
+        { name: 'tianshu_corp_user', value: 'corp_wukongCheckUser' },
+      ],
+      base_url: 'https://www.aliwork.com',
+    }), 'utf8');
+
+    try {
+      const output = runOkWithEnv(['login', '--check-only'], {
+        AGENT_WORK_ROOT: wukong.agentWorkRoot,
+        OPENYIDA_ENV: 'public',
+      }, wukong.projectDir);
+      const parsed = JSON.parse(output.trim());
+      expect(parsed).toMatchObject({
+        status: 'ok',
+        can_auto_use: true,
+        corp_id: 'corp',
+        user_id: 'wukongCheckUser',
+      });
+      expect(parsed).toHaveProperty('diagnostics.isWukong', true);
+      expect(parsed).toHaveProperty('diagnostics.csrf_token_found', true);
+      expect(parsed).toHaveProperty('diagnostics.corp_id_found', true);
+      expect(parsed).toHaveProperty('diagnostics.base_url_found', true);
     } finally {
       fs.rmSync(wukong.base, { recursive: true, force: true });
     }

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -77,8 +77,21 @@ npm install -g openyida@latest
 **在执行任何宜搭操作前，必须先运行环境检测命令**，确认当前 AI 工具环境和登录态：
 
 ```bash
-openyida env
+openyida env --json
+openyida login --check-only --json
 ```
+
+`openyida env --json` 用于确认当前 AI 工具、项目根目录、配置文件和登录态拆解项；`openyida login --check-only --json` 只读取本地登录缓存，不触发登录、不打开浏览器、不创建任何资源。
+
+**悟空（Wukong）降级规则**：如果在悟空环境中本地命令执行入口连续失败，不要继续重试，也不要判断为 OpenYida 登录失败。进入人工协同诊断模式，请用户在可用终端执行以下低风险命令并贴回输出：
+
+```bash
+openyida -v
+openyida env --json
+openyida login --check-only --json
+```
+
+在拿到上述输出并确认 `loggedIn/can_auto_use`、`csrf_token_found`、`corp_id_found`、`base_url_found` 等关键项前，禁止创建应用、页面、表单或发布页面等会产生真实宜搭资源的操作。
 
 **输出解读**：
 
@@ -88,7 +101,7 @@ openyida env
 | 当前生效环境 | 显示项目根目录路径 |
 | 登录态检测 | 显示是否已登录、域名、组织 ID |
 
-> **若显示"未登录"，自动执行 `openyida login`，无需手动操作。**。
+> **若显示"未登录"，先执行 `openyida login` 获取 browser handoff 登录 URL；完成浏览器登录后，必须再次执行 `openyida login --check-only --json` 验证缓存写入。不要在只读验证通过前执行真实资源创建。**
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a Codex postinstall import path so OpenYida can appear in Codex's `@` plugin menu as **宜搭**, and bundles the related runtime diagnostics that make agents safer to operate after install.

## Changes

- Generates a local Codex marketplace under `~/.openyida/codex-plugin` when `~/.codex` is detected.
- Creates the `openyida` plugin manifest, entry skill, copied Yida sub-skills, shared references, and the provided Yida SVG logo.
- Enables `openyida@openyida` in `~/.codex/config.toml` without overwriting existing sections.
- Adds browser `handoff_type` metadata for Codex-style login handoffs.
- Expands `openyida env --json` and `openyida login --check-only --json` diagnostics for cookie/cache readiness, project root, and Wukong cases.
- Lets `app-list` return login-expired markers to the outer auto-login retry path.
- Updates the Yida skill entry and CLI smoke tests for the safer read-only login checks.
- Documents the Codex `@宜搭` / `@openyida` installation behavior in the README.

## Validation

- `node --check scripts/postinstall.js`
- `npx eslint scripts/postinstall.js`
- isolated HOME postinstall simulation for generated manifest, marketplace, config, and logo
- `npm run check:ci`
