### PR TITLE
Fix in-app browser login handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida env [--json]` | Detect the active AI tool environment and login state |
 | `openyida env <list\|show\|switch\|add\|remove>` | Manage public/private Yida environment profiles |
 | `openyida commands [--json]` | Emit the machine-readable command manifest |
-| `openyida login [--qr\|--browser] [--corp-id <corpId>]` | Log in to Yida |
+| `openyida login [--qr\|--browser\|--import-cookies <file>] [--corp-id <corpId>]` | Log in to Yida |
 | `openyida logout` | Log out or switch account |
 | `openyida auth <status\|login\|refresh\|logout>` | Manage login status |
 | `openyida org list` | List accessible organizations |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -207,9 +207,16 @@ function printLoginResult(result) {
     console.log(JSON.stringify({
       status: result.status,
       handoff_type: result.handoff_type || 'browser',
+      handoff_version: result.handoff_version,
       can_auto_use: false,
       browser: result.browser,
       login_url: result.login_url,
+      cookie_file: result.cookie_file,
+      cookie_import_command: result.cookie_import_command,
+      post_login_check_command: result.post_login_check_command,
+      cookie_domains: result.cookie_domains,
+      required_cookie_names: result.required_cookie_names,
+      cookie_export_format: result.cookie_export_format,
       message: result.message,
     }));
     return;
@@ -222,6 +229,7 @@ function printLoginResult(result) {
     user_id: result && result.user_id,
     csrf_token: result && result.csrf_token ? `${result.csrf_token.slice(0, 16)}...` : undefined,
     cookies_count: Array.isArray(result && result.cookies) ? result.cookies.length : 0,
+    cookie_file: result && result.cookie_file,
   };
   console.log(JSON.stringify(summary));
 }
@@ -289,10 +297,21 @@ async function main() {
     }
 
     case 'login': {
-      const { checkLoginOnly } = require('../lib/auth/login');
+      const { checkLoginOnly, importCookieCache } = require('../lib/auth/login');
       if (args[0] === '--check-only') {
         const result = checkLoginOnly({ includeSecrets: args.includes('--with-cookies') });
         console.log(JSON.stringify(result, null, 2));
+      } else if (args.includes('--import-cookies')) {
+        const cookieJsonPath = getArgValue(args, '--import-cookies');
+        if (!cookieJsonPath) {
+          throw new Error('Usage: openyida login --import-cookies <cookies.json> [--base-url <url>]');
+        }
+        const fs = require('fs');
+        const path = require('path');
+        const resolvedPath = path.resolve(process.cwd(), cookieJsonPath);
+        const payload = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+        const result = importCookieCache(payload, { baseUrl: getArgValue(args, '--base-url') });
+        printLoginResult(result);
       } else if (args.includes('--browser') || args.includes('--codex') || args.includes('--qoder') || args.includes('--wukong')) {
         const { codexLogin } = require('../lib/auth/codex-login');
         const result = await codexLogin();

--- a/lib/auth/codex-login.js
+++ b/lib/auth/codex-login.js
@@ -7,12 +7,34 @@
 
 'use strict';
 
-const { detectActiveTool } = require('../core/utils');
-const { resolveLoginUrl } = require('../core/env-manager');
+const { detectActiveTool, findProjectRoot } = require('../core/utils');
+const { getCookieFilePath, resolveLoginUrl } = require('../core/env-manager');
 const { t } = require('../core/i18n');
 
 /** 支持内置浏览器 handoff 的工具列表 */
 const BROWSER_HANDOFF_TOOLS = ['codex', 'qoder', 'wukong'];
+
+function resolveUrlOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function buildCookieDomains(loginUrl) {
+  const domains = ['.aliwork.com', 'www.aliwork.com'];
+  const origin = resolveUrlOrigin(loginUrl);
+  if (!origin) {
+    return domains;
+  }
+
+  const hostname = new URL(origin).hostname;
+  if (!domains.includes(hostname)) {
+    domains.push(hostname);
+  }
+  return domains;
+}
 
 /**
  * 内置浏览器登录入口：不依赖 Playwright，也不走终端二维码接口。
@@ -32,10 +54,19 @@ async function codexLogin(options = {}) {
   }
 
   const loginUrl = options.loginUrl || resolveLoginUrl();
+  const projectRoot = findProjectRoot();
+  const cookieFile = getCookieFilePath(projectRoot);
+  const loginOrigin = resolveUrlOrigin(loginUrl);
+  const cookieImportCommand = [
+    'openyida login --import-cookies <cookies.json>',
+    loginOrigin ? `--base-url ${loginOrigin}` : null,
+  ].filter(Boolean).join(' ');
 
   info(t('codex_login.no_playwright'));
   info(t('codex_login.using_browser'));
   label('URL', loginUrl);
+  label('Cookie file', cookieFile);
+  label('Import command', cookieImportCommand);
   hint(t('codex_login.browser_handoff_hint'));
 
   const browserName = toolName && BROWSER_HANDOFF_TOOLS.includes(toolName) ? toolName : 'codex';
@@ -43,9 +74,16 @@ async function codexLogin(options = {}) {
   return {
     status: 'need_codex_browser_login',
     handoff_type: 'browser',
+    handoff_version: 2,
     can_auto_use: false,
     login_url: loginUrl,
     browser: browserName,
+    cookie_file: cookieFile,
+    cookie_import_command: cookieImportCommand,
+    post_login_check_command: 'openyida login --check-only --json',
+    cookie_domains: buildCookieDomains(loginUrl),
+    required_cookie_names: ['tianshu_csrf_token'],
+    cookie_export_format: 'browser_context_cookies_json',
     message: t('codex_login.handoff_message'),
   };
 }

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -11,6 +11,7 @@
  *   refreshCsrfFromCache() - 从缓存 Cookie 重新提取 csrf_token
  *   interactiveLogin()     - 打开浏览器扫码登录（需要用户自行安装 playwright）
  *   saveCookieCache()      - 保存 Cookie 到本地缓存（供 qr-login.js 使用）
+ *   importCookieCache()    - 从浏览器导出的 Cookie JSON 导入本地缓存
  *   logout()               - 退出登录，清空 Cookie 缓存
  */
 
@@ -51,6 +52,122 @@ function saveCookieCache(cookies, baseUrl) {
   fs.writeFileSync(cookieFile, JSON.stringify({ cookies, base_url: baseUrl }, null, 2), 'utf-8');
   const { c } = require('../core/chalk');
   process.stderr.write(`  ${c.green}✔${c.reset} Cookie saved to ${c.dim}${cookieFile}${c.reset}\n`);
+
+  return {
+    cookie_file: cookieFile,
+    base_url: baseUrl,
+    cookies_count: Array.isArray(cookies) ? cookies.length : 0,
+  };
+}
+
+function normalizeBaseUrl(value) {
+  if (!value) {
+    return null;
+  }
+  try {
+    return new URL(value).origin.replace(/\/+$/, '');
+  } catch {
+    throw new Error(`Invalid base URL: ${value}`);
+  }
+}
+
+function baseUrlFromCookieDomain(domain) {
+  if (!domain || typeof domain !== 'string') {
+    return null;
+  }
+
+  const host = domain.replace(/^\./, '').trim();
+  if (!host) {
+    return null;
+  }
+  if (host === 'aliwork.com') {
+    return DEFAULT_BASE_URL;
+  }
+  return `https://${host}`;
+}
+
+function inferBaseUrlFromCookies(cookies, fallbackBaseUrl) {
+  const fallback = normalizeBaseUrl(fallbackBaseUrl || DEFAULT_BASE_URL);
+  if (!Array.isArray(cookies) || cookies.length === 0) {
+    return fallback;
+  }
+
+  const preferredNames = ['yida_user_cookie', 'tianshu_csrf_token'];
+  for (const name of preferredNames) {
+    const cookie = cookies.find(item => item && item.name === name && item.domain);
+    const baseUrl = cookie ? baseUrlFromCookieDomain(cookie.domain) : null;
+    if (baseUrl) {
+      return normalizeBaseUrl(baseUrl);
+    }
+  }
+
+  const domainCookie = cookies.find(item => item && item.domain);
+  const domainBaseUrl = domainCookie ? baseUrlFromCookieDomain(domainCookie.domain) : null;
+  return domainBaseUrl ? normalizeBaseUrl(domainBaseUrl) : fallback;
+}
+
+function normalizeBrowserCookiePayload(payload) {
+  let source = null;
+  if (payload && Array.isArray(payload.cookies)) {
+    source = payload;
+  } else if (payload && payload.storageState && Array.isArray(payload.storageState.cookies)) {
+    source = payload.storageState;
+  }
+
+  let cookies = null;
+  if (Array.isArray(payload)) {
+    cookies = payload;
+  } else if (source) {
+    cookies = source.cookies;
+  }
+
+  if (!cookies) {
+    throw new Error('Cookie JSON must be a browser cookies array or an object with a cookies array.');
+  }
+  if (cookies.length === 0) {
+    throw new Error('Cookie JSON is empty.');
+  }
+
+  for (const cookie of cookies) {
+    if (!cookie || typeof cookie.name !== 'string' || typeof cookie.value !== 'string') {
+      throw new Error('Each cookie must contain string name and value fields.');
+    }
+  }
+
+  const baseUrl = source
+    ? source.base_url || source.baseUrl || source.origin || source.url
+    : null;
+
+  return { cookies, baseUrl };
+}
+
+function importCookieCache(payload, options = {}) {
+  const normalized = normalizeBrowserCookiePayload(payload);
+  let baseUrl;
+  if (options.baseUrl) {
+    baseUrl = normalizeBaseUrl(options.baseUrl);
+  } else if (normalized.baseUrl) {
+    baseUrl = normalizeBaseUrl(normalized.baseUrl);
+  } else {
+    baseUrl = inferBaseUrlFromCookies(normalized.cookies, DEFAULT_BASE_URL);
+  }
+  const { csrfToken, corpId, userId } = extractInfoFromCookies(normalized.cookies);
+
+  if (!csrfToken) {
+    throw new Error('No tianshu_csrf_token found in browser cookies. Please finish Yida login in the browser and export cookies again.');
+  }
+
+  const saveResult = saveCookieCache(normalized.cookies, baseUrl);
+  return {
+    ok: true,
+    csrf_token: csrfToken,
+    corp_id: corpId,
+    user_id: userId,
+    base_url: baseUrl,
+    cookies: normalized.cookies,
+    cookies_count: normalized.cookies.length,
+    cookie_file: saveResult.cookie_file,
+  };
 }
 
 // ── 仅检查登录态 ──────────────────────────────────────
@@ -191,7 +308,7 @@ function ensureLogin() {
   if (cookieData && cookieData.cookies) {
     const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
     if (csrfToken) {
-      const { c: cc, success: chalkSuccess2, label: chalkLabel } = require('../core/chalk');
+      const { success: chalkSuccess2, label: chalkLabel } = require('../core/chalk');
       chalkSuccess2(t('login.using_cache'));
       chalkLabel('CSRF', `${csrfToken.slice(0, 16)}…`);
       if (corpId) {chalkLabel('Corp ID', corpId);}
@@ -270,7 +387,7 @@ function interactiveLogin() {
     return null;
   }
 
-  const { c: lc, info: chalkInfo, label: chalkLabel2 } = require('../core/chalk');
+  const { info: chalkInfo, label: chalkLabel2 } = require('../core/chalk');
   chalkInfo(t('login.browser_opening'));
   chalkLabel2('URL', loginUrl);
 
@@ -422,5 +539,8 @@ module.exports = {
   refreshCsrfFromCache,
   interactiveLogin,
   saveCookieCache,
+  importCookieCache,
+  normalizeBrowserCookiePayload,
+  inferBaseUrlFromCookies,
   logout,
 };

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -20,7 +20,7 @@ const COMMAND_GROUPS = [
     id: 'auth',
     titleKey: 'help.group_auth',
     commands: [
-      command('login', ['login'], 'login [--qr|--browser] [--corp-id <corpId>]', 'help.cmd_login', {
+      command('login', ['login'], 'login [--qr|--browser|--import-cookies <file>] [--corp-id <corpId>]', 'help.cmd_login', {
         requiresLogin: false,
         output: 'json',
       }),

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1330,12 +1330,12 @@ Options:
     example2: '         openyida create-process "APP_XXX" --formUuid FORM-YYY process-definition.json',
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -980,12 +980,12 @@ openyida - Yida CLI ツール
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -589,12 +589,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -586,12 +586,12 @@ module.exports = {
     },
   },
   codex_login: {
-    title: '  openyida login --codex - Codex Login Mode',
-    not_codex: 'Current environment is not detected as Codex; returning a Codex browser login handoff only.',
-    no_playwright: 'Codex mode does not require Playwright or a separate Chromium install.',
-    using_browser: 'Use the Codex in-app browser to open the Yida login page and scan with DingTalk.',
-    browser_handoff_hint: 'After browser login succeeds, the Codex session is logged in. CLI Cookie export requires a Codex browser bridge.',
-    handoff_message: 'Open login_url in the Codex in-app browser and scan with DingTalk.',
+    title: '  openyida login --browser - In-app Browser Login Mode',
+    not_codex: 'Current environment is not detected as Codex/Qoder/Wukong; returning a browser login handoff only.',
+    no_playwright: 'In-app browser login does not require Playwright or a separate Chromium install.',
+    using_browser: 'Use the current in-app browser to open the Yida login page and scan with DingTalk.',
+    browser_handoff_hint: 'After browser login succeeds, export browser context cookies and run cookie_import_command to persist CLI login.',
+    handoff_message: 'Open login_url in the in-app browser, scan with DingTalk, then export cookies and run cookie_import_command.',
     cache_available: 'Existing CLI Cookie cache is available; no browser login needed.',
   },
 };

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -1016,12 +1016,12 @@ openyida - 宜搭命令列工具
     node_approval: '審批節點',
   },
   codex_login: {
-    title: '  openyida login --codex - Codex 登入模式',
-    not_codex: '目前環境未偵測為 Codex，僅返回 Codex 瀏覽器登入 handoff。',
-    no_playwright: 'Codex 登入模式不需要安裝 Playwright 或額外 Chromium。',
-    using_browser: '請使用 Codex 內建瀏覽器開啟宜搭登入頁，並用釘釘掃碼。',
-    browser_handoff_hint: '瀏覽器登入成功後，Codex 會話已登入；CLI Cookie 匯出需要 Codex 瀏覽器橋接能力。',
-    handoff_message: '請在 Codex 內建瀏覽器開啟 login_url，並使用釘釘掃碼登入。',
+    title: '  openyida login --browser - 內建瀏覽器登入模式',
+    not_codex: '目前環境未偵測為 Codex/Qoder/悟空，僅返回瀏覽器登入 handoff。',
+    no_playwright: '內建瀏覽器登入模式不需要安裝 Playwright 或額外 Chromium。',
+    using_browser: '請使用目前宿主的內建瀏覽器開啟宜搭登入頁，並用釘釘掃碼。',
+    browser_handoff_hint: '瀏覽器登入成功後，匯出目前 browser context cookies，並執行 cookie_import_command 寫入 CLI 登入快取。',
+    handoff_message: '請在內建瀏覽器開啟 login_url，用釘釘掃碼登入，然後匯出 Cookie 並執行 cookie_import_command。',
     cache_available: '已存在可用的 CLI Cookie 緩存，無需重新開啟瀏覽器登入。',
   },
 };

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1291,12 +1291,12 @@ openyida - 宜搭命令行工具
     summary_ok: '所有 Sequence 状态正常',
   },
   codex_login: {
-    title: '  openyida login --codex - Codex 登录模式',
-    not_codex: '当前环境未检测为 Codex，仅返回 Codex 浏览器登录 handoff。',
-    no_playwright: 'Codex 登录模式不需要安装 Playwright 或额外 Chromium。',
-    using_browser: '请使用 Codex 内置浏览器打开宜搭登录页，并用钉钉扫码。',
-    browser_handoff_hint: '浏览器登录成功后，Codex 会话已登录；CLI Cookie 导出需要 Codex 浏览器桥接能力。',
-    handoff_message: '请在 Codex 内置浏览器打开 login_url，并使用钉钉扫码登录。',
+    title: '  openyida login --browser - 内置浏览器登录模式',
+    not_codex: '当前环境未检测为 Codex/Qoder/悟空，仅返回浏览器登录 handoff。',
+    no_playwright: '内置浏览器登录模式不需要安装 Playwright 或额外 Chromium。',
+    using_browser: '请使用当前宿主的内置浏览器打开宜搭登录页，并用钉钉扫码。',
+    browser_handoff_hint: '浏览器登录成功后，导出当前 browser context cookies，并执行 cookie_import_command 写入 CLI 登录缓存。',
+    handoff_message: '请在内置浏览器打开 login_url，用钉钉扫码登录，然后导出 Cookie 并执行 cookie_import_command。',
     cache_available: '已存在可用的 CLI Cookie 缓存，无需重新打开浏览器登录。',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.4.24",
+  "version": "2026.5.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.4.24",
+      "version": "2026.5.6-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.4.24",
+  "version": "2026.5.6-beta.3",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -89,7 +89,7 @@ describe('CLI offline smoke', () => {
     const output = runOk(['--help']);
     expect(output).toContain('OpenYida');
     expect(output).toContain('env [--json]');
-    expect(output).toContain('login [--qr|--browser] [--corp-id <corpId>]');
+    expect(output).toContain('login [--qr|--browser|--import-cookies <file>] [--corp-id <corpId>]');
     expect(output).toContain('create-form');
     expect(output).toContain('list-forms');
     expect(output).toContain('connector');
@@ -176,7 +176,12 @@ describe('CLI offline smoke', () => {
         browser: 'codex',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
+        handoff_version: 2,
+        cookie_import_command: 'openyida login --import-cookies <cookies.json> --base-url https://example.test',
+        post_login_check_command: 'openyida login --check-only --json',
+        required_cookie_names: ['tianshu_csrf_token'],
       });
+      expect(parsed.cookie_file).toContain('cookies-public.json');
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }
@@ -226,6 +231,48 @@ describe('CLI offline smoke', () => {
         browser: 'codex',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
+        handoff_version: 2,
+        cookie_import_command: 'openyida login --import-cookies <cookies.json> --base-url https://example.test',
+      });
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('login --import-cookies persists browser cookies for subsequent CLI use', () => {
+    const workspace = createCodexWorkspace();
+    const cookieJsonPath = path.join(workspace, 'browser-cookies.json');
+    fs.writeFileSync(cookieJsonPath, JSON.stringify({
+      cookies: [
+        { name: 'tianshu_csrf_token', value: 'imported-cli-token-1234567890', domain: '.aliwork.com' },
+        { name: 'tianshu_corp_user', value: 'corp_importedUser', domain: '.aliwork.com' },
+      ],
+    }), 'utf8');
+
+    try {
+      const output = runOkWithEnv(['login', '--import-cookies', cookieJsonPath, '--base-url', 'https://tenant.aliwork.com/workPlatform'], {
+        OPENYIDA_ENV: 'public',
+      }, workspace);
+      const parsed = JSON.parse(output.trim());
+      expect(parsed).toMatchObject({
+        ok: true,
+        base_url: 'https://tenant.aliwork.com',
+        corp_id: 'corp',
+        user_id: 'importedUser',
+        cookies_count: 2,
+      });
+      expect(parsed.cookie_file).toContain('cookies-public.json');
+
+      const checkOutput = runOkWithEnv(['login', '--check-only'], {
+        OPENYIDA_ENV: 'public',
+      }, workspace);
+      const checkParsed = JSON.parse(checkOutput.trim());
+      expect(checkParsed).toMatchObject({
+        status: 'ok',
+        can_auto_use: true,
+        corp_id: 'corp',
+        user_id: 'importedUser',
+        base_url: 'https://tenant.aliwork.com',
       });
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
@@ -247,6 +294,8 @@ describe('CLI offline smoke', () => {
         browser: 'wukong',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
+        handoff_version: 2,
+        cookie_import_command: 'openyida login --import-cookies <cookies.json> --base-url https://example.test',
       });
     } finally {
       fs.rmSync(wukong.base, { recursive: true, force: true });
@@ -298,6 +347,8 @@ describe('CLI offline smoke', () => {
         browser: 'wukong',
         login_url: 'https://example.test/workPlatform',
         can_auto_use: false,
+        handoff_version: 2,
+        cookie_import_command: 'openyida login --import-cookies <cookies.json> --base-url https://example.test',
       });
     } finally {
       fs.rmSync(wukong.base, { recursive: true, force: true });

--- a/tests/codex-login.test.js
+++ b/tests/codex-login.test.js
@@ -2,6 +2,7 @@
 
 jest.mock('../lib/core/env-manager', () => ({
   resolveLoginUrl: jest.fn(() => 'https://www.aliwork.com/workPlatform'),
+  getCookieFilePath: jest.fn(() => '/tmp/openyida/project/.cache/cookies-public.json'),
 }));
 
 jest.mock('../lib/core/chalk', () => ({
@@ -51,6 +52,12 @@ describe('codexLogin', () => {
       browser: 'codex',
       login_url: 'https://www.aliwork.com/workPlatform',
       can_auto_use: false,
+      handoff_version: 2,
+      cookie_file: '/tmp/openyida/project/.cache/cookies-public.json',
+      cookie_import_command: 'openyida login --import-cookies <cookies.json> --base-url https://www.aliwork.com',
+      post_login_check_command: 'openyida login --check-only --json',
+      cookie_domains: ['.aliwork.com', 'www.aliwork.com'],
+      required_cookie_names: ['tianshu_csrf_token'],
     });
     expect(chalk.info).toHaveBeenCalledWith(expect.stringContaining('Playwright'));
     expect(chalk.warn).not.toHaveBeenCalled();

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -15,8 +15,6 @@ jest.mock('../lib/core/i18n', () => ({
 const {
   extractInfoFromCookies,
   loadCookieData,
-  findProjectRoot,
-  detectActiveTool,
 } = require('../lib/core/utils');
 
 //─ extractInfoFromCookies─────────────────────────
@@ -207,6 +205,81 @@ describe('saveCookieCache 文件写入', () => {
     expect(result).not.toBeNull();
     expect(result.csrf_token).toBe('token123');
     expect(result.base_url).toBe(baseUrl);
+  });
+});
+
+//─ browser cookie import──────────────────────────
+
+describe('browser Cookie 导入', () => {
+  let testDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'import-cookie-cache-'));
+    const projectDir = path.join(testDir, 'project');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'config.json'), '{}', 'utf-8');
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('inferBaseUrlFromCookies 优先识别专属域名，公有云根域回退到 www', () => {
+    const { inferBaseUrlFromCookies } = require('../lib/auth/login');
+
+    expect(inferBaseUrlFromCookies([
+      { name: 'yida_user_cookie', value: 'x', domain: '.tenant.aliwork.com' },
+    ])).toBe('https://tenant.aliwork.com');
+
+    expect(inferBaseUrlFromCookies([
+      { name: 'tianshu_csrf_token', value: 'x', domain: '.aliwork.com' },
+    ])).toBe('https://www.aliwork.com');
+  });
+
+  test('normalizeBrowserCookiePayload 支持 cookies 对象和 storageState 对象', () => {
+    const { normalizeBrowserCookiePayload } = require('../lib/auth/login');
+    const cookies = [{ name: 'tianshu_csrf_token', value: 'token', domain: '.aliwork.com' }];
+
+    expect(normalizeBrowserCookiePayload({ cookies }).cookies).toEqual(cookies);
+    expect(normalizeBrowserCookiePayload({ storageState: { cookies } }).cookies).toEqual(cookies);
+  });
+
+  test('importCookieCache 写入当前环境 Cookie 文件并返回诊断信息', () => {
+    const { importCookieCache } = require('../lib/auth/login');
+    const cookies = [
+      { name: 'tianshu_csrf_token', value: 'imported-token-1234567890', domain: '.aliwork.com' },
+      { name: 'tianshu_corp_user', value: 'dingCorp_user42', domain: '.aliwork.com' },
+    ];
+
+    const result = importCookieCache({ cookies }, { baseUrl: 'https://tenant.aliwork.com/workPlatform' });
+    const cookieFile = path.join(testDir, 'project', '.cache', 'cookies-public.json');
+    const realCookieFile = fs.realpathSync(cookieFile);
+    const written = JSON.parse(fs.readFileSync(cookieFile, 'utf-8'));
+
+    expect(result).toMatchObject({
+      ok: true,
+      csrf_token: 'imported-token-1234567890',
+      corp_id: 'dingCorp',
+      user_id: 'user42',
+      base_url: 'https://tenant.aliwork.com',
+      cookies_count: 2,
+      cookie_file: realCookieFile,
+    });
+    expect(written).toMatchObject({
+      cookies,
+      base_url: 'https://tenant.aliwork.com',
+    });
+  });
+
+  test('importCookieCache 拒绝缺少 tianshu_csrf_token 的导出文件', () => {
+    const { importCookieCache } = require('../lib/auth/login');
+    expect(() => importCookieCache({
+      cookies: [{ name: 'tianshu_corp_user', value: 'corp_user' }],
+    })).toThrow('No tianshu_csrf_token');
   });
 });
 

--- a/yida-skills/skills/yida-login/SKILL.md
+++ b/yida-skills/skills/yida-login/SKILL.md
@@ -58,7 +58,24 @@ openyida login --qoder
 openyida login --wukong
 ```
 
-这些命令返回 `login_url` handoff。收到 handoff 后，用当前宿主的 in-app browser 打开 `login_url`，让用户用钉钉扫码并等待跳转到宜搭工作台。若后续 CLI 仍缺少 `.cache/cookies*.json`，说明当前环境缺少浏览器 Cookie 导出桥接能力，不要手动编造或写入 Cookie。
+这些命令返回 `login_url` handoff，并包含 `cookie_import_command`、`cookie_file`、`post_login_check_command` 等字段。收到 handoff 后：
+
+1. 用当前宿主的 in-app browser 打开 `login_url`
+2. 让用户用钉钉扫码并等待跳转到宜搭工作台
+3. 使用宿主浏览器能力导出当前 browser context cookies 为 JSON 文件（格式为 cookies 数组，或 `{ "cookies": [...] }`）
+4. 执行 handoff 返回的 `cookie_import_command`，将 cookies 写入 `.cache/cookies*.json`
+5. 执行 `post_login_check_command`，确认 `can_auto_use: true`
+
+如果当前宿主没有任何浏览器 Cookie 导出能力，不要手动编造或写入 Cookie；改用 `openyida login --qr` 完成登录。
+
+### 导入浏览器 Cookie
+
+```bash
+openyida login --import-cookies /path/to/cookies.json --base-url https://www.aliwork.com
+openyida login --check-only --json
+```
+
+`--import-cookies` 只接受真实浏览器导出的 Cookie JSON，必须包含 `tianshu_csrf_token`。导入成功后 CLI 会写入当前环境对应的 `.cache/cookies*.json`。
 
 ## 输出
 


### PR DESCRIPTION
## Summary

- Complete the CLI-side cookie persistence loop for Codex/Qoder/Wukong in-app browser login handoff.
- Add `openyida login --import-cookies <cookies.json> [--base-url <url>]` to import real browser-exported cookies into the active environment cache.
- Return a richer browser handoff payload with `cookie_file`, `cookie_import_command`, `post_login_check_command`, cookie domains, and required cookie names.
- Update login skill docs, command manifest, README, tests, and localized login messaging.
- Bump beta version to `2026.5.6-beta.3`.

## Validation

- `npm run check:ci`
- `npm test -- tests/login.test.js tests/codex-login.test.js tests/cli-smoke.test.js --runInBand`
- `npm pack --dry-run`
- Installed `openyida@beta` globally and verified `openyida --version` -> `2026.5.6-beta.3`
- Smoke-tested installed `openyida login --import-cookies` followed by `openyida login --check-only`

## Release

- npm: `openyida@2026.5.6-beta.3` published with dist-tag `beta`
- Git tag: `v2026.5.6-beta.3`
- GitHub release: https://github.com/openyida/openyida/releases/tag/v2026.5.6-beta.3