### PR TITLE
[codex] add corp manager cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida task-center <type> [options]` | Query todo, created, processed, CC, or proxy-submitted tasks |
 | `openyida get-permission <appType> <formUuid>` | Query form permission configuration |
 | `openyida save-permission <appType> <formUuid> [options]` | Save form permission configuration |
+| `openyida corp-manager <sub-command>` | Manage platform admins, sub-admins, app admins, and address book visibility |
 | `openyida verify-short-url <appType> <formUuid> <url>` | Verify a short URL |
 | `openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]` | Save public access or sharing configuration |
 | `openyida get-page-config <appType> <formUuid>` | Query public access or sharing configuration |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -827,6 +827,12 @@ async function main() {
       break;
     }
 
+    case 'corp-manager': {
+      const { run: runCorpManager } = require('../lib/corp-manager/corp-manager');
+      await runCorpManager(args);
+      break;
+    }
+
     case 'flash-to-prd': {
       const { run: runFlashToPrd } = require('../lib/flash-note/flash-to-prd');
       await runFlashToPrd(args);

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -72,6 +72,7 @@ const COMMAND_GROUPS = [
       command('task-center', ['task-center'], 'task-center <type> [options]', 'help.cmd_task_center'),
       command('get-permission', ['get-permission'], 'get-permission <appType> <formUuid>', 'help.cmd_get_permission'),
       command('save-permission', ['save-permission'], 'save-permission <appType> <formUuid> ...', 'help.cmd_save_permission'),
+      command('corp-manager', ['corp-manager'], 'corp-manager <search-user|list|add|remove|address-book> ...', 'help.cmd_corp_manager', { output: 'json' }),
     ],
   },
   {

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'مركز المهام العالمي (معلق/معالج/نسخة إلخ)',
     cmd_get_permission: 'استعلام إعدادات أذونات النموذج',
     cmd_save_permission: 'حفظ إعدادات أذونات النموذج',
+    cmd_corp_manager: 'إدارة أذونات منصة المؤسسة',
     group_process: 'العمليات',
     cmd_configure_process: 'تكوين ونشر قواعد العملية',
     cmd_create_process: 'إنشاء نموذج عملية (متكامل)',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'Globales Aufgabenzentrum (Aufgaben/Bearbeitet/CC etc.)',
     cmd_get_permission: 'Formularberechtigungen abfragen',
     cmd_save_permission: 'Formularberechtigungen speichern',
+    cmd_corp_manager: 'Plattformberechtigungen verwalten',
     group_process: 'Prozesse',
     cmd_configure_process: 'Prozessregeln konfigurieren & veröffentlichen',
     cmd_create_process: 'Prozessformular erstellen (All-in-One)',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -41,6 +41,7 @@ module.exports = {
     cmd_task_center: 'Global task center (todo/processed/cc etc.)',
     cmd_get_permission: 'Query form permission config',
     cmd_save_permission: 'Save form permission config',
+    cmd_corp_manager: 'Manage platform admins and address book permissions',
     group_process: 'Process',
     cmd_configure_process: 'Configure and publish process rules',
     cmd_create_process: 'Create process form (all-in-one)',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'Centro de tareas global (pendiente/procesado/CC etc.)',
     cmd_get_permission: 'Consultar configuración de permisos',
     cmd_save_permission: 'Guardar configuración de permisos',
+    cmd_corp_manager: 'Gestionar permisos de plataforma',
     group_process: 'Procesos',
     cmd_configure_process: 'Configurar y publicar reglas de proceso',
     cmd_create_process: 'Crear formulario de proceso (todo en uno)',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'Centre de tâches global (à faire/traité/CC etc.)',
     cmd_get_permission: 'Consulter la configuration des permissions',
     cmd_save_permission: 'Enregistrer la configuration des permissions',
+    cmd_corp_manager: 'Gérer les permissions de plateforme',
     group_process: 'Processus',
     cmd_configure_process: 'Configurer et publier les règles de processus',
     cmd_create_process: 'Créer un formulaire de processus (tout-en-un)',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'वैश्विक कार्य केंद्र (लंबित/संसाधित/CC आदि)',
     cmd_get_permission: 'फॉर्म अनुमति कॉन्फ़िगरेशन पूछें',
     cmd_save_permission: 'फॉर्म अनुमति कॉन्फ़िगरेशन सहेजें',
+    cmd_corp_manager: 'प्लेटफ़ॉर्म अनुमतियां प्रबंधित करें',
     group_process: 'प्रक्रिया',
     cmd_configure_process: 'प्रक्रिया नियम कॉन्फ़िगर और प्रकाशित करें',
     cmd_create_process: 'प्रक्रिया फॉर्म बनाएं (एकीकृत)',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -40,6 +40,7 @@ module.exports = {
     cmd_task_center: 'グローバルタスクセンター（未処理/処理済/CC等）',
     cmd_get_permission: 'フォーム権限設定を照会',
     cmd_save_permission: 'フォーム権限設定を保存',
+    cmd_corp_manager: 'プラットフォーム権限を管理',
     group_process: 'プロセス',
     cmd_configure_process: 'プロセスルールを設定＆公開',
     cmd_create_process: 'プロセスフォームを作成（一体型）',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: '글로벌 작업 센터 (할일/처리됨/참조 등)',
     cmd_get_permission: '양식 권한 설정 조회',
     cmd_save_permission: '양식 권한 설정 저장',
+    cmd_corp_manager: '플랫폼 권한 관리',
     group_process: '프로세스',
     cmd_configure_process: '프로세스 규칙 설정 및 게시',
     cmd_create_process: '프로세스 양식 생성 (통합형)',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'Centro de tarefas global (pendente/processado/CC etc.)',
     cmd_get_permission: 'Consultar configuração de permissões',
     cmd_save_permission: 'Salvar configuração de permissões',
+    cmd_corp_manager: 'Gerenciar permissões da plataforma',
     group_process: 'Processos',
     cmd_configure_process: 'Configurar e publicar regras de processo',
     cmd_create_process: 'Criar formulário de processo (tudo-em-um)',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -38,6 +38,7 @@ module.exports = {
     cmd_task_center: 'Trung tâm tác vụ toàn cầu (cần làm/đã xử lý/CC v.v.)',
     cmd_get_permission: 'Truy vấn cấu hình quyền biểu mẫu',
     cmd_save_permission: 'Lưu cấu hình quyền biểu mẫu',
+    cmd_corp_manager: 'Quản lý quyền nền tảng',
     group_process: 'Quy trình',
     cmd_configure_process: 'Cấu hình và xuất bản quy tắc quy trình',
     cmd_create_process: 'Tạo biểu mẫu quy trình (tích hợp)',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -40,6 +40,7 @@ module.exports = {
     cmd_task_center: '全域任務中心（待辦/已處理/抄送等）',
     cmd_get_permission: '查詢表單權限設定',
     cmd_save_permission: '儲存表單權限設定',
+    cmd_corp_manager: '管理平台管理員與通訊錄權限',
     group_process: '流程',
     cmd_configure_process: '設定並發布流程規則',
     cmd_create_process: '建立流程表單（一體化）',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -41,6 +41,7 @@ module.exports = {
     cmd_task_center: '全局任务中心（待办/已处理/抄送等）',
     cmd_get_permission: '查询表单权限配置',
     cmd_save_permission: '保存表单权限配置',
+    cmd_corp_manager: '管理平台管理员与通讯录权限',
     group_process: '流程',
     cmd_configure_process: '配置并发布流程规则',
     cmd_create_process: '创建流程表单（一体化）',

--- a/lib/corp-manager/api.js
+++ b/lib/corp-manager/api.js
@@ -1,0 +1,311 @@
+'use strict';
+
+const querystring = require('querystring');
+
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpGet,
+  httpPost,
+  requestWithAutoLogin,
+} = require('../core/utils');
+
+const ROLE_ALIASES = {
+  app: 'applicationCreateRole',
+  application: 'applicationCreateRole',
+  applicationCreateRole: 'applicationCreateRole',
+  platform: 'corpAdminRole',
+  main: 'corpAdminRole',
+  corp: 'corpAdminRole',
+  corpAdminRole: 'corpAdminRole',
+  sub: 'subCorpAdminRole',
+  subPlatform: 'subCorpAdminRole',
+  subCorpAdminRole: 'subCorpAdminRole',
+};
+
+const ROLE_LABELS = {
+  applicationCreateRole: '应用管理员',
+  corpAdminRole: '平台管理员',
+  subCorpAdminRole: '平台子管理员',
+};
+
+const SCENE_LABELS = {
+  appManage: '应用管理',
+  bulletinBoard: '公告栏定制',
+};
+
+function getAuthRef() {
+  let cookieData = loadCookieData();
+  if (!cookieData || !cookieData.cookies || !cookieData.csrf_token) {
+    cookieData = triggerLogin();
+  }
+
+  if (!cookieData || !cookieData.cookies || !cookieData.csrf_token) {
+    throw new Error('无法获取有效登录态或 CSRF Token');
+  }
+
+  return {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+}
+
+function normalizeRole(role) {
+  const normalized = ROLE_ALIASES[role];
+  if (!normalized) {
+    throw new Error(`无效角色：${role}，可用值：app, platform, sub`);
+  }
+  return normalized;
+}
+
+function normalizeText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    return value.zh_CN || value.pureEn_US || value.en_US || value.value || value.text || value.label || '';
+  }
+  return String(value);
+}
+
+function buildCommonParams(authRef, params = {}) {
+  return {
+    _csrf_token: authRef.csrfToken,
+    _locale_time_zone_offset: '28800000',
+    _stamp: String(Date.now()),
+    ...params,
+  };
+}
+
+async function corpGet(path, params, authRef = getAuthRef()) {
+  return requestWithAutoLogin(
+    (auth) => httpGet(auth.baseUrl, path, buildCommonParams(auth, params), auth.cookies),
+    authRef,
+  );
+}
+
+async function corpPost(path, params, authRef = getAuthRef()) {
+  return requestWithAutoLogin(
+    (auth) => httpPost(auth.baseUrl, path, querystring.stringify(buildCommonParams(auth, params)), auth.cookies),
+    authRef,
+  );
+}
+
+function assertSuccess(result, action) {
+  if (result && result.success) {
+    return result;
+  }
+  const message = result && (result.errorMsg || result.message || result.errorCode);
+  throw new Error(`${action}失败${message ? `：${message}` : ''}`);
+}
+
+function normalizeAdmin(record) {
+  return {
+    userId: record.userId || record.adminWorkNo || '',
+    userName: normalizeText(record.userName),
+    businessWorkNo: record.businessWorkNo || '',
+    departmentId: record.departmentId || '',
+    departmentNamePath: normalizeText(record.departmentNamePath),
+    roleType: record.roleType || '',
+    roleLabel: ROLE_LABELS[record.roleType] || record.roleType || '',
+    mainAdmin: !!record.mainAdmin,
+    orgAdmin: !!record.orgAdmin,
+    manageDeptIds: record.manageDeptIds || [],
+    manageDeptNames: record.manageDeptNames || [],
+    manageScene: record.manageScene || [],
+    manageSceneLabels: (record.manageScene || []).map(scene => SCENE_LABELS[scene] || scene),
+  };
+}
+
+function normalizeUser(record) {
+  const depts = Array.isArray(record.depts) ? record.depts : [];
+  return {
+    userId: record.id || record.emplId || record.userId || record.workNo || '',
+    userName: normalizeText(record.name || record.text || record.userName || record.displayName),
+    departmentNamePath: normalizeText(record.deptDesc || record.deptFullPath || record.departmentNamePath),
+    departmentIds: depts.map(dept => String(dept.id || '')).filter(Boolean),
+    departments: depts.map(dept => ({
+      id: String(dept.id || ''),
+      name: normalizeText(dept.deptName || dept.deptPathName || dept.name || dept.text),
+      path: normalizeText(dept.deptPathName || dept.deptName || dept.name || dept.text),
+    })),
+    avatar: record.personalPhoto || record.avatar || '',
+    sourceIdentifier: record.sourceIdentifier || '',
+  };
+}
+
+function parseAdminList(result) {
+  const content = (result && result.content) || {};
+  return {
+    success: true,
+    currentPage: Number(content.currentPage || 1),
+    pageSize: Number(content.limit || content.pageSize || 0),
+    totalCount: Number(content.totalCount || 0),
+    admins: (content.values || []).map(normalizeAdmin),
+  };
+}
+
+async function listAdmins(options = {}, authRef = getAuthRef()) {
+  const roleType = normalizeRole(options.role || options.roleType || 'app');
+  const params = {
+    currentPage: String(options.page || 1),
+    pageIndex: String(options.page || 1),
+    pageSize: String(options.size || 20),
+    roleType,
+  };
+
+  if (options.userId) {
+    params.adminWorkNos = options.userId;
+  }
+
+  const result = await corpPost('/query/corpadmin/listCorpAppOrSubAdmins.json', params, authRef);
+  assertSuccess(result, '查询管理员列表');
+  return parseAdminList(result);
+}
+
+async function searchUsers(options = {}, authRef = getAuthRef()) {
+  const keyword = options.keyword || options.key || '';
+  if (!keyword) {
+    throw new Error('缺少搜索关键词');
+  }
+
+  const result = await corpGet('/query/userservice/searchUsersOrDepts.json', {
+    key: keyword,
+    start: '0',
+    size: String(options.size || 50),
+    option: 'employee',
+  }, authRef);
+  assertSuccess(result, '搜索人员');
+
+  const content = result.content || {};
+  const values = content.values || content.data || [];
+  const users = values
+    .filter(item => !item.dept)
+    .map(normalizeUser);
+
+  const deptFilter = options.dept || options.department;
+  const filteredUsers = deptFilter
+    ? users.filter(user => user.departmentNamePath.includes(deptFilter))
+    : users;
+
+  return {
+    success: true,
+    totalCount: filteredUsers.length,
+    users: filteredUsers,
+  };
+}
+
+function buildSubAdminConfig(options = {}) {
+  const deptIds = options.deptIds || options.departmentIds || [];
+  if (!Array.isArray(deptIds) || deptIds.length === 0) {
+    throw new Error('添加或更新平台子管理员时必须提供 --dept-ids');
+  }
+
+  const scenes = options.scenes || ['appManage', 'bulletinBoard'];
+  return JSON.stringify({
+    deptList: deptIds.map(id => String(id)),
+    scene: scenes.map(scene => String(scene)).filter(Boolean),
+  });
+}
+
+async function saveAdmin(options = {}, authRef = getAuthRef()) {
+  const roleType = normalizeRole(options.role || options.roleType || 'app');
+  const userId = options.userId || options.user || options.adminWorkNos;
+  if (!userId) {
+    throw new Error('缺少成员 userId');
+  }
+
+  const params = {
+    adminWorkNos: userId,
+    roleType,
+  };
+
+  if (roleType === 'subCorpAdminRole') {
+    params.config = buildSubAdminConfig(options);
+  }
+
+  const result = await corpPost('/query/corpadmin/saveAppOrSubAdmins.json', params, authRef);
+  assertSuccess(result, '保存管理员');
+  return {
+    success: true,
+    roleType,
+    roleLabel: ROLE_LABELS[roleType],
+    userId,
+    content: result.content || {},
+  };
+}
+
+async function removeAdmin(options = {}, authRef = getAuthRef()) {
+  const roleType = normalizeRole(options.role || options.roleType || 'app');
+  const userId = options.userId || options.user || options.adminWorkNos;
+  if (!userId) {
+    throw new Error('缺少成员 userId');
+  }
+
+  const result = await corpPost('/query/corpadmin/batchDeleteAdmins.json', {
+    adminWorkNos: userId,
+    roleType,
+  }, authRef);
+  assertSuccess(result, '移除管理员');
+  return {
+    success: true,
+    roleType,
+    roleLabel: ROLE_LABELS[roleType],
+    userId,
+    content: result.content || {},
+  };
+}
+
+async function getAddressBookVisible(authRef = getAuthRef()) {
+  const result = await corpGet('/query/corpadmin/getAddressBookVisible.json', {}, authRef);
+  assertSuccess(result, '查询通讯录权限');
+  const content = result.content || {};
+  return {
+    success: true,
+    isAllVisible: content.isAllVisible || 'n',
+    isAdminVisible: content.isAdminVisible || 'n',
+  };
+}
+
+async function saveAddressBookVisible(options = {}, authRef = getAuthRef()) {
+  const current = await getAddressBookVisible(authRef);
+  const isAllVisible = options.isAllVisible || options.allVisible || current.isAllVisible;
+  const isAdminVisible = options.isAdminVisible || options.adminVisible || current.isAdminVisible;
+
+  const result = await corpPost('/query/corpadmin/saveAddressBoolVisible.json', {
+    isAllVisible,
+    isAdminVisible,
+  }, authRef);
+  assertSuccess(result, '保存通讯录权限');
+
+  return {
+    success: true,
+    isAllVisible,
+    isAdminVisible,
+    content: result.content || {},
+  };
+}
+
+module.exports = {
+  ROLE_ALIASES,
+  ROLE_LABELS,
+  SCENE_LABELS,
+  getAuthRef,
+  normalizeRole,
+  normalizeText,
+  normalizeAdmin,
+  normalizeUser,
+  buildSubAdminConfig,
+  listAdmins,
+  searchUsers,
+  saveAdmin,
+  removeAdmin,
+  getAddressBookVisible,
+  saveAddressBookVisible,
+};

--- a/lib/corp-manager/corp-manager.js
+++ b/lib/corp-manager/corp-manager.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const {
+  buildSubAdminConfig,
+  listAdmins,
+  searchUsers,
+  saveAdmin,
+  removeAdmin,
+  getAddressBookVisible,
+  saveAddressBookVisible,
+} = require('./api');
+
+const USAGE = `openyida corp-manager - 平台权限管理
+
+Usage:
+  openyida corp-manager search-user <keyword> [--dept <text>] [--size N]
+  openyida corp-manager list <app|platform|sub> [--user <userId>] [--page N] [--size N]
+  openyida corp-manager add <app|platform|sub> --user <userId> [--dept-ids <id1,id2>] [--scenes appManage,bulletinBoard]
+  openyida corp-manager remove <app|platform|sub> --user <userId>
+  openyida corp-manager address-book get
+  openyida corp-manager address-book set [--all-visible y|n] [--admin-visible y|n]
+
+Examples:
+  openyida corp-manager search-user "余浩" --dept "宜搭,钉钉官方同学"
+  openyida corp-manager add sub --user 014734242419657712 --dept-ids 848712658 --scenes appManage,bulletinBoard
+  openyida corp-manager remove sub --user 014734242419657712
+`;
+
+function fail(message) {
+  console.error(message);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+function parseCliOptions(tokens) {
+  const positionals = [];
+  const options = {};
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.startsWith('--')) {
+      const key = token.slice(2).replace(/-/g, '_');
+      const next = tokens[i + 1];
+      if (next && !next.startsWith('--')) {
+        options[key] = next;
+        i += 1;
+      } else {
+        options[key] = true;
+      }
+    } else {
+      positionals.push(token);
+    }
+  }
+
+  return { positionals, options };
+}
+
+function splitList(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return String(value).split(',').map(item => item.trim()).filter(Boolean);
+}
+
+function toPositiveInt(value, defaultValue) {
+  const parsed = Number.parseInt(value || `${defaultValue}`, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return parsed;
+}
+
+function normalizeVisible(value, flagName) {
+  if (value === undefined || value === true) {
+    return undefined;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['y', 'yes', 'true', '1', 'on'].includes(normalized)) {
+    return 'y';
+  }
+  if (['n', 'no', 'false', '0', 'off'].includes(normalized)) {
+    return 'n';
+  }
+  throw new Error(`${flagName} 只支持 y/n`);
+}
+
+function printJson(payload) {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+async function runSearchUser(positionals, options) {
+  const keyword = positionals[0];
+  if (!keyword) {
+    fail('缺少搜索关键词');
+  }
+
+  const result = await searchUsers({
+    keyword,
+    dept: options.dept || options.department,
+    size: toPositiveInt(options.size, 50),
+  });
+  printJson(result);
+}
+
+async function runList(positionals, options) {
+  const role = positionals[0];
+  if (!role) {
+    fail('缺少角色：app、platform 或 sub');
+  }
+
+  const result = await listAdmins({
+    role,
+    userId: options.user || options.user_id,
+    page: toPositiveInt(options.page, 1),
+    size: toPositiveInt(options.size, 20),
+  });
+  printJson(result);
+}
+
+async function runAdd(positionals, options) {
+  const role = positionals[0];
+  const userId = options.user || options.user_id;
+  if (!role) {
+    fail('缺少角色：app、platform 或 sub');
+  }
+  if (!userId) {
+    fail('缺少 --user <userId>');
+  }
+
+  const result = await saveAdmin({
+    role,
+    userId,
+    deptIds: splitList(options.dept_ids || options.department_ids),
+    scenes: splitList(options.scenes || 'appManage,bulletinBoard'),
+  });
+  printJson(result);
+}
+
+async function runRemove(positionals, options) {
+  const role = positionals[0];
+  const userId = options.user || options.user_id;
+  if (!role) {
+    fail('缺少角色：app、platform 或 sub');
+  }
+  if (!userId) {
+    fail('缺少 --user <userId>');
+  }
+
+  const result = await removeAdmin({ role, userId });
+  printJson(result);
+}
+
+async function runAddressBook(positionals, options) {
+  const action = positionals[0];
+  if (action === 'get') {
+    printJson(await getAddressBookVisible());
+    return;
+  }
+
+  if (action === 'set') {
+    const allVisible = normalizeVisible(options.all_visible, '--all-visible');
+    const adminVisible = normalizeVisible(options.admin_visible, '--admin-visible');
+    if (allVisible === undefined && adminVisible === undefined) {
+      fail('address-book set 至少需要 --all-visible 或 --admin-visible');
+    }
+    printJson(await saveAddressBookVisible({
+      allVisible,
+      adminVisible,
+    }));
+    return;
+  }
+
+  fail('address-book 子命令只支持 get 或 set');
+}
+
+async function run(args) {
+  const { positionals, options } = parseCliOptions(args);
+  const action = positionals.shift();
+
+  if (!action || action === '--help' || action === '-h') {
+    console.log(USAGE);
+    return;
+  }
+
+  if (action === 'search-user') {
+    await runSearchUser(positionals, options);
+  } else if (action === 'list') {
+    await runList(positionals, options);
+  } else if (action === 'add') {
+    await runAdd(positionals, options);
+  } else if (action === 'remove') {
+    await runRemove(positionals, options);
+  } else if (action === 'address-book') {
+    await runAddressBook(positionals, options);
+  } else {
+    fail(`未知 corp-manager 子命令：${action}`);
+  }
+}
+
+module.exports = {
+  USAGE,
+  parseCliOptions,
+  splitList,
+  normalizeVisible,
+  buildSubAdminConfig,
+  run,
+};

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -104,6 +104,7 @@ describe('CLI offline smoke', () => {
     expect(output).toContain('create-form');
     expect(output).toContain('list-forms');
     expect(output).toContain('connector');
+    expect(output).toContain('corp-manager');
     expect(output).toContain('dws');
     expect(output).toContain('commands [--json]');
     expect(output).toContain('sample [--list]');
@@ -137,6 +138,7 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('list-forms');
     expect(commands).toContain('build-page');
     expect(commands).toContain('connector.smart-create');
+    expect(commands).toContain('corp-manager');
     expect(commands).toContain('commands');
     expect(parsed.commands.find(entry => entry.id === 'commands')).toMatchObject({
       usage: 'openyida commands [--json]',
@@ -515,6 +517,7 @@ describe('CLI offline smoke', () => {
       { args: ['get-page-config'], expected: 'get-page-config' },
       { args: ['process', 'preview'], expected: 'process preview' },
       { args: ['connector', 'missing-subcommand'], expected: 'connector' },
+      { args: ['corp-manager', 'list'], expected: 'corp-manager' },
     ];
 
     for (const item of cases) {

--- a/tests/corp-manager.test.js
+++ b/tests/corp-manager.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const querystring = require('querystring');
+
+jest.mock('../lib/core/utils', () => ({
+  loadCookieData: jest.fn(),
+  triggerLogin: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://www.aliwork.com'),
+  httpGet: jest.fn(),
+  httpPost: jest.fn(),
+  requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+}));
+
+const utils = require('../lib/core/utils');
+const {
+  buildSubAdminConfig,
+  listAdmins,
+  searchUsers,
+  saveAdmin,
+  getAddressBookVisible,
+  saveAddressBookVisible,
+} = require('../lib/corp-manager/api');
+
+const mockCookieData = {
+  csrf_token: 'csrf',
+  cookies: [{ name: 'tianshu_csrf_token', value: 'csrf' }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  utils.loadCookieData.mockReturnValue(mockCookieData);
+});
+
+describe('corp-manager api', () => {
+  test('searchUsers normalizes same-name employees and supports department filtering', async () => {
+    utils.httpGet.mockResolvedValueOnce({
+      success: true,
+      content: {
+        values: [
+          {
+            id: 'u1',
+            name: '余浩',
+            deptDesc: '宜搭体验中心组织',
+            depts: [{ id: 'd1', deptPathName: '宜搭体验中心组织' }],
+          },
+          {
+            id: 'u2',
+            name: '余浩',
+            deptDesc: '宜搭,钉钉官方同学',
+            depts: [{ id: '848712658', deptPathName: '宜搭,钉钉官方同学' }],
+          },
+        ],
+      },
+    });
+
+    const result = await searchUsers({ keyword: '余浩', dept: '钉钉官方同学' });
+
+    expect(utils.httpGet).toHaveBeenCalledWith(
+      'https://www.aliwork.com',
+      '/query/userservice/searchUsersOrDepts.json',
+      expect.objectContaining({ key: '余浩', option: 'employee' }),
+      mockCookieData.cookies,
+    );
+    expect(result.users).toEqual([
+      expect.objectContaining({
+        userId: 'u2',
+        userName: '余浩',
+        departmentNamePath: '宜搭,钉钉官方同学',
+        departmentIds: ['848712658'],
+      }),
+    ]);
+  });
+
+  test('listAdmins maps role aliases and normalizes admin rows', async () => {
+    utils.httpPost.mockResolvedValueOnce({
+      success: true,
+      content: {
+        currentPage: 1,
+        totalCount: 1,
+        values: [{
+          userId: 'u1',
+          userName: { zh_CN: '余浩' },
+          departmentNamePath: '钉钉官方同学',
+          roleType: 'applicationCreateRole',
+        }],
+      },
+    });
+
+    const result = await listAdmins({ role: 'app', userId: 'u1' });
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+
+    expect(body).toMatchObject({
+      roleType: 'applicationCreateRole',
+      adminWorkNos: 'u1',
+    });
+    expect(result.admins[0]).toMatchObject({
+      userId: 'u1',
+      userName: '余浩',
+      roleLabel: '应用管理员',
+    });
+  });
+
+  test('saveAdmin sends sub-admin deptList as id strings', async () => {
+    utils.httpPost.mockResolvedValueOnce({ success: true, content: {} });
+
+    const result = await saveAdmin({
+      role: 'sub',
+      userId: '014734242419657712',
+      deptIds: ['848712658'],
+      scenes: ['appManage', 'bulletinBoard'],
+    });
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    const config = JSON.parse(body.config);
+
+    expect(result).toMatchObject({
+      success: true,
+      roleType: 'subCorpAdminRole',
+      userId: '014734242419657712',
+    });
+    expect(config).toEqual({
+      deptList: ['848712658'],
+      scene: ['appManage', 'bulletinBoard'],
+    });
+  });
+
+  test('buildSubAdminConfig requires department ids', () => {
+    expect(() => buildSubAdminConfig({ deptIds: [] })).toThrow('--dept-ids');
+  });
+
+  test('address book set preserves omitted visibility flags', async () => {
+    utils.httpGet.mockResolvedValueOnce({
+      success: true,
+      content: { isAllVisible: 'n', isAdminVisible: 'n' },
+    });
+    utils.httpPost.mockResolvedValueOnce({ success: true, content: {} });
+
+    const result = await saveAddressBookVisible({ adminVisible: 'y' });
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+
+    expect(body).toMatchObject({
+      isAllVisible: 'n',
+      isAdminVisible: 'y',
+    });
+    expect(result).toMatchObject({
+      isAllVisible: 'n',
+      isAdminVisible: 'y',
+    });
+  });
+
+  test('getAddressBookVisible normalizes empty response defaults', async () => {
+    utils.httpGet.mockResolvedValueOnce({ success: true, content: {} });
+
+    await expect(getAddressBookVisible()).resolves.toMatchObject({
+      isAllVisible: 'n',
+      isAdminVisible: 'n',
+    });
+  });
+});

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -366,7 +366,6 @@ describe('interactiveLogin 浏览器优先级', () => {
     const result = loginModule.interactiveLogin();
 
     expect(cdpModule.cdpBrowserLogin).toHaveBeenCalledTimes(1);
-    expect(childProcess.execSync).toHaveBeenCalledWith('npm root -g', { encoding: 'utf-8' });
     expect(childProcess.execSync).toHaveBeenCalledWith(
       expect.stringMatching(/^node ".+openyida-login-.+\.js"$/),
       expect.objectContaining({ timeout: 660000 })

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -171,6 +171,7 @@ openyida copy
 | `yida-publish-page` | `skills/yida-publish-page/SKILL.md` | 编译并发布自定义页面 | `openyida publish <源文件路径> <appType> <formUuid> [--health-check]` |
 | `yida-page-config` | `skills/yida-page-config/SKILL.md` | 页面公开访问/组织内分享配置 | `openyida verify-short-url <appType> <formUuid> <url>` |
 | `yida-form-permission` | `skills/yida-form-permission/SKILL.md` | 表单权限查询与保存 | `openyida get-permission <appType> <formUuid>` |
+| `yida-corp-manager` | `skills/yida-corp-manager/SKILL.md` | 平台管理员、应用管理员、子管理员与通讯录权限 | `openyida corp-manager <子命令>` |
 | `yida-form-detail` | `skills/yida-form-detail/SKILL.md` | 表单详情页 formDetail 样式优化 | 详见 SKILL.md |
 | `yida-data-management` | `skills/yida-data-management/SKILL.md` | 表单/流程/任务数据查询与变更 | `openyida data query form <appType> <formUuid>` |
 | `yida-table-form` | `skills/yida-table-form/SKILL.md` | 表格形态批量录入页面 | 详见 SKILL.md |

--- a/yida-skills/skills/yida-corp-manager/SKILL.md
+++ b/yida-skills/skills/yida-corp-manager/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: yida-corp-manager
+description: 宜搭平台权限管理。查询和维护应用管理员、平台管理员、平台子管理员，以及通讯录可见性开关。适用于用户提到平台权限管理、corpManager、应用管理员、平台管理员、子管理员、通讯录权限。不适用于表单权限组（应使用 yida-form-permission）。
+---
+
+# 平台权限管理
+
+## 严格要求 (MUST DO)
+
+- 修改前先查询当前状态：人员先 `search-user`，角色先 `list`，通讯录开关先 `address-book get`。
+- 增删改管理员会影响真实组织权限，执行前向用户确认目标人员、角色、部门范围和管理场景。
+- 同名人员必须用 `search-user` 的 `departmentNamePath` 区分，不得只凭姓名操作。
+- 平台子管理员必须指定 `--dept-ids`，场景默认 `appManage,bulletinBoard`。
+
+## 不适用场景
+
+- 表单权限组、数据权限、操作权限：使用 `yida-form-permission`。
+- 流程节点字段权限：使用 `yida-process-rule`。
+- 页面公开访问或组织内分享：使用 `yida-page-config`。
+
+## 常用命令
+
+搜索人员，确认 userId：
+
+```bash
+openyida corp-manager search-user "余浩" --dept "宜搭,钉钉官方同学"
+```
+
+查询管理员：
+
+```bash
+openyida corp-manager list app --user <userId>
+openyida corp-manager list platform --user <userId>
+openyida corp-manager list sub --user <userId>
+```
+
+添加或更新管理员：
+
+```bash
+openyida corp-manager add app --user <userId>
+openyida corp-manager add platform --user <userId>
+openyida corp-manager add sub --user <userId> --dept-ids 848712658 --scenes appManage,bulletinBoard
+```
+
+移除管理员：
+
+```bash
+openyida corp-manager remove app --user <userId>
+openyida corp-manager remove platform --user <userId>
+openyida corp-manager remove sub --user <userId>
+```
+
+通讯录权限：
+
+```bash
+openyida corp-manager address-book get
+openyida corp-manager address-book set --all-visible n --admin-visible y
+```
+
+## 角色映射
+
+| CLI 角色 | 页面含义 | 接口 roleType |
+|---------|----------|---------------|
+| `app` | 应用管理员 | `applicationCreateRole` |
+| `platform` | 平台管理员 | `corpAdminRole` |
+| `sub` | 平台子管理员 | `subCorpAdminRole` |
+
+## 子管理员参数
+
+`--dept-ids` 传部门 ID，多个用逗号分隔。可先通过人员搜索结果里的 `departmentIds` 获取常用部门 ID。`--scenes` 支持：
+
+| scene | 含义 |
+|-------|------|
+| `appManage` | 应用管理 |
+| `bulletinBoard` | 公告栏定制 |
+
+## 安全检查清单
+
+1. `search-user` 确认目标人员 userId 和部门路径。
+2. `list <role> --user <userId>` 确认当前角色状态。
+3. 展示将要执行的 add/remove/address-book set 命令。
+4. 用户确认后执行。
+5. 再次 `list` 或 `address-book get` 验证结果。


### PR DESCRIPTION
## Summary

- Add `openyida corp-manager` for platform permission management, including user search, admin list/add/remove, and address book visibility commands.
- Add the `yida-corp-manager` skill and wire the command into the manifest, README, and locale help text.
- Cover the API wrapper and command manifest behavior with tests, including same-name user disambiguation and sub-admin payload shape.

## Validation

- `npm run check:ci`
- Real API smoke with `余浩 / 014734242419657712`: search, sub-admin add, sub-admin update, remove, and final list returning `totalCount: 0`.
