### PR TITLE
feat: add local A2A adapter

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -312,6 +312,12 @@ async function main() {
       break;
     }
 
+    case 'a2a': {
+      const { run } = require('../lib/a2a/cmd');
+      await run(args);
+      break;
+    }
+
     case 'env': {
       if (shouldUseEnvManagement(args)) {
         const { run } = require('../lib/core/env-cmd');

--- a/lib/a2a/cmd.js
+++ b/lib/a2a/cmd.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { createA2aHttpServer, DEFAULT_HOST, DEFAULT_PORT, listen } = require('./server');
+
+function hasFlag(args, name) {
+  return args.includes(name);
+}
+
+function getArgValue(args, name, defaultValue) {
+  const index = args.indexOf(name);
+  if (index === -1 || !args[index + 1] || args[index + 1].startsWith('--')) {
+    return defaultValue;
+  }
+  return args[index + 1];
+}
+
+function printUsage() {
+  console.log(`
+Usage: openyida a2a <serve|agent-card> [options]
+
+Commands:
+  serve                 Start a local read-only A2A HTTP adapter
+  agent-card            Print the A2A Agent Card JSON
+
+Options:
+  --host <host>         Bind host, default: ${DEFAULT_HOST}
+  --port <port>         Bind port, default: ${DEFAULT_PORT}
+  --base-url <url>      Public base URL shown in Agent Card
+  --json                Print machine-readable startup output
+
+Examples:
+  openyida a2a agent-card
+  openyida a2a serve --host 127.0.0.1 --port 8787
+`);
+}
+
+function parseServerOptions(args) {
+  const host = getArgValue(args, '--host', DEFAULT_HOST);
+  const port = Number(getArgValue(args, '--port', DEFAULT_PORT));
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid --port value: ${port}`);
+  }
+
+  return {
+    host,
+    port,
+    baseUrl: getArgValue(args, '--base-url', `http://${host}:${port}`),
+  };
+}
+
+async function run(args = []) {
+  const subCommand = args[0];
+  const subArgs = args.slice(1);
+
+  if (!subCommand || subCommand === '--help' || subCommand === '-h') {
+    printUsage();
+    return;
+  }
+
+  if (subCommand === 'agent-card') {
+    const { createAgentCard } = require('./server');
+    const options = parseServerOptions(subArgs);
+    console.log(JSON.stringify(createAgentCard(options), null, 2));
+    return;
+  }
+
+  if (subCommand === 'serve') {
+    const options = parseServerOptions(subArgs);
+    const server = createA2aHttpServer(options);
+    await listen(server, options);
+
+    const startup = {
+      ok: true,
+      readonly: true,
+      host: options.host,
+      port: options.port,
+      base_url: options.baseUrl,
+      agent_card_url: `${options.baseUrl}/.well-known/agent-card.json`,
+      message_send_url: `${options.baseUrl}/message:send`,
+    };
+
+    if (hasFlag(subArgs, '--json')) {
+      console.log(JSON.stringify(startup));
+    } else {
+      console.log(`OpenYida A2A local adapter listening on ${options.baseUrl}`);
+      console.log(`Agent Card: ${startup.agent_card_url}`);
+      console.log('Mode: read-only preview');
+    }
+    return;
+  }
+
+  throw new Error(`Unknown a2a subcommand: ${subCommand}`);
+}
+
+module.exports = {
+  parseServerOptions,
+  run,
+};

--- a/lib/a2a/server.js
+++ b/lib/a2a/server.js
@@ -1,0 +1,370 @@
+'use strict';
+
+const http = require('http');
+const { version } = require('../../package.json');
+const { buildCommandManifest } = require('../core/command-manifest');
+const { t } = require('../core/i18n');
+
+const A2A_PROTOCOL_VERSION = '1.0';
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8787;
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+
+function createJsonResponse(statusCode, body, headers = {}) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': JSON_CONTENT_TYPE,
+      'cache-control': 'no-store',
+      ...headers,
+    },
+    body: JSON.stringify(body, null, 2),
+  };
+}
+
+function createTextResponse(statusCode, body, headers = {}) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      ...headers,
+    },
+    body,
+  };
+}
+
+function createA2aError(code, message, details) {
+  return {
+    error: {
+      code,
+      message,
+      ...(details === undefined ? {} : { details }),
+    },
+  };
+}
+
+function createAgentCard(options = {}) {
+  const baseUrl = options.baseUrl || `http://${options.host || DEFAULT_HOST}:${options.port || DEFAULT_PORT}`;
+  return {
+    protocolVersion: A2A_PROTOCOL_VERSION,
+    name: 'OpenYida Local Adapter',
+    description: 'Local read-only A2A adapter for OpenYida CLI capabilities.',
+    url: baseUrl,
+    provider: {
+      organization: 'OpenYida',
+      url: 'https://github.com/openyida/openyida',
+    },
+    version,
+    documentationUrl: 'https://github.com/openyida/openyida',
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+      stateTransitionHistory: true,
+    },
+    defaultInputModes: ['text/plain', 'application/json'],
+    defaultOutputModes: ['text/plain', 'application/json'],
+    skills: [
+      {
+        id: 'openyida.command_manifest',
+        name: 'OpenYida command manifest',
+        description: 'Returns the machine-readable OpenYida CLI command manifest.',
+        tags: ['openyida', 'cli', 'commands'],
+        examples: ['List OpenYida commands', 'Show command manifest'],
+      },
+      {
+        id: 'openyida.a2a_health',
+        name: 'OpenYida A2A health',
+        description: 'Reports local A2A adapter health and readonly mode.',
+        tags: ['openyida', 'a2a', 'health'],
+        examples: ['health', 'status'],
+      },
+    ],
+    securitySchemes: {
+      localOnly: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-OpenYida-Local-Only',
+        description: 'The first preview server binds to localhost by default and does not require credentials.',
+      },
+    },
+    security: [{ localOnly: [] }],
+  };
+}
+
+function createTaskStore() {
+  const tasks = new Map();
+
+  return {
+    set(task) {
+      tasks.set(task.id, task);
+      return task;
+    },
+    get(taskId) {
+      return tasks.get(taskId) || null;
+    },
+    update(taskId, updater) {
+      const currentTask = tasks.get(taskId);
+      if (!currentTask) {return null;}
+      const nextTask = updater(currentTask);
+      tasks.set(taskId, nextTask);
+      return nextTask;
+    },
+  };
+}
+
+function createTaskId(now = Date.now()) {
+  const randomSuffix = Math.random().toString(36).slice(2, 10);
+  return `task-${now.toString(36)}-${randomSuffix}`;
+}
+
+function extractTextFromMessage(message) {
+  if (!message) {return '';}
+  if (typeof message === 'string') {return message;}
+  if (typeof message.text === 'string') {return message.text;}
+  if (Array.isArray(message.parts)) {
+    return message.parts
+      .map((part) => {
+        if (!part) {return '';}
+        if (typeof part === 'string') {return part;}
+        if (typeof part.text === 'string') {return part.text;}
+        if (part.kind === 'text' && typeof part.content === 'string') {return part.content;}
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+function createTextPart(text) {
+  return {
+    kind: 'text',
+    text,
+  };
+}
+
+function createDataPart(data) {
+  return {
+    kind: 'data',
+    data,
+  };
+}
+
+function createAgentMessage(parts) {
+  return {
+    role: 'agent',
+    parts,
+  };
+}
+
+function buildCommandManifestResult() {
+  const manifest = buildCommandManifest({ t, version });
+  return createAgentMessage([
+    createTextPart(`OpenYida exposes ${manifest.commands.length} CLI commands. This A2A preview is read-only.`),
+    createDataPart({ manifest }),
+  ]);
+}
+
+function buildHealthResult(options = {}) {
+  return createAgentMessage([
+    createTextPart('OpenYida A2A local adapter is running in read-only preview mode.'),
+    createDataPart({
+      ok: true,
+      protocolVersion: A2A_PROTOCOL_VERSION,
+      version,
+      readonly: true,
+      host: options.host || DEFAULT_HOST,
+      port: options.port || DEFAULT_PORT,
+    }),
+  ]);
+}
+
+function buildFallbackResult(inputText) {
+  return createAgentMessage([
+    createTextPart([
+      'OpenYida A2A preview currently supports read-only discovery commands.',
+      'Try: "health", "status", "commands", or "command manifest".',
+      inputText ? `Received: ${inputText}` : '',
+    ].filter(Boolean).join('\n')),
+  ]);
+}
+
+function runReadonlySkill(inputText, options = {}) {
+  const normalizedText = String(inputText || '').trim().toLowerCase();
+  if (!normalizedText || /health|status|ping|a2a/.test(normalizedText)) {
+    return buildHealthResult(options);
+  }
+  if (/command|manifest|commands|capabilit|能力|命令/.test(normalizedText)) {
+    return buildCommandManifestResult();
+  }
+  return buildFallbackResult(inputText);
+}
+
+function createCompletedTask(inputMessage, outputMessage, now = new Date()) {
+  return {
+    id: createTaskId(now.getTime()),
+    contextId: inputMessage && (inputMessage.contextId || inputMessage.context_id) || undefined,
+    status: {
+      state: 'completed',
+      timestamp: now.toISOString(),
+    },
+    history: [
+      {
+        role: 'user',
+        parts: inputMessage && Array.isArray(inputMessage.parts) ? inputMessage.parts : [createTextPart(extractTextFromMessage(inputMessage))],
+      },
+      outputMessage,
+    ],
+    artifacts: [
+      {
+        artifactId: 'openyida-readonly-result',
+        name: 'OpenYida read-only result',
+        parts: outputMessage.parts,
+      },
+    ],
+  };
+}
+
+function parseJsonBody(rawBody) {
+  if (!rawBody) {return {};}
+  return JSON.parse(rawBody);
+}
+
+function normalizePath(pathname) {
+  return pathname.replace(/\/+$/, '') || '/';
+}
+
+async function handleA2aRequest(request, rawBody = '', context = {}) {
+  const url = new URL(request.url, 'http://localhost');
+  const pathname = normalizePath(url.pathname);
+  const method = request.method || 'GET';
+  const taskStore = context.taskStore || createTaskStore();
+  const serverOptions = context.serverOptions || {};
+
+  if (method === 'OPTIONS') {
+    return createTextResponse(204, '', {
+      allow: 'GET,POST,OPTIONS',
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'GET,POST,OPTIONS',
+      'access-control-allow-headers': 'content-type,authorization',
+    });
+  }
+
+  if (method === 'GET' && (pathname === '/.well-known/agent-card.json' || pathname === '/agent-card.json')) {
+    return createJsonResponse(200, createAgentCard(serverOptions));
+  }
+
+  if (method === 'GET' && (pathname === '/' || pathname === '/health')) {
+    return createJsonResponse(200, {
+      ok: true,
+      name: 'openyida-a2a',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+      agentCard: '/.well-known/agent-card.json',
+    });
+  }
+
+  if (method === 'POST' && (pathname === '/message:send' || pathname === '/a2a/v1/message:send')) {
+    let payload;
+    try {
+      payload = parseJsonBody(rawBody);
+    } catch (err) {
+      return createJsonResponse(400, createA2aError('INVALID_JSON', err.message));
+    }
+
+    const inputMessage = payload.message || payload;
+    const inputText = extractTextFromMessage(inputMessage);
+    const outputMessage = runReadonlySkill(inputText, serverOptions);
+    const task = taskStore.set(createCompletedTask(inputMessage, outputMessage));
+    return createJsonResponse(200, task);
+  }
+
+  const taskMatch = pathname.match(/^\/(?:a2a\/v1\/)?tasks\/([^/]+)$/);
+  if (taskMatch && method === 'GET') {
+    const task = taskStore.get(decodeURIComponent(taskMatch[1]));
+    if (!task) {
+      return createJsonResponse(404, createA2aError('TASK_NOT_FOUND', 'Task not found.'));
+    }
+    return createJsonResponse(200, task);
+  }
+
+  const cancelMatch = pathname.match(/^\/(?:a2a\/v1\/)?tasks\/([^/]+):cancel$/);
+  if (cancelMatch && method === 'POST') {
+    const task = taskStore.update(decodeURIComponent(cancelMatch[1]), (currentTask) => ({
+      ...currentTask,
+      status: {
+        state: currentTask.status && currentTask.status.state === 'completed' ? 'completed' : 'canceled',
+        timestamp: new Date().toISOString(),
+      },
+    }));
+    if (!task) {
+      return createJsonResponse(404, createA2aError('TASK_NOT_FOUND', 'Task not found.'));
+    }
+    return createJsonResponse(200, task);
+  }
+
+  if (pathname.includes('message:stream') || pathname.includes('push')) {
+    return createJsonResponse(501, createA2aError(
+      'UNSUPPORTED_CAPABILITY',
+      'Streaming and push notifications are not supported by this read-only preview adapter.'
+    ));
+  }
+
+  return createJsonResponse(404, createA2aError('NOT_FOUND', `No A2A route for ${method} ${pathname}.`));
+}
+
+function writeNodeResponse(nodeResponse, response) {
+  nodeResponse.writeHead(response.statusCode, response.headers);
+  nodeResponse.end(response.body);
+}
+
+function readRequestBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    request.on('error', reject);
+  });
+}
+
+function createA2aHttpServer(options = {}) {
+  const taskStore = options.taskStore || createTaskStore();
+  return http.createServer(async (request, response) => {
+    try {
+      const rawBody = await readRequestBody(request);
+      const result = await handleA2aRequest(request, rawBody, {
+        taskStore,
+        serverOptions: options,
+      });
+      writeNodeResponse(response, result);
+    } catch (err) {
+      writeNodeResponse(response, createJsonResponse(500, createA2aError('INTERNAL_ERROR', err.message)));
+    }
+  });
+}
+
+function listen(server, options = {}) {
+  const host = options.host || DEFAULT_HOST;
+  const port = Number(options.port || DEFAULT_PORT);
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      server.off('error', reject);
+      resolve({ host, port });
+    });
+  });
+}
+
+module.exports = {
+  A2A_PROTOCOL_VERSION,
+  DEFAULT_HOST,
+  DEFAULT_PORT,
+  createA2aError,
+  createA2aHttpServer,
+  createAgentCard,
+  createTaskStore,
+  extractTextFromMessage,
+  handleA2aRequest,
+  listen,
+  runReadonlySkill,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -136,6 +136,10 @@ const COMMAND_GROUPS = [
         requiresLogin: false,
         output: 'json',
       }),
+      command('a2a', ['a2a'], 'a2a <serve|agent-card> [options]', 'help.cmd_a2a', {
+        requiresLogin: false,
+        output: 'text|json',
+      }),
       command('copy', ['copy'], 'copy [--force]', 'help.cmd_copy', { requiresLogin: false }),
       command('sample', ['sample'], 'sample [--list]', 'help.cmd_sample', { requiresLogin: false }),
       command('doctor', ['doctor'], 'doctor [--fix]', 'help.cmd_doctor', { requiresLogin: false }),

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (جهات الاتصال/التقويم/المهام/الموافقة إلخ)',
     group_utility: 'الأدوات',
     cmd_commands: 'Output machine-readable command manifest',
+    cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_copy: 'نسخ دليل عمل project',
     cmd_sample: 'إخراج أمثلة/قوالب الكود',
     cmd_doctor: 'تشخيص البيئة والإصلاح التلقائي',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (Kontakte/Kalender/Aufgaben/Genehmigung etc.)',
     group_utility: 'Werkzeuge',
     cmd_commands: 'Maschinenlesbares Command Manifest ausgeben',
+    cmd_a2a: 'Lokalen schreibgeschützten A2A-Adapter starten oder Agent Card ausgeben',
     cmd_copy: 'project-Arbeitsverzeichnis kopieren',
     cmd_sample: 'Codebeispiele/Vorlagen ausgeben',
     cmd_doctor: 'Umgebungsdiagnose & automatische Reparatur',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -73,6 +73,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (contacts/calendar/todo/approval etc.)',
     group_utility: 'Utility',
     cmd_commands: 'Output machine-readable command manifest',
+    cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_copy: 'Copy project working directory',
     cmd_sample: 'Output code samples/templates',
     cmd_doctor: 'Environment diagnostics & auto-fix',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (contactos/calendario/tareas/aprobación etc.)',
     group_utility: 'Utilidades',
     cmd_commands: 'Emitir manifiesto de comandos legible por máquina',
+    cmd_a2a: 'Iniciar adaptador A2A local de solo lectura o imprimir Agent Card',
     cmd_copy: 'Copiar directorio de trabajo project',
     cmd_sample: 'Generar ejemplos/plantillas de código',
     cmd_doctor: 'Diagnóstico de entorno y reparación automática',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (contacts/calendrier/tâches/approbation etc.)',
     group_utility: 'Utilitaires',
     cmd_commands: 'Afficher le manifeste des commandes lisible par machine',
+    cmd_a2a: 'Démarrer l’adaptateur A2A local en lecture seule ou afficher l’Agent Card',
     cmd_copy: 'Copier le répertoire de travail project',
     cmd_sample: 'Exporter des exemples/modèles de code',
     cmd_doctor: 'Diagnostic d\'environnement et réparation auto',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (संपर्क/कैलेंडर/कार्य/अनुमोदन आदि)',
     group_utility: 'उपकरण',
     cmd_commands: 'Output machine-readable command manifest',
+    cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_copy: 'project कार्य निर्देशिका कॉपी करें',
     cmd_sample: 'कोड सैंपल/टेम्पलेट आउटपुट करें',
     cmd_doctor: 'वातावरण निदान और स्वचालित मरम्मत',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -72,6 +72,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI（連絡先/カレンダー/ToDo/承認等）',
     group_utility: 'ユーティリティ',
     cmd_commands: '機械可読コマンド manifest を出力',
+    cmd_a2a: 'ローカル読み取り専用 A2A Adapter を起動、または Agent Card を出力',
     cmd_copy: 'project 作業ディレクトリをコピー',
     cmd_sample: 'コードサンプル/テンプレートを出力',
     cmd_doctor: '環境診断と自動修復',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (연락처/캘린더/할일/승인 등)',
     group_utility: '유틸리티',
     cmd_commands: 'Output machine-readable command manifest',
+    cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_copy: 'project 작업 디렉토리 복사',
     cmd_sample: '코드 샘플/템플릿 출력',
     cmd_doctor: '환경 진단 및 자동 수정',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (contatos/calendário/tarefas/aprovação etc.)',
     group_utility: 'Utilitários',
     cmd_commands: 'Emitir manifesto de comandos legível por máquina',
+    cmd_a2a: 'Iniciar adaptador A2A local somente leitura ou imprimir Agent Card',
     cmd_copy: 'Copiar diretório de trabalho project',
     cmd_sample: 'Gerar exemplos/modelos de código',
     cmd_doctor: 'Diagnóstico de ambiente e reparo automático',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -70,6 +70,7 @@ module.exports = {
     cmd_dws: 'DingTalk CLI (danh bạ/lịch/việc cần làm/phê duyệt v.v.)',
     group_utility: 'Tiện ích',
     cmd_commands: 'Output machine-readable command manifest',
+    cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_copy: 'Sao chép thư mục làm việc project',
     cmd_sample: 'Xuất mẫu ví dụ/mẫu mã',
     cmd_doctor: 'Chẩn đoán môi trường và sửa tự động',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -72,6 +72,7 @@ module.exports = {
     cmd_dws: '釘釘 CLI（通訊錄/日曆/待辦/審批等）',
     group_utility: '工具',
     cmd_commands: '輸出機器可讀命令清單',
+    cmd_a2a: '啟動本機唯讀 A2A Adapter 或輸出 Agent Card',
     cmd_copy: '複製 project 工作目錄',
     cmd_sample: '輸出程式碼範例/模板',
     cmd_doctor: '環境診斷與自動修復',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -73,6 +73,7 @@ module.exports = {
     cmd_dws: '钉钉 CLI（通讯录/日历/待办/审批等）',
     group_utility: '工具',
     cmd_commands: '输出机器可读命令清单',
+    cmd_a2a: '启动本地只读 A2A Adapter 或输出 Agent Card',
     cmd_copy: '复制 project 工作目录',
     cmd_sample: '输出代码示例/模板',
     cmd_doctor: '环境诊断与自动修复',

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -107,6 +107,7 @@ describe('CLI offline smoke', () => {
     expect(output).toContain('corp-manager');
     expect(output).toContain('dws');
     expect(output).toContain('commands [--json]');
+    expect(output).toContain('a2a <serve|agent-card> [options]');
     expect(output).toContain('sample [--list]');
     expect(output).toContain('generate-page <template>');
     expect(output).toContain('build-page <sourceFile>');
@@ -140,11 +141,32 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('connector.smart-create');
     expect(commands).toContain('corp-manager');
     expect(commands).toContain('commands');
+    expect(commands).toContain('a2a');
+    expect(parsed.commands.find(entry => entry.id === 'a2a')).toMatchObject({
+      usage: 'openyida a2a <serve|agent-card> [options]',
+      output: 'text|json',
+      requires_login: false,
+    });
     expect(parsed.commands.find(entry => entry.id === 'commands')).toMatchObject({
       usage: 'openyida commands [--json]',
       output: 'json',
       requires_login: false,
     });
+  });
+
+  test('a2a agent-card renders a valid Agent Card without requiring login', () => {
+    const output = runOk(['a2a', 'agent-card']);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      protocolVersion: '1.0',
+      name: 'OpenYida Local Adapter',
+      capabilities: {
+        streaming: false,
+        pushNotifications: false,
+      },
+    });
+    expect(parsed.skills.map(skill => skill.id)).toContain('openyida.command_manifest');
   });
 
   test('sample --list renders available templates without network access', () => {

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -6,6 +6,10 @@ const {
   sanitizeLoginResult,
   selectYidaLoginOrganization,
 } = require('../lib/mcp/server');
+const {
+  createTaskStore,
+  handleA2aRequest,
+} = require('../lib/a2a/server');
 
 describe('OpenYida MCP server helpers', () => {
   test('builds MCP elicitation schema for organization single-select', () => {
@@ -121,5 +125,61 @@ describe('OpenYida MCP server helpers', () => {
       selected_corp: null,
       csrf_token: 'abcdefghijklmnop...',
     });
+  });
+});
+
+describe('OpenYida A2A local adapter helpers', () => {
+  test('serves Agent Card discovery without login state', async () => {
+    const response = await handleA2aRequest({
+      method: 'GET',
+      url: '/.well-known/agent-card.json',
+    });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body).toMatchObject({
+      protocolVersion: '1.0',
+      name: 'OpenYida Local Adapter',
+      capabilities: {
+        streaming: false,
+        pushNotifications: false,
+      },
+    });
+    expect(body.skills.map(skill => skill.id)).toContain('openyida.command_manifest');
+  });
+
+  test('handles message:send and stores completed task', async () => {
+    const taskStore = createTaskStore();
+    const response = await handleA2aRequest({
+      method: 'POST',
+      url: '/message:send',
+    }, JSON.stringify({
+      message: {
+        role: 'user',
+        parts: [{ kind: 'text', text: 'commands' }],
+      },
+    }), { taskStore });
+    const task = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(task.status.state).toBe('completed');
+    expect(task.artifacts[0].parts[1].data.manifest.name).toBe('openyida');
+
+    const getResponse = await handleA2aRequest({
+      method: 'GET',
+      url: `/tasks/${task.id}`,
+    }, '', { taskStore });
+    expect(JSON.parse(getResponse.body).id).toBe(task.id);
+  });
+
+  test('returns unsupported capability for streaming routes', async () => {
+    const response = await handleA2aRequest({
+      method: 'POST',
+      url: '/message:stream',
+    });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(501);
+    expect(body.error.code).toBe('UNSUPPORTED_CAPABILITY');
   });
 });


### PR DESCRIPTION
## Summary

- add a local read-only A2A 1.0 preview adapter for OpenYida
- expose Agent Card discovery, health check, message:send, task get, and task cancel routes
- register `openyida a2a <serve|agent-card>` in CLI help, command manifest, and locales
- add offline CLI and protocol helper tests

## Safety

- default bind host is `127.0.0.1`
- adapter is read-only preview mode
- does not read or return cookies
- does not create or modify real Yida resources
- streaming and push routes return unsupported capability errors

## Validation

- `node --check lib/a2a/server.js`
- `node --check lib/a2a/cmd.js`
- `node --check bin/yida.js`
- `node --check tests/mcp-server.test.js`
- `node --check tests/cli-smoke.test.js`
- `npx jest tests/mcp-server.test.js tests/cli-smoke.test.js --runInBand`
- `npx eslint lib/a2a/server.js lib/a2a/cmd.js bin/yida.js lib/core/command-manifest.js tests/mcp-server.test.js tests/cli-smoke.test.js`
- local HTTP smoke: `agent-card-ok`, `message-send-ok`
