### PR TITLE
[codex] Add DingTalk AppLink generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida integration enable <appType> <formUuid> <processCode>` | Enable an automation flow |
 | `openyida integration disable <appType> <formUuid> <processCode>` | Disable an automation flow |
 | `openyida dws <command> [args]` | Access DingTalk CLI capabilities such as contacts, calendar, todo, and approval |
+| `openyida dingtalk-link <url> [--target fullScreen] [--legacy-scheme] [--json]` | Generate DingTalk AppLink URLs for opening pages in DingTalk; use `--legacy-scheme` only when old `dingtalk://` links are required |
 
 ### Utilities
 

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -879,6 +879,13 @@ async function main() {
       await runDws(args);
       break;
     }
+
+    case 'dingtalk-link': {
+      const { run: runDingTalkLink } = require('../lib/dingtalk/dingtalk-link');
+      await runDingTalkLink(args);
+      break;
+    }
+
     case 'export-conversation': {
       const { exportConversation } = require('../lib/conversation/export-conversation');
       // 解析选项

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -126,6 +126,10 @@ const COMMAND_GROUPS = [
     commands: [
       command('integration.create', ['integration', 'create'], 'integration create <appType> ...', 'help.cmd_integration'),
       command('dws', ['dws'], 'dws <command> [args]', 'help.cmd_dws'),
+      command('dingtalk-link', ['dingtalk-link'], 'dingtalk-link <url> [--target fullScreen] [--legacy-scheme] [--json]', 'help.cmd_dingtalk_link', {
+        requiresLogin: false,
+        output: 'text|json',
+      }),
     ],
   },
   {

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'التكامل & DingTalk',
     cmd_integration: 'إنشاء تدفق أتمتة التكامل',
     cmd_dws: 'DingTalk CLI (جهات الاتصال/التقويم/المهام/الموافقة إلخ)',
+    cmd_dingtalk_link: 'إنشاء روابط DingTalk AppLink / dingtalk:// القديمة',
     group_utility: 'الأدوات',
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'Integration & DingTalk',
     cmd_integration: 'Integrations-Automatisierungsflow erstellen',
     cmd_dws: 'DingTalk CLI (Kontakte/Kalender/Aufgaben/Genehmigung etc.)',
+    cmd_dingtalk_link: 'DingTalk AppLink / alte dingtalk:// Seitenlinks erzeugen',
     group_utility: 'Werkzeuge',
     cmd_commands: 'Maschinenlesbares Command Manifest ausgeben',
     cmd_a2a: 'Lokalen schreibgeschützten A2A-Adapter starten oder Agent Card ausgeben',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -71,6 +71,7 @@ module.exports = {
     group_integration: 'Integration & DingTalk',
     cmd_integration: 'Create integration automation flow',
     cmd_dws: 'DingTalk CLI (contacts/calendar/todo/approval etc.)',
+    cmd_dingtalk_link: 'Generate DingTalk AppLink / legacy dingtalk:// page links',
     group_utility: 'Utility',
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'Integración & DingTalk',
     cmd_integration: 'Crear flujo de automatización',
     cmd_dws: 'DingTalk CLI (contactos/calendario/tareas/aprobación etc.)',
+    cmd_dingtalk_link: 'Generar enlaces DingTalk AppLink / dingtalk:// heredados',
     group_utility: 'Utilidades',
     cmd_commands: 'Emitir manifiesto de comandos legible por máquina',
     cmd_a2a: 'Iniciar adaptador A2A local de solo lectura o imprimir Agent Card',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'Intégration & DingTalk',
     cmd_integration: 'Créer un flux d\'automatisation',
     cmd_dws: 'DingTalk CLI (contacts/calendrier/tâches/approbation etc.)',
+    cmd_dingtalk_link: 'Générer des liens DingTalk AppLink / dingtalk:// historiques',
     group_utility: 'Utilitaires',
     cmd_commands: 'Afficher le manifeste des commandes lisible par machine',
     cmd_a2a: 'Démarrer l’adaptateur A2A local en lecture seule ou afficher l’Agent Card',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'एकीकरण & DingTalk',
     cmd_integration: 'एकीकरण स्वचालन फ्लो बनाएं',
     cmd_dws: 'DingTalk CLI (संपर्क/कैलेंडर/कार्य/अनुमोदन आदि)',
+    cmd_dingtalk_link: 'DingTalk AppLink / legacy dingtalk:// पेज लिंक बनाएं',
     group_utility: 'उपकरण',
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -70,6 +70,7 @@ module.exports = {
     group_integration: '統合 & DingTalk',
     cmd_integration: '統合自動化フローを作成',
     cmd_dws: 'DingTalk CLI（連絡先/カレンダー/ToDo/承認等）',
+    cmd_dingtalk_link: 'DingTalk AppLink / 旧 dingtalk:// ページリンクを生成',
     group_utility: 'ユーティリティ',
     cmd_commands: '機械可読コマンド manifest を出力',
     cmd_a2a: 'ローカル読み取り専用 A2A Adapter を起動、または Agent Card を出力',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: '통합 & DingTalk',
     cmd_integration: '통합 자동화 플로우 생성',
     cmd_dws: 'DingTalk CLI (연락처/캘린더/할일/승인 등)',
+    cmd_dingtalk_link: 'DingTalk AppLink / 기존 dingtalk:// 페이지 링크 생성',
     group_utility: '유틸리티',
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'Integração & DingTalk',
     cmd_integration: 'Criar fluxo de automação',
     cmd_dws: 'DingTalk CLI (contatos/calendário/tarefas/aprovação etc.)',
+    cmd_dingtalk_link: 'Gerar links DingTalk AppLink / dingtalk:// legados',
     group_utility: 'Utilitários',
     cmd_commands: 'Emitir manifesto de comandos legível por máquina',
     cmd_a2a: 'Iniciar adaptador A2A local somente leitura ou imprimir Agent Card',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -68,6 +68,7 @@ module.exports = {
     group_integration: 'Tích hợp & DingTalk',
     cmd_integration: 'Tạo luồng tự động hóa tích hợp',
     cmd_dws: 'DingTalk CLI (danh bạ/lịch/việc cần làm/phê duyệt v.v.)',
+    cmd_dingtalk_link: 'Tạo liên kết DingTalk AppLink / dingtalk:// cũ',
     group_utility: 'Tiện ích',
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -70,6 +70,7 @@ module.exports = {
     group_integration: '整合 & 釘釘',
     cmd_integration: '建立整合自動化邏輯流',
     cmd_dws: '釘釘 CLI（通訊錄/日曆/待辦/審批等）',
+    cmd_dingtalk_link: '生成釘釘 AppLink / 相容 dingtalk:// 跳轉連結',
     group_utility: '工具',
     cmd_commands: '輸出機器可讀命令清單',
     cmd_a2a: '啟動本機唯讀 A2A Adapter 或輸出 Agent Card',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -71,6 +71,7 @@ module.exports = {
     group_integration: '集成 & 钉钉',
     cmd_integration: '创建集成自动化逻辑流',
     cmd_dws: '钉钉 CLI（通讯录/日历/待办/审批等）',
+    cmd_dingtalk_link: '生成钉钉 AppLink / 兼容 dingtalk:// 跳转链接',
     group_utility: '工具',
     cmd_commands: '输出机器可读命令清单',
     cmd_a2a: '启动本地只读 A2A Adapter 或输出 Agent Card',

--- a/lib/dingtalk/dingtalk-link.js
+++ b/lib/dingtalk/dingtalk-link.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { warn } = require('../core/chalk');
+
+const APPLINK_PAGE_LINK = 'https://applink.dingtalk.com/page/link';
+const LEGACY_PAGE_LINK = 'dingtalk://dingtalkclient/page/link';
+const DEFAULT_TARGET = 'fullScreen';
+
+function parseArgs(args) {
+  const options = {
+    url: null,
+    target: DEFAULT_TARGET,
+    legacyScheme: false,
+    json: false,
+    help: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--url') {
+      options.url = args[++i];
+    } else if (arg === '--target') {
+      options.target = args[++i];
+    } else if (arg === '--legacy-scheme') {
+      options.legacyScheme = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (!arg.startsWith('--') && !options.url) {
+      options.url = arg;
+    }
+  }
+
+  return options;
+}
+
+function isDingTalkPageLink(value) {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'dingtalk:' && parsed.hostname === 'dingtalkclient') {
+      return parsed.pathname === '/page/link';
+    }
+    return parsed.protocol === 'https:' && parsed.hostname === 'applink.dingtalk.com' && parsed.pathname === '/page/link';
+  } catch {
+    return false;
+  }
+}
+
+function extractPageUrl(value) {
+  if (!isDingTalkPageLink(value)) {
+    return { pageUrl: value, target: null };
+  }
+
+  const parsed = new URL(value);
+  return {
+    pageUrl: parsed.searchParams.get('url') || '',
+    target: parsed.searchParams.get('target'),
+  };
+}
+
+function assertHttpUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('DingTalk page links require an absolute http(s) URL.');
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('DingTalk page links require an absolute http(s) URL.');
+  }
+  return parsed.toString();
+}
+
+function buildDingTalkPageLink(input) {
+  const options = {
+    url: input && input.url,
+    target: input && input.target,
+    legacyScheme: !!(input && input.legacyScheme),
+  };
+  const hasTargetOption = !!(input && Object.prototype.hasOwnProperty.call(input, 'target'));
+
+  if (!options.url) {
+    throw new Error('Missing URL. Usage: openyida dingtalk-link <url>');
+  }
+
+  const extracted = extractPageUrl(options.url);
+  const pageUrl = assertHttpUrl(extracted.pageUrl);
+  const target = hasTargetOption ? options.target : (extracted.target || DEFAULT_TARGET);
+  const base = options.legacyScheme ? LEGACY_PAGE_LINK : APPLINK_PAGE_LINK;
+  const link = new URL(base);
+  link.searchParams.set('url', pageUrl);
+  if (target) {
+    link.searchParams.set('target', target);
+  }
+  return link.toString();
+}
+
+function printHelp() {
+  console.log('Usage: openyida dingtalk-link <url> [--target fullScreen] [--legacy-scheme] [--json]');
+  console.log('');
+  console.log('Generate DingTalk AppLink URLs for opening web pages in DingTalk.');
+  console.log('AppLink is the default because dingtalk:// may be claimed by DingTalk variants such as dedicated DingTalk clients.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  openyida dingtalk-link https://attend.dingtalk.com/attend/index.html');
+  console.log('  openyida dingtalk-link "dingtalk://dingtalkclient/page/link?url=https%3A%2F%2Fexample.com"');
+  console.log('  openyida dingtalk-link https://example.com --legacy-scheme');
+}
+
+async function run(args) {
+  const options = parseArgs(args);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  try {
+    const link = buildDingTalkPageLink(options);
+    if (options.json) {
+      console.log(JSON.stringify({
+        url: link,
+        kind: options.legacyScheme ? 'legacy-scheme' : 'applink',
+        target: options.target || null,
+      }, null, 2));
+      return;
+    }
+    console.log(link);
+  } catch (error) {
+    warn(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  APPLINK_PAGE_LINK,
+  LEGACY_PAGE_LINK,
+  buildDingTalkPageLink,
+  extractPageUrl,
+  run,
+};

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -106,6 +106,7 @@ describe('CLI offline smoke', () => {
     expect(output).toContain('connector');
     expect(output).toContain('corp-manager');
     expect(output).toContain('dws');
+    expect(output).toContain('dingtalk-link');
     expect(output).toContain('commands [--json]');
     expect(output).toContain('a2a <serve|agent-card> [options]');
     expect(output).toContain('sample [--list]');
@@ -140,6 +141,7 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('build-page');
     expect(commands).toContain('connector.smart-create');
     expect(commands).toContain('corp-manager');
+    expect(commands).toContain('dingtalk-link');
     expect(commands).toContain('commands');
     expect(commands).toContain('a2a');
     expect(parsed.commands.find(entry => entry.id === 'a2a')).toMatchObject({
@@ -150,6 +152,11 @@ describe('CLI offline smoke', () => {
     expect(parsed.commands.find(entry => entry.id === 'commands')).toMatchObject({
       usage: 'openyida commands [--json]',
       output: 'json',
+      requires_login: false,
+    });
+    expect(parsed.commands.find(entry => entry.id === 'dingtalk-link')).toMatchObject({
+      usage: 'openyida dingtalk-link <url> [--target fullScreen] [--legacy-scheme] [--json]',
+      output: 'text|json',
       requires_login: false,
     });
   });

--- a/tests/dingtalk-link.test.js
+++ b/tests/dingtalk-link.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { execFileSync, spawnSync } = require('child_process');
+const path = require('path');
+
+const {
+  buildDingTalkPageLink,
+  extractPageUrl,
+} = require('../lib/dingtalk/dingtalk-link');
+
+const ROOT = path.join(__dirname, '..');
+const BIN = path.join(ROOT, 'bin', 'yida.js');
+
+function cliEnv() {
+  return {
+    ...process.env,
+    CI: '1',
+    OPENYIDA_LANG: 'en',
+  };
+}
+
+function runOk(args) {
+  return execFileSync(process.execPath, [BIN, ...args], {
+    cwd: ROOT,
+    env: cliEnv(),
+    encoding: 'utf8',
+    timeout: 10000,
+  }).trim();
+}
+
+describe('dingtalk-link', () => {
+  test('builds AppLink page links by default', () => {
+    expect(buildDingTalkPageLink({
+      url: 'https://attend.dingtalk.com/attend/index.html',
+    })).toBe('https://applink.dingtalk.com/page/link?url=https%3A%2F%2Fattend.dingtalk.com%2Fattend%2Findex.html&target=fullScreen');
+  });
+
+  test('converts legacy dingtalk:// page links to AppLink', () => {
+    const legacy = 'dingtalk://dingtalkclient/page/link?url=https%3A%2F%2Fattend.dingtalk.com%2Fattend%2Findex.html';
+
+    expect(buildDingTalkPageLink({ url: legacy })).toBe('https://applink.dingtalk.com/page/link?url=https%3A%2F%2Fattend.dingtalk.com%2Fattend%2Findex.html&target=fullScreen');
+  });
+
+  test('can intentionally generate legacy scheme links', () => {
+    expect(buildDingTalkPageLink({
+      url: 'https://example.com/path?q=1',
+      legacyScheme: true,
+      target: 'self',
+    })).toBe('dingtalk://dingtalkclient/page/link?url=https%3A%2F%2Fexample.com%2Fpath%3Fq%3D1&target=self');
+  });
+
+  test('extracts page url and target from AppLink', () => {
+    expect(extractPageUrl('https://applink.dingtalk.com/page/link?url=https%3A%2F%2Fexample.com%2F&target=fullScreen')).toEqual({
+      pageUrl: 'https://example.com/',
+      target: 'fullScreen',
+    });
+  });
+
+  test('CLI outputs AppLink without requiring login', () => {
+    const output = runOk(['dingtalk-link', 'https://attend.dingtalk.com/attend/index.html']);
+    expect(output).toBe('https://applink.dingtalk.com/page/link?url=https%3A%2F%2Fattend.dingtalk.com%2Fattend%2Findex.html&target=fullScreen');
+  });
+
+  test('CLI rejects non-http page urls', () => {
+    const result = spawnSync(process.execPath, [BIN, 'dingtalk-link', 'javascript:alert(1)'], {
+      cwd: ROOT,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain('DingTalk page links require an absolute http(s) URL.');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `openyida dingtalk-link` to generate DingTalk AppLink page URLs by default.
- Support converting legacy `dingtalk://dingtalkclient/page/link` inputs and intentionally generating legacy scheme links with `--legacy-scheme`.
- Register the command in the manifest/help output, update README, and add locale strings and tests.

## Why
`dingtalk://` can be claimed by dedicated DingTalk clients, so generated links may open the wrong client. AppLink gives OpenYida and AI agents a safer default for DingTalk page jumps while preserving legacy compatibility when explicitly requested.

## Validation
- `npm test -- --runTestsByPath tests/dingtalk-link.test.js tests/cli-smoke.test.js`
- `npm test -- --runTestsByPath tests/i18n.test.js`
- `npx eslint bin/yida.js lib/dingtalk/dingtalk-link.js lib/core/command-manifest.js tests/dingtalk-link.test.js tests/cli-smoke.test.js --ext .js`
- `npm run check:syntax`
- `npm run check:structure`