### PR TITLE
test: cover basic-info skill in e2e matrix

### DIFF
--- a/scripts/e2e-real/skill-coverage.js
+++ b/scripts/e2e-real/skill-coverage.js
@@ -11,6 +11,7 @@ const SKILLS_DIR = path.join(ROOT, 'yida-skills', 'skills');
 const SKILL_COVERAGE = {
   'large-file-write': { level: 'offline', tests: ['write fixture generation uses fs APIs in runner tests'] },
   'yida-app': { level: 'real-e2e', stages: ['app', 'form', 'page', 'data', 'report', 'dashboard'] },
+  'yida-basic-info': { level: 'offline-unit', tests: ['tests/basic-info.test.js'], reason: 'basic-info reads org admin metadata and can update domains; unit coverage avoids mutating shared real org settings' },
   'yida-chart': { level: 'real-e2e', stages: ['report', 'dashboard'], tests: ['report chart config generation'] },
   'yida-connector': { level: 'offline', stages: ['connector-local'], commands: ['connector gen-template', 'connector parse-api'] },
   'yida-corp-manager': { level: 'offline-unit', tests: ['tests/corp-manager.test.js'], reason: 'enterprise admin mutations are not safe for shared real org E2E' },


### PR DESCRIPTION
## Summary
- add yida-basic-info to the real E2E skill coverage matrix
- point it at tests/basic-info.test.js so the coverage gate recognizes the new skill
- document why this stays offline: basic-info can touch org admin domain settings

## Verification
- node scripts/e2e-real/skill-coverage.js --json
- node --check scripts/e2e-real/skill-coverage.js
- npx jest tests/e2e-real-skill-coverage.test.js tests/basic-info.test.js --runInBand
- npm run check:syntax
- npm run check:ci