### PR TITLE
feat(auth): support overseas DingTalk domain login.dingtalk.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,10 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | Command | Description |
 |---------|-------------|
 | `openyida env [--json]` | Detect the active AI tool environment and login state |
+| `openyida env setup` | Choose a customer-friendly login environment preset: public, overseas, Alibaba intranet, or private deployment |
 | `openyida env <list\|show\|switch\|add\|remove>` | Manage public/private Yida environment profiles |
 | `openyida commands [--json]` | Emit the machine-readable command manifest |
-| `openyida login [--qr\|--agent-qr\|--codex\|--browser] [--corp-id <corpId>]` | Log in to Yida |
+| `openyida login [--qr\|--agent-qr\|--codex\|--browser] [--env <name>\|--overseas] [--corp-id <corpId>]` | Log in to Yida |
 | `openyida logout` | Log out or switch account |
 | `openyida auth <status\|login\|refresh\|logout>` | Manage login status |
 | `openyida org list` | List accessible organizations |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -284,6 +284,39 @@ function getArgValue(cliArgs, name) {
   return cliArgs[index + 1];
 }
 
+function applyLoginEnvironmentFlags(cliArgs) {
+  const envFlagMap = {
+    '--public': 'public',
+    '--intl': 'intl',
+    '--overseas': 'intl',
+    '--international': 'intl',
+    '--global': 'intl',
+    '--alibaba': 'alibaba',
+    '--internal': 'alibaba',
+    '--intranet': 'alibaba',
+  };
+  const filteredArgs = [];
+
+  for (let index = 0; index < cliArgs.length; index++) {
+    const arg = cliArgs[index];
+    if (arg === '--env') {
+      const envName = cliArgs[index + 1];
+      if (envName && !envName.startsWith('--')) {
+        process.env.OPENYIDA_ENV = envName;
+        index++;
+      }
+      continue;
+    }
+    if (envFlagMap[arg]) {
+      process.env.OPENYIDA_ENV = envFlagMap[arg];
+      continue;
+    }
+    filteredArgs.push(arg);
+  }
+
+  return filteredArgs;
+}
+
 // 解析全局 --quiet 开关：从 args 中剔除并设置 YIDA_QUIET=1，让 chalk.js
 // 的所有装饰输出（banner/step/info/...）变 no-op，AI 即可直接 `... --quiet | jq`。
 function applyQuietFlag() {
@@ -352,40 +385,41 @@ async function main() {
 
     case 'login': {
       const { checkLoginOnly } = require('../lib/auth/login');
-      if (args.includes('--agent-poll') || args.includes('--codex-poll')) {
-        const sessionFile = getArgValue(args, '--agent-poll') || getArgValue(args, '--codex-poll');
+      const loginArgs = applyLoginEnvironmentFlags(args);
+      if (loginArgs.includes('--agent-poll') || loginArgs.includes('--codex-poll')) {
+        const sessionFile = getArgValue(loginArgs, '--agent-poll') || getArgValue(loginArgs, '--codex-poll');
         const { pollCodexQrLogin } = require('../lib/auth/qr-login');
         const result = await pollCodexQrLogin(sessionFile, {
-          corpId: getArgValue(args, '--corp-id'),
+          corpId: getArgValue(loginArgs, '--corp-id'),
         });
         printLoginResult(result);
-      } else if (args.includes('--agent-select') || args.includes('--codex-select')) {
-        const sessionFile = getArgValue(args, '--agent-select') || getArgValue(args, '--codex-select');
+      } else if (loginArgs.includes('--agent-select') || loginArgs.includes('--codex-select')) {
+        const sessionFile = getArgValue(loginArgs, '--agent-select') || getArgValue(loginArgs, '--codex-select');
         const { selectCodexQrCorp } = require('../lib/auth/qr-login');
         const result = await selectCodexQrCorp(sessionFile, {
-          corpId: getArgValue(args, '--corp-id'),
+          corpId: getArgValue(loginArgs, '--corp-id'),
         });
         printLoginResult(result);
-      } else if (args[0] === '--check-only') {
-        const result = checkLoginOnly({ includeSecrets: args.includes('--with-cookies') });
+      } else if (loginArgs[0] === '--check-only') {
+        const result = checkLoginOnly({ includeSecrets: loginArgs.includes('--with-cookies') });
         console.log(JSON.stringify(result, null, 2));
-      } else if (shouldUseCodexQrLogin(args)) {
+      } else if (shouldUseCodexQrLogin(loginArgs)) {
         const { startCodexQrLogin } = require('../lib/auth/qr-login');
-        const result = await startCodexQrLogin({ corpId: getArgValue(args, '--corp-id') });
+        const result = await startCodexQrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
         printLoginResult(result);
-      } else if (args.includes('--browser')) {
+      } else if (loginArgs.includes('--browser')) {
         const { interactiveLogin } = require('../lib/auth/login');
         const result = interactiveLogin({ force: true });
         printLoginResult(result);
-      } else if (args.includes('--qoder') || args.includes('--wukong')) {
+      } else if (loginArgs.includes('--qoder') || loginArgs.includes('--wukong')) {
         const { codexLogin } = require('../lib/auth/codex-login');
-        const result = await codexLogin({ tool: args.includes('--qoder') ? 'qoder' : 'wukong' });
+        const result = await codexLogin({ tool: loginArgs.includes('--qoder') ? 'qoder' : 'wukong' });
         printLoginResult(result);
-      } else if (args.includes('--qr')) {
+      } else if (loginArgs.includes('--qr')) {
         const { qrLogin } = require('../lib/auth/qr-login');
-        const result = await qrLogin({ corpId: getArgValue(args, '--corp-id') });
+        const result = await qrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
         console.log(JSON.stringify(result));
-      } else if (shouldUseAgentLogin(args)) {
+      } else if (shouldUseAgentLogin(loginArgs)) {
         const cachedResult = checkLoginOnly({ includeSecrets: true });
         if (cachedResult.status === 'ok') {
           printLoginResult(cachedResult);
@@ -398,17 +432,17 @@ async function main() {
             printLoginResult(browserResult);
           } else {
             const { startCodexQrLogin } = require('../lib/auth/qr-login');
-            const result = await startCodexQrLogin({ corpId: getArgValue(args, '--corp-id') });
+            const result = await startCodexQrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
             printLoginResult(result);
           }
         }
-      } else if (shouldUseBrowserHandoffLogin(args)) {
+      } else if (shouldUseBrowserHandoffLogin(loginArgs)) {
         const cachedResult = checkLoginOnly({ includeSecrets: true });
         if (cachedResult.status === 'ok') {
           printLoginResult(cachedResult);
         } else {
           const { codexLogin } = require('../lib/auth/codex-login');
-          const result = await codexLogin({ tool: args.includes('--codex') ? 'codex' : undefined });
+          const result = await codexLogin({ tool: loginArgs.includes('--codex') ? 'codex' : undefined });
           printLoginResult(result);
         }
       } else {
@@ -418,7 +452,7 @@ async function main() {
           break;
         }
         const { qrLogin } = require('../lib/auth/qr-login');
-        const result = await qrLogin({ corpId: getArgValue(args, '--corp-id') });
+        const result = await qrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
         console.log(JSON.stringify(result));
       }
       break;
@@ -437,8 +471,9 @@ async function main() {
       if (subCommand === 'status') {
         authStatus();
       } else if (subCommand === 'login') {
-        const loginType = shouldUseBrowserHandoffLogin(args) ? 'browser' : 'qrcode';
-        await authLogin({ type: loginType, corpId: getArgValue(args, '--corp-id') });
+        const authArgs = [subCommand, ...applyLoginEnvironmentFlags(args.slice(1))];
+        const loginType = shouldUseBrowserHandoffLogin(authArgs) ? 'browser' : 'qrcode';
+        await authLogin({ type: loginType, corpId: getArgValue(authArgs, '--corp-id') });
       } else if (subCommand === 'refresh') {
         authRefresh();
       } else if (subCommand === 'logout') {

--- a/lib/auth/qr-login.js
+++ b/lib/auth/qr-login.js
@@ -366,8 +366,9 @@ async function writeQrCodeImage(url, filePath, options = {}) {
 function isDingtalkOAuthChallengeUrl(url) {
   try {
     const parsedUrl = new URL(url);
-    return parsedUrl.hostname.endsWith('dingtalk.com') &&
-      parsedUrl.pathname.startsWith('/oauth2/');
+    const hostname = parsedUrl.hostname;
+    const isDingtalkDomain = hostname.endsWith('dingtalk.com') || hostname.endsWith('dingtalk.io');
+    return isDingtalkDomain && parsedUrl.pathname.startsWith('/oauth2/');
   } catch {
     return false;
   }
@@ -1436,5 +1437,6 @@ module.exports = {
     buildNeedQrScanResult,
     getTargetCorpId,
     deriveAliworkBaseUrl,
+    isDingtalkOAuthChallengeUrl,
   },
 };

--- a/lib/auth/qr-login.js
+++ b/lib/auth/qr-login.js
@@ -24,7 +24,7 @@ const { saveCookieCache } = require('./login');
 const { t } = require('../core/i18n');
 const { warn } = require('../core/chalk');
 
-const { resolveLoginUrl, resolveEndpoint, deriveBaseUrlFromUrl } = require('../core/env-manager');
+const { resolveLoginUrl, resolveEndpoint, deriveBaseUrlFromUrl, getCurrentEnvConfig } = require('../core/env-manager');
 
 function shellQuote(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
@@ -34,9 +34,11 @@ function getTargetCorpId(options = {}, session = {}) {
   return options.corpId || options.targetCorpId || session.targetCorpId || null;
 }
 
-function buildCodexPollCommand(sessionFile, targetCorpId) {
+function buildCodexPollCommand(sessionFile, targetCorpId, envName) {
   const baseCommand = `openyida login --agent-poll ${shellQuote(sessionFile)}`;
-  return targetCorpId ? `${baseCommand} --corp-id ${shellQuote(targetCorpId)}` : baseCommand;
+  const envArg = envName ? ` --env ${shellQuote(envName)}` : '';
+  const corpArg = targetCorpId ? ` --corp-id ${shellQuote(targetCorpId)}` : '';
+  return `${baseCommand}${envArg}${corpArg}`;
 }
 
 function buildQrImageMarkdown(qrImageFile) {
@@ -55,7 +57,7 @@ function buildAgentQrResponseMarkdown(result) {
   return lines.join('\n');
 }
 
-function buildNeedQrScanResult({ qrUrl, qrImageFile, sessionFile, targetCorpId }) {
+function buildNeedQrScanResult({ qrUrl, qrImageFile, sessionFile, targetCorpId, envName }) {
   const qrImageMarkdown = buildQrImageMarkdown(qrImageFile);
   const result = {
     status: 'need_qr_scan',
@@ -65,7 +67,7 @@ function buildNeedQrScanResult({ qrUrl, qrImageFile, sessionFile, targetCorpId }
     qr_image_file: qrImageFile || null,
     qr_image_markdown: qrImageMarkdown,
     session_file: sessionFile,
-    poll_command: buildCodexPollCommand(sessionFile, targetCorpId),
+    poll_command: buildCodexPollCommand(sessionFile, targetCorpId, envName),
     message: 'Scan the QR code with DingTalk, then run poll_command.',
   };
   result.agent_response_markdown = buildAgentQrResponseMarkdown(result);
@@ -1013,7 +1015,8 @@ function buildCodexCorpInteraction(corpList) {
   };
 }
 
-function buildNeedCorpSelectionResult(sessionFile, corpList) {
+function buildNeedCorpSelectionResult(sessionFile, corpList, envName) {
+  const envArg = envName ? ` --env ${shellQuote(envName)}` : '';
   return {
     status: 'need_corp_selection',
     handoff_type: 'codex_native_select',
@@ -1025,7 +1028,7 @@ function buildNeedCorpSelectionResult(sessionFile, corpList) {
       main_org: !!corp.mainOrg,
     })),
     interaction: buildCodexCorpInteraction(corpList),
-    select_command_template: `openyida login --codex-select ${shellQuote(sessionFile)} --corp-id <corpId>`,
+    select_command_template: `openyida login --codex-select ${shellQuote(sessionFile)}${envArg} --corp-id <corpId>`,
   };
 }
 
@@ -1087,7 +1090,7 @@ async function maybeReturnCorpSelectionAfterExchange(session, sessionFile, optio
       stage: 'pending_corp_switch',
       updatedAt: new Date().toISOString(),
     });
-    return buildNeedCorpSelectionResult(sessionFile, corpList);
+    return buildNeedCorpSelectionResult(sessionFile, corpList, session.currentEnvName);
   }
 
   if (!selectedCorp && corpList.length === 1) {
@@ -1101,6 +1104,7 @@ function buildFakeCodexQrLoginResult(options = {}) {
   const sessionId = 'test-session';
   const { sessionFile, qrImageFile } = getCodexQrSessionPaths(sessionId);
   const targetCorpId = getTargetCorpId(options);
+  const currentEnvName = getCurrentEnvConfig().name;
   saveCodexQrSession(sessionFile, {
     schema_version: 1,
     mode: 'codex_qr_login',
@@ -1111,6 +1115,7 @@ function buildFakeCodexQrLoginResult(options = {}) {
     cookieHeader: '',
     context: { type: 'legacy' },
     targetCorpId,
+    currentEnvName,
     createdAt: new Date().toISOString(),
   });
 
@@ -1119,6 +1124,7 @@ function buildFakeCodexQrLoginResult(options = {}) {
     qrImageFile,
     sessionFile,
     targetCorpId,
+    envName: currentEnvName,
   });
 }
 
@@ -1129,6 +1135,7 @@ async function startCodexQrLogin(options = {}) {
 
   const baseUrl = (options.baseUrl || resolveEndpoint(null)).replace(/\/+$/, '');
   const targetCorpId = getTargetCorpId(options);
+  const currentEnvName = getCurrentEnvConfig().name;
   const sessionId = options.sessionId || createCodexQrSessionId();
   const { sessionFile, qrImageFile } = getCodexQrSessionPaths(sessionId);
 
@@ -1158,6 +1165,7 @@ async function startCodexQrLogin(options = {}) {
     cookieHeader,
     context,
     targetCorpId,
+    currentEnvName,
     createdAt: new Date().toISOString(),
   });
 
@@ -1166,6 +1174,7 @@ async function startCodexQrLogin(options = {}) {
     qrImageFile: imageWritten ? qrImageFile : null,
     sessionFile,
     targetCorpId,
+    envName: currentEnvName,
   });
 }
 
@@ -1200,9 +1209,10 @@ async function pollCodexQrLogin(sessionFile, options = {}) {
           corpList,
           stage: 'pending_dingtalk_oauth_org',
           targetCorpId,
+          currentEnvName: session.currentEnvName,
           updatedAt: new Date().toISOString(),
         });
-        return buildNeedCorpSelectionResult(sessionFile, corpList);
+        return buildNeedCorpSelectionResult(sessionFile, corpList, session.currentEnvName);
       }
     }
 

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -20,7 +20,7 @@ const COMMAND_GROUPS = [
     id: 'auth',
     titleKey: 'help.group_auth',
     commands: [
-      command('login', ['login'], 'login [--qr|--agent-qr|--codex|--browser] [--corp-id <corpId>]', 'help.cmd_login', {
+      command('login', ['login'], 'login [--qr|--agent-qr|--codex|--browser] [--env <name>|--overseas] [--corp-id <corpId>]', 'help.cmd_login', {
         requiresLogin: false,
         output: 'json',
       }),
@@ -31,7 +31,7 @@ const COMMAND_GROUPS = [
         requiresLogin: false,
         output: 'text|json',
       }),
-      command('env-management', ['env'], 'env <list|show|switch|add|remove>', 'help.cmd_env_management', {
+      command('env-management', ['env'], 'env <setup|list|show|switch|add|remove>', 'help.cmd_env_management', {
         requiresLogin: false,
       }),
     ],

--- a/lib/core/env-cmd.js
+++ b/lib/core/env-cmd.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+const { execSync } = require('child_process');
 const readline = require('readline');
 const { warn } = require('./chalk');
 const {
@@ -18,6 +19,10 @@ const {
   saveEnvsConfig,
   DEFAULT_BASE_URL,
   DEFAULT_LOGIN_URL,
+  DEFAULT_PUBLIC_ENV,
+  DEFAULT_INTERNATIONAL_ENV,
+  DEFAULT_ALIBABA_INTERNAL_ENV,
+  resolveEnvNameAlias,
 } = require('./env-manager');
 
 // ── 颜色常量 ──────────────────────────────────────────
@@ -67,6 +72,79 @@ function formatEnvLabel(envName, currentEnv) {
   return `${CYAN}${envName}${RESET}`;
 }
 
+function getLoginHost(loginUrl) {
+  try {
+    return new URL(loginUrl || DEFAULT_LOGIN_URL).hostname;
+  } catch {
+    return loginUrl || DEFAULT_LOGIN_URL;
+  }
+}
+
+function isBuiltinEnvName(envName) {
+  return ['public', 'intl', 'alibaba'].includes(envName);
+}
+
+function isDingTalkWukongRunning() {
+  if (process.platform !== 'darwin') {return false;}
+  try {
+    return execSync('ps -axo args', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+      .includes('/Applications/DingTalkWuKong.app/');
+  } catch {
+    return false;
+  }
+}
+
+function detectSetupRecommendation() {
+  if (process.env.OPENYIDA_ENV) {
+    return resolveEnvNameAlias(process.env.OPENYIDA_ENV);
+  }
+  if ((process.env.OPENYIDA_LOGIN_URL || '').includes('login.dingtalk.io')) {
+    return 'intl';
+  }
+  if ((process.env.OPENYIDA_ENDPOINT || '').includes('alibaba-inc.com')) {
+    return 'alibaba';
+  }
+  if (isDingTalkWukongRunning()) {
+    return 'intl';
+  }
+
+  let activeTool = null;
+  try {
+    activeTool = require('./utils').detectActiveTool();
+  } catch {
+    activeTool = null;
+  }
+  if (activeTool && activeTool.tool === 'wukong') {
+    return 'intl';
+  }
+
+  return 'public';
+}
+
+function switchToEnv(envName) {
+  const resolvedEnvName = resolveEnvNameAlias(envName);
+  const config = loadEnvsConfig();
+
+  if (!config.environments[resolvedEnvName]) {
+    warn(`${RED}错误：环境 "${envName}" 不存在${RESET}`);
+    warn(`使用 ${CYAN}openyida env list${RESET} 查看所有环境`);
+    process.exit(1);
+  }
+
+  const previousEnv = config.current;
+  config.current = resolvedEnvName;
+  saveEnvsConfig(config);
+
+  console.log('');
+  console.log(`${GREEN}✅ 已切换环境${RESET}`);
+  console.log(`  ${DIM}${previousEnv}${RESET} → ${GREEN}${BOLD}${resolvedEnvName}${RESET}`);
+  console.log(`  地址：${config.environments[resolvedEnvName].baseUrl}`);
+  console.log(`  登录：${getLoginHost(config.environments[resolvedEnvName].loginUrl)}`);
+  console.log('');
+  console.log(`${DIM}下一步：运行 openyida login；在悟空中可运行 openyida login --wukong${RESET}`);
+  console.log('');
+}
+
 // ── 子命令实现 ────────────────────────────────────────
 
 /**
@@ -88,6 +166,7 @@ function cmdList() {
       const label = formatEnvLabel(envName, config.current);
       console.log(`  ${label}`);
       console.log(`    ${DIM}地址：${RESET}${envConfig.baseUrl || DEFAULT_BASE_URL}`);
+      console.log(`    ${DIM}登录：${RESET}${getLoginHost(envConfig.loginUrl || DEFAULT_LOGIN_URL)}`);
       if (envConfig.description) {
         console.log(`    ${DIM}描述：${RESET}${envConfig.description}`);
       }
@@ -95,7 +174,7 @@ function cmdList() {
   }
 
   console.log('');
-  console.log(`${DIM}使用 openyida env switch <name> 切换环境${RESET}`);
+  console.log(`${DIM}使用 openyida env setup 进入向导，或 openyida env switch <name> 切换环境${RESET}`);
   console.log(`${DIM}使用 openyida env add <name> 添加私有化环境${RESET}`);
   console.log('');
 }
@@ -106,7 +185,7 @@ function cmdList() {
  */
 function cmdShow(envName) {
   const config = loadEnvsConfig();
-  const targetName = envName || config.current;
+  const targetName = resolveEnvNameAlias(envName || config.current);
   const envConfig = config.environments[targetName];
 
   if (!envConfig) {
@@ -146,30 +225,21 @@ function cmdSwitch(envName) {
     process.exit(1);
   }
 
+  const resolvedEnvName = resolveEnvNameAlias(envName);
   const config = loadEnvsConfig();
 
-  if (!config.environments[envName]) {
+  if (!config.environments[resolvedEnvName]) {
     warn(`${RED}错误：环境 "${envName}" 不存在${RESET}`);
     warn(`使用 ${CYAN}openyida env list${RESET} 查看所有环境`);
     process.exit(1);
   }
 
-  if (config.current === envName) {
-    console.log(`${YELLOW}当前已在 "${envName}" 环境，无需切换${RESET}`);
+  if (config.current === resolvedEnvName) {
+    console.log(`${YELLOW}当前已在 "${resolvedEnvName}" 环境，无需切换${RESET}`);
     return;
   }
 
-  const previousEnv = config.current;
-  config.current = envName;
-  saveEnvsConfig(config);
-
-  console.log('');
-  console.log(`${GREEN}✅ 已切换环境${RESET}`);
-  console.log(`  ${DIM}${previousEnv}${RESET} → ${GREEN}${BOLD}${envName}${RESET}`);
-  console.log(`  地址：${config.environments[envName].baseUrl}`);
-  console.log('');
-  console.log(`${DIM}提示：登录态已自动切换，如需重新登录请运行 openyida login --qr${RESET}`);
-  console.log('');
+  switchToEnv(resolvedEnvName);
 }
 
 /**
@@ -183,8 +253,9 @@ function cmdRemove(envName) {
     process.exit(1);
   }
 
-  if (envName === 'public') {
-    warn(`${RED}错误：不能删除默认的公有云环境 "public"${RESET}`);
+  envName = resolveEnvNameAlias(envName);
+  if (isBuiltinEnvName(envName)) {
+    warn(`${RED}错误：不能删除内置环境 "${envName}"${RESET}`);
     process.exit(1);
   }
 
@@ -232,6 +303,11 @@ async function cmdAdd(envName) {
 
   if (envName === 'public') {
     warn(`${RED}错误："public" 是保留的默认环境名称，不能添加${RESET}`);
+    process.exit(1);
+  }
+
+  if (resolveEnvNameAlias(envName) !== envName || isBuiltinEnvName(envName)) {
+    warn(`${RED}错误："${envName}" 是内置环境或内置别名，不能作为私有化环境名称${RESET}`);
     process.exit(1);
   }
 
@@ -302,6 +378,75 @@ async function cmdAdd(envName) {
   console.log('');
 }
 
+async function cmdSetup() {
+  const config = loadEnvsConfig();
+  const recommendedEnv = detectSetupRecommendation();
+  const options = [
+    {
+      key: 'public',
+      title: '阿里云公有云 / 国内钉钉',
+      baseUrl: DEFAULT_PUBLIC_ENV.baseUrl,
+      loginUrl: DEFAULT_PUBLIC_ENV.loginUrl,
+    },
+    {
+      key: 'intl',
+      title: '海外 DingTalk / Dingtalk Wukong',
+      baseUrl: DEFAULT_INTERNATIONAL_ENV.baseUrl,
+      loginUrl: DEFAULT_INTERNATIONAL_ENV.loginUrl,
+    },
+    {
+      key: 'alibaba',
+      title: '阿里内网员工环境',
+      baseUrl: DEFAULT_ALIBABA_INTERNAL_ENV.baseUrl,
+      loginUrl: DEFAULT_ALIBABA_INTERNAL_ENV.loginUrl,
+    },
+    {
+      key: 'custom',
+      title: '私有化部署 / 专属域名',
+      baseUrl: '自定义',
+      loginUrl: '自定义',
+    },
+  ];
+  const defaultIndex = Math.max(0, options.findIndex((item) => item.key === recommendedEnv));
+
+  console.log('');
+  console.log(`${BOLD}OpenYida 环境设置向导${RESET}`);
+  console.log(`${'─'.repeat(50)}`);
+  console.log(`${DIM}请选择客户实际登录入口。可随时用 openyida env switch 切换。${RESET}`);
+  console.log('');
+
+  options.forEach((item, index) => {
+    const isRecommended = index === defaultIndex;
+    console.log(`  ${CYAN}${index + 1}.${RESET} ${item.title}${isRecommended ? ` ${GREEN}← 推荐${RESET}` : ''}`);
+    console.log(`     ${DIM}地址：${item.baseUrl}${RESET}`);
+    console.log(`     ${DIM}登录：${getLoginHost(item.loginUrl)}${RESET}`);
+  });
+  console.log('');
+
+  const answer = await askQuestion(`${BOLD}选择环境${RESET}（1-${options.length}）：`, String(defaultIndex + 1));
+  const selectedIndex = Number.parseInt(answer, 10) - 1;
+  const selected = options[selectedIndex];
+  if (!selected) {
+    warn(`${RED}错误：无效选择${RESET}`);
+    process.exit(1);
+  }
+
+  if (selected.key === 'custom') {
+    const envName = await askQuestion(`${BOLD}私有化环境名称${RESET}（如 private-prod）：`, '');
+    await cmdAdd(envName);
+    return;
+  }
+
+  if (config.current === selected.key) {
+    console.log('');
+    console.log(`${YELLOW}当前已在 "${selected.key}" 环境，无需切换${RESET}`);
+    console.log('');
+    return;
+  }
+
+  switchToEnv(selected.key);
+}
+
 /**
  * 显示 env 命令帮助信息。
  */
@@ -314,6 +459,7 @@ function showHelp() {
   console.log('');
   console.log(`${CYAN}子命令：${RESET}`);
   console.log(`  ${GREEN}list${RESET}              列出所有环境及当前激活环境`);
+  console.log(`  ${GREEN}setup${RESET}             交互式选择公有云、海外、内网或私有化环境`);
   console.log(`  ${GREEN}add <name>${RESET}        交互式添加私有化环境配置`);
   console.log(`  ${GREEN}switch <name>${RESET}     切换当前激活环境`);
   console.log(`  ${GREEN}remove <name>${RESET}     移除环境配置`);
@@ -321,6 +467,7 @@ function showHelp() {
   console.log('');
   console.log(`${CYAN}示例：${RESET}`);
   console.log(`  ${BLUE}openyida env list${RESET}                     查看所有环境`);
+  console.log(`  ${BLUE}openyida env setup${RESET}                    进入环境设置向导`);
   console.log(`  ${BLUE}openyida env add private-prod${RESET}         添加私有化生产环境`);
   console.log(`  ${BLUE}openyida env switch private-prod${RESET}      切换到私有化环境`);
   console.log(`  ${BLUE}openyida env show private-prod${RESET}        查看环境详情`);
@@ -356,6 +503,12 @@ async function run(args) {
 
     case 'switch':
       cmdSwitch(subArgs[0]);
+      break;
+
+    case 'setup':
+    case 'init':
+    case 'configure':
+      await cmdSetup();
       break;
 
     case 'remove':

--- a/lib/core/env-manager.js
+++ b/lib/core/env-manager.js
@@ -31,9 +31,48 @@ const { findProjectRoot } = require('./utils');
 
 const DEFAULT_BASE_URL = 'https://www.aliwork.com';
 const DEFAULT_LOGIN_URL = 'https://www.aliwork.com/workPlatform';
+const DINGTALK_OAUTH_CLIENT_ID = 'suite9xvlxxerybljwheo';
+const DINGTALK_LOGIN_ORIGIN = 'https://login.dingtalk.com';
+const DINGTALK_INTL_LOGIN_ORIGIN = 'https://login.dingtalk.io';
 const ALIBABA_INTERNAL_BASE_URL = 'https://yida-group.alibaba-inc.com';
 const ALIBABA_INTERNAL_LOGIN_URL = `${ALIBABA_INTERNAL_BASE_URL}/workPlatform`;
 const ENVS_CONFIG_FILE = 'openyida-envs.json';
+
+function normalizeUrlOrigin(value, fallback) {
+  const raw = value || fallback;
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) {return fallback;}
+  const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    return new URL(withProtocol).origin.replace(/\/+$/, '');
+  } catch {
+    return fallback;
+  }
+}
+
+function buildDingtalkOAuthLoginUrl(options = {}) {
+  const loginOrigin = normalizeUrlOrigin(options.loginOrigin || DINGTALK_LOGIN_ORIGIN, DINGTALK_LOGIN_ORIGIN);
+  const baseUrl = normalizeUrlOrigin(options.baseUrl || DEFAULT_BASE_URL, DEFAULT_BASE_URL);
+  const continueUrl = `${baseUrl}${options.continuePath || '/workPlatform'}`;
+  const callbackUrl = `${baseUrl}/dingtalk_sso_call_back?continue=${encodeURIComponent(continueUrl)}`;
+  const params = new URLSearchParams({
+    redirect_uri: callbackUrl,
+    response_type: 'code',
+    client_id: options.clientId || DINGTALK_OAUTH_CLIENT_ID,
+    scope: 'openid corpid',
+    lang: options.lang || 'zh_CN',
+  });
+
+  return `${loginOrigin}/oauth2/auth?${params.toString()}`;
+}
+
+const INTERNATIONAL_LOGIN_URL = buildDingtalkOAuthLoginUrl({
+  loginOrigin: DINGTALK_INTL_LOGIN_ORIGIN,
+  baseUrl: DEFAULT_BASE_URL,
+  lang: 'en_US',
+});
 
 /** 默认公有云环境配置 */
 const DEFAULT_PUBLIC_ENV = {
@@ -51,9 +90,34 @@ const DEFAULT_ALIBABA_INTERNAL_ENV = {
   cookieFile: 'cookies-alibaba.json',
 };
 
+/** 海外版 DingTalk / Wukong 环境配置 */
+const DEFAULT_INTERNATIONAL_ENV = {
+  baseUrl: DEFAULT_BASE_URL,
+  loginUrl: INTERNATIONAL_LOGIN_URL,
+  description: '海外版 DingTalk / Wukong（login.dingtalk.io）',
+  cookieFile: 'cookies-intl.json',
+};
+
 const BUILTIN_ENVIRONMENTS = {
   public: DEFAULT_PUBLIC_ENV,
+  intl: DEFAULT_INTERNATIONAL_ENV,
   alibaba: DEFAULT_ALIBABA_INTERNAL_ENV,
+};
+
+const ENV_ALIASES = {
+  public: 'public',
+  aliyun: 'public',
+  domestic: 'public',
+  china: 'public',
+  overseas: 'intl',
+  oversea: 'intl',
+  international: 'intl',
+  global: 'intl',
+  abroad: 'intl',
+  intl: 'intl',
+  alibaba: 'alibaba',
+  internal: 'alibaba',
+  intranet: 'alibaba',
 };
 
 const SHARED_COOKIE_DOMAINS = new Set([
@@ -77,6 +141,12 @@ function buildDefaultEnvsConfig() {
     current: 'public',
     environments: cloneBuiltinEnvironments(),
   };
+}
+
+function resolveEnvNameAlias(envName) {
+  if (!envName) {return envName;}
+  const normalized = String(envName).trim().toLowerCase();
+  return ENV_ALIASES[normalized] || envName;
 }
 
 function ensureBuiltinEnvironments(config) {
@@ -229,7 +299,7 @@ function saveEnvsConfig(config, projectRoot) {
  */
 function getCurrentEnvConfig(projectRoot) {
   const envsConfig = loadEnvsConfig(projectRoot);
-  const envName = process.env.OPENYIDA_ENV || envsConfig.current || 'public';
+  const envName = resolveEnvNameAlias(process.env.OPENYIDA_ENV || envsConfig.current || 'public');
   const envConfig = envsConfig.environments[envName] || envsConfig.environments.public || DEFAULT_PUBLIC_ENV;
 
   return { name: envName, config: envConfig };
@@ -335,10 +405,17 @@ function resolveLoginUrl(projectRoot) {
 module.exports = {
   DEFAULT_BASE_URL,
   DEFAULT_LOGIN_URL,
+  DINGTALK_OAUTH_CLIENT_ID,
+  DINGTALK_LOGIN_ORIGIN,
+  DINGTALK_INTL_LOGIN_ORIGIN,
+  INTERNATIONAL_LOGIN_URL,
   ALIBABA_INTERNAL_BASE_URL,
   ALIBABA_INTERNAL_LOGIN_URL,
   DEFAULT_PUBLIC_ENV,
+  DEFAULT_INTERNATIONAL_ENV,
   DEFAULT_ALIBABA_INTERNAL_ENV,
+  buildDingtalkOAuthLoginUrl,
+  resolveEnvNameAlias,
   loadEnvsConfig,
   saveEnvsConfig,
   getCurrentEnvConfig,

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -108,7 +108,6 @@ describe('CLI offline smoke', () => {
     expect(output).toContain('corp-manager');
     expect(output).toContain('dws');
     expect(output).toContain('dingtalk-link');
-    expect(output).toContain('commands [--json]');
     expect(output).toContain('a2a <serve|agent-card> [options]');
     expect(output).toContain('sample [--list]');
     expect(output).toContain('generate-page <template>');

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -100,7 +100,7 @@ describe('CLI offline smoke', () => {
     const output = runOk(['--help']);
     expect(output).toContain('OpenYida');
     expect(output).toContain('env [--json]');
-    expect(output).toContain('login [--qr|--agent-qr|--codex|--browser] [--corp-id <corpId>]');
+    expect(output).toContain('login [--qr|--agent-qr|--codex|--browser] [--env <name>|--overseas] [--corp-id <corpId>]');
     expect(output).toContain('corp-efficiency');
     expect(output).toContain('create-form');
     expect(output).toContain('list-forms');

--- a/tests/integration-check.test.js
+++ b/tests/integration-check.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { SUPPORTED_LANGUAGES } = require('../lib/core/i18n');
+const { SUPPORTED_LANGUAGES, t } = require('../lib/core/i18n');
 const {
   formatProgressBar,
   sanitizeSheetName,
@@ -121,8 +121,9 @@ describe('integration check', () => {
   });
 
   test('buildAppRows records no-abnormal and app-error rows', () => {
-    expect(buildAppRows('APP_EMPTY', [])[1][14]).toBe('未发现执行异常日志');
-    expect(buildAppRows('APP_ERR', [], [{ appType: 'APP_ERR', message: '登录态失效' }])[1][14]).toBe('应用检查失败：登录态失效');
+    expect(buildAppRows('APP_EMPTY', [])[1][14]).toBe(t('integration_check.no_abnormal'));
+    expect(buildAppRows('APP_ERR', [], [{ appType: 'APP_ERR', message: '登录态失效' }])[1][14])
+      .toBe(t('integration_check.app_failed', '登录态失效'));
   });
 
   test('all locale packs include integration check messages', () => {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -277,6 +277,46 @@ describe('cdp-browser-login 工具函数', () => {
   });
 });
 
+//─ env-manager 海外登录环境─────────────────────────
+
+describe('env-manager 海外登录环境', () => {
+  test('默认环境配置包含海外 DingTalk 登录预设', () => {
+    const {
+      loadEnvsConfig,
+      INTERNATIONAL_LOGIN_URL,
+      resolveEnvNameAlias,
+    } = require('../lib/core/env-manager');
+
+    const config = loadEnvsConfig(path.join(os.tmpdir(), `openyida-env-missing-${Date.now()}`));
+
+    expect(config.environments).toHaveProperty('intl');
+    expect(config.environments.intl.baseUrl).toBe('https://www.aliwork.com');
+    expect(config.environments.intl.loginUrl).toBe(INTERNATIONAL_LOGIN_URL);
+    expect(config.environments.intl.cookieFile).toBe('cookies-intl.json');
+    expect(resolveEnvNameAlias('overseas')).toBe('intl');
+    expect(resolveEnvNameAlias('international')).toBe('intl');
+  });
+
+  test('海外 OAuth 登录 URL 使用 login.dingtalk.io 并回调到 YiDA', () => {
+    const { buildDingtalkOAuthLoginUrl } = require('../lib/core/env-manager');
+    const loginUrl = buildDingtalkOAuthLoginUrl({
+      loginOrigin: 'https://login.dingtalk.io',
+      baseUrl: 'https://www.aliwork.com',
+      lang: 'en_US',
+    });
+    const parsedUrl = new URL(loginUrl);
+    const redirectUri = parsedUrl.searchParams.get('redirect_uri');
+
+    expect(parsedUrl.origin).toBe('https://login.dingtalk.io');
+    expect(parsedUrl.pathname).toBe('/oauth2/auth');
+    expect(parsedUrl.searchParams.get('client_id')).toBe('suite9xvlxxerybljwheo');
+    expect(parsedUrl.searchParams.get('scope')).toBe('openid corpid');
+    expect(parsedUrl.searchParams.get('lang')).toBe('en_US');
+    expect(redirectUri).toContain('https://www.aliwork.com/dingtalk_sso_call_back');
+    expect(redirectUri).toContain(encodeURIComponent('https://www.aliwork.com/workPlatform'));
+  });
+});
+
 //─ interactiveLogin 浏览器优先级───────────────────────
 
 describe('interactiveLogin 浏览器优先级', () => {

--- a/tests/qr-login.test.js
+++ b/tests/qr-login.test.js
@@ -458,3 +458,39 @@ describe('DingTalk OAuth organization selection', () => {
     )).toBe('https://yida.company.example');
   });
 });
+
+describe('isDingtalkOAuthChallengeUrl', () => {
+  test('recognizes dingtalk.com OAuth URLs', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl(
+      'https://login.dingtalk.com/oauth2/challenge'
+    )).toBe(true);
+  });
+
+  test('recognizes dingtalk.io OAuth challenge URL', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl(
+      'https://login.dingtalk.io/oauth2/challenge'
+    )).toBe(true);
+  });
+
+  test('recognizes dingtalk.io OAuth auth URL with redirect_uri', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl(
+      'https://login.dingtalk.io/oauth2/auth?redirect_uri=xxx'
+    )).toBe(true);
+  });
+
+  test('rejects dingtalk.io URL with non-oauth2 path', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl(
+      'https://login.dingtalk.io/other-path'
+    )).toBe(false);
+  });
+
+  test('rejects non-dingtalk domains', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl(
+      'https://login.example.com/oauth2/challenge'
+    )).toBe(false);
+  });
+
+  test('returns false for invalid URLs', () => {
+    expect(__test__.isDingtalkOAuthChallengeUrl('not-a-url')).toBe(false);
+  });
+});

--- a/tests/qr-login.test.js
+++ b/tests/qr-login.test.js
@@ -105,6 +105,21 @@ describe('terminal QR code rendering', () => {
     });
   });
 
+  test('keeps selected environment in QR poll command', () => {
+    expect(__test__.buildCodexPollCommand('/tmp/session.json', 'ding-main', 'intl')).toBe(
+      "openyida login --agent-poll '/tmp/session.json' --env 'intl' --corp-id 'ding-main'"
+    );
+
+    const result = __test__.buildNeedQrScanResult({
+      qrUrl: 'https://login.dingtalk.io/oauth2/qr_confirm.htm?code=abc',
+      qrImageFile: null,
+      sessionFile: '/tmp/session.json',
+      targetCorpId: null,
+      envName: 'intl',
+    });
+    expect(result.poll_command).toBe("openyida login --agent-poll '/tmp/session.json' --env 'intl'");
+  });
+
   test('resolveQrcodeModule tries package name before adjacent install paths', () => {
     const qrcode = { toString: jest.fn() };
     const requireFn = jest.fn((request) => {


### PR DESCRIPTION
## 背景

海外 DingTalk / Dingtalk Wukong 的登录入口使用 `login.dingtalk.io`，而国内钉钉、公有云、阿里内网、私有化部署又各自可能有不同的登录域名。之前逻辑只覆盖了常规 `.dingtalk.com` OAuth 域名，海外 Wukong 扫码登录和后续 Cookie 环境保存容易走错。

## 改动

- 新增内置 `intl` 环境，OAuth 登录地址走 `login.dingtalk.io`，Cookie 独立保存到 `cookies-intl.json`
- `openyida login` 支持 `--overseas` / `--intl` / `--env <name>` 等环境选择参数
- 终端二维码、Agent QR、组织选择后的 poll/select 命令会保留当前环境，避免海外扫码后写回默认国内环境
- 新增 `openyida env setup` 交互式配置向导，覆盖国内公有云、海外 DingTalk/Wukong、阿里内网、私有化部署，并根据 Wukong / `.io` / 内网域名做推荐
- 更新 README、命令 manifest 和登录/二维码相关测试

## 验证

- `npm test -- --runTestsByPath tests/cli-smoke.test.js tests/login.test.js tests/qr-login.test.js tests/codex-login.test.js`
- `npm run check:ci`
- 手动验证 `login.dingtalk.io` OAuth challenge 与二维码生成链路可返回海外二维码确认地址