### PR TITLE
feat: 支持宜搭集成自动化审批结果事件与审批节点事件发布

### DIFF
--- a/lib/integration/integration-create.js
+++ b/lib/integration/integration-create.js
@@ -81,6 +81,9 @@ async function run(args) {
   const notificationTitle = parseFlag(subArgs, '--title') || flowName;
   const notificationContent = parseFlag(subArgs, '--content') || '表单有新记录提交，请及时查看。';
   const eventsRaw = parseFlag(subArgs, '--events') || 'insert';
+  const approvalActionsRaw = parseFlag(subArgs, '--approval-actions') || '';
+  const approvalNodeIdsRaw = parseFlag(subArgs, '--approval-node-ids') || '';
+  const triggerRecursively = hasFlag(subArgs, '--trigger-recursively');
   const shouldPublish = hasFlag(subArgs, '--publish');
 
   const receiverUserIds = receiversRaw
@@ -94,9 +97,30 @@ async function run(args) {
   const formEventTypes = mapEventTypes(
     eventsRaw.split(',').map((event) => event.trim()).filter(Boolean)
   );
+  const approvalActions = approvalActionsRaw
+    ? approvalActionsRaw.split(',').map((item) => item.trim()).filter(Boolean)
+    : [];
+  const approvalNodeIds = approvalNodeIdsRaw
+    ? approvalNodeIdsRaw.split(',').map((item) => item.trim()).filter(Boolean)
+    : [];
 
   if (formEventTypes.length === 0) {
     warn(t('integration.create_invalid_events'));
+    process.exit(1);
+  }
+
+  if (formEventTypes.includes('processFinish') && approvalActions.length === 0) {
+    warn('审批事件触发时必须传入 --approval-actions agree,disagree,terminated 中的至少一项');
+    process.exit(1);
+  }
+
+  if (formEventTypes.includes('activityTask') && approvalActions.length === 0) {
+    warn('审批节点事件触发时必须传入 --approval-actions agree,disagree,terminated 中的至少一项');
+    process.exit(1);
+  }
+
+  if (formEventTypes.includes('activityTask') && approvalNodeIds.length === 0) {
+    warn('审批节点事件触发时必须传入 --approval-node-ids node_xxx[,node_yyy]');
     process.exit(1);
   }
 
@@ -118,6 +142,25 @@ async function run(args) {
           bFieldName: parts[1],
           aFieldId: parts[2],
           componentType: parts[3] || 'TextField',
+        });
+      }
+      index++;
+    }
+  }
+
+  // --trigger-condition 支持多次传入，格式：fieldId:fieldName:opCode:value[:componentType[:valueType]]
+  const triggerConditions = [];
+  for (let index = 0; index < subArgs.length; index++) {
+    if (subArgs[index] === '--trigger-condition' && subArgs[index + 1]) {
+      const parts = subArgs[index + 1].split(':');
+      if (parts.length >= 4) {
+        triggerConditions.push({
+          fieldId: parts[0],
+          fieldName: parts[1],
+          opCode: parts[2],
+          value: parts[3],
+          componentType: parts[4] || 'TextField',
+          valueType: parts[5] || 'literal',
         });
       }
       index++;
@@ -215,6 +258,18 @@ async function run(args) {
     warn(t('integration.create_process_code', processCodeInput));
   }
   warn(t('integration.create_events', formEventTypes.join(', ')));
+  if (approvalActions.length > 0) {
+    warn(`审批动作: ${approvalActions.join(', ')}`);
+  }
+  if (approvalNodeIds.length > 0) {
+    warn(`审批节点: ${approvalNodeIds.join(', ')}`);
+  }
+  if (triggerRecursively) {
+    warn('允许自动触发: true');
+  }
+  if (triggerConditions.length > 0) {
+    warn(`触发过滤条件: ${triggerConditions.length}`);
+  }
   warn(t('integration.create_receivers', receiverUserIds.length > 0 ? receiverUserIds.join(', ') : t('integration.create_receivers_empty')));
   warn(t('integration.create_notify_title', notificationTitle));
   warn(t('integration.create_notify_content', notificationContent));
@@ -330,6 +385,10 @@ async function run(args) {
     dataFormUuid: dataFormUuid ?? undefined,
     dataConditions,
     hasMessageNode,
+    approvalActions,
+    approvalNodeIds,
+    triggerRecursively,
+    triggerConditions,
     connectorId: connectorIdArg,
     actionId: actionIdArg,
     connectorAssignments,
@@ -352,6 +411,10 @@ async function run(args) {
     dataFormUuid: dataFormUuid ?? undefined,
     dataConditions,
     hasMessageNode,
+    approvalActions,
+    approvalNodeIds,
+    triggerRecursively,
+    triggerConditions,
     connectorId: connectorIdArg,
     actionId: actionIdArg,
     connectorAssignments,

--- a/lib/integration/integration-process-builder.js
+++ b/lib/integration/integration-process-builder.js
@@ -21,10 +21,70 @@ function mapEventTypes(events) {
     update: 'update',
     delete: 'delete',
     comment: 'comment',
+    processfinish: 'processFinish',
+    process_finish: 'processFinish',
+    approval: 'processFinish',
+    approve: 'processFinish',
+    process: 'processFinish',
+    activitytask: 'activityTask',
+    activity_task: 'activityTask',
+    approvalnode: 'activityTask',
+    approval_node: 'activityTask',
   };
   return events
     .map((event) => eventMapping[event.toLowerCase()])
     .filter(Boolean);
+}
+
+function mapTriggerOperator(opCode) {
+  const operatorMapping = {
+    Equal: '等于',
+    NotEqual: '不等于',
+    Contain: '包含',
+    NotContain: '不包含',
+    HasValue: '有值',
+    NoValue: '没有值',
+    GreaterThan: '大于',
+    LessThan: '小于',
+    GreaterThanOrEqual: '大于等于',
+    LessThanOrEqual: '小于等于',
+    In: '等于任意一个',
+    NotIn: '不等于任意一个',
+  };
+  return operatorMapping[opCode] || opCode || '等于';
+}
+
+function buildTriggerCondition(triggerConditions) {
+  const groupId = generateRuleGroupId();
+  const rules = (triggerConditions || []).map((condition) => {
+    const opCode = condition.opCode || 'Equal';
+    const valueType = condition.valueType || 'literal';
+    const rawValue = condition.value;
+    const ruleValue = valueType === 'literal' && !isNaN(Number(rawValue))
+      ? Number(rawValue)
+      : rawValue;
+    return {
+      id: condition.fieldId,
+      op: mapTriggerOperator(opCode),
+      operators: [],
+      value: ruleValue,
+      componentType: condition.componentType || 'TextField',
+      ruleId: generateRuleItemId(),
+      parentId: groupId,
+      extValue: valueType === 'literal' ? 'value' : valueType,
+      ruleValue,
+      name: condition.fieldName || condition.fieldId,
+      valueType,
+      ruleType: 'rule_text',
+      opCode,
+    };
+  });
+  return {
+    condition: 'AND',
+    rules,
+    ruleId: groupId,
+    conditionCode: '&&',
+  };
 }
 
 /**
@@ -95,7 +155,8 @@ function buildProcessJson(options) {
     processCode, formUuid, appType, formEventTypes,
     notificationTitle, notificationContent, toUsers, userFields, nodeIds,
     addDataFormUuid, addDataAssignments,
-    dataFormUuid, dataConditions, hasMessageNode,
+    dataFormUuid, dataConditions, hasMessageNode, approvalActions,
+    approvalNodeIds, triggerRecursively, triggerConditions,
     // ConnectorCall 节点（可选）：用于在集成自动化内调用任意连接器动作（如"钉钉待办/创建待办任务"）
     connectorId, actionId, connectorAssignments, connectorDescription,
   } = options;
@@ -104,6 +165,26 @@ function buildProcessJson(options) {
   const hasDataNode = Boolean(dataFormUuid);
   const hasConnectorCallNode = Boolean(connectorId && actionId);
   const includeMessageNode = hasMessageNode !== false;
+  const isApprovalNodeEvent = formEventTypes.includes('activityTask');
+  const isApprovalProcessEvent = formEventTypes.includes('processFinish');
+  const normalizedApprovalActions = Array.isArray(approvalActions)
+    ? approvalActions.map((item) => String(item).trim()).filter(Boolean)
+    : [];
+  const normalizedApprovalNodeIds = Array.isArray(approvalNodeIds)
+    ? approvalNodeIds.map((item) => String(item).trim()).filter(Boolean)
+    : [];
+  const normalizedTriggerConditions = Array.isArray(triggerConditions)
+    ? triggerConditions.filter(Boolean)
+    : [];
+  const triggerConditionObject = normalizedTriggerConditions.length > 0
+    ? buildTriggerCondition(normalizedTriggerConditions)
+    : null;
+  const activityTask = isApprovalNodeEvent
+    ? normalizedApprovalNodeIds.map((activityId) => ({
+      activityId: [activityId],
+      activityAction: normalizedApprovalActions,
+    }))
+    : [];
 
   // nodeIds 顺序：[triggerNodeId, addDataNodeId?, dataNodeId?, connectorCallNodeId?, messageNodeId?, endNodeId]
   let nodeIdIndex = 0;
@@ -142,9 +223,11 @@ function buildProcessJson(options) {
           formEventType: formEventTypes,
           formEventField: '',
           formUuid,
-          conditions: null,
-          activityAction: [],
-          triggerFormEventRecursively: false,
+          conditions: triggerConditionObject,
+          activityAction: isApprovalProcessEvent || isApprovalNodeEvent ? normalizedApprovalActions : [],
+          triggerFormEventRecursively: Boolean(triggerRecursively),
+          activityId: isApprovalNodeEvent ? normalizedApprovalNodeIds : [],
+          activityTask,
         },
         triggerType: 'FormEvent',
       },
@@ -314,6 +397,8 @@ function buildProcessJson(options) {
 
 module.exports = {
   mapEventTypes,
+  mapTriggerOperator,
+  buildTriggerCondition,
   buildDataRetrieveCondition,
   buildDataCreateAssignments,
   buildConnectorCallAssignments,

--- a/lib/integration/integration-view-builder.js
+++ b/lib/integration/integration-view-builder.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { generateDataRuleId, generateRuleGroupId, generateButtonUuid } = require('./integration-node-ids');
-const { buildDataRetrieveCondition } = require('./integration-process-builder');
+const { buildDataRetrieveCondition, buildTriggerCondition } = require('./integration-process-builder');
 const {
   lookupConnectorPreset,
   buildConnectorRulesFromInputs,
@@ -50,7 +50,8 @@ function buildViewJson(options) {
     formUuid, formEventTypes, notificationTitle, notificationContent,
     toUsers, userFields, appType, nodeIds,
     addDataFormUuid, addDataAssignments, addDataFormSchema, addDataFormName,
-    dataFormUuid, dataConditions, hasMessageNode,
+    dataFormUuid, dataConditions, hasMessageNode, approvalActions,
+    approvalNodeIds, triggerRecursively, triggerConditions,
     // ConnectorCall 节点（可选）
     connectorId, actionId, connectorAssignments, connectorName, connectorIcon, connectorInputs,
   } = options;
@@ -59,6 +60,43 @@ function buildViewJson(options) {
   const hasDataNode = Boolean(dataFormUuid);
   const hasConnectorCallNode = Boolean(connectorId && actionId);
   const includeMessageNode = hasMessageNode !== false;
+  const isApprovalNodeEvent = formEventTypes.includes('activityTask');
+  const isApprovalProcessEvent = formEventTypes.includes('processFinish');
+  const normalFormEventTypes = formEventTypes.filter((eventType) => eventType !== 'processFinish' && eventType !== 'activityTask');
+  const startFormEventTypes = isApprovalProcessEvent || isApprovalNodeEvent
+    ? ['processEvents', ...normalFormEventTypes]
+    : formEventTypes;
+  const normalizedApprovalActions = Array.isArray(approvalActions)
+    ? approvalActions.map((item) => String(item).trim()).filter(Boolean)
+    : [];
+  const normalizedApprovalNodeIds = Array.isArray(approvalNodeIds)
+    ? approvalNodeIds.map((item) => String(item).trim()).filter(Boolean)
+    : [];
+  const normalizedTriggerConditions = Array.isArray(triggerConditions)
+    ? triggerConditions.filter(Boolean)
+    : [];
+  const triggerConditionObject = normalizedTriggerConditions.length > 0
+    ? buildTriggerCondition(normalizedTriggerConditions)
+    : {
+      condition: 'AND',
+      rules: [
+        {
+          id: '',
+          op: '等于',
+          operators: [],
+          componentType: 'TextField',
+        },
+      ],
+    };
+  const approvalNodeActionTasks = isApprovalNodeEvent
+    ? normalizedApprovalNodeIds.map((activityId) => ({
+      activityId: [activityId],
+      activityAction: normalizedApprovalActions,
+    }))
+    : [];
+  const startExamineApproveType = isApprovalNodeEvent
+    ? 'activityTask'
+    : 'processFinish';
 
   // nodeIds 顺序：[canvasId, triggerNodeId, addDataNodeId?, dataNodeId?, connectorCallNodeId?, messageNodeId?, endNodeId]
   let nodeIdIndex = 0;
@@ -83,28 +121,19 @@ function buildViewJson(options) {
         },
         nodeError: '',
         start: {
-          examineApproveType: 'processFinish',
-          formEventType: formEventTypes,
+          examineApproveType: startExamineApproveType,
+          formEventType: startFormEventTypes,
           formEventField: '',
-          dataFilterType: 'all',
+          dataFilterType: normalizedTriggerConditions.length > 0 ? 'byRule' : 'all',
           fieldType: 'all',
-          conditions: {
-            condition: 'AND',
-            rules: [
-              {
-                id: '',
-                op: '等于',
-                operators: [],
-                componentType: 'TextField',
-              },
-            ],
-          },
+          conditions: triggerConditionObject,
           formUuid,
           triggerType: 'FormEvent',
           type: 'form',
-          triggerFormEventRecursively: false,
-          examineApproveNode: '',
-          examineApproveActiveList: [],
+          triggerFormEventRecursively: Boolean(triggerRecursively),
+          examineApproveNode: isApprovalNodeEvent ? (normalizedApprovalNodeIds[0] || '') : '',
+          examineApproveActiveList: isApprovalProcessEvent || isApprovalNodeEvent ? normalizedApprovalActions : [],
+          examineApproveActiveTask: approvalNodeActionTasks,
         },
       },
     },

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -86,7 +86,11 @@ openyida integration check <appType...> [--json] [--output result.xlsx] [--no-pr
 | `--receivers <userId,...>` | 空（无接收人） | 接收钉钉工作通知的用户 ID，多个用逗号分隔 |
 | `--title <title>` | 同 flowName | 通知标题，支持 `#{fieldId-ComponentType}#` 引用表单字段 |
 | `--content <content>` | `"表单有新记录提交，请及时查看。"` | 通知内容，支持 `#{fieldId-ComponentType}#` 引用表单字段 |
-| `--events <insert,update>` | `insert` | 触发事件，可选值：`insert`/`update`/`delete`/`comment`（也支持别名 `create`），多个用逗号分隔 |
+| `--events <insert,update>` | `insert` | 触发事件，可选值：`insert`/`update`/`delete`/`comment`/`processFinish`/`activityTask`（也支持别名 `create`/`approval`/`approvalNode`），多个用逗号分隔 |
+| `--approval-actions <agree,...>` | 空 | 当 `--events processFinish` 或 `--events activityTask` 时必填；可选值：`agree`/`disagree`/`terminated`，多个用逗号分隔 |
+| `--approval-node-ids <nodeId,...>` | 空 | 当 `--events activityTask` 时必填；审批节点 ID，多个用逗号分隔 |
+| `--trigger-condition <fieldId:fieldName:opCode:value[:componentType[:valueType]]>` | 空 | 触发器过滤条件，可多次传入；示例：`radioField_xxx:采购类型:Equal:材料采购:RadioField:literal` |
+| `--trigger-recursively` | 关闭 | 允许自动触发，对应设计器里的“允许自动触发” |
 | `--data-form-uuid <formUuid>` | 不启用 | 获取单条数据节点的目标表单 UUID（B 表单），传入后在触发节点和通知节点之间插入 GetSingleDataNode |
 | `--data-condition <bFieldId:bFieldName:aFieldId[:componentType]>` | 无 | 获取单条数据的过滤条件，可多次传入；格式：`B表单字段ID:B表单字段名:A表单字段ID[:组件类型]`，组件类型默认 `TextField` |
 | `--add-data-form-uuid <formUuid>` | 不启用 | 新增数据节点的目标表单 UUID，传入后在通知节点之后插入 AddDataNode |


### PR DESCRIPTION
﻿## 背景

在宜搭「集成&自动化」里，流程事件分为两类：

1. 审批结果事件
   - 对应设计器里的「流程事件 -> 审批结果」
   - 典型动作值：`agree` / `disagree` / `terminated`

2. 审批节点事件
   - 对应设计器里的「流程事件 -> 审批节点」
   - 需要同时指定审批节点 ID 和审批动作
   - 可与普通表单事件一起混合发布，如 `insert/update/delete/comment + activityTask`

此前 `openyida integration create` 只完整支持普通表单事件，无法按宜搭真实发布参数构造上述两类流程事件，导致审批事件型自动化无法稳定发布。

## 本次变更

### 1. 支持审批结果事件 `processFinish`

- 新增 `processFinish` 事件支持
- 新增事件别名：`approval`、`approve`、`process`
- 新增参数：`--approval-actions <agree,...>`

执行层 `processJson` 和展示层 `viewJson` 会同时补齐审批结果事件所需字段：

- `processJson.nodes[0].props.inputs.formEventType = ["processFinish"]`
- `processJson.nodes[0].props.inputs.activityAction = [...]`
- `viewJson.schema.children[0].props.start.formEventType = ["processEvents"]`
- `viewJson.schema.children[0].props.start.examineApproveType = "processFinish"`
- `viewJson.schema.children[0].props.start.examineApproveActiveList = [...]`

### 2. 支持审批节点事件 `activityTask`

- 新增 `activityTask` 事件支持
- 新增事件别名：`approvalNode`、`approval_node`
- 新增参数：
  - `--approval-node-ids <nodeId,...>`
  - `--trigger-condition <fieldId:fieldName:opCode:value[:componentType[:valueType]]>`
  - `--trigger-recursively`

执行层 `processJson` 会补齐：

- `formEventType` 包含 `activityTask`
- `activityAction`
- `activityId`
- `activityTask`
- `conditions`
- `triggerFormEventRecursively`

展示层 `viewJson` 会补齐：

- `formEventType` 包含 `processEvents`，并保留普通事件
- `examineApproveType = "activityTask"`
- `examineApproveNode`
- `examineApproveActiveList`
- `examineApproveActiveTask`
- `dataFilterType = "byRule"`（有触发过滤条件时）
- `conditions`
- `triggerFormEventRecursively`

### 3. 更新技能文档

更新 `yida-integration` 技能文档，补充：

- `processFinish`
- `activityTask`
- `--approval-actions`
- `--approval-node-ids`
- `--trigger-condition`
- `--trigger-recursively`

## 验证

### 审批结果事件发布验证

```bash
openyida integration create APP_T78WHHQFUX8JKC2414QX FORM-22FA63CA2E014D0CBD64F8B1C00F6D5CPRRT ZZPECLI \
  --events processFinish \
  --approval-actions agree,disagree,terminated \
  --data-form-uuid FORM-DB8EA4797EE64E10B39B859FA22974C3Z7OV \
  --publish
```

结果：`published = true`

### 审批节点事件发布验证

```bash
openyida integration create APP_T78WHHQFUX8JKC2414QX FORM-22FA63CA2E014D0CBD64F8B1C00F6D5CPRRT ZZ_ACTIVITY_TASK_CLI \
  --events insert,update,delete,comment,activityTask \
  --approval-actions agree \
  --approval-node-ids node_ocmifc7moo7 \
  --trigger-recursively \
  --trigger-condition "radioField_md2o4lor:采购类型:Equal:材料采购:RadioField:literal" \
  --data-form-uuid FORM-DB8EA4797EE64E10B39B859FA22974C3Z7OV \
  --publish
```

结果：`published = true`
