### PR TITLE
feat(intl): enable Wukong + Global YiDA workflow

### DIFF
--- a/lib/core/env-manager.js
+++ b/lib/core/env-manager.js
@@ -34,6 +34,7 @@ const DEFAULT_LOGIN_URL = 'https://www.aliwork.com/workPlatform';
 const DINGTALK_OAUTH_CLIENT_ID = 'suite9xvlxxerybljwheo';
 const DINGTALK_LOGIN_ORIGIN = 'https://login.dingtalk.com';
 const DINGTALK_INTL_LOGIN_ORIGIN = 'https://login.dingtalk.io';
+const DEFAULT_INTERNATIONAL_BASE_URL = 'https://www.yidaapps.com';
 const ALIBABA_INTERNAL_BASE_URL = 'https://yida-group.alibaba-inc.com';
 const ALIBABA_INTERNAL_LOGIN_URL = `${ALIBABA_INTERNAL_BASE_URL}/workPlatform`;
 const ENVS_CONFIG_FILE = 'openyida-envs.json';
@@ -64,14 +65,23 @@ function buildDingtalkOAuthLoginUrl(options = {}) {
     scope: 'openid corpid',
     lang: options.lang || 'zh_CN',
   });
+  if (options.forceLogin) {
+    params.set('FEForceLogin', 'true');
+  }
 
   return `${loginOrigin}/oauth2/auth?${params.toString()}`;
 }
 
+// 海外 YiDA / DingTalk International 登录入口。
+// 必须满足三个条件才能让国际版钉钉扫码识别：
+//   1. login origin 为 login.dingtalk.io
+//   2. redirect_uri 落在 www.yidaapps.com（否则登完跳回国内域名，海外后端拿不到 session）
+//   3. 追加 FEForceLogin=true，强制走国际版登录流程
 const INTERNATIONAL_LOGIN_URL = buildDingtalkOAuthLoginUrl({
   loginOrigin: DINGTALK_INTL_LOGIN_ORIGIN,
-  baseUrl: DEFAULT_BASE_URL,
+  baseUrl: DEFAULT_INTERNATIONAL_BASE_URL,
   lang: 'en_US',
+  forceLogin: true,
 });
 
 /** 默认公有云环境配置 */
@@ -90,11 +100,11 @@ const DEFAULT_ALIBABA_INTERNAL_ENV = {
   cookieFile: 'cookies-alibaba.json',
 };
 
-/** 海外版 DingTalk / Wukong 环境配置 */
+/** 海外版 YiDA / DingTalk International 环境配置 */
 const DEFAULT_INTERNATIONAL_ENV = {
-  baseUrl: DEFAULT_BASE_URL,
+  baseUrl: DEFAULT_INTERNATIONAL_BASE_URL,
   loginUrl: INTERNATIONAL_LOGIN_URL,
-  description: '海外版 DingTalk / Wukong（login.dingtalk.io）',
+  description: '海外版 YiDA / DingTalk International（www.yidaapps.com）',
   cookieFile: 'cookies-intl.json',
 };
 
@@ -109,25 +119,49 @@ const ENV_ALIASES = {
   aliyun: 'public',
   domestic: 'public',
   china: 'public',
+  '国内': 'public',
+  '国内版': 'public',
+  '中国': 'public',
+  '中国版': 'public',
+  '国内宜搭': 'public',
+  '中国宜搭': 'public',
   overseas: 'intl',
   oversea: 'intl',
   international: 'intl',
   global: 'intl',
   abroad: 'intl',
   intl: 'intl',
+  '海外': 'intl',
+  '海外版': 'intl',
+  '国际': 'intl',
+  '国际版': 'intl',
+  '全球': 'intl',
+  '全球版': 'intl',
+  '海外宜搭': 'intl',
+  '海外yida': 'intl',
+  '国际宜搭': 'intl',
+  '全球宜搭': 'intl',
+  '日本': 'intl',
+  '日本宜搭': 'intl',
+  '日本yida': 'intl',
   alibaba: 'alibaba',
   internal: 'alibaba',
   intranet: 'alibaba',
+  '阿里': 'alibaba',
+  '阿里内网': 'alibaba',
+  '内网': 'alibaba',
 };
 
 const SHARED_COOKIE_DOMAINS = new Set([
   'aliwork.com',
   'alibaba-inc.com',
+  'yidaapps.com',
 ]);
 
 const KNOWN_YIDA_HOSTS = new Set([
   'www.aliwork.com',
   'yida-group.alibaba-inc.com',
+  'www.yidaapps.com',
 ]);
 
 function cloneBuiltinEnvironments() {
@@ -199,6 +233,7 @@ function isYidaServiceHost(hostname) {
   if (!host) { return false; }
   if (KNOWN_YIDA_HOSTS.has(host)) { return true; }
   if (host.endsWith('.aliwork.com') && host !== 'aliwork.com') { return true; }
+  if (host.endsWith('.yidaapps.com') && host !== 'yidaapps.com') { return true; }
   if (host.endsWith('.alibaba-inc.com') && host !== 'alibaba-inc.com') {
     return host.startsWith('yida-') || host.includes('.yida-') || host.includes('.yida.');
   }
@@ -408,6 +443,7 @@ module.exports = {
   DINGTALK_OAUTH_CLIENT_ID,
   DINGTALK_LOGIN_ORIGIN,
   DINGTALK_INTL_LOGIN_ORIGIN,
+  DEFAULT_INTERNATIONAL_BASE_URL,
   INTERNATIONAL_LOGIN_URL,
   ALIBABA_INTERNAL_BASE_URL,
   ALIBABA_INTERNAL_LOGIN_URL,

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -248,6 +248,13 @@ function findProjectRoot() {
 
 /**
  * 从 Cookie 列表中提取 csrf_token、corp_id、user_id。
+ *
+ * 国内宜搭（aliwork.com）：corpId/userId 合并写在 `tianshu_corp_user` 里，
+ * 形如 `${corpId}_${userId}`，按最后一个下划线切分。
+ *
+ * 海外 YiDA（yidaapps.com）：不写 `tianshu_corp_user`，而是单独写 `corp_id` cookie
+ * 存放 corpId 明文；userId 加密在 `pub_uid` 里客户端无法解密，留 null 接受。
+ *
  * @param {Array} cookies
  * @returns {{ csrfToken: string|null, corpId: string|null, userId: string|null }}
  */
@@ -265,6 +272,13 @@ function extractInfoFromCookies(cookies) {
         corpId = cookie.value.slice(0, lastUnderscore);
         userId = cookie.value.slice(lastUnderscore + 1);
       }
+    }
+  }
+
+  if (!corpId) {
+    const corpCookie = cookies.find((c) => c && c.name === 'corp_id' && c.value);
+    if (corpCookie) {
+      corpId = corpCookie.value;
     }
   }
 

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -81,6 +81,33 @@ describe('extractInfoFromCookies', () => {
     expect(result.corpId).toBe('mycorp');
     expect(result.userId).toBe('myuser');
   });
+
+  test('海外版从独立的 corp_id cookie 提取 corpId（无 tianshu_corp_user 时）', () => {
+    // 海外 YiDA (yidaapps.com) 设置独立 corp_id cookie，不写合并的 tianshu_corp_user
+    const cookies = [
+      { name: 'tianshu_csrf_token', value: '1476ad85-f647-466b-b77f-cc02cd596912' },
+      { name: 'corp_id', value: 'dingd3873f8e79a7a819c126026dc61154d0' },
+      { name: 'pub_uid', value: 'a098nc6nxOd%2BJZWEncFBiQ%3D%3D' },
+    ];
+
+    const result = extractInfoFromCookies(cookies);
+    expect(result.csrfToken).toBe('1476ad85-f647-466b-b77f-cc02cd596912');
+    expect(result.corpId).toBe('dingd3873f8e79a7a819c126026dc61154d0');
+    // userId 加密在 pub_uid 里客户端无法解密，海外环境保持 null
+    expect(result.userId).toBeNull();
+  });
+
+  test('两种 cookie 同存在时，tianshu_corp_user 优先于独立 corp_id', () => {
+    const cookies = [
+      { name: 'tianshu_csrf_token', value: 'tok' },
+      { name: 'tianshu_corp_user', value: 'cnCorp_cnUser' },
+      { name: 'corp_id', value: 'overseasCorp' },
+    ];
+
+    const result = extractInfoFromCookies(cookies);
+    expect(result.corpId).toBe('cnCorp');
+    expect(result.userId).toBe('cnUser');
+  });
 });
 
 //─ loadCookieData─────────────────────────────────

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -290,30 +290,100 @@ describe('env-manager 海外登录环境', () => {
     const config = loadEnvsConfig(path.join(os.tmpdir(), `openyida-env-missing-${Date.now()}`));
 
     expect(config.environments).toHaveProperty('intl');
-    expect(config.environments.intl.baseUrl).toBe('https://www.aliwork.com');
+    expect(config.environments.intl.baseUrl).toBe('https://www.yidaapps.com');
     expect(config.environments.intl.loginUrl).toBe(INTERNATIONAL_LOGIN_URL);
     expect(config.environments.intl.cookieFile).toBe('cookies-intl.json');
     expect(resolveEnvNameAlias('overseas')).toBe('intl');
     expect(resolveEnvNameAlias('international')).toBe('intl');
   });
 
-  test('海外 OAuth 登录 URL 使用 login.dingtalk.io 并回调到 YiDA', () => {
-    const { buildDingtalkOAuthLoginUrl } = require('../lib/core/env-manager');
-    const loginUrl = buildDingtalkOAuthLoginUrl({
-      loginOrigin: 'https://login.dingtalk.io',
-      baseUrl: 'https://www.aliwork.com',
-      lang: 'en_US',
-    });
-    const parsedUrl = new URL(loginUrl);
+  test('内置 INTERNATIONAL_LOGIN_URL 回调到 yidaapps.com 且包含 FEForceLogin=true', () => {
+    const { INTERNATIONAL_LOGIN_URL } = require('../lib/core/env-manager');
+    const parsedUrl = new URL(INTERNATIONAL_LOGIN_URL);
     const redirectUri = parsedUrl.searchParams.get('redirect_uri');
 
     expect(parsedUrl.origin).toBe('https://login.dingtalk.io');
     expect(parsedUrl.pathname).toBe('/oauth2/auth');
-    expect(parsedUrl.searchParams.get('client_id')).toBe('suite9xvlxxerybljwheo');
-    expect(parsedUrl.searchParams.get('scope')).toBe('openid corpid');
-    expect(parsedUrl.searchParams.get('lang')).toBe('en_US');
-    expect(redirectUri).toContain('https://www.aliwork.com/dingtalk_sso_call_back');
-    expect(redirectUri).toContain(encodeURIComponent('https://www.aliwork.com/workPlatform'));
+    expect(parsedUrl.searchParams.get('FEForceLogin')).toBe('true');
+    expect(redirectUri).toContain('https://www.yidaapps.com/dingtalk_sso_call_back');
+    expect(redirectUri).toContain(encodeURIComponent('https://www.yidaapps.com/workPlatform'));
+  });
+
+  test('buildDingtalkOAuthLoginUrl 默认不带 FEForceLogin，仅在 forceLogin=true 时注入', () => {
+    const { buildDingtalkOAuthLoginUrl } = require('../lib/core/env-manager');
+
+    const defaultUrl = new URL(buildDingtalkOAuthLoginUrl({
+      loginOrigin: 'https://login.dingtalk.com',
+      baseUrl: 'https://www.aliwork.com',
+    }));
+    expect(defaultUrl.searchParams.has('FEForceLogin')).toBe(false);
+
+    const forcedUrl = new URL(buildDingtalkOAuthLoginUrl({
+      loginOrigin: 'https://login.dingtalk.io',
+      baseUrl: 'https://www.yidaapps.com',
+      lang: 'en_US',
+      forceLogin: true,
+    }));
+    expect(forcedUrl.searchParams.get('FEForceLogin')).toBe('true');
+    expect(forcedUrl.origin).toBe('https://login.dingtalk.io');
+    expect(forcedUrl.searchParams.get('client_id')).toBe('suite9xvlxxerybljwheo');
+    expect(forcedUrl.searchParams.get('scope')).toBe('openid corpid');
+    expect(forcedUrl.searchParams.get('lang')).toBe('en_US');
+  });
+
+  test('isYidaServiceHost 识别 yidaapps.com 和子域名', () => {
+    const { isYidaServiceHost } = require('../lib/core/env-manager');
+
+    expect(isYidaServiceHost('www.yidaapps.com')).toBe(true);
+    expect(isYidaServiceHost('foo.yidaapps.com')).toBe(true);
+    expect(isYidaServiceHost('yidaapps.com')).toBe(false);
+    expect(isYidaServiceHost('evil-yidaapps.com')).toBe(false);
+  });
+
+  test('中文别名解析到对应内置环境', () => {
+    const { resolveEnvNameAlias } = require('../lib/core/env-manager');
+
+    // 海外别名 → intl
+    expect(resolveEnvNameAlias('海外')).toBe('intl');
+    expect(resolveEnvNameAlias('海外版')).toBe('intl');
+    expect(resolveEnvNameAlias('国际')).toBe('intl');
+    expect(resolveEnvNameAlias('国际版')).toBe('intl');
+    expect(resolveEnvNameAlias('全球')).toBe('intl');
+    expect(resolveEnvNameAlias('全球版')).toBe('intl');
+    expect(resolveEnvNameAlias('海外宜搭')).toBe('intl');
+    expect(resolveEnvNameAlias('国际宜搭')).toBe('intl');
+    expect(resolveEnvNameAlias('全球宜搭')).toBe('intl');
+    expect(resolveEnvNameAlias('日本')).toBe('intl');
+    expect(resolveEnvNameAlias('日本宜搭')).toBe('intl');
+    expect(resolveEnvNameAlias('海外YiDA')).toBe('intl');
+    expect(resolveEnvNameAlias('日本YiDA')).toBe('intl');
+
+    // 国内别名 → public
+    expect(resolveEnvNameAlias('国内')).toBe('public');
+    expect(resolveEnvNameAlias('国内版')).toBe('public');
+    expect(resolveEnvNameAlias('中国')).toBe('public');
+    expect(resolveEnvNameAlias('国内宜搭')).toBe('public');
+
+    // 阿里内网别名 → alibaba
+    expect(resolveEnvNameAlias('阿里')).toBe('alibaba');
+    expect(resolveEnvNameAlias('阿里内网')).toBe('alibaba');
+    expect(resolveEnvNameAlias('内网')).toBe('alibaba');
+  });
+
+  test('前后空白和大小写归一化', () => {
+    const { resolveEnvNameAlias } = require('../lib/core/env-manager');
+
+    expect(resolveEnvNameAlias('  海外  ')).toBe('intl');
+    expect(resolveEnvNameAlias('GLOBAL')).toBe('intl');
+    expect(resolveEnvNameAlias('Overseas')).toBe('intl');
+    expect(resolveEnvNameAlias('海外YIDA')).toBe('intl');
+  });
+
+  test('未知名称原样透传', () => {
+    const { resolveEnvNameAlias } = require('../lib/core/env-manager');
+
+    expect(resolveEnvNameAlias('custom-env')).toBe('custom-env');
+    expect(resolveEnvNameAlias('某个未知环境')).toBe('某个未知环境');
   });
 });
 

--- a/yida-skills/skills/yida-login/SKILL.md
+++ b/yida-skills/skills/yida-login/SKILL.md
@@ -100,7 +100,15 @@ openyida login --agent-qr
 - 中文：海外、海外版、国际、国际版、全球、全球版、海外宜搭、国际宜搭、全球宜搭、日本、日本宜搭
 - 英文：overseas、international、global、abroad、intl、Global YiDA
 
-**命令示例**（任选一种 flag 皆等价）：
+**推荐流程（已知能稳定调通业务 API）**：
+
+```bash
+openyida env switch intl     # 持久切到 intl，后续命令默认走海外
+openyida login --browser     # 浏览器登录拿 cookies（写入 cookies-intl.json）
+openyida app-list            # 验证 API 调通
+```
+
+**也支持的命令形式**（任选一种 flag 皆等价）：
 
 ```bash
 openyida login --intl                  # 推荐写法
@@ -110,14 +118,9 @@ openyida login --agent-qr --intl       # AI 工具二维码 + 海外环境
 openyida login --env intl              # 通用 --env 形式
 ```
 
-也可以先持久切换环境，后续登录命令默认走海外：
+`--intl` 标志会在生成二维码时使用 `login.dingtalk.io`，海外 DingTalk 可扫码完成 OAuth。
 
-```bash
-openyida env switch intl               # 或者 openyida env switch 海外
-openyida login                          # 此后默认海外
-```
-
-`--intl` 标志会在生成二维码时使用 `login.dingtalk.io`，海外 DingTalk 可正常扫码。
+**Known limitation（海外环境）**：CLI 二维码登录（`--qr` / `--agent-qr`）拿到的 session cookies 当前不被 `www.yidaapps.com` 业务 API 完整认可——OAuth 链路本身能完成（可拿到 csrf_token / corp_id），但接下来调 `app-list` / `create-app` / `create-form` 等 API 时服务端返回 `errorCode:302 LOGIN FAILED`。在该问题修复前，海外环境优先用 `--browser` 模式登录；浏览器登录拿到的 cookies 可正常调用所有业务 API。
 
 ## 输出
 

--- a/yida-skills/skills/yida-login/SKILL.md
+++ b/yida-skills/skills/yida-login/SKILL.md
@@ -15,6 +15,7 @@ description: 宜搭登录态管理。扫码登录，Cookie 持久化到 .cache/c
 - 执行任何宜搭操作前，必须先运行 `openyida env` 确认环境和登录态
 - Cookie 失效时，重新登录后必须验证新 Cookie 可用（运行任意查询命令确认）
 - **本技能不读写 memory**：登录态通过 `.cache/cookies.json` 持久化，不依赖跨会话的 memory 状态
+- 用户提到登录"海外宜搭/国际版/日本宜搭/全球宜搭/Global YiDA"等海外语义时，必须给登录命令加 `--intl`（或 `--global` / `--overseas`），否则会生成中国钉钉的二维码，海外 DingTalk 无法扫码
 
 ## 适用场景
 
@@ -89,6 +90,34 @@ openyida login --agent-qr
 ```
 
 该命令返回 `need_qr_scan` JSON，包含可直接渲染的 `qr_image_markdown` 和 `agent_response_markdown`。扫码后执行 `poll_command`。兼容旧命令 `openyida login --codex-qr`。
+
+### 海外宜搭 / Global YiDA 登录
+
+海外用户使用 DingTalk International（`login.dingtalk.io`）扫码，中国钉钉账号无法扫码海外二维码、反之亦然。海外登录必须显式声明环境，否则默认走国内 `login.dingtalk.com`。
+
+**触发条件**（用户表达任意一项即视为海外场景，必须加 `--intl`）：
+
+- 中文：海外、海外版、国际、国际版、全球、全球版、海外宜搭、国际宜搭、全球宜搭、日本、日本宜搭
+- 英文：overseas、international、global、abroad、intl、Global YiDA
+
+**命令示例**（任选一种 flag 皆等价）：
+
+```bash
+openyida login --intl                  # 推荐写法
+openyida login --global                # 别名
+openyida login --overseas              # 别名
+openyida login --agent-qr --intl       # AI 工具二维码 + 海外环境
+openyida login --env intl              # 通用 --env 形式
+```
+
+也可以先持久切换环境，后续登录命令默认走海外：
+
+```bash
+openyida env switch intl               # 或者 openyida env switch 海外
+openyida login                          # 此后默认海外
+```
+
+`--intl` 标志会在生成二维码时使用 `login.dingtalk.io`，海外 DingTalk 可正常扫码。
 
 ## 输出
 


### PR DESCRIPTION
## 背景

#369 (commit 24ac87f) 新增 `intl` 环境支持 `login.dingtalk.io`，但实测海外租户（`www.yidaapps.com`）通过 Wukong / AI 工具触发"登录海外宜搭" + "创建测试表单应用"端到端流程时，OAuth 链路有三处不成立：

1. `redirect_uri` 落在 `www.aliwork.com`，回调后跳到国内后端而非 `www.yidaapps.com` 海外租户
2. 缺 `FEForceLogin=true`，国际版 DingTalk 静默拒绝二维码
3. 海外 cookie schema 用独立 `corp_id` cookie 而非合并的 `tianshu_corp_user`，导致 `corp_id` 解析为 null

## 改动

- `intl` 环境 `baseUrl` 改为 `https://www.yidaapps.com`，`buildDingtalkOAuthLoginUrl` 新增 `forceLogin: true` 选项注入 `FEForceLogin=true`（默认 false，国内 `public` 流程不变）
- `SHARED_COOKIE_DOMAINS` / `KNOWN_YIDA_HOSTS` / `isYidaServiceHost` 补充 `yidaapps.com` 和 `*.yidaapps.com` 子域支持
- `extractInfoFromCookies` 当 `tianshu_corp_user` 缺失时回退读独立 `corp_id` cookie（国内行为不变，合并 cookie 优先）；`userId` 海外环境保留 null（`pub_uid` 加密，业务 API 不依赖客户端 userId，注册应用等写操作不受影响）
- `ENV_ALIASES` 扩充中文别名（海外 / 国际版 / 全球 / 日本 / 海外宜搭 / 日本宜搭 / 国际宜搭 / 全球宜搭 …），AI 自然语言"登录海外宜搭"可正确映射到 `intl`
- `yida-skills/skills/yida-login/SKILL.md` 新增"海外宜搭 / Global YiDA 登录"章节，含触发词、推荐命令流程、已知 limitation

## 已知 limitation（已写入 SKILL.md）

CLI 二维码模式（`--qr` / `--agent-qr`）完成 OAuth 后拿到 11 个 cookies 含完整 `tianshu_csrf_token`，但调业务 API（`app-list` / `create-app` / `create-form` 等）服务端返回 `{"success":false,"errorCode":"302","errorMsg":"LOGIN FAILED"}`。`--browser` 模式拿到的 cookies 可正常调用（本地 `app-list` 返回 3 个海外应用验证通过）。推测 `www.yidaapps.com` 在 `/workPlatform` HTML 内有 JS 写入 session-binding cookie，Node 端 OAuth 流程不触发。SKILL.md 现引导海外环境优先用 `--browser`，二维码模式留待后续 PR 跟进。

## 验证

- `npm run check:ci` 通过（clean env，避免 Claude Code 环境变量污染 `detectActiveTool` 测试）
- `openyida env switch intl` + `openyida login --agent-qr` 生成的二维码 URL 在 `login.dingtalk.io` 带 `FEForceLogin=true` + yidaapps.com callback
- 扫码后 `openyida login --agent-poll` 返回 `{ ok: true, base_url: "https://www.yidaapps.com", corp_id: "dingd3873…", cookies_count: 11 }`
- `openyida login --browser --intl` + `openyida app-list --size 3` 返回 3 个海外应用，浏览器登录链路完整可用
- Wukong 触发"登录海外宜搭" + "创建测试表单应用"端到端走通（按 SKILL.md 引导用 `--browser`）

@yize 这是 #369 的 follow-up，麻烦看看，特别是 known limitation 部分有没有上下文我没考虑到的。

AI-assisted-by: Claude Code
