### PR TITLE
feat: support Yida content locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,13 +268,15 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 
 Environment selectors such as `--env intl`, `--intl`, `--overseas`, `--global`, and `--yidaapps` can be used on login-required commands to choose the target Yida environment for that run. The `intl` preset targets Global YiDA at `https://www.yidaapps.com` and uses DingTalk International OAuth at `https://login.dingtalk.io`; use `openyida login --browser --intl` when you need cookies accepted by Global YiDA business APIs.
 
+For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation commands, or set `OPENYIDA_CONTENT_LOCALE`. OpenYida writes YiDA resource names with `zh_CN`, `en_US`, and `ja_JP` values so Global YiDA does not fall back to Chinese-only metadata.
+
 ### Applications
 
 | Command | Description |
 |---------|-------------|
 | `openyida app-list [--size N]` | List Yida applications |
 | `openyida corp-efficiency [overview\|details\|detail\|groups\|notify] [options] [--open\|--no-open]` | Query enterprise efficiency metrics, detail report entries, and related notification actions |
-| `openyida create-app "<name>"\|--name <name> [options] [--open\|--no-open]` | Create an application and output `appType` |
+| `openyida create-app "<name>"\|--name <name> [options] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create an application and output `appType` |
 | `openyida update-app <appType> --name "..."` | Update application metadata |
 | `openyida app-permission <get\|set\|add\|remove\|search-user> ...` | Manage app primary admins, data admins, and developer members |
 | `openyida export <appType> [output]` | Export an application migration package |
@@ -284,18 +286,18 @@ Environment selectors such as `--env intl`, `--intl`, `--overseas`, `--global`, 
 
 | Command | Description |
 |---------|-------------|
-| `openyida create-form create <appType> "<name>" <fields.json> [--open\|--no-open]` | Create a form page |
-| `openyida create-form update <appType> <formUuid> <changes.json> [--open\|--no-open]` | Update a form page |
+| `openyida create-form create <appType> "<name>" <fields.json> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a form page |
+| `openyida create-form update <appType> <formUuid> <changes.json> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Update a form page |
 | `openyida create-form add-option <appType> <formUuid> <fieldLabel> <option1> [option2] ...` | Append options to a SelectField/RadioField/CheckboxField/MultiSelectField |
 | `openyida list-forms <appType> [--keyword <text>]` | List forms in an application |
 | `openyida get-schema <appType> <formUuid\|--all> [--field <labelOrFieldId>]` | Fetch one form schema, batch export all, or pick a single field's full props |
-| `openyida create-page <appType> "<name>" [--mode dashboard] [--open\|--no-open]` | Create a custom display page; dashboard mode hides top/workbench chrome |
+| `openyida create-page <appType> "<name>" [--mode dashboard] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a custom display page; dashboard mode hides top/workbench chrome |
 | `openyida generate-page <template> [--spec file]` | Generate custom page source from templates (`product-homepage`, `todo-mvc`) |
 | `openyida build-page <sourceFile> [--output file\|--write]` | Build/fix Yida-compatible page source from OpenYida authoring JSX |
 | `openyida check-page <sourceFile> [--compat] [--json]` | Check page compatibility; `.oyd.jsx` is compatibility-built before linting |
 | `openyida compile <sourceFile> [--compat]` | Compile a custom page locally; `.oyd.jsx` sources are compatibility-built first |
 | `openyida publish <sourceFile> <appType> <formUuid> [--compat] [--health-check] [--force] [--open\|--no-open]` | Compile and publish a custom display page; by default the target must be `formType=display` |
-| `openyida update-form-config <appType> <formUuid> <isRenderNav> <title>` | Update page/form display configuration |
+| `openyida update-form-config <appType> <formUuid> <isRenderNav> <title> [--locale zh_CN\|en_US\|ja_JP]` | Update page/form display configuration |
 
 ### Data, Permissions, and Sharing
 

--- a/lib/app/create-app.js
+++ b/lib/app/create-app.js
@@ -17,6 +17,7 @@ const {
   requestWithAutoLogin,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
+const { buildYidaI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 
 const DEFAULT_APP_OPTIONS = {
@@ -111,6 +112,7 @@ function parseCreateAppArgs(args) {
     colour: null,
     navTheme: null,
     layoutDirection: null,
+    locale: null,
   };
   const positional = [];
 
@@ -152,6 +154,15 @@ function parseCreateAppArgs(args) {
       case '--layout-direction':
       case '--layoutDirection':
         params.layoutDirection = readOptionValue(args, index, arg);
+        index++;
+        break;
+      case '--locale':
+      case '--content-locale':
+      case '--lang':
+        params.locale = readOptionValue(args, index, arg);
+        if (!normalizeYidaLocale(params.locale)) {
+          throw new Error(`Unsupported locale: ${params.locale}`);
+        }
         index++;
         break;
       default:
@@ -211,7 +222,7 @@ async function run(args) {
 
   const { appName, description, icon, iconColor, colour, navTheme, layoutDirection } = params;
 
-  const { c, banner, step, label, info, success: chalkSuccess, fail: chalkFail, result: chalkResult, sep } = require('../core/chalk');
+  const { c, banner, step, label, info, success: chalkSuccess, result: chalkResult } = require('../core/chalk');
 
   banner(t('create_app.title'));
   label('Name', appName);
@@ -234,6 +245,9 @@ async function run(args) {
     cookieData,
   };
   chalkSuccess(t('common.login_ready', authRef.baseUrl));
+
+  const contentLocale = resolveContentLocale({ locale: params.locale, baseUrl: authRef.baseUrl });
+  label('Locale', contentLocale);
 
   // Step 2: 创建应用
   step(2, t('create_app.step_create'));
@@ -261,14 +275,14 @@ async function run(args) {
   const response = await requestWithAutoLogin((auth) => {
     const postData = querystring.stringify({
       _csrf_token: auth.csrfToken,
-      appName: JSON.stringify({ zh_CN: appName, en_US: appName, type: 'i18n' }),
-      description: JSON.stringify({ zh_CN: description, en_US: description, type: 'i18n' }),
+      appName: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
+      description: JSON.stringify(buildYidaI18n(description, { en_US: description, ja_JP: description })),
       icon: iconValue,
       iconUrl: iconValue,
       colour,
       navTheme,
       layoutDirection,
-      defaultLanguage: 'zh_CN',
+      defaultLanguage: contentLocale,
       openExclusive: openExclusive,
       openPhysicColumn: openPhysicColumn,
       openIsolationDatabase: 'n',

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -63,6 +63,7 @@ const path = require('path');
 const querystring = require('querystring');
 const { loadCookieData, triggerLogin, refreshCsrfToken, resolveBaseUrl, isLoginExpired, isCsrfTokenExpired } = require('../core/utils');
 const { t } = require('../core/i18n');
+const { buildYidaI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { banner, step, label, success, fail, warn, info, error, result, usage, hint, listItem } = require('../core/chalk');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 
@@ -99,13 +100,14 @@ function parseArgs() {
     layout: 'single',  // 布局：single/double/card/section
     theme: 'default',  // 主题：default/compact/comfortable
     labelAlign: 'top', // 标签对齐：top/left/right
+    contentLocale: null,
     browserOpenMode: openOption.mode,
   };
 
   // 复制一份 args 用于解析（避免修改原始数组影响后续处理）
   const args = [...rawArgs];
 
-  // 解析 --layout, --theme, --label-align, --force 参数
+  // 解析 --layout, --theme, --label-align, --locale, --force 参数
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--layout' && i + 1 < args.length) {
       options.layout = args[i + 1];
@@ -117,6 +119,14 @@ function parseArgs() {
       i--;
     } else if (args[i] === '--label-align' && i + 1 < args.length) {
       options.labelAlign = args[i + 1];
+      args.splice(i, 2);
+      i--;
+    } else if ((args[i] === '--locale' || args[i] === '--content-locale' || args[i] === '--lang') && i + 1 < args.length) {
+      options.contentLocale = args[i + 1];
+      if (!normalizeYidaLocale(options.contentLocale)) {
+        error(`Unsupported locale: ${options.contentLocale}`);
+      }
+      process.env.OPENYIDA_CONTENT_LOCALE = normalizeYidaLocale(options.contentLocale);
       args.splice(i, 2);
       i--;
     } else if (args[i] === '--force') {
@@ -292,21 +302,24 @@ function generateFieldId(componentName) {
 
 // ── i18n 辅助 ────────────────────────────────────────
 
-function i18n(text, enText) {
-  return { type: 'i18n', zh_CN: text, en_US: enText || text };
+function i18n(text, enText, jaText) {
+  return buildYidaI18n(text, {
+    en_US: enText || text,
+    ja_JP: jaText || text,
+  });
 }
 
 // ── 默认占位符 ───────────────────────────────────────
 
-const PLACEHOLDER_INPUT = i18n('请输入', 'Please enter');
-const PLACEHOLDER_SELECT = i18n('请选择', 'please select');
+const PLACEHOLDER_INPUT = i18n('请输入', 'Please enter', '入力してください');
+const PLACEHOLDER_SELECT = i18n('请选择', 'Please select', '選択してください');
 
 // ── 生成选项数据源 ───────────────────────────────────
 
 function buildOptionDataSource(options) {
   return options.map(function (optionText, optionIndex) {
     return {
-      text: { zh_CN: optionText, en_US: optionText, type: 'i18n' },
+      text: i18n(optionText, optionText, optionText),
       value: optionText,
       sid: 'serial_' + Date.now().toString(36) + optionIndex,
       disable: false,
@@ -400,7 +413,7 @@ function buildFieldComponent(field) {
     props.complexValue = {
       complexType: 'custom',
       formula: '',
-      value: { en_US: '', zh_CN: '', type: 'i18n' },
+      value: i18n('', '', ''),
     };
     props.variable = '';
     props.formula = '';
@@ -416,7 +429,7 @@ function buildFieldComponent(field) {
   // 数字字段
   if (componentName === 'NumberField') {
     props.hasClear = true;
-    props.placeholder = field.placeholder ? i18n(field.placeholder) : i18n('请输入数字', 'Please enter a number');
+    props.placeholder = field.placeholder ? i18n(field.placeholder) : i18n('请输入数字', 'Please enter a number', '数値を入力してください');
     props.valueType = 'custom';
     props.__gridSpan = 1;
     props.tips = i18n('', '');
@@ -489,7 +502,7 @@ function buildFieldComponent(field) {
       } else if (typeof rawDataSource[0] === 'object' && rawDataSource[0].value !== undefined) {
         dataSource = rawDataSource.map(function (item, idx) {
           return {
-            text: item.text || { zh_CN: String(item.value), en_US: String(item.value), type: 'i18n' },
+            text: item.text || i18n(String(item.value), String(item.value), String(item.value)),
             value: item.value,
             sid: item.sid || 'serial_' + Date.now().toString(36) + idx,
             disable: item.disable || false,
@@ -536,7 +549,7 @@ function buildFieldComponent(field) {
       props.isUseDataSourceColor = false;
       props.dataSourceLinkage = '';
       props.filterLocal = true;
-      props.notFoundContent = i18n('无数据', 'Not Found');
+      props.notFoundContent = i18n('无数据', 'No data', 'データがありません');
       props.searchConfig = {
         dataType: 'jsonp',
         url: '',
@@ -586,7 +599,7 @@ function buildFieldComponent(field) {
 
   // 部门字段
   if (componentName === 'DepartmentSelectField') {
-    props.placeholder = i18n('请输入关键字进行搜索', 'Please enter keyword');
+    props.placeholder = i18n('请输入关键字进行搜索', 'Please enter keyword', 'キーワードを入力してください');
     props.__gridSpan = 1;
     props.tips = i18n('', '');
     props.multiple = field.multiple || false;
@@ -637,8 +650,8 @@ function buildFieldComponent(field) {
     props.countryMode = 'default';
     props.countryScope = 1;
     props.addressType = 'ADDRESS';
-    props.subLabel = i18n('详细地址', 'Detailed Address');
-    props.detailPlaceholder = i18n('请输入详细地址', 'Please input detailed address');
+    props.subLabel = i18n('详细地址', 'Detailed Address', '詳細住所');
+    props.detailPlaceholder = i18n('请输入详细地址', 'Please input detailed address', '詳細住所を入力してください');
     props.hasClear = true;
     props.enableLocation = true;
     props.value = {};
@@ -659,7 +672,7 @@ function buildFieldComponent(field) {
     };
     props.type = 'normal';
     props.listType = 'text';
-    props.buttonText = i18n('上传文件', 'Upload');
+    props.buttonText = i18n('上传文件', 'Upload file', 'ファイルをアップロード');
     props.buttonSize = 'medium';
     props.buttonType = 'normal';
     props.multiple = true;
@@ -691,7 +704,7 @@ function buildFieldComponent(field) {
     props.normalListType = 'image';
     props.cardListType = 'card';
     props.listType = 'image';
-    props.buttonText = i18n('图片上传', 'Upload');
+    props.buttonText = i18n('图片上传', 'Upload image', '画像をアップロード');
     props.buttonSize = 'medium';
     props.buttonType = 'normal';
     props.enableCameraDate = true;
@@ -718,26 +731,26 @@ function buildFieldComponent(field) {
     props.linkage = '';
     props.tips = i18n('', '');
     props.showIndex = true;
-    props.copyButtonText = i18n('复制', 'Copy');
+    props.copyButtonText = i18n('复制', 'Copy', 'コピー');
     props.addButtonBehavior = 'NORMAL';
     props.pageSize = 20;
-    props.addButtonText = i18n('新增一项', 'Add item');
+    props.addButtonText = i18n('新增一项', 'Add item', '項目を追加');
     props.enableExport = true;
     props.addButtonPosition = 'bottom';
     props.actionsColumnWidth = 70;
     props.theme = 'split';
-    props.delButtonText = i18n('删除', 'Remove');
+    props.delButtonText = i18n('删除', 'Remove', '削除');
     props.useCustomColumnsWidth = false;
     props.showSortable = false;
-    props.moveUp = i18n('上移', 'Up');
+    props.moveUp = i18n('上移', 'Up', '上へ');
     props.maxItems = 500;
     props.tableLayout = 'fixed';
     props.showActions = true;
-    props.indexName = i18n('项目', 'Line');
+    props.indexName = i18n('项目', 'Line', '項目');
     props.showCopyAction = false;
     props.showDelAction = true;
     props.showTableHead = true;
-    props.moveDown = i18n('下移', 'Down');
+    props.moveDown = i18n('下移', 'Down', '下へ');
     props.pcFreezeColumnStartCounts = '0';
     props.layout = 'TABLE';
     props.showDeleteConfirm = true;
@@ -763,7 +776,7 @@ function buildFieldComponent(field) {
     props.__gridSpan = 1;
     props.tips = i18n('', '');
     props.placeholder = PLACEHOLDER_SELECT;
-    props.notFoundContent = i18n('无数据', 'Not Found');
+    props.notFoundContent = i18n('无数据', 'No data', 'データがありません');
     props.hasClear = true;
     props.multiple = field.multiple || false;
     props.dataEntryMode = false;
@@ -1313,8 +1326,8 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
         contentMarginMobile: '0',
         className: 'page_' + Date.now().toString(36),
         contentBgColorMobile: 'white',
-        titleName: i18n('标题名称', 'title'),
-        titleDesc: i18n('标题描述', 'title'),
+        titleName: i18n('标题名称', 'title', 'タイトル'),
+        titleDesc: i18n('标题描述', 'description', '説明'),
         titleColor: 'light',
         titleBg: 'https://img.alicdn.com/imgextra/i2/O1CN0143ATPP1wIa9TrVvzN_!!6000000006285-2-tps-3360-400.png_.webp',
         backgroundColorCustom: '#f1f2f3',
@@ -1390,9 +1403,9 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
                 formLabelVisible: true,
                 columns: columns,
                 labelAlign: labelAlign || 'top',
-                submitText: i18n('提交', 'Submit'),
-                stageText: i18n('暂存', 'Stage'),
-                submitAndNewText: i18n('提交并继续', 'Submit and New'),
+                submitText: i18n('提交', 'Submit', '送信'),
+                stageText: i18n('暂存', 'Save draft', '下書き保存'),
+                submitAndNewText: i18n('提交并继续', 'Submit and New', '送信して続ける'),
                 fieldId: 'formContainer_' + Date.now().toString(36) + 'a',
                 aiFormConfig: { systemPrompt: '', model: 'qwen' },
                 beforeSubmit: false,
@@ -1642,15 +1655,15 @@ function buildEmptyFormSchema() {
                   id: nextNodeId(),
                   props: {
                     beforeSubmit: false,
-                    'submitProps.text': i18n('提交', 'Submit'),
-                    submitText: i18n('提交', 'Submit'),
-                    submitProps: { text: i18n('提交', 'Submit') },
+                    'submitProps.text': i18n('提交', 'Submit', '送信'),
+                    submitText: i18n('提交', 'Submit', '送信'),
+                    submitProps: { text: i18n('提交', 'Submit', '送信') },
                     labelAlign: 'top',
                     columns: 1,
                     afterSubmit: false,
                     fieldId: 'formContainer_' + Date.now().toString(36) + 'b',
-                    stageText: i18n('暂存', 'Stage'),
-                    submitAndNewText: i18n('提交并继续', 'Submit and New'),
+                    stageText: i18n('暂存', 'Save draft', '下書き保存'),
+                    submitAndNewText: i18n('提交并继续', 'Submit and New', '送信して続ける'),
                     onProcessActionValidate: false,
                     afterFormDataInit: false,
                   },
@@ -1702,10 +1715,7 @@ function extractLabelText(component) {
   if (typeof label === 'string') {
     return label;
   }
-  if (label.zh_CN) {
-    return label.zh_CN;
-  }
-  return '';
+  return label.zh_CN || label.ja_JP || label.en_US || label.pureEn_US || '';
 }
 
 function findFormContainer(node) {
@@ -2480,7 +2490,7 @@ async function mainAddOption(parsedArgs, csrfToken, cookies, baseUrl, cookieData
       warn('选项已存在，跳过: ' + optionText);
     } else {
       const newItem = {
-        text: { zh_CN: optionText, en_US: optionText, type: 'i18n' },
+        text: i18n(optionText, optionText, optionText),
         value: optionText,
         sid: 'serial_' + Date.now().toString(36) + existingDataSource.length + addedOptions.length,
         disable: false,
@@ -2720,6 +2730,7 @@ async function main() {
   const { csrf_token: csrfToken, cookies } = cookieData;
   const baseUrl = resolveBaseUrl(cookieData);
   success(t('common.login_ready', baseUrl));
+  label('Locale:', resolveContentLocale({ locale: parsedArgs.contentLocale, baseUrl: baseUrl }));
 
   if (parsedArgs.mode === 'update') {
     await mainUpdate(parsedArgs, csrfToken, cookies, baseUrl, cookieData);

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -15,17 +15,26 @@ const {
   requestWithAutoLogin,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
+const { buildYidaI18n, buildYidaTitleI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 
 function parseArgs(args) {
   const openOption = parseOpenOption(args);
   const filteredArgs = [];
   let mode = 'default';
+  let locale = null;
 
   for (let i = 0; i < openOption.args.length; i++) {
     const arg = openOption.args[i];
     if (arg === '--mode' && openOption.args[i + 1]) {
       mode = openOption.args[++i];
+      continue;
+    }
+    if ((arg === '--locale' || arg === '--content-locale' || arg === '--lang') && openOption.args[i + 1]) {
+      locale = openOption.args[++i];
+      if (!normalizeYidaLocale(locale)) {
+        throw new Error(`Unsupported locale: ${locale}`);
+      }
       continue;
     }
     filteredArgs.push(arg);
@@ -36,20 +45,16 @@ function parseArgs(args) {
     appType: filteredArgs[0],
     pageName: filteredArgs[1],
     mode,
+    locale,
     openMode: openOption.mode,
   };
 }
 
 function buildPageInfoPostData(csrfToken, formUuid, pageName, isRenderNav) {
-  const titleJson = JSON.stringify({
-    pureEn_US: pageName,
+  const titleJson = JSON.stringify(buildYidaTitleI18n(pageName, {
     en_US: pageName,
-    zh_CN: pageName,
-    envLocale: null,
-    type: 'i18n',
-    ja_JP: null,
-    key: null,
-  });
+    ja_JP: pageName,
+  }));
 
   return querystring.stringify({
     _api: 'Form.updateFormSchemaInfo',
@@ -94,7 +99,13 @@ async function configureDashboardMode(authRef, appType, pageId, pageName) {
 }
 
 async function run(args) {
-  const options = parseArgs(args || []);
+  let options;
+  try {
+    options = parseArgs(args || []);
+  } catch (err) {
+    const { error: chalkError } = require('../core/chalk');
+    chalkError(err.message, { hint: t('create_page.usage') });
+  }
 
   if (options.args.length < 2) {
     const { error: chalkError } = require('../core/chalk');
@@ -132,6 +143,9 @@ async function run(args) {
   };
   chalkSuccess(t('common.login_ready', authRef.baseUrl));
 
+  const contentLocale = resolveContentLocale({ locale: options.locale, baseUrl: authRef.baseUrl });
+  label('Locale', contentLocale);
+
   // Step 2: 创建自定义页面
   step(2, t('create_page.step_create'));
   info(t('create_page.sending'));
@@ -140,7 +154,7 @@ async function run(args) {
     const postData = querystring.stringify({
       _csrf_token: auth.csrfToken,
       formType: 'display',
-      title: JSON.stringify({ zh_CN: pageName, en_US: pageName, type: 'i18n' }),
+      title: JSON.stringify(buildYidaI18n(pageName, { en_US: pageName, ja_JP: pageName })),
     });
     return httpPost(
       auth.baseUrl,

--- a/lib/app/import-app.js
+++ b/lib/app/import-app.js
@@ -19,19 +19,21 @@ const {
   requestWithAutoLogin,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
-const { banner, step, label, success, fail, warn, info, error, result, usage, listItem, hint } = require('../core/chalk');
+const { buildYidaI18n, resolveContentLocale } = require('../core/yida-i18n');
+const { banner, step, label, success, fail, warn, info, error, result, usage, hint } = require('../core/chalk');
 
 // ── 创建新应用 ────────────────────────────────────────
 
 async function createApp(appName, authRef) {
+  const contentLocale = resolveContentLocale({ baseUrl: authRef.baseUrl });
   const postData = querystring.stringify({
     _csrf_token: authRef.csrfToken,
-    appName: JSON.stringify({ zh_CN: appName, en_US: appName, type: 'i18n' }),
-    description: JSON.stringify({ zh_CN: appName, en_US: appName, type: 'i18n' }),
+    appName: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
+    description: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
     icon: 'xian-yingyong%%#0089FF',
     iconUrl: 'xian-yingyong%%#0089FF',
     colour: 'blue',
-    defaultLanguage: 'zh_CN',
+    defaultLanguage: contentLocale,
     openExclusive: 'n',
     openPhysicColumn: 'n',
     openIsolationDatabase: 'n',
@@ -56,7 +58,7 @@ async function createBlankForm(appType, formTitle, authRef) {
   const postData = querystring.stringify({
     _csrf_token: authRef.csrfToken,
     formType: 'receipt',
-    title: JSON.stringify({ zh_CN: formTitle, en_US: formTitle, type: 'i18n' }),
+    title: JSON.stringify(buildYidaI18n(formTitle, { en_US: formTitle, ja_JP: formTitle })),
   });
 
   const result = await requestWithAutoLogin((auth) => {

--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -15,6 +15,7 @@ const {
   requestWithAutoLogin,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
+const { buildYidaI18n } = require('../core/yida-i18n');
 
 /**
  * 解析命令行参数
@@ -135,21 +136,18 @@ async function run(args) {
 
   // 应用名称（支持国际化）
   if (params.name) {
-    postDataObj.appName = JSON.stringify({
-      zh_CN: params.name,
+    postDataObj.appName = JSON.stringify(buildYidaI18n(params.name, {
       en_US: params.name,
-      type: 'i18n',
-      pureEn_US: params.name,
-    });
+      ja_JP: params.name,
+    }, { includePureEn: true }));
   }
 
   // 应用描述
   if (params.desc) {
-    postDataObj.description = JSON.stringify({
-      zh_CN: params.desc,
+    postDataObj.description = JSON.stringify(buildYidaI18n(params.desc, {
       en_US: params.desc,
-      type: 'i18n',
-    });
+      ja_JP: params.desc,
+    }));
   }
 
   // 图标

--- a/lib/app/update-form-config.js
+++ b/lib/app/update-form-config.js
@@ -4,10 +4,23 @@ const querystring = require('querystring');
 
 const { loadCookieData, triggerLogin, refreshCsrfToken, resolveBaseUrl, isLoginExpired, isCsrfTokenExpired } = require('../core/utils');
 const { t } = require('../core/i18n');
+const { buildYidaTitleI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { banner, step, label, success, fail, warn, info, error, result, usage } = require('../core/chalk');
 
 function parseArgs() {
   const args = process.argv.slice(2);
+  let locale = null;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if ((arg === '--locale' || arg === '--content-locale' || arg === '--lang') && args[i + 1]) {
+      locale = args[i + 1];
+      if (!normalizeYidaLocale(locale)) {
+        error(`Unsupported locale: ${locale}`);
+      }
+      args.splice(i, 2);
+      i--;
+    }
+  }
   if (args.length < 4) {
     usage(t('update_form_config.usage'), t('update_form_config.example'));
     info(t('update_form_config.params_label'));
@@ -20,19 +33,15 @@ function parseArgs() {
     formUuid: args[1],
     isRenderNav: args[2],
     title: args[3],
+    locale,
   };
 }
 
 function buildPostData(csrfToken, formUuid, isRenderNav, title) {
-  const titleJson = JSON.stringify({
-    pureEn_US: title,
+  const titleJson = JSON.stringify(buildYidaTitleI18n(title, {
     en_US: title,
-    zh_CN: title,
-    envLocale: null,
-    type: 'i18n',
-    ja_JP: null,
-    key: null,
-  });
+    ja_JP: title,
+  }));
 
   return querystring.stringify({
     _api: 'Form.updateFormSchemaInfo',
@@ -135,7 +144,7 @@ function sendPostRequest(baseUrl, cookies, requestPath, postData) {
 }
 
 async function main() {
-  const { appType, formUuid, isRenderNav, title } = parseArgs();
+  const { appType, formUuid, isRenderNav, title, locale } = parseArgs();
 
   banner(t('update_form_config.title'));
   label('App ID:', appType);
@@ -152,6 +161,7 @@ async function main() {
   let { cookies } = cookieData;
   let baseUrl = resolveBaseUrl(cookieData);
   success(t('common.login_ready', baseUrl));
+  label('Locale:', resolveContentLocale({ locale, baseUrl }));
 
   step(2, t('update_form_config.step_update'));
   info(t('update_form_config.sending_request'));

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -44,7 +44,7 @@ const COMMAND_GROUPS = [
       command('corp-efficiency', ['corp-efficiency'], 'corp-efficiency [overview|details|detail|groups|notify] [options] [--open|--no-open]', 'help.cmd_corp_efficiency', {
         output: 'json',
       }),
-      command('create-app', ['create-app'], 'create-app "<name>"|--name <name> [options] [--open|--no-open]', 'help.cmd_create_app'),
+      command('create-app', ['create-app'], 'create-app "<name>"|--name <name> [options] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_app'),
       command('update-app', ['update-app'], 'update-app <appType> --name "..."', 'help.cmd_update_app'),
       command('app-permission', ['app-permission'], 'app-permission <get|set|add|remove|search-user> ...', 'help.cmd_app_permission', {
         output: 'json',
@@ -57,11 +57,11 @@ const COMMAND_GROUPS = [
     id: 'form',
     titleKey: 'help.group_form',
     commands: [
-      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> ... [--open|--no-open]', 'help.cmd_create_form'),
-      command('create-form.update', ['create-form', 'update'], 'create-form update <appType> ... [--open|--no-open]', 'help.cmd_update_form'),
+      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> ... [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_form'),
+      command('create-form.update', ['create-form', 'update'], 'create-form update <appType> ... [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_update_form'),
       command('list-forms', ['list-forms'], 'list-forms <appType> [--keyword <text>]', 'help.cmd_list_forms'),
       command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all>', 'help.cmd_get_schema'),
-      command('create-page', ['create-page'], 'create-page <appType> "<name>" [--mode dashboard] [--open|--no-open]', 'help.cmd_create_page'),
+      command('create-page', ['create-page'], 'create-page <appType> "<name>" [--mode dashboard] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_page'),
       command('generate-page', ['generate-page'], 'generate-page <template>', 'help.cmd_generate_page'),
       command('build-page', ['build-page'], 'build-page <sourceFile> [--output file|--write]', 'help.cmd_build_page', { requiresLogin: false }),
       command('check-page', ['check-page'], 'check-page <src> [--compat]', 'help.cmd_check_page', { output: 'text|json' }),

--- a/lib/core/yida-i18n.js
+++ b/lib/core/yida-i18n.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const DEFAULT_CONTENT_LOCALE = 'zh_CN';
+const INTERNATIONAL_CONTENT_LOCALE = 'en_US';
+const SUPPORTED_CONTENT_LOCALES = ['zh_CN', 'en_US', 'ja_JP'];
+
+const LOCALE_ALIASES = {
+  zh: 'zh_CN',
+  'zh-cn': 'zh_CN',
+  'zh-hans': 'zh_CN',
+  'zh_cn': 'zh_CN',
+  cn: 'zh_CN',
+  chinese: 'zh_CN',
+  '中文': 'zh_CN',
+  '简体中文': 'zh_CN',
+  en: 'en_US',
+  'en-us': 'en_US',
+  'en_us': 'en_US',
+  english: 'en_US',
+  '英文': 'en_US',
+  ja: 'ja_JP',
+  jp: 'ja_JP',
+  'ja-jp': 'ja_JP',
+  'ja_jp': 'ja_JP',
+  japanese: 'ja_JP',
+  '日语': 'ja_JP',
+  '日本语': 'ja_JP',
+  '日本語': 'ja_JP',
+};
+
+function normalizeRawLocale(value) {
+  if (!value) { return ''; }
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-')
+    .split('.')[0];
+}
+
+function normalizeYidaLocale(value) {
+  const raw = normalizeRawLocale(value);
+  if (!raw) { return null; }
+  if (LOCALE_ALIASES[raw]) { return LOCALE_ALIASES[raw]; }
+  const primary = raw.split('-')[0];
+  return LOCALE_ALIASES[primary] || null;
+}
+
+function isInternationalBaseUrl(baseUrl) {
+  if (!baseUrl) { return false; }
+  try {
+    const hostname = new URL(String(baseUrl)).hostname.toLowerCase();
+    return hostname === 'www.yidaapps.com' || hostname.endsWith('.yidaapps.com');
+  } catch {
+    return String(baseUrl).toLowerCase().includes('yidaapps.com');
+  }
+}
+
+function detectContentLocaleFromEnv() {
+  const candidates = [
+    process.env.OPENYIDA_CONTENT_LOCALE,
+    process.env.YIDA_CONTENT_LOCALE,
+    process.env.OPENYIDA_APP_LOCALE,
+    process.env.OPENYIDA_LANG,
+    process.env.LC_ALL,
+    process.env.LANG,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeYidaLocale(candidate);
+    if (normalized) { return normalized; }
+  }
+  return null;
+}
+
+function resolveContentLocale(options = {}) {
+  return normalizeYidaLocale(options.locale || options.contentLocale)
+    || detectContentLocaleFromEnv()
+    || (isInternationalBaseUrl(options.baseUrl) ? INTERNATIONAL_CONTENT_LOCALE : DEFAULT_CONTENT_LOCALE);
+}
+
+function toText(value) {
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function normalizeTranslations(translations) {
+  if (typeof translations === 'string') {
+    return { en_US: translations };
+  }
+  return translations && typeof translations === 'object' ? translations : {};
+}
+
+function buildYidaI18n(text, translations = {}, options = {}) {
+  const normalizedTranslations = normalizeTranslations(translations);
+  const baseText = toText(text);
+  const enText = toText(normalizedTranslations.en_US || normalizedTranslations.pureEn_US || baseText);
+  const result = {
+    type: 'i18n',
+    zh_CN: toText(normalizedTranslations.zh_CN || baseText),
+    en_US: enText,
+    ja_JP: toText(normalizedTranslations.ja_JP || baseText),
+  };
+
+  if (options.includePureEn) {
+    result.pureEn_US = enText;
+  }
+  if (options.includeMeta) {
+    result.envLocale = null;
+    result.key = null;
+  }
+
+  return result;
+}
+
+function buildYidaTitleI18n(text, translations = {}) {
+  return buildYidaI18n(text, translations, {
+    includePureEn: true,
+    includeMeta: true,
+  });
+}
+
+module.exports = {
+  SUPPORTED_CONTENT_LOCALES,
+  buildYidaI18n,
+  buildYidaTitleI18n,
+  detectContentLocaleFromEnv,
+  isInternationalBaseUrl,
+  normalizeYidaLocale,
+  resolveContentLocale,
+};

--- a/lib/process/configure-process.js
+++ b/lib/process/configure-process.js
@@ -30,7 +30,8 @@ const {
   httpGet,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
-const { banner, step, label, success, fail, warn, info, error, result, hint, listItem, usage } = require('../core/chalk');
+const { buildYidaI18n } = require('../core/yida-i18n');
+const { warn } = require('../core/chalk');
 
 // ── 操作符映射（基于浏览器捕获的真实数据）────────────
 
@@ -75,29 +76,32 @@ function generateNodeId() {
   return 'node_oc' + Date.now().toString(36) + (nodeIdCounter++).toString(36);
 }
 
-function i18n(zhText, enText) {
-  return { en_US: enText || zhText, zh_CN: zhText, type: 'i18n' };
+function i18n(zhText, enText, jaText) {
+  return buildYidaI18n(zhText, {
+    en_US: enText || zhText,
+    ja_JP: jaText || zhText,
+  });
 }
 
 // ── 构建审批/抄送动作列表 ────────────────────────────
 
 function buildActions() {
   const actionDefs = [
-    { action: 'agree', zh: '同意', en: 'Agree', hidden: false },
-    { action: 'disagree', zh: '拒绝', en: 'Disagree', hidden: false },
-    { action: 'save', zh: '保存', en: 'Save', hidden: true },
-    { action: 'forward', zh: '转交', en: 'Forward', hidden: true },
-    { action: 'append', zh: '加签', en: 'Append', hidden: true },
-    { action: 'return', zh: '退回', en: 'Return', hidden: true },
+    { action: 'agree', zh: '同意', en: 'Agree', ja: '同意', hidden: false },
+    { action: 'disagree', zh: '拒绝', en: 'Disagree', ja: '拒否', hidden: false },
+    { action: 'save', zh: '保存', en: 'Save', ja: '保存', hidden: true },
+    { action: 'forward', zh: '转交', en: 'Forward', ja: '転送', hidden: true },
+    { action: 'append', zh: '加签', en: 'Append', ja: '承認者を追加', hidden: true },
+    { action: 'return', zh: '退回', en: 'Return', ja: '差し戻し', hidden: true },
   ];
 
   return actionDefs.map(function (def) {
     return {
       hidden: def.hidden,
-      name: i18n(def.zh, def.en),
+      name: i18n(def.zh, def.en, def.ja),
       action: def.action,
-      text: i18n(def.zh, def.en),
-      alias: i18n(def.zh, def.en),
+      text: i18n(def.zh, def.en, def.ja),
+      alias: i18n(def.zh, def.en, def.ja),
     };
   });
 }
@@ -337,7 +341,7 @@ function buildApprovalNode(node, nextNodeId, nameToIdMap) {
   }
 
   const processNode = {
-    name: i18n(node.name || '审批人', 'Approver'),
+    name: i18n(node.name || '审批人', 'Approver', node.name || '承認者'),
     description: node.description || '请选择审批人',
     type: 'approval',
     approvalType: 'ext_target_approval_originator',
@@ -350,7 +354,7 @@ function buildApprovalNode(node, nextNodeId, nameToIdMap) {
 
   const viewNodeProps = {
     nodeName: 'ApprovalNode',
-    name: i18n(node.name || '审批人', 'Approver'),
+    name: i18n(node.name || '审批人', 'Approver', node.name || '承認者'),
     description: node.description || '请选择审批人',
     approverRules: {
       type: 'ext_target_approval_originator',
@@ -374,7 +378,7 @@ function buildApprovalNode(node, nextNodeId, nameToIdMap) {
     componentName: 'ApprovalNode',
     id: nodeId,
     props: viewNodeProps,
-    title: i18n('审批人', 'Approver'),
+    title: i18n('审批人', 'Approver', '承認者'),
   };
 
   return { processNode, viewNode };
@@ -386,7 +390,7 @@ function buildCarbonNode(node, nextNodeId) {
   const nodeId = node._nodeId;
 
   const processNode = {
-    name: i18n(node.name || '抄送人', 'CC'),
+    name: i18n(node.name || '抄送人', 'CC', node.name || '共有先'),
     description: '',
     type: 'carbon',
     approvalType: 'ext_target_approval_originator',
@@ -410,7 +414,7 @@ function buildCarbonNode(node, nextNodeId) {
     id: nodeId,
     props: {
       nodeName: 'CarbonNode',
-      name: i18n(node.name || '抄送人', 'CC'),
+      name: i18n(node.name || '抄送人', 'CC', node.name || '共有先'),
       description: node.description || '请选择抄送人',
       approverRules: {
         type: 'ext_target_approval_originator',
@@ -421,7 +425,7 @@ function buildCarbonNode(node, nextNodeId) {
         description: '发起人本人',
       },
     },
-    title: i18n('抄送人', 'CC'),
+    title: i18n('抄送人', 'CC', '共有先'),
   };
 
   return { processNode, viewNode };
@@ -485,7 +489,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
       : [exitNodeId];
 
     const condProcessNode = {
-      name: i18n(condDescription || '条件', 'Condition'),
+      name: i18n(condDescription || '条件', 'Condition', condDescription || '条件'),
       description: '',
       type: 'condition',
       nodeId: condNodeId,
@@ -504,7 +508,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
       componentName: 'ConditionNode',
       id: condNodeId,
       props: {
-        name: i18n(condDescription || '条件', 'Condition'),
+        name: i18n(condDescription || '条件', 'Condition', condDescription || '条件'),
         description: '',
         conditions: {
           calculate: 'condition',
@@ -533,7 +537,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
   conditionNodeIds.push(defaultCondNodeId);
 
   const defaultCondProcessNode = {
-    name: i18n('其他情况', 'Other situations'),
+    name: i18n('其他情况', 'Other situations', 'その他の場合'),
     description: '',
     type: 'condition',
     nodeId: defaultCondNodeId,
@@ -554,7 +558,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
     props: {
       isDefault: true,
       buttons: [{ name: '关闭' }],
-      name: i18n('其他情况', 'Other situations'),
+      name: i18n('其他情况', 'Other situations', 'その他の場合'),
       description: '',
     },
   };
@@ -563,7 +567,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
 
   // 构建 route processNode
   const routeProcessNode = {
-    name: { zh_CN: 'ConditionNode', en_US: '' },
+    name: i18n('ConditionNode', 'ConditionNode', '条件ノード'),
     description: '',
     type: 'route',
     nodeId: routeNodeId,
@@ -617,7 +621,7 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
 
   // 组装发起节点
   const applyProcessNode = {
-    name: i18n('发起', 'start'),
+    name: i18n('发起', 'start', '開始'),
     description: '',
     type: 'apply',
     nodeId: 'sid_instStart',
@@ -629,7 +633,7 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
 
   // 组装结束节点
   const finishProcessNode = {
-    name: i18n('结束', 'end'),
+    name: i18n('结束', 'end', '終了'),
     description: '',
     type: 'finish',
     nodeId: finishNodeId,
@@ -684,7 +688,7 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
     id: generateNodeId(),
     props: {
       nodeName: 'ApplyNode',
-      name: i18n('发起', 'start'),
+      name: i18n('发起', 'start', '開始'),
     },
   });
 
@@ -696,7 +700,7 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
     componentName: 'EndNode',
     id: finishNodeId,
     props: {
-      name: i18n('结束', 'end'),
+      name: i18n('结束', 'end', '終了'),
     },
   });
 

--- a/lib/report/http.js
+++ b/lib/report/http.js
@@ -2,6 +2,7 @@
 
 const querystring = require('querystring');
 const { httpPost } = require('../core/utils');
+const { buildYidaI18n } = require('../core/yida-i18n');
 
 /**
  * 调用 saveFormSchemaInfo 创建空白报表
@@ -10,7 +11,7 @@ async function createBlankReport(baseUrl, csrfToken, cookies, appType, reportTit
   const postData = querystring.stringify({
     _csrf_token: csrfToken,
     formType: 'report',
-    title: JSON.stringify({ zh_CN: reportTitle, en_US: reportTitle, type: 'i18n' }),
+    title: JSON.stringify(buildYidaI18n(reportTitle, { en_US: reportTitle, ja_JP: reportTitle })),
   });
   return httpPost(baseUrl, `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`, postData, cookies);
 }

--- a/tests/create-app.test.js
+++ b/tests/create-app.test.js
@@ -30,6 +30,7 @@ describe('create-app argument parsing', () => {
       '--name', '电商经营管理看板',
       '--desc', 'E-commerce operations management dashboard demo',
       '--theme', 'deepBlue',
+      '--locale', 'ja_JP',
     ]);
 
     expect(parsed).toMatchObject({
@@ -40,10 +41,15 @@ describe('create-app argument parsing', () => {
       iconColor: '#0089FF',
       navTheme: 'dark',
       layoutDirection: 'slide',
+      locale: 'ja_JP',
     });
   });
 
   test('rejects unknown flags instead of treating them as the app name', () => {
     expect(() => parseCreateAppArgs(['--unknown'])).toThrow('Unknown option: --unknown');
+  });
+
+  test('rejects unsupported locales', () => {
+    expect(() => parseCreateAppArgs(['--name', 'CRM', '--locale', 'ko_KR'])).toThrow('Unsupported locale: ko_KR');
   });
 });

--- a/tests/create-page.test.js
+++ b/tests/create-page.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const querystring = require('querystring');
+const { buildPageInfoPostData, parseArgs } = require('../lib/app/create-page');
+
+describe('create-page locale handling', () => {
+  test('parseArgs accepts content locale flags', () => {
+    expect(parseArgs(['APP_X', '経営ダッシュボード', '--mode', 'dashboard', '--locale', 'ja'])).toMatchObject({
+      appType: 'APP_X',
+      pageName: '経営ダッシュボード',
+      mode: 'dashboard',
+      locale: 'ja',
+    });
+  });
+
+  test('buildPageInfoPostData fills Japanese title instead of null', () => {
+    const parsed = querystring.parse(buildPageInfoPostData('csrf', 'FORM_X', '経営ダッシュボード', false));
+    const title = JSON.parse(parsed.title);
+
+    expect(title).toMatchObject({
+      type: 'i18n',
+      zh_CN: '経営ダッシュボード',
+      en_US: '経営ダッシュボード',
+      pureEn_US: '経営ダッシュボード',
+      ja_JP: '経営ダッシュボード',
+    });
+  });
+});

--- a/tests/yida-i18n.test.js
+++ b/tests/yida-i18n.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const {
+  buildYidaI18n,
+  buildYidaTitleI18n,
+  normalizeYidaLocale,
+  resolveContentLocale,
+} = require('../lib/core/yida-i18n');
+
+describe('Yida resource i18n helpers', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  test('normalizes common content locale aliases', () => {
+    expect(normalizeYidaLocale('ja')).toBe('ja_JP');
+    expect(normalizeYidaLocale('ja_JP')).toBe('ja_JP');
+    expect(normalizeYidaLocale('en-US')).toBe('en_US');
+    expect(normalizeYidaLocale('zh_CN.UTF-8')).toBe('zh_CN');
+  });
+
+  test('defaults overseas environments to English content locale', () => {
+    delete process.env.OPENYIDA_CONTENT_LOCALE;
+    delete process.env.YIDA_CONTENT_LOCALE;
+    delete process.env.OPENYIDA_APP_LOCALE;
+    delete process.env.OPENYIDA_LANG;
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
+
+    expect(resolveContentLocale({ baseUrl: 'https://www.yidaapps.com' })).toBe('en_US');
+    expect(resolveContentLocale({ baseUrl: 'https://www.aliwork.com' })).toBe('zh_CN');
+  });
+
+  test('honors explicit Japanese locale over environment defaults', () => {
+    process.env.OPENYIDA_LANG = 'zh';
+
+    expect(resolveContentLocale({
+      locale: 'ja_JP',
+      baseUrl: 'https://www.aliwork.com',
+    })).toBe('ja_JP');
+  });
+
+  test('builds multilingual YiDA i18n objects with Japanese filled', () => {
+    expect(buildYidaI18n('提交', {
+      en_US: 'Submit',
+      ja_JP: '送信',
+    })).toEqual({
+      type: 'i18n',
+      zh_CN: '提交',
+      en_US: 'Submit',
+      ja_JP: '送信',
+    });
+  });
+
+  test('builds form/page title objects without null Japanese locale', () => {
+    expect(buildYidaTitleI18n('経費申請', {
+      en_US: 'Expense Request',
+      ja_JP: '経費申請',
+    })).toMatchObject({
+      type: 'i18n',
+      zh_CN: '経費申請',
+      en_US: 'Expense Request',
+      pureEn_US: 'Expense Request',
+      ja_JP: '経費申請',
+      envLocale: null,
+      key: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared YiDA i18n helper for zh_CN, en_US, and ja_JP content metadata
- add --locale/--content-locale support to app, form, and custom page creation flows
- fill app/form/page/process/report metadata with locale-aware i18n values for Global YiDA
- add focused coverage for locale resolution and create-page locale payloads

## Notes
- based on latest origin/main after #374 and #375 were merged
- intentionally excludes the local unstaged overlap/scratch/demo changes preserved in stash

## Validation
- node --check lib/core/yida-i18n.js && node --check lib/app/create-app.js && node --check lib/app/create-form.js && node --check lib/app/create-page.js && node --check lib/app/import-app.js && node --check lib/app/update-app.js && node --check lib/app/update-form-config.js && node --check lib/core/command-manifest.js && node --check lib/process/configure-process.js && node --check lib/report/http.js
- npm test -- --runTestsByPath tests/create-app.test.js tests/create-page.test.js tests/yida-i18n.test.js
- npm run check:skills (passes with existing long-skill warnings)
- git diff --check