### PR TITLE
feat: add QoderWork desktop app detection and login support

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -25,13 +25,16 @@ function isAgentEnvironment(env) {
     env.CODEX_THREAD_ID ||
     env.CODEX_HOME ||
     env.CLAUDE_CODE ||
+    env.CLAUDE_CODE_ENTRYPOINT ||
     env.OPENCODE ||
     env.QODER_IDE ||
     env.QODER_AGENT ||
+    env.QODERCLI_INTEGRATION_MODE ||
     env.CURSOR_TRACE_ID ||
     env.AGENT_WORK_ROOT ||
     env.OPENYIDA_AGENT_MODE ||
-    (env.__CFBundleIdentifier || '').toLowerCase().includes('codex')
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('codex') ||
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('qoder')
   );
 }
 
@@ -438,9 +441,19 @@ async function main() {
           if (browserResult) {
             printLoginResult(browserResult);
           } else {
-            const { startCodexQrLogin } = require('../lib/auth/qr-login');
-            const result = await startCodexQrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
-            printLoginResult(result);
+            // CDP/Playwright 失败后的兜底策略：
+            // QoderWork 有 in-app browser，优先使用 browser handoff；其余走终端二维码
+            const { detectActiveTool } = require('../lib/core/utils');
+            const activeTool = detectActiveTool();
+            if (activeTool && activeTool.tool === 'qoderwork') {
+              const { codexLogin } = require('../lib/auth/codex-login');
+              const result = await codexLogin({ tool: 'qoderwork' });
+              printLoginResult(result);
+            } else {
+              const { startCodexQrLogin } = require('../lib/auth/qr-login');
+              const result = await startCodexQrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
+              printLoginResult(result);
+            }
           }
         }
       } else if (shouldUseBrowserHandoffLogin(loginArgs)) {

--- a/lib/auth/codex-login.js
+++ b/lib/auth/codex-login.js
@@ -12,11 +12,12 @@ const { resolveLoginUrl } = require('../core/env-manager');
 const { t } = require('../core/i18n');
 
 /** 支持内置浏览器 handoff 的工具列表 */
-const BROWSER_HANDOFF_TOOLS = ['codex', 'qoder', 'wukong'];
+const BROWSER_HANDOFF_TOOLS = ['codex', 'qoder', 'qoderwork', 'wukong'];
 
 const BROWSER_HANDOFF_TOOL_META = {
   codex: { browser: 'codex', displayName: 'Codex', flag: '--codex' },
   qoder: { browser: 'qoder', displayName: 'Qoder', flag: '--qoder' },
+  qoderwork: { browser: 'qoderwork', displayName: 'QoderWork', flag: '--qoder' },
   wukong: { browser: 'wukong', displayName: '悟空（Wukong）', flag: '--wukong' },
 };
 

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -40,6 +40,7 @@ function getInstalledTools() {
     { dirName: '.claude', displayName: 'Claude Code' },
     { dirName: '.aone_copilot', displayName: 'Aone Copilot' },
     { dirName: '.cursor', displayName: 'Cursor' },
+    { dirName: '.qoderwork', displayName: 'QoderWork' },
     { dirName: '.qoder', displayName: 'Qoder' },
   ];
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -37,7 +37,21 @@ function detectActiveTool() {
 
   // 优先级1：通过环境变量检测
 
-  // Qoder (qoder.com)
+  // QoderWork (桌面客户端，__CFBundleIdentifier=com.qoder.work 或 QODERCLI_INTEGRATION_MODE=qoder_work)
+  // 必须在 Claude Code 之前检测，因为 QoderWork 内部设置了 CLAUDE_CODE_ENTRYPOINT 会干扰后续判断
+  if (
+    env.QODERCLI_INTEGRATION_MODE === 'qoder_work' ||
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('qoder')
+  ) {
+    return {
+      tool: 'qoderwork',
+      displayName: 'QoderWork',
+      dirName: '.qoderwork',
+      workspaceRoot: path.join(cwd, 'project'),
+    };
+  }
+
+  // Qoder IDE / Qoder Agent（CLI 集成模式）
   if (env.QODER_IDE || env.QODER_AGENT) {
     return {
       tool: 'qoder',

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -29,6 +29,7 @@ function cliEnv() {
     // 清除可能从父进程继承的 AI 工具环境变量，避免干扰测试
     QODER_IDE: '',
     QODER_AGENT: '',
+    QODERCLI_INTEGRATION_MODE: '',
     CODEX_SHELL: '',
     CODEX_CI: '',
     CODEX_THREAD_ID: '',
@@ -40,6 +41,7 @@ function cliEnv() {
     VSCODE_GIT_ASKPASS_NODE: '',
     AGENT_WORK_ROOT: '',
     OPENYIDA_AGENT_MODE: '',
+    __CFBundleIdentifier: '',
   };
 }
 

--- a/tests/codex-login.test.js
+++ b/tests/codex-login.test.js
@@ -22,9 +22,11 @@ describe('codexLogin', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CURSOR_TRACE_ID;
     delete process.env.AGENT_WORK_ROOT;
     delete process.env.TERM_PROGRAM;

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -181,9 +181,11 @@ describe('detectActiveTool Windows 路径兼容', () => {
 
   test('AGENT_WORK_ROOT 使用正斜杠路径时检测为悟空', () => {
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -198,9 +200,11 @@ describe('detectActiveTool Windows 路径兼容', () => {
 
   test('AGENT_WORK_ROOT 使用 Windows 反斜杠路径时检测为悟空', () => {
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -497,6 +497,9 @@ describe('interactiveLogin 浏览器优先级', () => {
   function resetToolEnv() {
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    delete process.env.__CFBundleIdentifier;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -713,9 +716,11 @@ describe('findProjectRoot 环境检测', () => {
     originalCwd = process.cwd();
     // 清除所有 AI 工具环境变量，确保测试不受当前运行环境影响
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -868,9 +873,11 @@ describe('detectActiveTool', () => {
     originalEnv = { ...process.env };
     // 清除所有 AI 工具环境变量，确保测试不受当前运行环境影响
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -884,6 +891,37 @@ describe('detectActiveTool', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+  });
+
+  test('QoderWork 桌面客户端环境识别（QODERCLI_INTEGRATION_MODE）', () => {
+    process.env.QODERCLI_INTEGRATION_MODE = 'qoder_work';
+    const { detectActiveTool: detectTool } = require('../lib/core/utils');
+
+    const tool = detectTool();
+    expect(tool).not.toBeNull();
+    expect(tool.tool).toBe('qoderwork');
+    expect(tool.displayName).toBe('QoderWork');
+    expect(tool.dirName).toBe('.qoderwork');
+  });
+
+  test('QoderWork 桌面客户端环境识别（__CFBundleIdentifier）', () => {
+    process.env.__CFBundleIdentifier = 'com.qoder.work';
+    const { detectActiveTool: detectTool } = require('../lib/core/utils');
+
+    const tool = detectTool();
+    expect(tool).not.toBeNull();
+    expect(tool.tool).toBe('qoderwork');
+    expect(tool.displayName).toBe('QoderWork');
+  });
+
+  test('QoderWork 优先级高于 Claude Code（CLAUDE_CODE_ENTRYPOINT 共存时）', () => {
+    process.env.QODERCLI_INTEGRATION_MODE = 'qoder_work';
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'sdk-ts';
+    const { detectActiveTool: detectTool } = require('../lib/core/utils');
+
+    const tool = detectTool();
+    expect(tool).not.toBeNull();
+    expect(tool.tool).toBe('qoderwork');
   });
 
   test('Qoder 环境识别', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -315,9 +315,11 @@ describe('detectActiveTool', () => {
   beforeEach(() => {
     // 清除所有 AI 工具环境变量，确保测试不受当前运行环境影响
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -371,8 +373,10 @@ describe('detectActiveTool', () => {
 
   test('AGENT_WORK_ROOT 包含 .real 时检测为悟空', () => {
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CURSOR_TRACE_ID;
     process.env.AGENT_WORK_ROOT = '/home/user/.real/workspace';
@@ -396,9 +400,11 @@ describe('detectActiveTool', () => {
 
   test('TERM_PROGRAM=vscode 且有 .aone_copilot 目录时检测为 Aone Copilot', () => {
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;
@@ -425,9 +431,11 @@ describe('detectActiveTool', () => {
 
   test('无任何 AI 工具环境变量时返回 null', () => {
     delete process.env.CLAUDE_CODE;
+    delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
+    delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
     delete process.env.CODEX_CI;
     delete process.env.CODEX_THREAD_ID;


### PR DESCRIPTION
## Summary

- Add QoderWork-specific detection in `detectActiveTool()` (via `QODERCLI_INTEGRATION_MODE` and `__CFBundleIdentifier`), placed before Claude Code to prevent misidentification caused by inherited `CLAUDE_CODE_ENTRYPOINT`
- Expand `isAgentEnvironment()` to recognize QoderWork environment variables
- When CDP login fails in QoderWork, fall back to browser handoff (`need_codex_browser_login`) instead of terminal QR code, since QoderWork has an in-app browser but terminal QR rendering is poor
- Add `.qoderwork` to `getInstalledTools()` for `openyida env` detection
- Add `qoderwork` to browser handoff tools list in `codex-login.js`

## Files changed

**Source (5 files):**
- `lib/core/utils.js` — QoderWork detection block before Claude Code
- `bin/yida.js` — `isAgentEnvironment()` expansion + agent login fallback for QoderWork
- `lib/auth/codex-login.js` — `qoderwork` added to `BROWSER_HANDOFF_TOOLS` + metadata
- `lib/core/env.js` — `.qoderwork` added to installed tools list

**Tests (5 files):**
- `tests/login.test.js` — 3 new QoderWork detection tests + env cleanup
- `tests/utils.test.js` — env var cleanup for `CLAUDE_CODE_ENTRYPOINT` / `QODERCLI_INTEGRATION_MODE`
- `tests/codex-login.test.js` — same env cleanup
- `tests/cli-smoke.test.js` — env isolation in `cliEnv()`
- `tests/copy.test.js` — env cleanup in Windows path compat tests

## Test plan

- [x] `detectActiveTool()` returns `{ tool: 'qoderwork' }` in QoderWork environment
- [x] `openyida login --check-only` reports `activeTool: "qoderwork"`
- [x] `openyida env` shows QoderWork as active tool
- [x] CDP login fallback returns browser handoff (not QR) for QoderWork
- [x] Existing Codex/Qoder/Claude Code/OpenCode/Wukong login fallback behavior unchanged (QR)
- [x] Full test suite: 54 suites, 646 tests passing

	🤖 Generated with [Qoder][https://qoder.com]