### PR TITLE
test: use current node for dws integration cli checks

### DIFF
--- a/tests/dws-integration.test.js
+++ b/tests/dws-integration.test.js
@@ -5,12 +5,18 @@
 
 'use strict';
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
+
+function runOpenYida(args) {
+  return execFileSync(process.execPath, ['bin/yida.js', ...args], {
+    encoding: 'utf8',
+  });
+}
 
 describe('钉钉 CLI 集成', () => {
   // 测试 1: dws 命令帮助信息
   test('dws --help 显示帮助信息', () => {
-    const output = execSync('node bin/yida.js dws --help', { encoding: 'utf8' });
+    const output = runOpenYida(['dws', '--help']);
     expect(output).toContain('openyida dws - 钉钉 CLI 集成');
     expect(output).toContain('常用命令');
     expect(output).toContain('contact user search');
@@ -18,13 +24,13 @@ describe('钉钉 CLI 集成', () => {
 
   // 测试 2: 无参数显示帮助
   test('dws (无参数) 显示帮助信息', () => {
-    const output = execSync('node bin/yida.js dws', { encoding: 'utf8' });
+    const output = runOpenYida(['dws']);
     expect(output).toContain('openyida dws - 钉钉 CLI 集成');
   });
 
   // 测试 3: 主帮助包含 dws 命令
   test('主帮助包含 dws 命令', () => {
-    const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
+    const output = runOpenYida(['--help']);
     expect(output).toContain('dws');
     // i18n: 中文环境输出 "钉钉 CLI"，英文环境输出 "DingTalk CLI"
     const hasDwsDescription = output.includes('钉钉 CLI') || output.includes('DingTalk CLI');
@@ -33,7 +39,7 @@ describe('钉钉 CLI 集成', () => {
 
   // 测试 4: 示例命令在帮助中
   test('示例命令在帮助中', () => {
-    const output = execSync('node bin/yida.js --help', { encoding: 'utf8' });
+    const output = runOpenYida(['--help']);
     expect(output).toContain('dws contact user search');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Windows failure in `tests/dws-integration.test.js` where child processes invoked a bare `node` command through the shell.

## Changes

- Replaces `execSync('node bin/yida.js ...')` with `execFileSync(process.execPath, ['bin/yida.js', ...args])`.
- Adds a small helper so all DWS integration CLI checks use the same cross-platform invocation path.

## Verification

- `npx jest tests/dws-integration.test.js --runInBand`
- `npm test -- --runInBand`