### PR TITLE
fix: align publish argument order

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -629,24 +629,15 @@ async function main() {
     }
 
     case 'publish': {
-      // 参数顺序：<源文件路径> <appType> <formUuid>
-      // publish.js 内部读取顺序：argv[2]=appType, argv[3]=formUuid, argv[4]=sourceFile
       const passThroughFlags = new Set(['--skip-lint', '--health-check', '--check', '--open', '--no-open', '--compat', '--modern', '--force']);
-      const forwardedFlags = args.filter(arg => passThroughFlags.has(arg));
       const filteredArgs = args.filter(arg => !passThroughFlags.has(arg));
       if (filteredArgs.length < 3) {
         warn(t('cli.publish_usage'));
         warn(t('cli.publish_example'));
         process.exit(1);
       }
-      const [sourceFile, appType, formUuid] = filteredArgs;
-      process.argv = [
-        process.argv[0], process.argv[1],
-        appType, formUuid, sourceFile,
-        ...forwardedFlags
-      ];
       const publishMain = require('../lib/app/publish');
-      await publishMain();
+      await publishMain(args);
       break;
     }
 

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -3,10 +3,10 @@
  * publish.js - 宜搭自定义页面发布工具（Node.js 版）
  *
  * 用法：
- *   openyida publish <appType> <formUuid> <源文件路径>
+ *   openyida publish <源文件路径> <appType> <formUuid>
  *
  * 示例：
- *   openyida publish APP_XXX FORM-XXX pages/xxx.js
+ *   openyida publish pages/xxx.js APP_XXX FORM-XXX
  *
  * 流程：
  * 1. 读取源文件，通过内置 babel-transform 编译 + UglifyJS 压缩
@@ -38,8 +38,34 @@ const PREFIX = '_view';
 
 // ── 参数解析 ─────────────────────────────────────────
 
-function parseArgs() {
-  const openOption = parseOpenOption(process.argv.slice(2));
+function looksLikeAppType(value) {
+  return /^APP_[A-Z0-9]+$/i.test(value || '');
+}
+
+function looksLikeFormUuid(value) {
+  return /^FORM-[A-Z0-9]+$/i.test(value || '');
+}
+
+function normalizePublishArgs(positionals) {
+  const [first, second, third] = positionals;
+
+  if (looksLikeAppType(first) && looksLikeFormUuid(second)) {
+    return {
+      appType: first,
+      formUuid: second,
+      sourceFile: third,
+    };
+  }
+
+  return {
+    sourceFile: first,
+    appType: second,
+    formUuid: third,
+  };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const openOption = parseOpenOption(argv);
   const args = openOption.args;
   const skipLint = args.includes('--skip-lint');
   const healthCheck = args.includes('--health-check') || args.includes('--check');
@@ -51,10 +77,11 @@ function parseArgs() {
     usage(t('publish.usage'), t('publish.example'));
     process.exit(1);
   }
+  const { appType, formUuid, sourceFile } = normalizePublishArgs(filteredArgs);
   return {
-    appType: filteredArgs[0],
-    formUuid: filteredArgs[1],
-    sourceFile: filteredArgs[2],
+    appType,
+    formUuid,
+    sourceFile,
     skipLint,
     healthCheck,
     compat,
@@ -647,8 +674,8 @@ function sendHealthCheckRequest(pageUrl, cookies) {
 
 // ── 主流程 ────────────────────────────────────────────
 
-async function main() {
-  const { appType, formUuid, sourceFile, skipLint, healthCheck, compat, force, browserOpenMode } = parseArgs();
+async function main(argv) {
+  const { appType, formUuid, sourceFile, skipLint, healthCheck, compat, force, browserOpenMode } = parseArgs(argv);
 
   let sourcePath = path.resolve(sourceFile);
   if (!fs.existsSync(sourcePath)) {
@@ -825,6 +852,8 @@ if (require.main === module) {
 } else {
   // 如果作为模块被 require，导出 main 函数
   module.exports = main;
+  module.exports.parseArgs = parseArgs;
+  module.exports.normalizePublishArgs = normalizePublishArgs;
   module.exports.findDuplicateSourceMismatches = findDuplicateSourceMismatches;
   module.exports.sendHealthCheckRequest = sendHealthCheckRequest;
   module.exports.normalizeFormType = normalizeFormType;

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ خطأ في النشر: {0}',
     source_not_found: '❌ لم يتم العثور على ملف المصدر: {0}',
-    usage: 'الاستخدام: openyida publish <appType> <formUuid> <ملفالمصدر> [--health-check]',
-    example: 'مثال: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'الاستخدام: openyida publish <ملفالمصدر> <appType> <formUuid> [--health-check]',
+    example: 'مثال: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ Veröffentlichungsfehler: {0}',
     source_not_found: '❌ Quelldatei nicht gefunden: {0}',
-    usage: 'Verwendung: openyida publish <appType> <formUuid> <Quelldatei> [--health-check]',
-    example: 'Beispiel: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Verwendung: openyida publish <Quelldatei> <appType> <formUuid> [--health-check]',
+    example: 'Beispiel: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1016,8 +1016,8 @@ Examples:
     exception: '\n❌ Publish error: {0}',
     error: '\n❌ Publish error: {0}',
     source_not_found: '❌ Source file not found: {0}',
-    usage: 'Usage: openyida publish <appType> <formUuid> <sourceFile> [--health-check]',
-    example: 'Example: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Usage: openyida publish <sourceFile> <appType> <formUuid> [--health-check]',
+    example: 'Example: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ Error de publicación: {0}',
     source_not_found: '❌ Archivo fuente no encontrado: {0}',
-    usage: 'Uso: openyida publish <appType> <formUuid> <archivoFuente> [--health-check]',
-    example: 'Ejemplo: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Uso: openyida publish <archivoFuente> <appType> <formUuid> [--health-check]',
+    example: 'Ejemplo: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ Erreur de publication : {0}',
     source_not_found: '❌ Fichier source introuvable : {0}',
-    usage: 'Utilisation : openyida publish <appType> <formUuid> <fichierSource> [--health-check]',
-    example: 'Exemple : openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Utilisation : openyida publish <fichierSource> <appType> <formUuid> [--health-check]',
+    example: 'Exemple : openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ प्रकाशन त्रुटि: {0}',
     source_not_found: '❌ स्रोत फ़ाइल नहीं मिली: {0}',
-    usage: 'उपयोग: openyida publish <appType> <formUuid> <स्रोतफ़ाइल> [--health-check]',
-    example: 'उदाहरण: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'उपयोग: openyida publish <स्रोतफ़ाइल> <appType> <formUuid> [--health-check]',
+    example: 'उदाहरण: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -938,8 +938,8 @@ openyida - Yida CLI ツール
     exception: '\n❌ 公開エラー: {0}',
     error: '\n❌ 公開エラー: {0}',
     source_not_found: '❌ ソースファイルが見つかりません：{0}',
-    usage: '使用方法: openyida publish <appType> <formUuid> <ソースファイル> [--health-check]',
-    example: '例: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: '使用方法: openyida publish <ソースファイル> <appType> <formUuid> [--health-check]',
+    example: '例: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -501,8 +501,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ 배포 오류: {0}',
     source_not_found: '❌ 소스 파일을 찾을 수 없습니다: {0}',
-    usage: '사용법: openyida publish <appType> <formUuid> <소스 파일> [--health-check]',
-    example: '예시: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: '사용법: openyida publish <소스 파일> <appType> <formUuid> [--health-check]',
+    example: '예시: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ Erro de publicação: {0}',
     source_not_found: '❌ Arquivo fonte não encontrado: {0}',
-    usage: 'Uso: openyida publish <appType> <formUuid> <arquivoFonte> [--health-check]',
-    example: 'Exemplo: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Uso: openyida publish <arquivoFonte> <appType> <formUuid> [--health-check]',
+    example: 'Exemplo: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -499,8 +499,8 @@ module.exports = {
     health_check_failed: '  ⚠️  Health check failed: HTTP {0} {1}',
     exception: '\n❌ Lỗi xuất bản: {0}',
     source_not_found: '❌ Không tìm thấy tệp nguồn: {0}',
-    usage: 'Cách dùng: openyida publish <appType> <formUuid> <tệpNguồn> [--health-check]',
-    example: 'Ví dụ: openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: 'Cách dùng: openyida publish <tệpNguồn> <appType> <formUuid> [--health-check]',
+    example: 'Ví dụ: openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -849,8 +849,8 @@ openyida - 宜搭命令列工具
     exception: '\n❌ 發布異常：{0}',
     error: '\n❌ 發布異常：{0}',
     source_not_found: '❌ 原始檔案不存在：{0}',
-    usage: '用法：openyida publish <appType> <formUuid> <原始檔路徑> [--health-check]',
-    example: '範例：openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: '用法：openyida publish <原始檔路徑> <appType> <formUuid> [--health-check]',
+    example: '範例：openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1018,8 +1018,8 @@ openyida - 宜搭命令行工具
     exception: '\n❌ 发布异常: {0}',
     error: '\n❌ 发布异常: {0}',
     source_not_found: '❌ 源文件不存在：{0}',
-    usage: '用法: openyida publish <appType> <formUuid> <源文件路径> [--health-check]',
-    example: '示例：openyida publish APP_XXX FORM-XXX pages/src/xxx.js --health-check',
+    usage: '用法: openyida publish <源文件路径> <appType> <formUuid> [--health-check]',
+    example: '示例：openyida publish pages/src/xxx.js APP_XXX FORM-XXX --health-check',
   },
 
   // ── lib/qr-login.js ────────────────────────────────

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -435,7 +435,7 @@ describe('CLI offline smoke', () => {
       }, workspace);
       const parsed = JSON.parse(output.trim());
       expect(parsed.poll_command).toContain('openyida login --agent-poll');
-      expect(parsed.poll_command).toMatch(/--corp-id ['"]ding-main['"]/)
+      expect(parsed.poll_command).toMatch(/--corp-id ['"]ding-main['"]/);
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -435,7 +435,7 @@ describe('CLI offline smoke', () => {
       }, workspace);
       const parsed = JSON.parse(output.trim());
       expect(parsed.poll_command).toContain('openyida login --agent-poll');
-      expect(parsed.poll_command).toContain("--corp-id 'ding-main'");
+      expect(parsed.poll_command).toMatch(/--corp-id ['"]ding-main['"]/)
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }
@@ -624,7 +624,7 @@ describe('CLI offline smoke', () => {
     const sourceFile = 'pages/src/missing-publish-source.oyd.jsx';
     const result = runAny(['publish', sourceFile, 'APP_XXX', 'FORM-XXX', '--no-open']);
     expect(result.status).toBe(1);
-    expect(result.output).toContain(sourceFile);
+    expect(result.output).toContain('missing-publish-source.oyd.jsx');
     expect(result.output).not.toContain(path.join(ROOT, 'FORM-XXX'));
   });
 });

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -619,4 +619,12 @@ describe('CLI offline smoke', () => {
       expect(result.output).toContain(item.expected);
     }
   });
+
+  test('publish keeps source-first CLI order through the router', () => {
+    const sourceFile = 'pages/src/missing-publish-source.oyd.jsx';
+    const result = runAny(['publish', sourceFile, 'APP_XXX', 'FORM-XXX', '--no-open']);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(sourceFile);
+    expect(result.output).not.toContain(path.join(ROOT, 'FORM-XXX'));
+  });
 });

--- a/tests/publish-args.test.js
+++ b/tests/publish-args.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const publish = require('../lib/app/publish');
+
+describe('publish argument parsing', () => {
+  test('uses source-first order for the public CLI contract', () => {
+    expect(publish.parseArgs([
+      'pages/src/home.oyd.jsx',
+      'APP_XXX',
+      'FORM-XXX',
+      '--health-check',
+      '--no-open',
+    ])).toMatchObject({
+      sourceFile: 'pages/src/home.oyd.jsx',
+      appType: 'APP_XXX',
+      formUuid: 'FORM-XXX',
+      healthCheck: true,
+      browserOpenMode: false,
+    });
+  });
+
+  test('keeps legacy direct publish.js order compatible', () => {
+    expect(publish.parseArgs([
+      'APP_XXX',
+      'FORM-XXX',
+      'pages/src/home.oyd.jsx',
+      '--force',
+    ])).toMatchObject({
+      sourceFile: 'pages/src/home.oyd.jsx',
+      appType: 'APP_XXX',
+      formUuid: 'FORM-XXX',
+      force: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- make publish.js parse the public source-first argument order directly
- keep legacy app-first direct publish.js calls compatible
- update publish usage/examples across locales
- add regression coverage for publish argument parsing and CLI router behavior

## Tests
- node --check bin/yida.js && node --check lib/app/publish.js && node --check tests/publish-args.test.js && node --check tests/cli-smoke.test.js
- npx eslint bin/yida.js lib/app/publish.js tests/publish-args.test.js tests/cli-smoke.test.js
- npm test -- --runTestsByPath tests/publish-args.test.js tests/cli-smoke.test.js