### PR TITLE
fix: open QR image for Windows login

### DIFF
--- a/lib/auth/qr-login.js
+++ b/lib/auth/qr-login.js
@@ -26,7 +26,10 @@ const { warn } = require('../core/chalk');
 
 const { resolveLoginUrl, resolveEndpoint, deriveBaseUrlFromUrl, getCurrentEnvConfig } = require('../core/env-manager');
 
-function shellQuote(value) {
+function shellQuote(value, options = {}) {
+  if ((options.platform || process.platform) === 'win32') {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+  }
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
 
@@ -34,10 +37,10 @@ function getTargetCorpId(options = {}, session = {}) {
   return options.corpId || options.targetCorpId || session.targetCorpId || null;
 }
 
-function buildCodexPollCommand(sessionFile, targetCorpId, envName) {
-  const baseCommand = `openyida login --agent-poll ${shellQuote(sessionFile)}`;
-  const envArg = envName ? ` --env ${shellQuote(envName)}` : '';
-  const corpArg = targetCorpId ? ` --corp-id ${shellQuote(targetCorpId)}` : '';
+function buildCodexPollCommand(sessionFile, targetCorpId, envName, options = {}) {
+  const baseCommand = `openyida login --agent-poll ${shellQuote(sessionFile, options)}`;
+  const envArg = envName ? ` --env ${shellQuote(envName, options)}` : '';
+  const corpArg = targetCorpId ? ` --corp-id ${shellQuote(targetCorpId, options)}` : '';
   return `${baseCommand}${envArg}${corpArg}`;
 }
 
@@ -57,7 +60,7 @@ function buildAgentQrResponseMarkdown(result) {
   return lines.join('\n');
 }
 
-function buildNeedQrScanResult({ qrUrl, qrImageFile, sessionFile, targetCorpId, envName }) {
+function buildNeedQrScanResult({ qrUrl, qrImageFile, qrImageOpened, sessionFile, targetCorpId, envName, platform }) {
   const qrImageMarkdown = buildQrImageMarkdown(qrImageFile);
   const result = {
     status: 'need_qr_scan',
@@ -65,9 +68,10 @@ function buildNeedQrScanResult({ qrUrl, qrImageFile, sessionFile, targetCorpId, 
     can_auto_use: false,
     qr_url: qrUrl,
     qr_image_file: qrImageFile || null,
+    qr_image_opened: !!qrImageOpened,
     qr_image_markdown: qrImageMarkdown,
     session_file: sessionFile,
-    poll_command: buildCodexPollCommand(sessionFile, targetCorpId, envName),
+    poll_command: buildCodexPollCommand(sessionFile, targetCorpId, envName, { platform }),
     message: 'Scan the QR code with DingTalk, then run poll_command.',
   };
   result.agent_response_markdown = buildAgentQrResponseMarkdown(result);
@@ -361,6 +365,97 @@ async function writeQrCodeImage(url, filePath, options = {}) {
     errorCorrectionLevel: 'M',
   });
   return true;
+}
+
+function shouldPreferQrImageInTerminal(options = {}) {
+  if (Object.prototype.hasOwnProperty.call(options, 'preferImage')) {
+    return !!options.preferImage;
+  }
+  return (options.platform || process.platform) === 'win32';
+}
+
+function shouldAutoOpenQrImageFile(options = {}) {
+  if (Object.prototype.hasOwnProperty.call(options, 'autoOpenImage')) {
+    return !!options.autoOpenImage;
+  }
+  return (options.platform || process.platform) === 'win32';
+}
+
+function getTerminalQrImageFile(options = {}) {
+  const fs = require('fs');
+  const path = require('path');
+  const projectRoot = options.projectRoot || findProjectRoot();
+  const qrDir = path.join(projectRoot, '.cache', 'qr-login');
+  const fileName = options.fileName || `login-${Date.now().toString(36)}.png`;
+  fs.mkdirSync(qrDir, { recursive: true });
+  return path.join(qrDir, fileName);
+}
+
+function openQrCodeImage(filePath, options = {}) {
+  const platform = options.platform || process.platform;
+  const spawnFn = options.spawnFn || require('child_process').spawn;
+  let command;
+  let args;
+
+  if (platform === 'win32') {
+    command = 'explorer.exe';
+    args = [filePath];
+  } else if (platform === 'darwin') {
+    command = 'open';
+    args = [filePath];
+  } else {
+    command = 'xdg-open';
+    args = [filePath];
+  }
+
+  try {
+    const child = spawnFn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (child && typeof child.unref === 'function') {
+      child.unref();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function displayQrCodeForLogin(url, options = {}) {
+  if (!shouldPreferQrImageInTerminal(options)) {
+    await renderQrCodeInTerminal(url, options);
+    return {
+      terminalRendered: true,
+      imageWritten: false,
+      imageOpened: false,
+      imageFile: null,
+    };
+  }
+
+  const imageFile = options.qrImageFile || getTerminalQrImageFile(options);
+  try {
+    const imageWritten = await writeQrCodeImage(url, imageFile, options);
+    if (imageWritten) {
+      return {
+        terminalRendered: false,
+        imageWritten: true,
+        imageOpened: openQrCodeImage(imageFile, options),
+        imageFile,
+      };
+    }
+  } catch {
+    // Fall back to the terminal renderer below.
+  }
+
+  await renderQrCodeInTerminal(url, options);
+  return {
+    terminalRendered: true,
+    imageWritten: false,
+    imageOpened: false,
+    imageFile: null,
+  };
 }
 
 // ── 宜搭登录 API ──────────────────────────────────────
@@ -1125,6 +1220,7 @@ function buildFakeCodexQrLoginResult(options = {}) {
     sessionFile,
     targetCorpId,
     envName: currentEnvName,
+    platform: options.platform,
   });
 }
 
@@ -1148,10 +1244,15 @@ async function startCodexQrLogin(options = {}) {
   cookieHeader = updatedCookieHeader;
 
   let imageWritten = false;
+  let imageOpened = false;
   try {
     imageWritten = await writeQrCodeImage(qrUrl, qrImageFile, options);
+    if (imageWritten && shouldAutoOpenQrImageFile(options)) {
+      imageOpened = openQrCodeImage(qrImageFile, options);
+    }
   } catch {
     imageWritten = false;
+    imageOpened = false;
   }
 
   saveCodexQrSession(sessionFile, {
@@ -1172,9 +1273,11 @@ async function startCodexQrLogin(options = {}) {
   return buildNeedQrScanResult({
     qrUrl,
     qrImageFile: imageWritten ? qrImageFile : null,
+    qrImageOpened: imageOpened,
     sessionFile,
     targetCorpId,
     envName: currentEnvName,
+    platform: options.platform,
   });
 }
 
@@ -1315,7 +1418,10 @@ async function qrLogin(options = {}) {
   // Step 3: 在终端渲染二维码
   qStep(3, t('qr_login.scan_hint'));
   process.stderr.write('\n');
-  await renderQrCodeInTerminal(qrUrl);
+  const qrDisplay = await displayQrCodeForLogin(qrUrl);
+  if (qrDisplay.imageWritten) {
+    qLabel('PNG', qrDisplay.imageFile);
+  }
   process.stderr.write('\n');
   qLabel('URL', qrUrl);
   process.stderr.write('\n');
@@ -1429,6 +1535,11 @@ module.exports = {
   __test__: {
     renderQrCodeInTerminal,
     writeQrCodeImage,
+    displayQrCodeForLogin,
+    shouldPreferQrImageInTerminal,
+    shouldAutoOpenQrImageFile,
+    getTerminalQrImageFile,
+    openQrCodeImage,
     resolveQrcodeModule,
     normalizeDingtalkOAuthOrgList,
     shouldChooseDingtalkOAuthOrganization,

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -435,7 +435,7 @@ describe('CLI offline smoke', () => {
       }, workspace);
       const parsed = JSON.parse(output.trim());
       expect(parsed.poll_command).toContain('openyida login --agent-poll');
-      expect(parsed.poll_command).toContain("--corp-id 'ding-main'");
+      expect(parsed.poll_command).toMatch(/--corp-id ['"]ding-main['"]/);
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }

--- a/tests/qr-login.test.js
+++ b/tests/qr-login.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 jest.mock('../lib/core/i18n', () => ({
   t: (key, ...args) => args.length > 0 ? `${key}: ${args.join(', ')}` : key,
 }));
@@ -89,6 +93,93 @@ describe('terminal QR code rendering', () => {
     });
   });
 
+  test('writes a real scan-ready PNG file with the configured QR dimensions', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-qr-png-'));
+    const filePath = path.join(tempDir, 'login.png');
+
+    try {
+      const result = await __test__.writeQrCodeImage('https://login.example/qr?code=abc', filePath);
+      const png = fs.readFileSync(filePath);
+
+      expect(result).toBe(true);
+      expect(png.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+      expect(png.subarray(12, 16).toString('ascii')).toBe('IHDR');
+      expect(png.readUInt32BE(16)).toBe(360);
+      expect(png.readUInt32BE(20)).toBe(360);
+      expect(png.length).toBeGreaterThan(1000);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('uses an opened PNG image on Windows terminals', async () => {
+    const toFile = jest.fn(async () => {});
+    const toString = jest.fn(async () => 'QR_CODE_TEXT');
+    const writeFn = jest.fn();
+    const warnFn = jest.fn();
+    const unref = jest.fn();
+    const spawnFn = jest.fn(() => ({ unref }));
+
+    const result = await __test__.displayQrCodeForLogin('https://login.example/qr?code=abc', {
+      qrcode: { toFile, toString },
+      platform: 'win32',
+      qrImageFile: 'C:\\tmp\\openyida-login.png',
+      spawnFn,
+      writeFn,
+      warnFn,
+    });
+
+    expect(result).toMatchObject({
+      terminalRendered: false,
+      imageWritten: true,
+      imageOpened: true,
+      imageFile: 'C:\\tmp\\openyida-login.png',
+    });
+    expect(toFile).toHaveBeenCalledWith('C:\\tmp\\openyida-login.png', 'https://login.example/qr?code=abc', {
+      type: 'png',
+      margin: 2,
+      width: 360,
+      errorCorrectionLevel: 'M',
+    });
+    expect(spawnFn).toHaveBeenCalledWith('explorer.exe', ['C:\\tmp\\openyida-login.png'], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    expect(unref).toHaveBeenCalled();
+    expect(toString).not.toHaveBeenCalled();
+    expect(writeFn).not.toHaveBeenCalled();
+    expect(warnFn).not.toHaveBeenCalled();
+    expect(__test__.shouldAutoOpenQrImageFile({ platform: 'win32' })).toBe(true);
+  });
+
+  test('keeps terminal QR rendering on non-Windows terminals', async () => {
+    const toFile = jest.fn(async () => {});
+    const toString = jest.fn(async () => 'QR_CODE_TEXT');
+    const writeFn = jest.fn();
+
+    const result = await __test__.displayQrCodeForLogin('https://login.example/qr?code=abc', {
+      qrcode: { toFile, toString },
+      platform: 'linux',
+      writeFn,
+      warnFn: jest.fn(),
+    });
+
+    expect(result).toMatchObject({
+      terminalRendered: true,
+      imageWritten: false,
+      imageOpened: false,
+      imageFile: null,
+    });
+    expect(toString).toHaveBeenCalledWith('https://login.example/qr?code=abc', {
+      type: 'terminal',
+      small: true,
+      errorCorrectionLevel: 'M',
+    });
+    expect(toFile).not.toHaveBeenCalled();
+    expect(writeFn).toHaveBeenCalledWith('QR_CODE_TEXT\n');
+  });
+
   test('builds Codex native single-select interaction for organizations', () => {
     const interaction = __test__.buildCodexCorpInteraction([
       { corpId: 'ding-main', corpName: 'Main Org', mainOrg: true },
@@ -106,9 +197,14 @@ describe('terminal QR code rendering', () => {
   });
 
   test('keeps selected environment in QR poll command', () => {
-    expect(__test__.buildCodexPollCommand('/tmp/session.json', 'ding-main', 'intl')).toBe(
+    expect(__test__.buildCodexPollCommand('/tmp/session.json', 'ding-main', 'intl', {
+      platform: 'linux',
+    })).toBe(
       "openyida login --agent-poll '/tmp/session.json' --env 'intl' --corp-id 'ding-main'"
     );
+    expect(__test__.buildCodexPollCommand('C:\\tmp\\session.json', 'ding-main', 'public', {
+      platform: 'win32',
+    })).toBe('openyida login --agent-poll "C:\\tmp\\session.json" --env "public" --corp-id "ding-main"');
 
     const result = __test__.buildNeedQrScanResult({
       qrUrl: 'https://login.dingtalk.io/oauth2/qr_confirm.htm?code=abc',
@@ -116,8 +212,25 @@ describe('terminal QR code rendering', () => {
       sessionFile: '/tmp/session.json',
       targetCorpId: null,
       envName: 'intl',
+      platform: 'linux',
     });
     expect(result.poll_command).toBe("openyida login --agent-poll '/tmp/session.json' --env 'intl'");
+    expect(result.qr_image_opened).toBe(false);
+
+    const windowsResult = __test__.buildNeedQrScanResult({
+      qrUrl: 'https://login.dingtalk.com/oauth2/qr_confirm.htm?code=abc',
+      qrImageFile: 'C:\\tmp\\openyida-login.png',
+      qrImageOpened: true,
+      sessionFile: 'C:\\tmp\\session.json',
+      targetCorpId: 'ding-main',
+      envName: 'public',
+      platform: 'win32',
+    });
+    expect(windowsResult).toMatchObject({
+      qr_image_file: 'C:\\tmp\\openyida-login.png',
+      qr_image_opened: true,
+      poll_command: 'openyida login --agent-poll "C:\\tmp\\session.json" --env "public" --corp-id "ding-main"',
+    });
   });
 
   test('resolveQrcodeModule tries package name before adjacent install paths', () => {


### PR DESCRIPTION
## Summary

- Generate a PNG QR code for Windows terminal login flows instead of relying on CMD/ANSI QR rendering.
- Auto-open the generated QR image through `explorer.exe` for Windows users, while preserving terminal QR rendering on non-Windows platforms.
- Use Windows-safe double-quoted `poll_command` output and expose whether the QR image was opened in agent handoff responses.

## Root Cause

Windows CMD can render terminal QR blocks poorly, so customers may see a QR code that cannot be scanned reliably during `openyida login` in Wukong/Windows environments.

## Validation

- `node --check lib/auth/qr-login.js`
- `NODE_PATH=/Users/js/workspace/openyida/openyida/node_modules /Users/js/workspace/openyida/openyida/node_modules/.bin/jest tests/qr-login.test.js --runInBand`
- `NODE_PATH=/Users/js/workspace/openyida/openyida/node_modules /Users/js/workspace/openyida/openyida/node_modules/.bin/eslint lib/auth/qr-login.js tests/qr-login.test.js`
- `git diff --check`
