### PR TITLE
[codex] add feedback form workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida formula evaluate <formula\|file> [--schema file]` | Static-check formula syntax and field references |
 | `openyida update` | Update OpenYida through npm |
 | `openyida export-conversation [options]` | Export AI conversation history |
+| `openyida feedback <setup\|url\|dismiss\|status>` | Create a public Yida feedback form, generate privacy-safe feedback links, and manage local reminder snooze state |
 | `openyida flash-to-prd --file <path> --name "<project>"` | Convert flash notes or meeting notes into a PRD prompt |
 | `openyida ai text --prompt "..."` | Call Yida's text generation AI API |
 | `openyida ai image --file <image> --app-type APP_XXX` | Upload an image and call the image recognition connector |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -206,6 +206,8 @@ function handleFirstRunGuide() {
 }
 
 function printLoginResult(result) {
+  noteLoginCommandResult(result);
+
   if (result && (result.status === 'need_qr_scan' || result.status === 'need_corp_selection')) {
     console.log(JSON.stringify(result));
     return;
@@ -246,6 +248,41 @@ function printLoginResult(result) {
     cookies_count: Array.isArray(result && result.cookies) ? result.cookies.length : 0,
   };
   console.log(JSON.stringify(summary));
+}
+
+function noteLoginCommandResult(result) {
+  try {
+    const { recordLoginEvent, printLoginLoopFeedbackHint } = require('../lib/feedback/feedback');
+    let status = 'failed';
+    let reason = 'login_failed';
+
+    if (result && (result.csrf_token || (result.status === 'ok' && result.can_auto_use))) {
+      status = 'success';
+      reason = 'login_ok';
+    } else if (result && result.status === 'need_qr_scan') {
+      status = 'need_qr_scan';
+      reason = 'need_qr_scan';
+    } else if (result && result.status === 'need_codex_browser_login') {
+      status = 'need_browser_login';
+      reason = 'need_browser_login';
+    } else if (result && result.status === 'need_corp_selection') {
+      status = 'success';
+      reason = 'need_corp_selection';
+    } else if (result && result.status) {
+      reason = result.status;
+    }
+
+    const loopStatus = recordLoginEvent(status, {
+      mode: args.join(' ') || 'default',
+      reason,
+      command: 'openyida login',
+    });
+    if (status !== 'success') {
+      printLoginLoopFeedbackHint(loopStatus);
+    }
+  } catch {
+    // Login feedback tracking is best-effort and must not affect CLI output.
+  }
 }
 
 function isAgentConversationEnvironment() {
@@ -428,7 +465,7 @@ async function main() {
       } else if (loginArgs.includes('--qr')) {
         const { qrLogin } = require('../lib/auth/qr-login');
         const result = await qrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
-        console.log(JSON.stringify(result));
+        printLoginResult(result);
       } else if (shouldUseAgentLogin(loginArgs)) {
         const cachedResult = checkLoginOnly({ includeSecrets: true });
         if (cachedResult.status === 'ok') {
@@ -473,7 +510,7 @@ async function main() {
         }
         const { qrLogin } = require('../lib/auth/qr-login');
         const result = await qrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
-        console.log(JSON.stringify(result));
+        printLoginResult(result);
       }
       break;
     }
@@ -1004,6 +1041,12 @@ async function main() {
         }
       }
       await exportConversation(options);
+      break;
+    }
+
+    case 'feedback': {
+      const { run: runFeedback } = require('../lib/feedback/feedback');
+      await runFeedback(args);
       break;
     }
 

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -176,6 +176,10 @@ const COMMAND_GROUPS = [
       command('export-conversation', ['export-conversation'], 'export-conversation [options]', 'help.cmd_export_conversation', {
         requiresLogin: false,
       }),
+      command('feedback', ['feedback'], 'feedback <setup|url|dismiss|status> [options]', 'help.cmd_feedback', {
+        requiresLogin: false,
+        output: 'text|json',
+      }),
       command('flash-to-prd', ['flash-to-prd'], 'flash-to-prd --file <path> --name "<project>"', 'help.cmd_flash_to_prd', {
         requiresLogin: false,
       }),

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'تشخيص البيئة والإصلاح التلقائي',
     cmd_update: 'التحقق والتحديث إلى أحدث إصدار',
     cmd_export_conversation: 'تصدير سجلات محادثة الذكاء الاصطناعي',
+    cmd_feedback: 'Configure experience feedback form and local reminder state',
     cmd_flash_to_prd: 'Convert flash notes or meeting notes to a PRD prompt',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'إدارة صور CDN (إعداد/رفع/تحديث)',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'Umgebungsdiagnose & automatische Reparatur',
     cmd_update: 'Auf neueste Version aktualisieren',
     cmd_export_conversation: 'KI-Gesprächsaufzeichnungen exportieren',
+    cmd_feedback: 'Feedback-Formular und lokalen Erinnerungsstatus konfigurieren',
     cmd_flash_to_prd: 'Flash Notes oder Meeting Notes in PRD-Prompt umwandeln',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'CDN-Bildverwaltung (Konfiguration/Upload/Aktualisierung)',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -88,6 +88,7 @@ module.exports = {
     cmd_formula_evaluate: 'Static-check Yida formula syntax and field refs',
     cmd_update: 'Check and update to latest version',
     cmd_export_conversation: 'Export AI conversation records',
+    cmd_feedback: 'Configure experience feedback form and local reminder state',
     cmd_flash_to_prd: 'Convert flash notes or meeting notes to a PRD prompt',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'CDN image management (config/upload/refresh)',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'Diagnóstico de entorno y reparación automática',
     cmd_update: 'Verificar y actualizar a la última versión',
     cmd_export_conversation: 'Exportar registros de conversación IA',
+    cmd_feedback: 'Configurar formulario de feedback y recordatorios locales',
     cmd_flash_to_prd: 'Convertir notas rápidas o de reunión a prompt PRD',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'Gestión de imágenes CDN (config/subir/refrescar)',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'Diagnostic d\'environnement et réparation auto',
     cmd_update: 'Vérifier et mettre à jour vers la dernière version',
     cmd_export_conversation: 'Exporter les enregistrements de conversation IA',
+    cmd_feedback: 'Configurer le formulaire de retour et les rappels locaux',
     cmd_flash_to_prd: 'Convertir des notes flash ou de réunion en prompt PRD',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'Gestion d\'images CDN (config/upload/rafraîchir)',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'वातावरण निदान और स्वचालित मरम्मत',
     cmd_update: 'नवीनतम संस्करण में अपडेट करें',
     cmd_export_conversation: 'AI वार्तालाप रिकॉर्ड निर्यात करें',
+    cmd_feedback: 'Configure experience feedback form and local reminder state',
     cmd_flash_to_prd: 'Convert flash notes or meeting notes to a PRD prompt',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'CDN छवि प्रबंधन (कॉन्फ़िग/अपलोड/रिफ्रेश)',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -86,6 +86,7 @@ module.exports = {
     cmd_doctor: '環境診断と自動修復',
     cmd_update: '最新バージョンに更新',
     cmd_export_conversation: 'AI 会話記録をエクスポート',
+    cmd_feedback: '体験フィードバックフォームとローカル通知状態を設定',
     cmd_flash_to_prd: 'フラッシュノート/議事録を PRD prompt に変換',
     cmd_ai: 'Yida AI text and image recognition APIs',
     cmd_cdn: 'CDN 画像管理（設定/アップロード/リフレッシュ）',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: '환경 진단 및 자동 수정',
     cmd_update: '최신 버전으로 업데이트',
     cmd_export_conversation: 'AI 대화 기록 내보내기',
+    cmd_feedback: '경험 피드백 양식 및 로컬 알림 상태 구성',
     cmd_flash_to_prd: 'Convert flash notes or meeting notes to a PRD prompt',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'CDN 이미지 관리 (설정/업로드/새로고침)',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'Diagnóstico de ambiente e reparo automático',
     cmd_update: 'Verificar e atualizar para a versão mais recente',
     cmd_export_conversation: 'Exportar registros de conversa IA',
+    cmd_feedback: 'Configurar formulário de feedback e lembretes locais',
     cmd_flash_to_prd: 'Converter notas rápidas ou de reunião para prompt PRD',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'Gerenciamento de imagens CDN (config/upload/atualizar)',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -84,6 +84,7 @@ module.exports = {
     cmd_doctor: 'Chẩn đoán môi trường và sửa tự động',
     cmd_update: 'Kiểm tra và cập nhật lên phiên bản mới nhất',
     cmd_export_conversation: 'Xuất bản ghi hội thoại AI',
+    cmd_feedback: 'Configure experience feedback form and local reminder state',
     cmd_flash_to_prd: 'Convert flash notes or meeting notes to a PRD prompt',
     cmd_ai: 'Call Yida AI text and image recognition APIs',
     cmd_cdn: 'Quản lý hình ảnh CDN (cấu hình/tải lên/làm mới)',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -86,6 +86,7 @@ module.exports = {
     cmd_doctor: '環境診斷與自動修復',
     cmd_update: '檢查並更新到最新版本',
     cmd_export_conversation: '匯出 AI 對話記錄',
+    cmd_feedback: '設定體驗回饋表單和本地提醒狀態',
     cmd_flash_to_prd: '閃記 / 會議紀要轉 PRD prompt',
     cmd_ai: '調用宜搭 AI 文生文和識圖能力',
     cmd_cdn: 'CDN 圖片管理（設定/上傳/刷新）',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -88,6 +88,7 @@ module.exports = {
     cmd_formula_evaluate: '静态检查宜搭公式语法和字段引用',
     cmd_update: '检查并更新到最新版本',
     cmd_export_conversation: '导出 AI 对话记录',
+    cmd_feedback: '配置体验反馈表单和本地提醒状态',
     cmd_flash_to_prd: '闪记 / 会议纪要转 PRD prompt',
     cmd_ai: '调用宜搭 AI 文生文和识图能力',
     cmd_cdn: 'CDN 图片管理（配置/上传/刷新）',

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -365,7 +365,34 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
 function triggerLogin(options = {}) {
   warn(t('login.trigger_login'));
   const { ensureLogin } = require('../auth/login');
-  return ensureLogin(options);
+  let loopStatus = null;
+  try {
+    const { recordLoginEvent } = require('../feedback/feedback');
+    loopStatus = recordLoginEvent('trigger', {
+      mode: options.force ? 'force' : 'auto',
+      reason: 'trigger_login',
+      command: 'triggerLogin',
+    });
+  } catch {
+    // Feedback loop tracking is best-effort and must never block login.
+  }
+
+  const result = ensureLogin(options);
+  try {
+    const { recordLoginEvent, printLoginLoopFeedbackHint } = require('../feedback/feedback');
+    const ok = !!(result && result.csrf_token);
+    loopStatus = recordLoginEvent(ok ? 'success' : 'failed', {
+      mode: options.force ? 'force' : 'auto',
+      reason: ok ? 'login_ok' : (result && result.status) || 'login_failed',
+      command: 'triggerLogin',
+    });
+    if (!ok) {
+      printLoginLoopFeedbackHint(loopStatus);
+    }
+  } catch {
+    // Best-effort only.
+  }
+  return result;
 }
 
 /**

--- a/lib/feedback/feedback.js
+++ b/lib/feedback/feedback.js
@@ -1,0 +1,1011 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+
+const { findProjectRoot, detectActiveTool } = require('../core/utils');
+const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
+const { banner, step, label, success, fail, hint } = require('../core/chalk');
+
+const DEFAULT_FORM_NAME = 'OpenYida 体验反馈';
+const DEFAULT_APP_NAME = 'OpenYida 体验反馈';
+const CONFIG_FILE_NAME = 'config.json';
+const REMINDER_FILE_NAME = 'reminder.json';
+const LOGIN_EVENTS_FILE_NAME = 'login-events.json';
+const LOGIN_LOOP_WINDOW_MS = 30 * 60 * 1000;
+const LOGIN_LOOP_THRESHOLD = 3;
+
+const FIELD_LABELS = {
+  result: '处理结果',
+  content: '反馈内容',
+  screenshot: '截图（选填）',
+  issueType: '问题类型',
+  score: '体验评分',
+  contact: '联系方式',
+  privacy: '隐私确认',
+  tool: 'AI 工具',
+  model: '模型',
+  command: '命令场景',
+  session: '匿名会话 ID',
+  version: 'OpenYida 版本',
+  reason: '触发原因',
+  diagnostics: '脱敏诊断信息',
+};
+
+const METADATA_PARAM_MAP = {
+  tool: ['oy_tool', 'tool', 'ai_tool'],
+  model: ['oy_model', 'model'],
+  command: ['oy_command', 'command', 'cmd'],
+  session: ['oy_session', 'session', 'session_id'],
+  version: ['oy_version', 'openyida_version', 'version'],
+  reason: ['oy_reason', 'reason'],
+  diagnostics: ['oy_diag', 'diagnostics', 'diag'],
+};
+
+function printUsage() {
+  process.stderr.write(`
+用法:
+  openyida feedback setup <appType> [--name "OpenYida 体验反馈"] [--path /o/openyida-feedback] [--open|--no-open]
+  openyida feedback setup --create-app [--app-name "OpenYida 体验反馈"] [--name "OpenYida 体验反馈"]
+  openyida feedback url [--tool Codex] [--model gpt-5] [--command publish] [--diagnostics "..."]
+  openyida feedback dismiss --today|--forever|--reset
+  openyida feedback status
+
+说明:
+  setup 会在宜搭创建一个公开反馈表单，并写入本地 .cache/openyida/feedback/config.json。
+  url 只生成带脱敏元数据的填写链接，不提交任何网络请求。
+  dismiss/status 只读写本地提醒状态。
+`);
+}
+
+function readOptionValue(args, index, optionName) {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+  return value;
+}
+
+function getFeedbackCacheDir(configPath) {
+  if (configPath) {
+    return path.dirname(path.resolve(configPath));
+  }
+  return path.join(findProjectRoot(), '.cache', 'openyida', 'feedback');
+}
+
+function getFeedbackConfigPath(configPath) {
+  if (configPath) {
+    return path.resolve(configPath);
+  }
+  return path.join(getFeedbackCacheDir(), CONFIG_FILE_NAME);
+}
+
+function getReminderPath(configPath) {
+  return path.join(getFeedbackCacheDir(configPath), REMINDER_FILE_NAME);
+}
+
+function getLoginEventsPath(configPath) {
+  return path.join(getFeedbackCacheDir(configPath), LOGIN_EVENTS_FILE_NAME);
+}
+
+function ensureFeedbackCacheDir(configPath) {
+  const dir = getFeedbackCacheDir(configPath);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function parseSetupArgs(args) {
+  const openOption = parseOpenOption(args);
+  const filteredArgs = openOption.args;
+  const options = {
+    appType: '',
+    createApp: false,
+    appName: DEFAULT_APP_NAME,
+    formName: DEFAULT_FORM_NAME,
+    openPath: '',
+    openAuth: 'n',
+    configPath: '',
+    openMode: openOption.mode,
+  };
+  const positionals = [];
+
+  for (let index = 0; index < filteredArgs.length; index++) {
+    const arg = filteredArgs[index];
+    if (arg === '--create-app') {
+      options.createApp = true;
+    } else if (arg === '--app-name') {
+      options.appName = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg === '--name' || arg === '--form-name') {
+      options.formName = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg === '--app-type' || arg === '--appType' || arg === '-a') {
+      options.appType = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg === '--path' || arg === '--open-url' || arg === '--openUrl') {
+      options.openPath = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg === '--open-auth' || arg === '--openAuth') {
+      options.openAuth = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg === '--config') {
+      options.configPath = readOptionValue(filteredArgs, index, arg);
+      index++;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  if (!options.appType && positionals[0]) {
+    options.appType = positionals[0];
+  }
+  if (options.openAuth !== 'y' && options.openAuth !== 'n') {
+    throw new Error('--open-auth must be y or n');
+  }
+  if (options.openPath && !/^\/o\/[A-Za-z0-9_-]+$/.test(options.openPath)) {
+    throw new Error('--path must look like /o/openyida-feedback');
+  }
+  return options;
+}
+
+function parseUrlArgs(args) {
+  const options = {
+    configPath: '',
+    tool: '',
+    model: '',
+    command: '',
+    session: '',
+    version: '',
+    reason: '',
+    diagnostics: '',
+    metaJson: '',
+    json: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--config') {
+      options.configPath = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--tool') {
+      options.tool = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--model') {
+      options.model = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--command') {
+      options.command = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--session-id' || arg === '--session') {
+      options.session = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--version') {
+      options.version = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--reason') {
+      options.reason = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--diagnostics' || arg === '--diag') {
+      options.diagnostics = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--meta-json') {
+      options.metaJson = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseDismissArgs(args) {
+  const options = {
+    configPath: '',
+    today: false,
+    forever: false,
+    reset: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--config') {
+      options.configPath = readOptionValue(args, index, arg);
+      index++;
+    } else if (arg === '--today') {
+      options.today = true;
+    } else if (arg === '--forever') {
+      options.forever = true;
+    } else if (arg === '--reset') {
+      options.reset = true;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseArgs(args = []) {
+  const command = args[0] || 'help';
+  const subArgs = args.slice(1);
+
+  if (command === 'setup') {
+    return { command, options: parseSetupArgs(subArgs) };
+  }
+  if (command === 'url') {
+    return { command, options: parseUrlArgs(subArgs) };
+  }
+  if (command === 'dismiss' || command === 'snooze') {
+    return { command: 'dismiss', options: parseDismissArgs(subArgs) };
+  }
+  if (command === 'status' || command === 'should-remind') {
+    const options = { configPath: '' };
+    for (let index = 0; index < subArgs.length; index++) {
+      const arg = subArgs[index];
+      if (arg === '--config') {
+        options.configPath = readOptionValue(subArgs, index, arg);
+        index++;
+      } else if (arg.startsWith('-')) {
+        throw new Error(`Unknown option: ${arg}`);
+      }
+    }
+    return { command, options };
+  }
+  if (command === '--help' || command === '-h' || command === 'help') {
+    return { command: 'help', options: {} };
+  }
+  throw new Error(`Unknown feedback sub-command: ${command}`);
+}
+
+function buildFeedbackFields() {
+  return [
+    {
+      type: 'RadioField',
+      label: FIELD_LABELS.result,
+      required: true,
+      options: ['未解决', '部分解决', '已解决', '只是建议'],
+    },
+    {
+      type: 'TextareaField',
+      label: FIELD_LABELS.content,
+      required: true,
+      placeholder: '请写下哪里没有达到预期，或你希望我们怎么改进。',
+    },
+    {
+      type: 'ImageField',
+      label: FIELD_LABELS.screenshot,
+    },
+    {
+      type: 'SelectField',
+      label: FIELD_LABELS.issueType,
+      options: ['登录认证', '创建应用', '表单配置', '页面发布', '数据查询', '连接器/集成', '文档/技能', '性能/稳定性', '其他'],
+    },
+    {
+      type: 'RateField',
+      label: FIELD_LABELS.score,
+    },
+    {
+      type: 'TextField',
+      label: FIELD_LABELS.contact,
+      placeholder: '选填；如需回复可填写联系方式。',
+    },
+    {
+      type: 'CheckboxField',
+      label: FIELD_LABELS.privacy,
+      required: true,
+      options: ['我确认本次反馈只提交我填写的内容、我主动上传的截图和脱敏诊断信息，不提交 Cookie、密钥或完整会话。'],
+    },
+    ...[
+      FIELD_LABELS.tool,
+      FIELD_LABELS.model,
+      FIELD_LABELS.command,
+      FIELD_LABELS.session,
+      FIELD_LABELS.version,
+      FIELD_LABELS.reason,
+      FIELD_LABELS.diagnostics,
+    ].map((fieldLabel) => ({
+      type: fieldLabel === FIELD_LABELS.diagnostics ? 'TextareaField' : 'TextField',
+      label: fieldLabel,
+      behavior: 'HIDDEN',
+      visibility: ['PC', 'MOBILE'],
+    })),
+  ];
+}
+
+function resolveCliPath() {
+  return path.join(__dirname, '..', '..', 'bin', 'yida.js');
+}
+
+function runOpenYidaJson(args, options = {}) {
+  const cliPath = options.cliPath || resolveCliPath();
+  const child = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: options.cwd || process.cwd(),
+    env: {
+      ...process.env,
+      YIDA_QUIET: '1',
+      OPENYIDA_NO_BROWSER_HANDOFF: '1',
+    },
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  if (child.status !== 0) {
+    const output = [child.stderr, child.stdout].filter(Boolean).join('\n').trim();
+    throw new Error(`openyida ${args.join(' ')} failed${output ? `: ${output}` : ''}`);
+  }
+
+  return parseJsonOutput(child.stdout, `openyida ${args.join(' ')}`);
+}
+
+function parseJsonOutput(output, source = 'command') {
+  const text = String(output || '').trim();
+  if (!text) {
+    throw new Error(`${source} did not return JSON`);
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (firstError) {
+    const firstBrace = text.indexOf('{');
+    const lastBrace = text.lastIndexOf('}');
+    if (firstBrace !== -1 && lastBrace > firstBrace) {
+      try {
+        return JSON.parse(text.slice(firstBrace, lastBrace + 1));
+      } catch {
+        // fall through
+      }
+    }
+    throw firstError;
+  }
+}
+
+function collectFieldMap(schemaResult, requiredLabels = Object.values(FIELD_LABELS)) {
+  const content = schemaResult && schemaResult.content;
+  const pages = content && content.pages;
+  const fieldMap = {};
+  const missing = new Set(requiredLabels);
+
+  function labelOf(node) {
+    const labelValue = node && node.props && node.props.label;
+    if (!labelValue) {
+      return '';
+    }
+    if (typeof labelValue === 'object') {
+      return labelValue.zh_CN || labelValue.en_US || labelValue.ja_JP || '';
+    }
+    return String(labelValue);
+  }
+
+  function visit(node) {
+    if (!node) {
+      return;
+    }
+    const fieldId = node.props && node.props.fieldId;
+    const fieldLabel = labelOf(node);
+    if (fieldId && requiredLabels.includes(fieldLabel)) {
+      fieldMap[fieldLabel] = fieldId;
+      missing.delete(fieldLabel);
+    }
+    if (Array.isArray(node.children)) {
+      node.children.forEach(visit);
+    }
+  }
+
+  (pages || []).forEach((page) => {
+    const root = page.componentsTree && page.componentsTree[0];
+    visit(root);
+  });
+
+  if (missing.size > 0) {
+    throw new Error(`反馈表单字段缺失: ${Array.from(missing).join(', ')}`);
+  }
+
+  return fieldMap;
+}
+
+function buildAutofillActionSource(fieldMap) {
+  const mapJson = JSON.stringify(fieldMap, null, 2);
+  const paramMapJson = JSON.stringify(METADATA_PARAM_MAP, null, 2);
+  return `var OPENYIDA_FEEDBACK_FIELDS = ${mapJson};
+var OPENYIDA_FEEDBACK_PARAMS = ${paramMapJson};
+
+function openyidaFeedbackGetComponent(ctx, fieldId) {
+  if (!fieldId) { return null; }
+  if (ctx && typeof ctx.$ === 'function') { return ctx.$(fieldId); }
+  if (typeof $ === 'function') { return $(fieldId); }
+  return null;
+}
+
+function openyidaFeedbackSetValue(ctx, label, value) {
+  if (value === undefined || value === null || value === '') { return; }
+  var fieldId = OPENYIDA_FEEDBACK_FIELDS[label];
+  var component = openyidaFeedbackGetComponent(ctx, fieldId);
+  if (!component) { return; }
+  if (typeof component.setValue === 'function') {
+    component.setValue(String(value), { triggerChange: false });
+    return;
+  }
+  if (typeof component.set === 'function') {
+    component.set('value', String(value));
+  }
+}
+
+function openyidaFeedbackDecodeBase64Url(value) {
+  if (!value) { return ''; }
+  try {
+    var normalized = String(value).replace(/-/g, '+').replace(/_/g, '/');
+    while (normalized.length % 4) { normalized += '='; }
+    var binary = window.atob(normalized);
+    var escaped = '';
+    for (var index = 0; index < binary.length; index++) {
+      escaped += '%' + ('00' + binary.charCodeAt(index).toString(16)).slice(-2);
+    }
+    return decodeURIComponent(escaped);
+  } catch (error) {
+    return '';
+  }
+}
+
+function openyidaFeedbackReadParams() {
+  var params = {};
+  try {
+    var searchParams = new URLSearchParams(window.location.search || '');
+    Object.keys(OPENYIDA_FEEDBACK_PARAMS).forEach(function(key) {
+      var names = OPENYIDA_FEEDBACK_PARAMS[key] || [];
+      for (var index = 0; index < names.length; index++) {
+        var value = searchParams.get(names[index]);
+        if (value) {
+          params[key] = value;
+          break;
+        }
+      }
+    });
+    var metaValue = searchParams.get('oy_meta') || searchParams.get('meta');
+    if (metaValue) {
+      var decoded = openyidaFeedbackDecodeBase64Url(metaValue);
+      if (decoded) {
+        var meta = JSON.parse(decoded);
+        Object.keys(meta || {}).forEach(function(key) {
+          if (params[key] === undefined && meta[key] !== undefined) {
+            params[key] = meta[key];
+          }
+        });
+      }
+    }
+  } catch (error) {
+    params.diagnostics = params.diagnostics || 'metadata_parse_failed';
+  }
+  return params;
+}
+
+export function didMount() {
+  var metadata = openyidaFeedbackReadParams();
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.tool}', metadata.tool);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.model}', metadata.model);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.command}', metadata.command);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.session}', metadata.session);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.version}', metadata.version);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.reason}', metadata.reason);
+  openyidaFeedbackSetValue(this, '${FIELD_LABELS.diagnostics}', metadata.diagnostics);
+}
+`;
+}
+
+function buildDefaultOpenPath(appType, formUuid) {
+  const digest = crypto
+    .createHash('sha1')
+    .update(`${appType}:${formUuid}:${Date.now()}`)
+    .digest('hex')
+    .slice(0, 10);
+  return `/o/openyida-feedback-${digest}`;
+}
+
+function inferBaseUrl(formResult, publicPath) {
+  if (formResult && formResult.url) {
+    try {
+      return new URL(formResult.url).origin;
+    } catch {
+      // ignore
+    }
+  }
+  if (formResult && formResult.publicUrl) {
+    try {
+      return new URL(formResult.publicUrl).origin;
+    } catch {
+      // ignore
+    }
+  }
+  return publicPath && publicPath.startsWith('http') ? new URL(publicPath).origin : 'https://www.aliwork.com';
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+function readFeedbackConfig(configPath) {
+  const envConfigPath = configPath || process.env.OPENYIDA_FEEDBACK_CONFIG || '';
+  const resolved = getFeedbackConfigPath(envConfigPath);
+  if (!fs.existsSync(resolved)) {
+    const publicUrl = process.env.OPENYIDA_FEEDBACK_PUBLIC_URL || '';
+    if (publicUrl) {
+      return {
+        schemaVersion: 1,
+        source: 'env',
+        publicUrl,
+        privacy: {
+          uploadsFullConversationByDefault: false,
+          hashesSessionId: true,
+        },
+      };
+    }
+    throw new Error(`未找到反馈表单配置: ${resolved}。请先运行 openyida feedback setup <appType>。`);
+  }
+  return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+}
+
+function packageVersion() {
+  try {
+    return require('../../package.json').version || '';
+  } catch {
+    return '';
+  }
+}
+
+function inferToolName() {
+  const active = detectActiveTool();
+  return active ? active.displayName || active.tool || '' : '';
+}
+
+function hashSessionId(value) {
+  if (!value) {
+    return '';
+  }
+  const digest = crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 16);
+  return `anon_${digest}`;
+}
+
+function truncateValue(value, maxLength) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  const text = String(value);
+  return text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
+}
+
+function sanitizeMetadata(raw = {}) {
+  const metadata = {};
+  const sessionValue = raw.session || raw.sessionId || raw.session_id || process.env.CODEX_THREAD_ID || process.env.CLAUDE_SESSION_ID || '';
+
+  metadata.tool = truncateValue(raw.tool || inferToolName(), 120);
+  metadata.model = truncateValue(raw.model || process.env.OPENYIDA_MODEL || process.env.CODEX_MODEL || '', 120);
+  metadata.command = truncateValue(raw.command || raw.cmd || '', 160);
+  metadata.session = hashSessionId(sessionValue);
+  metadata.version = truncateValue(raw.version || raw.openyidaVersion || packageVersion(), 80);
+  metadata.reason = truncateValue(raw.reason || '', 240);
+  metadata.diagnostics = truncateValue(raw.diagnostics || raw.diag || '', 1800);
+
+  Object.keys(metadata).forEach((key) => {
+    if (!metadata[key]) {
+      delete metadata[key];
+    }
+  });
+  return metadata;
+}
+
+function encodeMetadata(metadata) {
+  return Buffer.from(JSON.stringify(metadata), 'utf8').toString('base64url');
+}
+
+function buildFeedbackUrl(config, metadataInput = {}) {
+  const publicUrl = config.publicUrl || (config.baseUrl && config.openPath ? config.baseUrl + config.openPath : '');
+  if (!publicUrl) {
+    throw new Error('反馈表单配置缺少 publicUrl');
+  }
+
+  const metadata = sanitizeMetadata(metadataInput);
+  const url = new URL(publicUrl);
+  if (Object.keys(metadata).length > 0) {
+    url.searchParams.set('oy_meta', encodeMetadata(metadata));
+  }
+  return { url: url.toString(), metadata };
+}
+
+async function runSetup(options) {
+  if (!options.appType && !options.createApp) {
+    throw new Error('请提供 appType，或使用 --create-app 创建专用反馈应用');
+  }
+
+  banner('OpenYida 反馈表单配置');
+  label('Form', options.formName);
+  label('Open Auth', options.openAuth);
+
+  const cacheDir = ensureFeedbackCacheDir(options.configPath);
+  const fieldsFile = path.join(cacheDir, 'feedback-fields.json');
+  const patchFile = path.join(cacheDir, 'feedback-autofill-patch.json');
+  const actionsFile = path.join(cacheDir, 'feedback-autofill-actions.js');
+
+  let appType = options.appType;
+  let appResult = null;
+
+  if (!appType && options.createApp) {
+    step(1, '创建反馈应用');
+    appResult = runOpenYidaJson(['create-app', '--name', options.appName, '--desc', 'OpenYida feedback collection', '--no-open']);
+    appType = appResult.appType;
+    success(`应用已创建: ${appType}`);
+  }
+
+  step(options.createApp ? 2 : 1, '创建反馈表单');
+  writeJson(fieldsFile, buildFeedbackFields());
+  const formResult = runOpenYidaJson([
+    'create-form',
+    'create',
+    appType,
+    options.formName,
+    fieldsFile,
+    '--layout',
+    'section',
+    '--theme',
+    'comfortable',
+    '--label-align',
+    'top',
+    '--no-open',
+  ]);
+
+  const formUuid = formResult.formUuid;
+  if (!formUuid) {
+    throw new Error('创建反馈表单后未拿到 formUuid');
+  }
+  success(`反馈表单已创建: ${formUuid}`);
+
+  step(options.createApp ? 3 : 2, '写入元数据自动回填脚本');
+  const schemaResult = runOpenYidaJson(['get-schema', appType, formUuid]);
+  const fieldMap = collectFieldMap(schemaResult);
+  fs.writeFileSync(actionsFile, buildAutofillActionSource(fieldMap), 'utf8');
+  writeJson(patchFile, [{ action: 'actions-module', sourceFile: actionsFile }]);
+  runOpenYidaJson(['create-form', 'patch', appType, formUuid, patchFile, '--no-open']);
+  success('自动回填脚本已写入');
+
+  step(options.createApp ? 4 : 3, '开启公开提交链接');
+  const openPath = options.openPath || buildDefaultOpenPath(appType, formUuid);
+  const shareResult = runOpenYidaJson(['save-share-config', appType, formUuid, openPath, 'y', options.openAuth]);
+  if (!shareResult.success) {
+    throw new Error(shareResult.message || '公开访问配置失败');
+  }
+
+  const baseUrl = inferBaseUrl(formResult, openPath);
+  const publicUrl = `${baseUrl}${openPath}`;
+  const config = {
+    schemaVersion: 1,
+    appType,
+    appName: appResult ? options.appName : undefined,
+    formUuid,
+    formName: options.formName,
+    baseUrl,
+    openPath,
+    publicUrl,
+    openAuth: options.openAuth,
+    fields: fieldMap,
+    privacy: {
+      uploadsFullConversationByDefault: false,
+      hashesSessionId: true,
+      note: 'Only explicit user feedback and sanitized metadata should be submitted.',
+    },
+    createdAt: new Date().toISOString(),
+  };
+
+  const configPath = getFeedbackConfigPath(options.configPath);
+  writeJson(configPath, config);
+
+  success(`公开反馈表单已配置: ${publicUrl}`);
+  hint(`本地配置: ${configPath}`);
+
+  console.log(JSON.stringify(withBrowserHandoff(
+    {
+      success: true,
+      configPath,
+      appType,
+      formUuid,
+      publicUrl,
+      openPath,
+      fieldCount: Object.keys(fieldMap).length,
+    },
+    publicUrl,
+    { stage: 'feedback_setup_success', title: options.formName },
+    options.openMode
+  ), null, 2));
+}
+
+function runUrl(options) {
+  const config = readFeedbackConfig(options.configPath);
+  let metaFromJson = {};
+  if (options.metaJson) {
+    metaFromJson = JSON.parse(options.metaJson);
+  }
+  const { url, metadata } = buildFeedbackUrl(config, {
+    ...metaFromJson,
+    tool: options.tool || metaFromJson.tool,
+    model: options.model || metaFromJson.model,
+    command: options.command || metaFromJson.command,
+    session: options.session || metaFromJson.session,
+    version: options.version || metaFromJson.version,
+    reason: options.reason || metaFromJson.reason,
+    diagnostics: options.diagnostics || metaFromJson.diagnostics,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify({ success: true, url, metadata }, null, 2));
+    return;
+  }
+  console.log(url);
+}
+
+function endOfToday() {
+  const now = new Date();
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+function getReminderStatus(configPath) {
+  const reminderPath = getReminderPath(configPath);
+  if (!fs.existsSync(reminderPath)) {
+    return {
+      shouldRemind: true,
+      reason: 'active',
+      reminderPath,
+    };
+  }
+
+  const state = JSON.parse(fs.readFileSync(reminderPath, 'utf8'));
+  if (state.disabled === true) {
+    return {
+      shouldRemind: false,
+      reason: 'disabled',
+      reminderPath,
+      state,
+    };
+  }
+
+  if (state.snoozedUntil && new Date(state.snoozedUntil).getTime() > Date.now()) {
+    return {
+      shouldRemind: false,
+      reason: state.reason || 'snoozed',
+      snoozedUntil: state.snoozedUntil,
+      reminderPath,
+      state,
+    };
+  }
+
+  return {
+    shouldRemind: true,
+    reason: 'active',
+    reminderPath,
+    state,
+  };
+}
+
+function readJsonIfExists(filePath, fallback) {
+  try {
+    if (fs.existsSync(filePath)) {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    }
+  } catch {
+    // Ignore invalid local state; the next write will repair it.
+  }
+  return fallback;
+}
+
+function sanitizeLoginDetails(details = {}) {
+  return {
+    mode: truncateValue(details.mode || details.loginMode || '', 80),
+    reason: truncateValue(details.reason || details.status || '', 160),
+    command: truncateValue(details.command || 'login', 160),
+    activeTool: truncateValue(details.activeTool || inferToolName(), 80),
+  };
+}
+
+function recordLoginEvent(status, details = {}, options = {}) {
+  const eventsPath = getLoginEventsPath(options.configPath);
+  fs.mkdirSync(path.dirname(eventsPath), { recursive: true });
+
+  const now = Date.now();
+  const state = readJsonIfExists(eventsPath, { events: [] });
+  const events = Array.isArray(state.events) ? state.events : [];
+  const recentEvents = events.filter((event) => {
+    return event && event.timeMs && now - event.timeMs <= LOGIN_LOOP_WINDOW_MS;
+  });
+
+  recentEvents.push({
+    status: String(status || 'unknown'),
+    timeMs: now,
+    at: new Date(now).toISOString(),
+    details: sanitizeLoginDetails(details),
+  });
+
+  const nextState = {
+    schemaVersion: 1,
+    updatedAt: new Date(now).toISOString(),
+    events: recentEvents.slice(-30),
+  };
+  writeJson(eventsPath, nextState);
+  return getLoginLoopStatus(options.configPath);
+}
+
+function getLoginLoopStatus(configPath) {
+  const eventsPath = getLoginEventsPath(configPath);
+  const state = readJsonIfExists(eventsPath, { events: [] });
+  const now = Date.now();
+  const events = (Array.isArray(state.events) ? state.events : []).filter((event) => {
+    return event && event.timeMs && now - event.timeMs <= LOGIN_LOOP_WINDOW_MS;
+  });
+  const noisyEvents = events.filter((event) => {
+    return ['trigger', 'failed', 'need_login', 'need_qr_scan', 'need_browser_login'].includes(event.status);
+  });
+  const reminder = getReminderStatus(configPath);
+
+  return {
+    detected: noisyEvents.length >= LOGIN_LOOP_THRESHOLD,
+    shouldSuggestFeedback: noisyEvents.length >= LOGIN_LOOP_THRESHOLD && reminder.shouldRemind,
+    count: noisyEvents.length,
+    threshold: LOGIN_LOOP_THRESHOLD,
+    windowMinutes: Math.round(LOGIN_LOOP_WINDOW_MS / 60000),
+    eventsPath,
+    reminder,
+    lastEvent: events[events.length - 1] || null,
+  };
+}
+
+function buildLoginLoopDiagnostics(status) {
+  return JSON.stringify({
+    signal: 'login_loop',
+    count: status.count,
+    threshold: status.threshold,
+    windowMinutes: status.windowMinutes,
+    lastStatus: status.lastEvent && status.lastEvent.status,
+    lastReason: status.lastEvent && status.lastEvent.details && status.lastEvent.details.reason,
+    tool: inferToolName(),
+    version: packageVersion(),
+  });
+}
+
+function buildLoginLoopFeedbackHint(status, options = {}) {
+  if (!status || !status.shouldSuggestFeedback) {
+    return null;
+  }
+  let feedbackUrl = '';
+  try {
+    const config = readFeedbackConfig(options.configPath);
+    feedbackUrl = buildFeedbackUrl(config, {
+      command: 'openyida login',
+      reason: 'login_loop',
+      diagnostics: buildLoginLoopDiagnostics(status),
+    }).url;
+  } catch {
+    // Feedback form may not be configured yet. The dismiss command is still useful.
+  }
+
+  return {
+    reason: 'login_loop',
+    message: `检测到最近 ${status.windowMinutes} 分钟内已多次触发登录。`,
+    feedbackUrl,
+    dismissTodayCommand: 'openyida feedback dismiss --today',
+    dismissForeverCommand: 'openyida feedback dismiss --forever',
+  };
+}
+
+function printLoginLoopFeedbackHint(status, options = {}) {
+  const suggestion = buildLoginLoopFeedbackHint(status, options);
+  if (!suggestion) {
+    return;
+  }
+
+  process.stderr.write(`\n  ${suggestion.message}\n`);
+  if (suggestion.feedbackUrl) {
+    process.stderr.write(`  反馈链接: ${suggestion.feedbackUrl}\n`);
+  } else {
+    process.stderr.write('  反馈表单尚未配置；可先由维护者运行 openyida feedback setup <appType>。\n');
+  }
+  process.stderr.write(`  今天不再提醒: ${suggestion.dismissTodayCommand}\n`);
+}
+
+function runDismiss(options) {
+  const reminderPath = getReminderPath(options.configPath);
+  fs.mkdirSync(path.dirname(reminderPath), { recursive: true });
+
+  if (options.reset) {
+    if (fs.existsSync(reminderPath)) {
+      fs.unlinkSync(reminderPath);
+    }
+    console.log(JSON.stringify({ success: true, shouldRemind: true, reminderPath }, null, 2));
+    return;
+  }
+
+  if (!options.today && !options.forever) {
+    throw new Error('请指定 --today、--forever 或 --reset');
+  }
+
+  const state = options.forever
+    ? {
+      disabled: true,
+      reason: 'forever',
+      updatedAt: new Date().toISOString(),
+    }
+    : {
+      disabled: false,
+      reason: 'today',
+      snoozedUntil: endOfToday().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+  writeJson(reminderPath, state);
+  console.log(JSON.stringify({ success: true, reminderPath, state, status: getReminderStatus(options.configPath) }, null, 2));
+}
+
+function runStatus(options) {
+  console.log(JSON.stringify(getReminderStatus(options.configPath), null, 2));
+}
+
+async function run(args = []) {
+  let parsed;
+  try {
+    parsed = parseArgs(args);
+  } catch (error) {
+    fail(error.message);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (parsed.command === 'help') {
+    printUsage();
+    return;
+  }
+
+  try {
+    if (parsed.command === 'setup') {
+      await runSetup(parsed.options);
+      return;
+    }
+    if (parsed.command === 'url') {
+      runUrl(parsed.options);
+      return;
+    }
+    if (parsed.command === 'dismiss') {
+      runDismiss(parsed.options);
+      return;
+    }
+    if (parsed.command === 'status' || parsed.command === 'should-remind') {
+      runStatus(parsed.options);
+      return;
+    }
+  } catch (error) {
+    fail(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  FIELD_LABELS,
+  METADATA_PARAM_MAP,
+  buildAutofillActionSource,
+  buildFeedbackFields,
+  buildFeedbackUrl,
+  collectFieldMap,
+  encodeMetadata,
+  buildLoginLoopFeedbackHint,
+  getReminderStatus,
+  getLoginLoopStatus,
+  parseArgs,
+  parseJsonOutput,
+  printLoginLoopFeedbackHint,
+  recordLoginEvent,
+  sanitizeMetadata,
+  run,
+};

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  FIELD_LABELS,
+  buildAutofillActionSource,
+  buildFeedbackFields,
+  buildFeedbackUrl,
+  getLoginLoopStatus,
+  getReminderStatus,
+  parseArgs,
+  recordLoginEvent,
+  sanitizeMetadata,
+} = require('../lib/feedback/feedback');
+
+describe('feedback command helpers', () => {
+  test('parseArgs supports setup, url, and dismiss commands', () => {
+    expect(parseArgs(['setup', 'APP_XXX', '--name', '反馈', '--path', '/o/openyida-feedback'])).toMatchObject({
+      command: 'setup',
+      options: {
+        appType: 'APP_XXX',
+        formName: '反馈',
+        openPath: '/o/openyida-feedback',
+      },
+    });
+
+    expect(parseArgs(['url', '--tool', 'Codex', '--reason', 'login_loop'])).toMatchObject({
+      command: 'url',
+      options: {
+        tool: 'Codex',
+        reason: 'login_loop',
+      },
+    });
+
+    expect(parseArgs(['dismiss', '--today'])).toMatchObject({
+      command: 'dismiss',
+      options: { today: true },
+    });
+  });
+
+  test('buildFeedbackFields includes hidden sanitized metadata fields', () => {
+    const fields = buildFeedbackFields();
+    const metadataField = fields.find((field) => field.label === FIELD_LABELS.session);
+
+    expect(fields.some((field) => field.label === FIELD_LABELS.privacy && field.required)).toBe(true);
+    expect(fields).toContainEqual(expect.objectContaining({
+      type: 'ImageField',
+      label: FIELD_LABELS.screenshot,
+    }));
+    expect(metadataField).toMatchObject({
+      type: 'TextField',
+      behavior: 'HIDDEN',
+      visibility: ['PC', 'MOBILE'],
+    });
+  });
+
+  test('buildAutofillActionSource reads URL metadata without submitting secrets', () => {
+    const fieldMap = {
+      [FIELD_LABELS.tool]: 'textField_tool',
+      [FIELD_LABELS.model]: 'textField_model',
+      [FIELD_LABELS.command]: 'textField_command',
+      [FIELD_LABELS.session]: 'textField_session',
+      [FIELD_LABELS.version]: 'textField_version',
+      [FIELD_LABELS.reason]: 'textField_reason',
+      [FIELD_LABELS.diagnostics]: 'textareaField_diag',
+    };
+    const source = buildAutofillActionSource(fieldMap);
+
+    expect(source).toContain('URLSearchParams');
+    expect(source).toContain('oy_meta');
+    expect(source).toContain(FIELD_LABELS.diagnostics);
+    expect(source).not.toContain('cookie');
+  });
+
+  test('buildFeedbackUrl hashes session id and encodes metadata in one query param', () => {
+    const result = buildFeedbackUrl(
+      { publicUrl: 'https://www.aliwork.com/o/openyida-feedback' },
+      { tool: 'Codex', session: 'thread-secret', diagnostics: 'login failed' }
+    );
+    const url = new URL(result.url);
+
+    expect(url.searchParams.get('oy_meta')).toBeTruthy();
+    expect(result.metadata.tool).toBe('Codex');
+    expect(result.metadata.session).toMatch(/^anon_[a-f0-9]{16}$/);
+    expect(result.url).not.toContain('thread-secret');
+  });
+
+  test('sanitizeMetadata truncates long diagnostics', () => {
+    const metadata = sanitizeMetadata({
+      session: 'abc',
+      diagnostics: 'x'.repeat(3000),
+    });
+
+    expect(metadata.session).toMatch(/^anon_/);
+    expect(metadata.diagnostics.length).toBeLessThanOrEqual(1803);
+  });
+
+  test('login loop status trips after repeated login events and respects reminder state', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-feedback-'));
+    const configPath = path.join(tempDir, 'config.json');
+
+    expect(getReminderStatus(configPath).shouldRemind).toBe(true);
+
+    recordLoginEvent('trigger', { reason: 'missing_cookie' }, { configPath });
+    recordLoginEvent('need_qr_scan', { reason: 'need_qr_scan' }, { configPath });
+    const status = recordLoginEvent('failed', { reason: 'no_cookie_after_login' }, { configPath });
+
+    expect(status.detected).toBe(true);
+    expect(status.shouldSuggestFeedback).toBe(true);
+    expect(getLoginLoopStatus(configPath).count).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `openyida feedback` with `setup`, `url`, `dismiss`, and `status` subcommands.
- Create a public Yida feedback form workflow with text feedback, optional screenshot upload, and hidden sanitized metadata fields.
- Track repeated login triggers locally and surface a privacy-safe feedback link when a login loop is detected.
- Add command manifest, README, locale entries, and focused tests.

## Privacy

- Feedback links encode only sanitized metadata in `oy_meta`.
- Session identifiers are hashed before being included.
- The workflow does not upload cookies, CSRF tokens, full conversations, or screenshots automatically.
- Screenshots are user-selected and optional.

## Validation

- `node --check lib/feedback/feedback.js`
- `node --check bin/yida.js`
- `node --check lib/core/utils.js`
- `npx jest tests/feedback.test.js --runInBand`
- `eslint lib/feedback/feedback.js tests/feedback.test.js bin/yida.js lib/core/utils.js` with plugins resolved from the existing workspace dependencies
- `node bin/yida.js commands --json` contains the feedback command
- `OPENYIDA_FEEDBACK_PUBLIC_URL=... node bin/yida.js feedback url --tool Codex --reason login_loop --session-id secret-session --json`
