### PR TITLE
feat: support parallel process branches

### DIFF
--- a/lib/process/configure-process.js
+++ b/lib/process/configure-process.js
@@ -94,6 +94,10 @@ function normalizeList(value) {
   return Array.isArray(value) ? value : [value];
 }
 
+function clonePlain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
 function pickFirstDefined() {
   for (let i = 0; i < arguments.length; i++) {
     if (arguments[i] !== undefined && arguments[i] !== null && arguments[i] !== '') {
@@ -626,6 +630,19 @@ function assignNodeIdsRecursive(nodes, nameToIdMap) {
           assignNodeIdsRecursive(cond.childNodes, nameToIdMap);
         }
       });
+    } else if (node.type === 'parallel') {
+      node._nodeId = generateNodeId();
+      if (node.name) {
+        nameToIdMap[node.name] = node._nodeId;
+      }
+      const branches = getParallelBranches(node);
+      branches.forEach(function (branch) {
+        branch._nodeId = generateNodeId();
+        const childNodes = getBranchChildNodes(branch);
+        if (childNodes.length > 0) {
+          assignNodeIdsRecursive(childNodes, nameToIdMap);
+        }
+      });
     } else {
       node._nodeId = generateNodeId();
       if (node.name) {
@@ -649,6 +666,10 @@ function buildNodeListRecursive(nodes, exitNodeId, nameToIdMap) {
       const routeResult = buildRouteNode(node, nextNodeId, nameToIdMap);
       processNodes.push(routeResult.processNode);
       viewNodes.push(routeResult.viewNode);
+    } else if (node.type === 'parallel') {
+      const parallelResult = buildParallelNode(node, nextNodeId, nameToIdMap);
+      processNodes.push(parallelResult.processNode);
+      viewNodes.push(parallelResult.viewNode);
     } else if (node.type === 'approval') {
       const approvalResult = buildApprovalNode(node, nextNodeId, nameToIdMap);
       processNodes.push(approvalResult.processNode);
@@ -661,6 +682,16 @@ function buildNodeListRecursive(nodes, exitNodeId, nameToIdMap) {
   }
 
   return { processNodes, viewNodes };
+}
+
+function wireChildProcessNodes(childProcessNodes, parentNodeId) {
+  if (childProcessNodes.length === 0) {
+    return;
+  }
+  childProcessNodes[0].prevId = parentNodeId;
+  for (let i = 1; i < childProcessNodes.length; i++) {
+    childProcessNodes[i].prevId = childProcessNodes[i - 1].nodeId;
+  }
 }
 
 // ── 构建审批节点 ─────────────────────────────────────
@@ -857,14 +888,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
       const childResult = buildNodeListRecursive(cond.childNodes, exitNodeId, nameToIdMap);
       childProcessNodes = childResult.processNodes;
       childViewNodes = childResult.viewNodes;
-      // 设置条件分支内第一个子节点的 prevId 为条件节点 ID
-      if (childProcessNodes.length > 0) {
-        childProcessNodes[0].prevId = condNodeId;
-        // 设置后续子节点的 prevId 为前一个节点的 nodeId
-        for (let ci = 1; ci < childProcessNodes.length; ci++) {
-          childProcessNodes[ci].prevId = childProcessNodes[ci - 1].nodeId;
-        }
-      }
+      wireChildProcessNodes(childProcessNodes, condNodeId);
     }
 
     // 构建条件规则
@@ -900,9 +924,7 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
       prevId: routeNodeId,
       nextId: condNextId,
       props: conditionProps,
-      childNodes: childProcessNodes.map(function (n) {
-        return JSON.parse(JSON.stringify(n));
-      }),
+      childNodes: childProcessNodes.map(clonePlain),
     };
 
     conditionProcessNodes.push(condProcessNode);
@@ -991,6 +1013,196 @@ function buildRouteNode(node, exitNodeId, nameToIdMap) {
   };
 
   return { processNode: routeProcessNode, viewNode: routeViewNode };
+}
+
+// ── 构建并行分支节点 ────────────────────────────────
+
+function getParallelBranches(node) {
+  const branches = node.branches || node.conditions || node.parallelBranches || [];
+  return Array.isArray(branches) ? branches : [];
+}
+
+function getBranchChildNodes(branch) {
+  const childNodes = branch.childNodes || branch.nodes || branch.children || [];
+  return Array.isArray(childNodes) ? childNodes : [];
+}
+
+function buildAllDataConditionProps(branch, priority, isDefault) {
+  return {
+    calculate: 'all',
+    conditions: {
+      condition: 'AND',
+      rules: [
+        {
+          id: 'originator',
+          op: '等于',
+          operators: [],
+          componentType: 'EmployeeField',
+        },
+      ],
+    },
+    isDefault: isDefault,
+    priority: priority,
+    description: branch.description || '所有数据均可进入',
+  };
+}
+
+function buildParallelBranchConditionProps(branch, index) {
+  const priority = Number(pickFirstDefined(branch.priority, index + 1));
+  const isDefault = Boolean(branch.isDefault);
+  const rawConditions = branch.conditionProps
+    || branch.condition
+    || (isPlainObject(branch.conditions) ? branch.conditions : null);
+
+  if (isPlainObject(rawConditions) && rawConditions.calculate) {
+    const props = Object.assign({}, rawConditions, {
+      isDefault: isDefault,
+      priority: priority,
+    });
+    if (!props.description && branch.description) {
+      props.description = branch.description;
+    }
+    return props;
+  }
+
+  if (isPlainObject(rawConditions) && (rawConditions.rules || rawConditions.condition)) {
+    return {
+      calculate: 'condition',
+      conditions: rawConditions,
+      isDefault: isDefault,
+      priority: priority,
+      description: branch.description || branch.name || '',
+    };
+  }
+
+  if (branch.rules && branch.rules.length > 0) {
+    const condRules = buildConditionRules(branch.rules, branch.logic || 'AND');
+    return {
+      calculate: 'condition',
+      conditions: {
+        condition: condRules.condition || 'AND',
+        rules: condRules.rules || [],
+        ruleId: condRules.ruleId || 'group-' + generateUuid(),
+        conditionCode: condRules.conditionCode || '&&',
+      },
+      isDefault: isDefault,
+      priority: priority,
+      description: branch.description || branch.name || '',
+    };
+  }
+
+  return buildAllDataConditionProps(branch, priority, isDefault);
+}
+
+function buildParallelBranchProcessProps(conditionProps) {
+  const props = {};
+  if (conditionProps.isDefault !== undefined) {
+    props.isDefault = conditionProps.isDefault;
+  }
+  if (conditionProps.conditions !== undefined) {
+    props.conditions = clonePlain(conditionProps.conditions);
+  }
+  if (conditionProps.calculate !== undefined) {
+    props.calculate = conditionProps.calculate;
+  }
+  if (conditionProps.expression !== undefined) {
+    props.expression = conditionProps.expression;
+  }
+  return props;
+}
+
+function buildParallelNode(node, exitNodeId, nameToIdMap) {
+  const parallelNodeId = node._nodeId;
+  const branches = getParallelBranches(node);
+
+  if (branches.length === 0) {
+    throw new Error('parallel 节点至少需要一个 branches 分支');
+  }
+
+  const branchNodeIds = [];
+  const branchProcessNodes = [];
+  const branchViewNodes = [];
+
+  branches.forEach(function (branch, index) {
+    const branchNodeId = branch._nodeId;
+    const branchName = branch.name || ('条件' + (index + 1));
+    const branchConditionProps = buildParallelBranchConditionProps(branch, index);
+    const childNodes = getBranchChildNodes(branch);
+
+    branchNodeIds.push(branchNodeId);
+
+    let childProcessNodes = [];
+    let childViewNodes = [];
+    if (childNodes.length > 0) {
+      const childResult = buildNodeListRecursive(childNodes, exitNodeId, nameToIdMap);
+      childProcessNodes = childResult.processNodes;
+      childViewNodes = childResult.viewNodes;
+      wireChildProcessNodes(childProcessNodes, branchNodeId);
+    }
+
+    const branchNextId = childProcessNodes.length > 0
+      ? [childProcessNodes[0].nodeId]
+      : [exitNodeId];
+
+    const branchProcessNode = {
+      name: i18n(branchName, 'Parallel branch', branchName),
+      description: '',
+      type: 'condition',
+      nodeId: branchNodeId,
+      prevId: parallelNodeId,
+      nextId: branchNextId,
+      props: buildParallelBranchProcessProps(branchConditionProps),
+      childNodes: childProcessNodes.map(clonePlain),
+    };
+
+    branchProcessNodes.push(branchProcessNode);
+
+    const branchViewNode = {
+      componentName: 'ParallelNode',
+      id: branchNodeId,
+      props: {
+        name: branchConditionProps.isDefault
+          ? i18n(branchName, 'Other situations', branchName)
+          : branchName,
+        description: branch.description || '',
+        conditions: clonePlain(branchConditionProps),
+      },
+    };
+
+    if (branchConditionProps.isDefault) {
+      branchViewNode.props.buttons = branch.buttons || [{ name: '关闭' }];
+    }
+
+    if (childViewNodes.length > 0) {
+      branchViewNode.children = childViewNodes;
+    }
+
+    branchViewNodes.push(branchViewNode);
+  });
+
+  const parallelProcessNode = {
+    name: i18n(node.name || 'ParallelNode', node.name || 'ParallelNode', node.name || 'ParallelNode'),
+    description: '',
+    type: 'route',
+    nodeId: parallelNodeId,
+    prevId: '',
+    nextId: branchNodeIds,
+    props: { outgoingType: 'multiple' },
+    childNodes: branchProcessNodes,
+  };
+
+  const parallelViewNode = {
+    componentName: 'ConditionContainer',
+    id: parallelNodeId,
+    props: {
+      name: i18n(node.name || '并行分支', node.name || 'ParallelNode', node.name || '並行分岐'),
+    },
+    title: node.title || '并行分支',
+    type: 'parallel',
+    children: branchViewNodes,
+  };
+
+  return { processNode: parallelProcessNode, viewNode: parallelViewNode };
 }
 
 // ── 构建完整的 processJson 和 viewJson ──────────────

--- a/tests/configure-process.test.js
+++ b/tests/configure-process.test.js
@@ -121,3 +121,120 @@ describe('configure-process approver DSL', () => {
     expect(approverRules.description).toBe('发起人的第2级主管');
   });
 });
+
+describe('configure-process parallel DSL', () => {
+  test('builds parallel branches that rejoin the following node', () => {
+    const result = _private.buildProcessAndViewJson({
+      nodes: [
+        {
+          type: 'parallel',
+          name: '并行审批',
+          branches: [
+            {
+              name: '产管审批',
+              childNodes: [
+                {
+                  type: 'approval',
+                  name: '产管审批',
+                  approver: 'originator',
+                },
+              ],
+            },
+            {
+              name: '价管审批',
+              childNodes: [
+                {
+                  type: 'approval',
+                  name: '价管审批',
+                  approver: 'originator',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'carbon',
+          name: '抄送销售和BI',
+          approver: 'originator',
+        },
+      ],
+    }, 'TPROC-TEST', 'FORM-TEST', 'https://www.aliwork.com', 'APP_TEST');
+
+    const middleNodes = result.processJson.nodes.slice(1, -1);
+    const parallelNode = middleNodes[0];
+    const carbonNode = middleNodes[1];
+
+    expect(parallelNode.type).toBe('route');
+    expect(parallelNode.props.outgoingType).toBe('multiple');
+    expect(parallelNode.nextId).toHaveLength(2);
+    expect(parallelNode.childNodes).toHaveLength(2);
+    expect(carbonNode.type).toBe('carbon');
+    expect(carbonNode.prevId).toBe(parallelNode.nodeId);
+
+    parallelNode.childNodes.forEach(function (branchNode) {
+      expect(branchNode.type).toBe('condition');
+      expect(branchNode.prevId).toBe(parallelNode.nodeId);
+      expect(branchNode.props.calculate).toBe('all');
+      expect(branchNode.childNodes).toHaveLength(1);
+
+      const approvalNode = branchNode.childNodes[0];
+      expect(branchNode.nextId).toEqual([approvalNode.nodeId]);
+      expect(approvalNode.type).toBe('approval');
+      expect(approvalNode.prevId).toBe(branchNode.nodeId);
+      expect(approvalNode.nextId).toEqual([carbonNode.nodeId]);
+    });
+
+    const viewParallelNode = result.viewJson.schema.children.find(function (node) {
+      return node.componentName === 'ConditionContainer' && node.type === 'parallel';
+    });
+    expect(viewParallelNode).toBeTruthy();
+    expect(viewParallelNode.children).toHaveLength(2);
+    expect(viewParallelNode.children.map(function (node) { return node.componentName; })).toEqual([
+      'ParallelNode',
+      'ParallelNode',
+    ]);
+    expect(viewParallelNode.children[0].children[0].componentName).toBe('ApprovalNode');
+  });
+
+  test('builds route-style rules for conditional parallel branches', () => {
+    const result = _private.buildProcessAndViewJson({
+      nodes: [
+        {
+          type: 'parallel',
+          branches: [
+            {
+              name: '大额审批',
+              logic: 'OR',
+              rules: [
+                {
+                  fieldId: 'numberField_amount',
+                  fieldName: '金额',
+                  componentType: 'NumberField',
+                  op: 'GreaterThan',
+                  value: 1000,
+                },
+              ],
+              childNodes: [
+                {
+                  type: 'approval',
+                  name: '大额审批',
+                  approver: 'originator',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }, 'TPROC-TEST', 'FORM-TEST', 'https://www.aliwork.com', 'APP_TEST');
+
+    const parallelNode = result.processJson.nodes.find(function (node) {
+      return node.type === 'route' && node.props.outgoingType === 'multiple';
+    });
+    const branchNode = parallelNode.childNodes[0];
+
+    expect(branchNode.props.calculate).toBe('condition');
+    expect(branchNode.props.conditions.condition).toBe('OR');
+    expect(branchNode.props.conditions.conditionCode).toBe('||');
+    expect(branchNode.props.conditions.rules[0].formula).toBe('${numberField_amount}>1000');
+  });
+});


### PR DESCRIPTION
## Summary
- add `type: "parallel"` support for process definitions with branch `childNodes`
- emit the real Yida simple-flow shape for parallel branches: route container with `outgoingType: "multiple"`, condition child nodes, and `ConditionContainer(type: "parallel")` view schema
- cover unconditional and rule-based parallel branches in configure-process tests

## Validation
- `node --check lib/process/configure-process.js`
- `npx jest tests/configure-process.test.js --runInBand`
- `npm run check:ci`
- real Yida publish smoke: created app `APP_I333I2MNG0YUZ6P7CMJT`, form `FORM-121A69D4C7F34B3598FB4865B155AF49IKO0`, process `TPROC--R1H66K71CIQ56WELGTVNJ7HV82HU2GS5XYEPMI`

## Beta
- tag pushed: `v2026.5.21-beta.1`