### PR TITLE
feat: add external form access planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida verify-short-url <appType> <formUuid> <url>` | Verify a short URL |
 | `openyida save-share-config <appType> <formUuid> <url> <isOpen> [openAuth]` | Save public access or sharing configuration |
 | `openyida get-page-config <appType> <formUuid>` | Query public access or sharing configuration |
+| `openyida externalize-form <appType> <formUuid> [--schema-file file]` | Assess public-access blockers and generate external-safe mirror fields |
+
+`openyida externalize-form` is useful when a form contains fields such as `AssociationFormField`, `EmployeeField`, or `DepartmentSelectField` that depend on internal organization permissions. It produces a report plus optional `--mirror-fields-output` JSON that can be used with `openyida create-form create` to build a separate public intake form while keeping the internal form and its association fields private.
 
 ### Workflow, Reports, and Integrations
 

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -717,6 +717,12 @@ async function main() {
       break;
     }
 
+    case 'externalize-form': {
+      const { run } = require('../lib/app/externalize-form');
+      await run(args);
+      break;
+    }
+
     case 'update-form-config': {
       if (args.length < 4) {
         warn(t('cli.form_config_usage'));

--- a/lib/app/app-list.js
+++ b/lib/app/app-list.js
@@ -19,7 +19,6 @@ const {
   httpGet,
   requestWithAutoLogin,
 } = require('../core/utils');
-const { t } = require('../core/i18n');
 
 const API_PATH = '/query/app/getAppList.json';
 
@@ -90,11 +89,31 @@ function formatApp(app) {
   };
 }
 
+function hasHelpFlag(args) {
+  return (args || []).includes('--help') || (args || []).includes('-h');
+}
+
+function printUsage() {
+  process.stderr.write([
+    'Usage: openyida app-list [--size N]',
+    '',
+    'Options:',
+    '  --size N     Page size used when fetching apps, default: 20',
+    '  --help, -h   Show this help',
+    '',
+  ].join('\n'));
+}
+
 /**
  * app-list 命令主入口
  * @param {string[]} args
  */
 async function run(args) {
+  if (hasHelpFlag(args)) {
+    printUsage();
+    return;
+  }
+
   const pageSizeIndex = args.indexOf('--size');
   const pageSize = pageSizeIndex !== -1 && args[pageSizeIndex + 1]
     ? parseInt(args[pageSizeIndex + 1], 10)

--- a/lib/app/externalize-form.js
+++ b/lib/app/externalize-form.js
@@ -1,0 +1,642 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+  httpGet,
+  requestWithAutoLogin,
+} = require('../core/utils');
+
+const FIELD_COMPONENT_NAMES = new Set([
+  'TextField',
+  'TextareaField',
+  'SelectField',
+  'DateField',
+  'NumberField',
+  'RadioField',
+  'CheckboxField',
+  'EmployeeField',
+  'PhoneField',
+  'EmailField',
+  'CascadeSelectField',
+  'ImageField',
+  'AttachmentField',
+  'TableField',
+  'MultiSelectField',
+  'DepartmentSelectField',
+  'AssociationFormField',
+  'CountrySelectField',
+  'CitySelectField',
+  'RateField',
+  'SignatureField',
+  'SerialNumberField',
+  'AddressField',
+]);
+
+const PUBLIC_BLOCKED_TYPES = new Set([
+  'AssociationFormField',
+  'EmployeeField',
+  'DepartmentSelectField',
+]);
+
+const REVIEW_TYPES = new Set([
+  'AttachmentField',
+  'ImageField',
+  'SignatureField',
+  'TableField',
+  'CascadeSelectField',
+  'CountrySelectField',
+  'CitySelectField',
+  'AddressField',
+]);
+
+const SAFE_CREATE_FORM_TYPES = new Set([
+  'TextField',
+  'TextareaField',
+  'SelectField',
+  'DateField',
+  'NumberField',
+  'RadioField',
+  'CheckboxField',
+  'PhoneField',
+  'EmailField',
+  'MultiSelectField',
+  'RateField',
+  'AttachmentField',
+  'ImageField',
+]);
+
+function readOption(args, names, fallback = '') {
+  const optionNames = Array.isArray(names) ? names : [names];
+  for (const name of optionNames) {
+    const index = args.indexOf(name);
+    if (index !== -1 && args[index + 1] && !args[index + 1].startsWith('--')) {
+      return args[index + 1];
+    }
+  }
+  return fallback;
+}
+
+function parseArgs(args) {
+  const parsed = {
+    appType: '',
+    formUuid: '',
+    schemaFile: '',
+    output: '',
+    mirrorFieldsOutput: '',
+    format: 'json',
+    target: 'open',
+    mirrorTitle: '',
+    help: false,
+  };
+  const positional = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--schema-file' || arg === '--schema') {
+      parsed.schemaFile = readOption(args, arg);
+      index++;
+    } else if (arg === '--output' || arg === '-o') {
+      parsed.output = readOption(args, arg);
+      index++;
+    } else if (arg === '--mirror-fields-output' || arg === '--fields-output') {
+      parsed.mirrorFieldsOutput = readOption(args, arg);
+      index++;
+    } else if (arg === '--format') {
+      parsed.format = readOption(args, arg, 'json');
+      index++;
+    } else if (arg === '--target') {
+      parsed.target = readOption(args, arg, 'open');
+      index++;
+    } else if (arg === '--mirror-title') {
+      parsed.mirrorTitle = readOption(args, arg);
+      index++;
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  parsed.appType = positional[0] || '';
+  parsed.formUuid = positional[1] || '';
+  if (!['json', 'markdown'].includes(parsed.format)) {
+    throw new Error(`Unsupported format: ${parsed.format}`);
+  }
+  if (!['open', 'share'].includes(parsed.target)) {
+    throw new Error(`Unsupported target: ${parsed.target}`);
+  }
+  return parsed;
+}
+
+function printUsage() {
+  const lines = [
+    'Usage: openyida externalize-form <appType> <formUuid> [options]',
+    '',
+    'Options:',
+    '  --schema-file <file>          Read a saved get-schema JSON file instead of fetching remotely',
+    '  --output, -o <file>           Write the report to a file',
+    '  --mirror-fields-output <file> Write external-safe create-form fields JSON',
+    '  --format json|markdown        Output format, default: json',
+    '  --target open|share           Access target, default: open',
+    '  --mirror-title <title>        Title used in suggested create-form command',
+    '',
+    'Examples:',
+    '  openyida externalize-form APP_XXX FORM-XXX --schema-file .cache/schema.json',
+    '  openyida externalize-form APP_XXX FORM-XXX --mirror-fields-output .cache/external-fields.json',
+  ];
+  process.stderr.write(`${lines.join('\n')}\n`);
+}
+
+function extractText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(extractText).filter(Boolean).join(', ');
+  }
+  if (typeof value === 'object') {
+    return extractText(
+      value.zh_CN ||
+      value.en_US ||
+      value.ja_JP ||
+      value.value ||
+      value.text ||
+      value.label ||
+      value.name ||
+      value.title ||
+      ''
+    );
+  }
+  return '';
+}
+
+function isRequired(props) {
+  if (!props) {
+    return false;
+  }
+  if (props.required === true) {
+    return true;
+  }
+  const validation = Array.isArray(props.validation) ? props.validation : [];
+  return validation.some(rule => rule && rule.type === 'required');
+}
+
+function getPages(schemaResult) {
+  if (schemaResult && schemaResult.content && Array.isArray(schemaResult.content.pages)) {
+    return schemaResult.content.pages;
+  }
+  if (schemaResult && Array.isArray(schemaResult.pages)) {
+    return schemaResult.pages;
+  }
+  return [];
+}
+
+function collectFieldNodes(schemaResult) {
+  const fields = [];
+  const pages = getPages(schemaResult);
+
+  function traverse(node, parents) {
+    if (!node) {
+      return;
+    }
+    const props = node.props || {};
+    const label = extractText(props.label);
+    const nextParents = FIELD_COMPONENT_NAMES.has(node.componentName) && label
+      ? parents.concat(label)
+      : parents;
+
+    if (FIELD_COMPONENT_NAMES.has(node.componentName)) {
+      fields.push({
+        componentName: node.componentName,
+        props,
+        label,
+        fieldId: props.fieldId || '',
+        required: isRequired(props),
+        behavior: props.behavior || '',
+        path: nextParents.join(' > '),
+      });
+    }
+
+    const children = Array.isArray(node.children) ? node.children : [];
+    children.forEach(child => traverse(child, nextParents));
+  }
+
+  pages.forEach((page) => {
+    const roots = page && page.componentsTree ? page.componentsTree : [];
+    roots.forEach(root => traverse(root, []));
+  });
+
+  return fields;
+}
+
+function getRisk(field, target) {
+  if (target === 'share') {
+    if (field.componentName === 'AssociationFormField') {
+      return {
+        level: 'review',
+        reason: 'Association fields require internal form data permission and should be verified for org-share scenarios.',
+      };
+    }
+    return { level: 'safe', reason: 'Internal share keeps the visitor inside the organization permission boundary.' };
+  }
+
+  if (PUBLIC_BLOCKED_TYPES.has(field.componentName)) {
+    return {
+      level: 'blocked',
+      reason: `${field.componentName} depends on authenticated organization data and is not reliable for anonymous public access.`,
+    };
+  }
+  if (REVIEW_TYPES.has(field.componentName)) {
+    return {
+      level: 'review',
+      reason: `${field.componentName} may need a browser verification or a simpler external intake field.`,
+    };
+  }
+  return { level: 'safe', reason: 'Primitive input field, suitable for external intake.' };
+}
+
+function associationTarget(props) {
+  const associationForm = props && props.associationForm ? props.associationForm : {};
+  return {
+    appType: associationForm.appType || '',
+    formUuid: associationForm.formUuid || '',
+    formTitle: associationForm.formTitle || '',
+    mainFieldId: associationForm.mainFieldId || '',
+    mainFieldLabel: extractText(associationForm.mainFieldLabel),
+  };
+}
+
+function planField(field, target) {
+  const risk = getRisk(field, target);
+  const plan = {
+    label: field.label || field.fieldId || field.componentName,
+    fieldId: field.fieldId,
+    componentName: field.componentName,
+    required: field.required,
+    behavior: field.behavior,
+    path: field.path,
+    riskLevel: risk.level,
+    reason: risk.reason,
+    externalStrategy: 'keep',
+  };
+
+  if (field.componentName === 'AssociationFormField') {
+    plan.associationTarget = associationTarget(field.props);
+    plan.externalStrategy = 'snapshot-and-resolve-internal';
+  } else if (field.componentName === 'EmployeeField') {
+    plan.externalStrategy = 'collect-name-or-contact';
+  } else if (field.componentName === 'DepartmentSelectField') {
+    plan.externalStrategy = 'collect-department-text';
+  } else if (risk.level === 'review') {
+    plan.externalStrategy = 'verify-or-simplify';
+  }
+  return plan;
+}
+
+function mirrorLabel(label, suffix) {
+  if (!label) {
+    return suffix;
+  }
+  return `${label}${suffix}`;
+}
+
+function associationSnapshotLabel(plan) {
+  const target = plan.associationTarget || {};
+  const targetMainLabel = target.mainFieldLabel || '';
+  if (targetMainLabel) {
+    return targetMainLabel;
+  }
+  if (plan.label && plan.label.endsWith('名称')) {
+    return plan.label;
+  }
+  return mirrorLabel(plan.label, '名称');
+}
+
+function mirrorFieldForPlan(plan) {
+  const base = {
+    label: plan.label,
+    required: plan.required,
+    sourceFieldId: plan.fieldId,
+    sourceComponentName: plan.componentName,
+    sourceStrategy: plan.externalStrategy,
+  };
+
+  if (plan.componentName === 'AssociationFormField') {
+    const target = plan.associationTarget || {};
+    return [
+      {
+        type: 'TextField',
+        label: associationSnapshotLabel(plan),
+        required: plan.required,
+        sourceFieldId: plan.fieldId,
+        sourceComponentName: plan.componentName,
+        sourceStrategy: 'association-main-field-snapshot',
+        targetFormUuid: target.formUuid,
+        targetMainFieldId: target.mainFieldId,
+      },
+      {
+        type: 'TextField',
+        label: mirrorLabel(plan.label, '业务标识'),
+        required: false,
+        sourceFieldId: plan.fieldId,
+        sourceComponentName: plan.componentName,
+        sourceStrategy: 'association-business-key-for-internal-resolution',
+        targetFormUuid: target.formUuid,
+      },
+    ];
+  }
+
+  if (plan.componentName === 'EmployeeField') {
+    return [
+      { ...base, type: 'TextField', label: mirrorLabel(plan.label, '姓名') },
+      { ...base, type: 'TextField', label: mirrorLabel(plan.label, '联系方式'), required: false },
+    ];
+  }
+
+  if (plan.componentName === 'DepartmentSelectField') {
+    return [{ ...base, type: 'TextField', label: mirrorLabel(plan.label, '名称') }];
+  }
+
+  if (SAFE_CREATE_FORM_TYPES.has(plan.componentName)) {
+    return [{ ...base, type: plan.componentName }];
+  }
+
+  if (plan.componentName === 'SerialNumberField') {
+    return [];
+  }
+
+  return [{ ...base, type: 'TextareaField', label: mirrorLabel(plan.label, '说明'), required: false }];
+}
+
+function buildMirrorFields(fields) {
+  const mirrorFields = [];
+  fields.forEach((field) => {
+    mirrorFields.push(...mirrorFieldForPlan(field));
+  });
+  return mirrorFields;
+}
+
+function summarize(fields) {
+  const summary = {
+    totalFields: fields.length,
+    safeFields: 0,
+    reviewFields: 0,
+    blockedFields: 0,
+    associationFields: 0,
+    authBoundFields: 0,
+  };
+
+  fields.forEach((field) => {
+    if (field.riskLevel === 'safe') {
+      summary.safeFields++;
+    } else if (field.riskLevel === 'review') {
+      summary.reviewFields++;
+    } else if (field.riskLevel === 'blocked') {
+      summary.blockedFields++;
+    }
+    if (field.componentName === 'AssociationFormField') {
+      summary.associationFields++;
+    }
+    if (PUBLIC_BLOCKED_TYPES.has(field.componentName)) {
+      summary.authBoundFields++;
+    }
+  });
+  return summary;
+}
+
+function buildRecommendedActions(parsed, report) {
+  const actions = [
+    'Create a separate external intake form from mirrorFields instead of exposing the internal form directly.',
+    'Keep association fields in the internal form and resolve them after submission by business key or manual review.',
+    'Copy human-readable snapshots into the external form so public visitors never need target-form permissions.',
+  ];
+
+  if (parsed.mirrorFieldsOutput) {
+    const title = parsed.mirrorTitle || `${report.formTitle || 'External Intake'} External`;
+    actions.unshift(
+      `Create mirror form: openyida create-form create ${parsed.appType} "${title}" ${parsed.mirrorFieldsOutput}`
+    );
+  }
+
+  if (report.summary.blockedFields === 0 && report.summary.reviewFields === 0) {
+    actions.unshift('No blocked fields were found; public access can still be verified with save-share-config and Chrome.');
+  }
+  return actions;
+}
+
+function inferFormTitle(schemaResult, formUuid) {
+  const content = schemaResult && schemaResult.content ? schemaResult.content : schemaResult;
+  return extractText(
+    content && (
+      content.formName ||
+      content.formTitle ||
+      content.title ||
+      content.name
+    )
+  ) || formUuid;
+}
+
+function analyzeSchema(schemaResult, options = {}) {
+  const target = options.target || 'open';
+  const fields = collectFieldNodes(schemaResult).map(field => planField(field, target));
+  const report = {
+    success: true,
+    appType: options.appType || '',
+    formUuid: options.formUuid || '',
+    formTitle: inferFormTitle(schemaResult, options.formUuid || ''),
+    target,
+    source: options.source || 'schema',
+    summary: summarize(fields),
+    fields,
+    mirrorFields: buildMirrorFields(fields),
+    recommendedActions: [],
+    notes: [
+      'OpenYida cannot relax Yida platform permission boundaries for anonymous visitors.',
+      'This plan keeps internal association fields private and generates external-safe snapshot fields.',
+      'For fully automated sync, add an internal automation or API worker that resolves submitted business keys.',
+    ],
+  };
+  report.recommendedActions = buildRecommendedActions(options, report);
+  return report;
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# External Access Plan: ${report.formTitle || report.formUuid}`,
+    '',
+    `- App: ${report.appType || '-'}`,
+    `- Form: ${report.formUuid || '-'}`,
+    `- Target: ${report.target}`,
+    `- Total fields: ${report.summary.totalFields}`,
+    `- Blocked fields: ${report.summary.blockedFields}`,
+    `- Review fields: ${report.summary.reviewFields}`,
+    '',
+    '## Fields',
+    '',
+    '| Label | Type | Risk | Strategy | Reason |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+
+  report.fields.forEach((field) => {
+    lines.push(
+      `| ${field.label || '-'} | ${field.componentName} | ${field.riskLevel} | ${field.externalStrategy} | ${field.reason} |`
+    );
+  });
+
+  lines.push('', '## Recommended Actions', '');
+  report.recommendedActions.forEach(action => lines.push(`- ${action}`));
+  lines.push('', '## Mirror Fields', '', '```json');
+  lines.push(JSON.stringify(report.mirrorFields, null, 2));
+  lines.push('```', '');
+  return lines.join('\n');
+}
+
+function writeJson(filePath, data) {
+  const resolved = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, JSON.stringify(data, null, 2), 'utf-8');
+  return resolved;
+}
+
+function writeText(filePath, text) {
+  const resolved = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, text, 'utf-8');
+  return resolved;
+}
+
+function resolveOutputPath(filePath) {
+  const resolved = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  return resolved;
+}
+
+function loadSchemaFile(filePath) {
+  const raw = fs.readFileSync(path.resolve(filePath), 'utf-8');
+  return JSON.parse(raw);
+}
+
+function createAuthRef() {
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    cookieData = triggerLogin();
+  }
+  return {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+}
+
+async function fetchSchema(appType, formUuid, authRef) {
+  return requestWithAutoLogin((auth) => {
+    return httpGet(
+      auth.baseUrl,
+      `/alibaba/web/${appType}/_view/query/formdesign/getFormSchema.json`,
+      { formUuid, schemaVersion: 'V5' },
+      auth.cookies
+    );
+  }, authRef);
+}
+
+function ensureSuccessfulSchema(result) {
+  if (!result || result.success === false || result.__needLogin || result.__csrfExpired) {
+    const message = result && (result.errorMsg || result.message)
+      ? result.errorMsg || result.message
+      : 'Failed to fetch form schema';
+    throw new Error(message);
+  }
+}
+
+async function loadSchema(parsed) {
+  if (parsed.schemaFile) {
+    return {
+      schema: loadSchemaFile(parsed.schemaFile),
+      source: path.resolve(parsed.schemaFile),
+    };
+  }
+  const authRef = createAuthRef();
+  const schema = await fetchSchema(parsed.appType, parsed.formUuid, authRef);
+  ensureSuccessfulSchema(schema);
+  return { schema, source: 'remote' };
+}
+
+async function run(args) {
+  let parsed;
+  try {
+    parsed = parseArgs(args || []);
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+  if (!parsed.appType || !parsed.formUuid) {
+    printUsage();
+    process.exit(1);
+  }
+
+  try {
+    const loaded = await loadSchema(parsed);
+    const report = analyzeSchema(loaded.schema, {
+      ...parsed,
+      source: loaded.source,
+    });
+    const files = {};
+
+    if (parsed.mirrorFieldsOutput) {
+      files.mirrorFields = writeJson(parsed.mirrorFieldsOutput, report.mirrorFields);
+    }
+    if (parsed.output) {
+      files.report = resolveOutputPath(parsed.output);
+    }
+    report.files = files;
+    if (parsed.output) {
+      if (parsed.format === 'markdown') {
+        writeText(files.report, renderMarkdown(report));
+      } else {
+        writeJson(files.report, report);
+      }
+    }
+
+    const finalOutput = parsed.format === 'markdown'
+      ? renderMarkdown(report)
+      : JSON.stringify(report, null, 2);
+    console.log(finalOutput);
+  } catch (error) {
+    console.error(`externalize-form failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  parseArgs,
+  collectFieldNodes,
+  analyzeSchema,
+  renderMarkdown,
+  run,
+  _private: {
+    extractText,
+    isRequired,
+    planField,
+    buildMirrorFields,
+    summarize,
+  },
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -110,6 +110,9 @@ const COMMAND_GROUPS = [
       command('verify-short-url', ['verify-short-url'], 'verify-short-url <appType> ...', 'help.cmd_verify_url'),
       command('save-share-config', ['save-share-config'], 'save-share-config <appType> ...', 'help.cmd_save_share'),
       command('get-page-config', ['get-page-config'], 'get-page-config <appType> <formUuid>', 'help.cmd_get_page_config'),
+      command('externalize-form', ['externalize-form'], 'externalize-form <appType> <formUuid> [--schema-file file]', 'help.cmd_externalize_form', {
+        output: 'json|markdown',
+      }),
     ],
   },
   {

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'التحقق من الرابط المختصر',
     cmd_save_share: 'حفظ إعدادات الوصول العام / المشاركة',
     cmd_get_page_config: 'استعلام إعدادات الوصول العام للصفحة',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'التقارير',
     cmd_create_report: 'إنشاء تقرير Yida',
     cmd_append_chart: 'إضافة رسم بياني إلى تقرير موجود',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'Kurz-URL überprüfen',
     cmd_save_share: 'Öffentlichen Zugang / Freigabe speichern',
     cmd_get_page_config: 'Öffentliche Zugangskonfiguration abfragen',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Berichte',
     cmd_create_report: 'Yida-Bericht erstellen',
     cmd_append_chart: 'Diagramm zu bestehendem Bericht hinzufügen',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -56,6 +56,7 @@ module.exports = {
     cmd_verify_url: 'Verify short URL',
     cmd_save_share: 'Save public access / share config',
     cmd_get_page_config: 'Query page public access config',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Reports',
     cmd_create_report: 'Create a Yida report',
     cmd_append_chart: 'Append chart to existing report',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'Verificar URL corta',
     cmd_save_share: 'Guardar configuración de acceso público / compartir',
     cmd_get_page_config: 'Consultar configuración de acceso público',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Informes',
     cmd_create_report: 'Crear informe Yida',
     cmd_append_chart: 'Agregar gráfico a informe existente',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'Vérifier l\'URL courte',
     cmd_save_share: 'Enregistrer la configuration d\'accès public / partage',
     cmd_get_page_config: 'Consulter la configuration d\'accès public',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Rapports',
     cmd_create_report: 'Créer un rapport Yida',
     cmd_append_chart: 'Ajouter un graphique à un rapport existant',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'शॉर्ट URL सत्यापित करें',
     cmd_save_share: 'सार्वजनिक पहुंच / शेयर कॉन्फ़िगरेशन सहेजें',
     cmd_get_page_config: 'पेज सार्वजनिक पहुंच कॉन्फ़िगरेशन पूछें',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'रिपोर्ट',
     cmd_create_report: 'Yida रिपोर्ट बनाएं',
     cmd_append_chart: 'मौजूदा रिपोर्ट में चार्ट जोड़ें',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -55,6 +55,7 @@ module.exports = {
     cmd_verify_url: '短縮 URL を検証',
     cmd_save_share: '公開アクセス / 共有設定を保存',
     cmd_get_page_config: 'ページ公開アクセス設定を照会',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'レポート',
     cmd_create_report: '宜搭レポートを作成',
     cmd_append_chart: '既存レポートにチャートを追加',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: '단축 URL 확인',
     cmd_save_share: '공개 접근 / 공유 설정 저장',
     cmd_get_page_config: '페이지 공개 접근 설정 조회',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: '보고서',
     cmd_create_report: 'Yida 보고서 생성',
     cmd_append_chart: '기존 보고서에 차트 추가',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'Verificar URL curta',
     cmd_save_share: 'Salvar configuração de acesso público / compartilhamento',
     cmd_get_page_config: 'Consultar configuração de acesso público',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Relatórios',
     cmd_create_report: 'Criar relatório Yida',
     cmd_append_chart: 'Adicionar gráfico a relatório existente',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -53,6 +53,7 @@ module.exports = {
     cmd_verify_url: 'Xác minh URL ngắn',
     cmd_save_share: 'Lưu cấu hình truy cập công khai / chia sẻ',
     cmd_get_page_config: 'Truy vấn cấu hình truy cập công khai',
+    cmd_externalize_form: 'Plan external access-safe mirror fields',
     group_report: 'Báo cáo',
     cmd_create_report: 'Tạo báo cáo Yida',
     cmd_append_chart: 'Thêm biểu đồ vào báo cáo hiện có',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -55,6 +55,7 @@ module.exports = {
     cmd_verify_url: '驗證短連結 URL',
     cmd_save_share: '儲存公開訪問 / 分享設定',
     cmd_get_page_config: '查詢頁面公開訪問設定',
+    cmd_externalize_form: '生成外部開放安全評估和鏡像欄位方案',
     group_report: '報表',
     cmd_create_report: '建立宜搭報表',
     cmd_append_chart: '向已有報表追加圖表',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -56,6 +56,7 @@ module.exports = {
     cmd_verify_url: '验证短链接 URL',
     cmd_save_share: '保存公开访问 / 分享配置',
     cmd_get_page_config: '查询页面公开访问配置',
+    cmd_externalize_form: '生成外部开放安全评估和镜像字段方案',
     group_report: '报表',
     cmd_create_report: '创建宜搭报表',
     cmd_append_chart: '向已有报表追加图表',

--- a/tests/app-list.test.js
+++ b/tests/app-list.test.js
@@ -49,6 +49,17 @@ beforeEach(() => {
 // ── 正常查询：单页 ────────────────────────────────────────────────────
 
 describe('run() 正常查询', () => {
+  test('--help 只输出用法，不读取登录态', async () => {
+    const mockWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => {});
+
+    await run(['--help']);
+
+    expect(utils.loadCookieData).not.toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalledWith(expect.stringContaining('openyida app-list'));
+
+    mockWrite.mockRestore();
+  });
+
   test('单页结果：正确输出 JSON 到 stdout', async () => {
     const apps = [
       makeApp(),

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -129,6 +129,20 @@ describe('CLI offline smoke', () => {
     expect(output).not.toContain('读取登录态');
   });
 
+  test('app-list --help renders usage without requiring login', () => {
+    const result = runAny(['app-list', '--help']);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('openyida app-list');
+    expect(result.output).not.toContain('读取登录态');
+  });
+
+  test('externalize-form --help renders usage without requiring login', () => {
+    const result = runAny(['externalize-form', '--help']);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('openyida externalize-form');
+    expect(result.output).not.toContain('读取登录态');
+  });
+
   test('commands --json renders machine-readable command manifest', () => {
     const output = runOk(['commands', '--json']);
     const parsed = JSON.parse(output);
@@ -151,6 +165,7 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('corp-manager');
     expect(commands).toContain('agent-center');
     expect(commands).toContain('dingtalk-link');
+    expect(commands).toContain('externalize-form');
     expect(commands).toContain('commands');
     expect(commands).toContain('a2a');
     expect(commands).toContain('ai');
@@ -172,6 +187,11 @@ describe('CLI offline smoke', () => {
     expect(parsed.commands.find(entry => entry.id === 'ai')).toMatchObject({
       usage: 'openyida ai <text|image> [options]',
       output: 'text|json',
+      requires_login: true,
+    });
+    expect(parsed.commands.find(entry => entry.id === 'externalize-form')).toMatchObject({
+      usage: 'openyida externalize-form <appType> <formUuid> [--schema-file file]',
+      output: 'json|markdown',
       requires_login: true,
     });
   });

--- a/tests/externalize-form.test.js
+++ b/tests/externalize-form.test.js
@@ -1,0 +1,236 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.mock('../lib/core/utils', () => ({
+  loadCookieData: jest.fn(),
+  triggerLogin: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://www.aliwork.com'),
+  httpGet: jest.fn(),
+  requestWithAutoLogin: jest.fn(),
+}));
+
+const utils = require('../lib/core/utils');
+const {
+  parseArgs,
+  collectFieldNodes,
+  analyzeSchema,
+  renderMarkdown,
+  run,
+} = require('../lib/app/externalize-form');
+
+function makeSchema() {
+  return {
+    success: true,
+    content: {
+      formTitle: 'Hero Approval',
+      pages: [
+        {
+          componentsTree: [
+            {
+              componentName: 'FormContainer',
+              children: [
+                {
+                  componentName: 'AssociationFormField',
+                  props: {
+                    fieldId: 'associationFormField_customer',
+                    label: { zh_CN: '关联客户' },
+                    validation: [{ type: 'required' }],
+                    associationForm: {
+                      appType: 'APP_TARGET',
+                      formUuid: 'FORM-CUSTOMER',
+                      formTitle: '客户信息',
+                      mainFieldId: 'textField_name',
+                      mainFieldLabel: { zh_CN: '客户名称' },
+                    },
+                  },
+                },
+                {
+                  componentName: 'EmployeeField',
+                  props: {
+                    fieldId: 'employeeField_owner',
+                    label: { zh_CN: '负责人' },
+                  },
+                },
+                {
+                  componentName: 'TextField',
+                  props: {
+                    fieldId: 'textField_name',
+                    label: { zh_CN: '英雄姓名' },
+                    validation: [{ type: 'required' }],
+                  },
+                },
+                {
+                  componentName: 'AttachmentField',
+                  props: {
+                    fieldId: 'attachmentField_files',
+                    label: { zh_CN: '证明材料' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('parseArgs', () => {
+  test('parses externalize-form options', () => {
+    expect(parseArgs([
+      'APP_XXX',
+      'FORM-AAA',
+      '--schema-file',
+      '.cache/schema.json',
+      '--output',
+      '.cache/report.md',
+      '--mirror-fields-output',
+      '.cache/fields.json',
+      '--format',
+      'markdown',
+      '--target',
+      'open',
+      '--mirror-title',
+      '外部填报',
+    ])).toEqual({
+      appType: 'APP_XXX',
+      formUuid: 'FORM-AAA',
+      schemaFile: '.cache/schema.json',
+      output: '.cache/report.md',
+      mirrorFieldsOutput: '.cache/fields.json',
+      format: 'markdown',
+      target: 'open',
+      mirrorTitle: '外部填报',
+      help: false,
+    });
+  });
+
+  test('rejects unsupported output format', () => {
+    expect(() => parseArgs(['APP_XXX', 'FORM-AAA', '--format', 'xml'])).toThrow('Unsupported format');
+  });
+});
+
+describe('schema analysis', () => {
+  test('collects field nodes from a form schema', () => {
+    const fields = collectFieldNodes(makeSchema());
+    expect(fields.map(field => field.componentName)).toEqual([
+      'AssociationFormField',
+      'EmployeeField',
+      'TextField',
+      'AttachmentField',
+    ]);
+    expect(fields[0]).toMatchObject({
+      label: '关联客户',
+      fieldId: 'associationFormField_customer',
+      required: true,
+    });
+  });
+
+  test('flags auth-bound fields and creates mirror fields', () => {
+    const report = analyzeSchema(makeSchema(), {
+      appType: 'APP_XXX',
+      formUuid: 'FORM-AAA',
+      target: 'open',
+      mirrorFieldsOutput: '.cache/external-fields.json',
+    });
+
+    expect(report.summary).toMatchObject({
+      totalFields: 4,
+      blockedFields: 2,
+      reviewFields: 1,
+      safeFields: 1,
+      associationFields: 1,
+      authBoundFields: 2,
+    });
+    expect(report.fields.find(field => field.componentName === 'AssociationFormField')).toMatchObject({
+      riskLevel: 'blocked',
+      externalStrategy: 'snapshot-and-resolve-internal',
+      associationTarget: {
+        formUuid: 'FORM-CUSTOMER',
+        mainFieldId: 'textField_name',
+      },
+    });
+    expect(report.mirrorFields).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'TextField',
+        label: '客户名称',
+        sourceStrategy: 'association-main-field-snapshot',
+      }),
+      expect.objectContaining({
+        type: 'TextField',
+        label: '关联客户业务标识',
+        sourceStrategy: 'association-business-key-for-internal-resolution',
+      }),
+      expect.objectContaining({
+        type: 'TextField',
+        label: '负责人姓名',
+      }),
+      expect.objectContaining({
+        type: 'TextField',
+        label: '英雄姓名',
+      }),
+    ]));
+    expect(report.recommendedActions[0]).toContain('openyida create-form create');
+  });
+
+  test('renders markdown report with field risks', () => {
+    const markdown = renderMarkdown(analyzeSchema(makeSchema(), {
+      appType: 'APP_XXX',
+      formUuid: 'FORM-AAA',
+      target: 'open',
+    }));
+    expect(markdown).toContain('# External Access Plan');
+    expect(markdown).toContain('| 关联客户 | AssociationFormField | blocked |');
+    expect(markdown).toContain('```json');
+  });
+});
+
+describe('run', () => {
+  test('schema-file mode writes report and mirror fields without login', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-externalize-'));
+    const schemaFile = path.join(tmpDir, 'schema.json');
+    const reportFile = path.join(tmpDir, 'report.json');
+    const fieldsFile = path.join(tmpDir, 'fields.json');
+    fs.writeFileSync(schemaFile, JSON.stringify(makeSchema()), 'utf-8');
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await run([
+      'APP_XXX',
+      'FORM-AAA',
+      '--schema-file',
+      schemaFile,
+      '--output',
+      reportFile,
+      '--mirror-fields-output',
+      fieldsFile,
+    ]);
+
+    expect(utils.loadCookieData).not.toHaveBeenCalled();
+    expect(fs.existsSync(reportFile)).toBe(true);
+    expect(fs.existsSync(fieldsFile)).toBe(true);
+    const report = JSON.parse(fs.readFileSync(reportFile, 'utf-8'));
+    const mirrorFields = JSON.parse(fs.readFileSync(fieldsFile, 'utf-8'));
+    expect(report.summary.blockedFields).toBe(2);
+    expect(report.files.report).toBe(reportFile);
+    expect(mirrorFields.some(field => field.label === '客户名称')).toBe(true);
+    expect(JSON.parse(mockLog.mock.calls[0][0])).toHaveProperty('files.report', reportFile);
+
+    mockLog.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('--help prints usage without login', async () => {
+    const mockErrorWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => {});
+    await run(['--help']);
+    expect(utils.loadCookieData).not.toHaveBeenCalled();
+    expect(mockErrorWrite).toHaveBeenCalledWith(expect.stringContaining('externalize-form'));
+    mockErrorWrite.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add `openyida externalize-form` to analyze form schemas for public-access blockers such as `AssociationFormField`, `EmployeeField`, and `DepartmentSelectField`
- generate JSON/Markdown reports plus optional external-safe mirror field definitions for `create-form create`
- wire the command into CLI routing, command manifest, README, and all locale command descriptions
- fix `openyida app-list --help` so it exits before login/network work

## Verification
- `npm test -- tests/externalize-form.test.js tests/app-list.test.js tests/cli-smoke.test.js --runInBand`
- `node bin/yida.js externalize-form APP_J1T18U375G4Y2B5W7DO1 FORM-F1F779F46DAB4DCA97C4415506186D71OXJS --schema-file .cache/openyida/station-hero/hero-schema.json --output .cache/openyida/externalize/hero-external-plan.json --mirror-fields-output .cache/openyida/externalize/hero-mirror-fields.json --quiet`
- `node bin/yida.js externalize-form APP_J1T18U375G4Y2B5W7DO1 FORM-F1F779F46DAB4DCA97C4415506186D71OXJS --quiet`
- Chrome verified `https://www.aliwork.com/s/station-hero-ops` renders the station hero dashboard, stats, charts, quick actions, and recent tasks
- `npm run check:ci`
