### PR TITLE
[codex] fix copy --force fallback

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -426,7 +426,7 @@ async function main() {
 
     case 'copy': {
       const { run } = require('../lib/core/copy');
-      run();
+      run(args);
       break;
     }
 

--- a/lib/core/copy.js
+++ b/lib/core/copy.js
@@ -81,6 +81,30 @@ function mergeCopyDir(sourceDir, destDir) {
   return copiedCount;
 }
 
+function resolveExistingPath(targetPath) {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+function isSameDirectory(a, b) {
+  const pathA = resolveExistingPath(a);
+  const pathB = resolveExistingPath(b);
+  if (process.platform === 'win32') {
+    return pathA.toLowerCase() === pathB.toLowerCase();
+  }
+  return pathA === pathB;
+}
+
+function clearDirectoryContents(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    fs.rmSync(path.join(dir, entry.name), { recursive: true, force: true });
+  }
+}
+
 /**
  * 强制复制目录：先清空目标目录，再完整复制。
  * @returns {number} 复制的文件数量
@@ -89,7 +113,11 @@ function forceCopyDir(sourceDir, destDir) {
   if (!fs.existsSync(sourceDir)) {return 0;}
 
   if (fs.existsSync(destDir)) {
-    fs.rmSync(destDir, { recursive: true, force: true });
+    if (isSameDirectory(destDir, process.cwd())) {
+      clearDirectoryContents(destDir);
+    } else {
+      fs.rmSync(destDir, { recursive: true, force: true });
+    }
     console.log(t('copy.cleared', destDir));
   }
 
@@ -182,9 +210,11 @@ function createSymlink(sourceDir, destLink) {
  * @param {string|null} activeToolName
  * @param {string|null} activeProjectRoot
  * @param {Array} envResults
+ * @param {object} [options]
+ * @param {boolean} [options.allowCurrentDir=false] - 未检测到活跃 AI 工具时，是否允许使用当前目录
  * @returns {string} 目标根目录路径
  */
-function resolveDestBaseFromEnv(activeToolName, activeProjectRoot, envResults) {
+function resolveDestBaseFromEnv(activeToolName, activeProjectRoot, envResults, options = {}) {
   const activeResult = envResults.find((r) => r.displayName === activeToolName);
   const isWukong = activeResult && activeResult.dirName === '.real';
 
@@ -198,6 +228,10 @@ function resolveDestBaseFromEnv(activeToolName, activeProjectRoot, envResults) {
   }
 
   if (activeToolName) {
+    return process.cwd();
+  }
+
+  if (options.allowCurrentDir) {
     return process.cwd();
   }
 
@@ -223,13 +257,13 @@ function copyItem(label, sourceDir, destDir, isForce) {
 
 /**
  * 执行 copy 命令主逻辑。
+ * @param {string[]} [args=process.argv.slice(3)] 命令参数
  */
-function run() {
+function run(args = process.argv.slice(3)) {
   const { c, sep, banner, info, success, hint, label, fail: chalkFail, listItem } = require('./chalk');
 
   banner(t('copy.title'), { stderr: false });
 
-  const args = process.argv.slice(3);
   const isForce = args.includes('--force');
   const wantsSkills = args.includes('-skills');
   const wantsProject = args.includes('-project');
@@ -250,7 +284,9 @@ function run() {
   const { activeToolName, activeProjectRoot, results: envResults } = detectEnvironment();
   const activeEnvResult = envResults.find((r) => r.isActive);
   const isWukong = activeEnvResult && activeEnvResult.dirName === '.real';
-  const destBase = resolveDestBaseFromEnv(activeToolName, activeProjectRoot, envResults);
+  const destBase = resolveDestBaseFromEnv(activeToolName, activeProjectRoot, envResults, {
+    allowCurrentDir: isForce,
+  });
   label('Target', destBase, { stderr: false });
   if (isForce) {
     warn(t('copy.force_mode'), false);
@@ -345,8 +381,8 @@ function run() {
   }
 
   // 4. 打印汇总
-  const copyCount = results.filter(r => r.type === 'copy').reduce((sum, r) => sum + r.count, 0);
-  const linkCount = results.filter(r => r.type === 'symlink').length;
+  const copyCount = results.filter((r) => r.type === 'copy').reduce((sum, r) => sum + r.count, 0);
+  const linkCount = results.filter((r) => r.type === 'symlink').length;
   console.log('');
   console.log(`  ${sep()}`);
   success(t('copy.done'), false);
@@ -369,4 +405,10 @@ function run() {
   console.log(`  ${sep()}\n`);
 }
 
-module.exports = { run };
+module.exports = {
+  run,
+  _internal: {
+    forceCopyDir,
+    resolveDestBaseFromEnv,
+  },
+};

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -269,6 +269,18 @@ describe('CLI offline smoke', () => {
     expect(result.output).toContain('未知的 env 子命令');
   });
 
+  test('copy --force initializes current directory when no AI tool is active', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-copy-force-'));
+    try {
+      const output = runOkWithEnv(['copy', '--force'], {}, workspace);
+      expect(output).toContain('--force 模式');
+      expect(fs.existsSync(path.join(workspace, 'config.json'))).toBe(true);
+      expect(fs.existsSync(path.join(workspace, 'pages', 'src'))).toBe(true);
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
   test('login falls back to QR handoff in Codex environment when CDP is unavailable', () => {
     const workspace = createCodexWorkspace();
     try {

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -224,6 +224,7 @@ describe('detectActiveTool Windows 路径兼容', () => {
 describe('resolveDestBaseFromEnv 逻辑验证', () => {
   const os = require('os');
   const path = require('path');
+  const { _internal } = require('../lib/core/copy');
 
   test('悟空环境且 activeProjectRoot 是扁平工作区时，返回工作区本身', () => {
     const activeProjectRoot = path.join(os.homedir(), '.real', 'workspace');
@@ -280,5 +281,56 @@ describe('resolveDestBaseFromEnv 逻辑验证', () => {
     }
 
     expect(destBase).toBe(process.cwd());
+  });
+
+  test('--force 允许未检测到活跃 AI 工具时使用当前目录', () => {
+    const originalCwd = process.cwd();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yida-copy-force-'));
+
+    try {
+      process.chdir(tmpDir);
+      const destBase = _internal.resolveDestBaseFromEnv(null, null, [], {
+        allowCurrentDir: true,
+      });
+      expect(destBase).toBe(fs.realpathSync(tmpDir));
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('forceCopyDir 行为', () => {
+  const { _internal } = require('../lib/core/copy');
+
+  let tmpDir;
+  let originalCwd;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yida-force-copy-'));
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('目标目录是当前工作目录时清空内容但保留目录本身', () => {
+    const sourceDir = path.join(tmpDir, 'source');
+    const destDir = path.join(tmpDir, 'dest');
+    fs.mkdirSync(sourceDir);
+    fs.mkdirSync(destDir);
+    fs.writeFileSync(path.join(sourceDir, 'fresh.txt'), 'fresh');
+    fs.writeFileSync(path.join(destDir, 'stale.txt'), 'stale');
+
+    process.chdir(destDir);
+    const count = _internal.forceCopyDir(sourceDir, destDir);
+
+    expect(count).toBe(1);
+    expect(fs.existsSync(destDir)).toBe(true);
+    expect(process.cwd()).toBe(fs.realpathSync(destDir));
+    expect(fs.existsSync(path.join(destDir, 'stale.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(destDir, 'fresh.txt'), 'utf8')).toBe('fresh');
   });
 });


### PR DESCRIPTION
## Summary

Fix `openyida copy --force` so it can initialize the current directory when no active AI tool environment is detected.

## Root Cause

The command output told users to rerun with `--force`, but destination resolution did not receive or honor the force flag. As a result, the no-active-tool branch still exited before copying.

## Changes

- Pass parsed CLI args from `bin/yida.js` into `copy.run(args)`.
- Allow `resolveDestBaseFromEnv` to fall back to `process.cwd()` when explicitly requested by `--force`.
- Add unit and CLI smoke coverage for the no-active-tool `copy --force` path.

## Validation

- `node --check lib/core/copy.js && node --check bin/yida.js`
- `npx jest tests/copy.test.js --runInBand`
- `npx jest tests/cli-smoke.test.js --runInBand`
- `npx eslint --quiet bin/yida.js lib/core/copy.js tests/copy.test.js tests/cli-smoke.test.js`