### PR TITLE
[codex] fix login base url detection

### DIFF
--- a/lib/auth/cdp-browser-login.js
+++ b/lib/auth/cdp-browser-login.js
@@ -13,7 +13,7 @@ const path = require('path');
 const net = require('net');
 const crypto = require('crypto');
 const { execFileSync, spawn } = require('child_process');
-const { deriveBaseUrlFromCookies, deriveBaseUrlFromUrl } = require('../core/env-manager');
+const { deriveBaseUrlFromCookies, deriveBaseUrlFromLoginState } = require('../core/env-manager');
 
 function findBrowserExecutable() {
   if (process.env.OPENYIDA_CHROME_PATH && fs.existsSync(process.env.OPENYIDA_CHROME_PATH)) {
@@ -284,6 +284,10 @@ async function getCurrentPageUrl(client, fallbackUrl) {
   }
 }
 
+function deriveBaseUrlFromBrowserState(cookies, loginUrl, currentPageUrl) {
+  return deriveBaseUrlFromLoginState(cookies, loginUrl, currentPageUrl);
+}
+
 async function runCdpBrowserLogin(options = {}) {
   const browserPath = options.browserPath || findBrowserExecutable();
   if (!browserPath) {
@@ -332,10 +336,9 @@ async function runCdpBrowserLogin(options = {}) {
       const cookies = Array.isArray(result.cookies) ? result.cookies : [];
       if (cookies.some((cookie) => cookie.name === 'tianshu_csrf_token' && cookie.value)) {
         const currentPageUrl = await getCurrentPageUrl(client, target.url || loginUrl);
-        const fallbackBaseUrl = deriveBaseUrlFromUrl(loginUrl, currentPageUrl);
         return {
           cookies,
-          base_url: deriveBaseUrl(cookies, fallbackBaseUrl),
+          base_url: deriveBaseUrlFromBrowserState(cookies, loginUrl, currentPageUrl),
         };
       }
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -381,6 +384,7 @@ module.exports = {
   cdpBrowserLogin,
   createCdpClient,
   deriveBaseUrl,
+  deriveBaseUrlFromBrowserState,
   findBrowserExecutable,
   runCdpBrowserLogin,
 };

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -311,7 +311,7 @@ function playwrightInteractiveLogin(loginUrl, playwrightPath) {
   const scriptContent = `
 const playwright = require(${JSON.stringify(playwrightPath)});
 const { chromium } = playwright;
-const { deriveBaseUrlFromCookies, deriveBaseUrlFromUrl } = require(${JSON.stringify(envManagerPath)});
+const { deriveBaseUrlFromLoginState } = require(${JSON.stringify(envManagerPath)});
 
 (async () => {
   // 优先使用本地已安装的 Chrome，避免下载 Playwright 内置 Chromium
@@ -349,8 +349,7 @@ const { deriveBaseUrlFromCookies, deriveBaseUrlFromUrl } = require(${JSON.string
 
   const currentUrl = page.url();
   const cookies = await context.cookies();
-  const fallbackBaseUrl = deriveBaseUrlFromUrl(${JSON.stringify(loginUrl)}, currentUrl);
-  const baseUrl = deriveBaseUrlFromCookies(cookies, fallbackBaseUrl);
+  const baseUrl = deriveBaseUrlFromLoginState(cookies, ${JSON.stringify(loginUrl)}, currentUrl);
   await browser.close();
 
   console.log(JSON.stringify({ cookies, base_url: baseUrl }));

--- a/lib/core/env-manager.js
+++ b/lib/core/env-manager.js
@@ -8,9 +8,9 @@
  *
  * 优先级（高 → 低）：
  *   1. 环境变量 OPENYIDA_ENDPOINT
- *   2. 环境变量 OPENYIDA_ENV 指定的环境配置
- *   3. 当前激活的环境配置（openyida-envs.json current 字段）
- *   4. cookieData.base_url（历史兼容）
+ *   2. cookieData.base_url（登录后实际跳转域名）
+ *   3. 环境变量 OPENYIDA_ENV 指定的环境配置
+ *   4. 当前激活的环境配置（openyida-envs.json current 字段）
  *   5. 默认公有云 https://www.aliwork.com
  *
  * 导出函数：
@@ -21,6 +21,7 @@
  *   migrateOldCookieFile()    - 迁移旧版 cookies.json → cookies-public.json
  *   resolveEndpoint()         - 解析最终 baseUrl（含完整优先级）
  *   resolveLoginUrl()         - 解析最终登录 URL
+ *   deriveBaseUrlFromLoginState() - 从 Cookie + 浏览器当前 URL 解析实际 baseUrl
  */
 
 'use strict';
@@ -329,6 +330,20 @@ function deriveBaseUrlFromCookies(cookies = [], fallbackUrl = DEFAULT_BASE_URL) 
   return fallbackOrigin;
 }
 
+function deriveBaseUrlFromLoginState(cookies = [], loginUrl = DEFAULT_LOGIN_URL, currentUrl = null) {
+  const fallbackBaseUrl = deriveBaseUrlFromUrl(loginUrl, currentUrl);
+  const cookieBaseUrl = deriveBaseUrlFromCookies(cookies, fallbackBaseUrl);
+  const currentOrigin = normalizeBaseUrl(currentUrl, null);
+  const currentHost = normalizeHostname(currentOrigin);
+  const loginHost = normalizeHostname(normalizeBaseUrl(loginUrl, null));
+
+  if (currentOrigin && isYidaServiceHost(currentHost) && currentHost !== loginHost) {
+    return currentOrigin;
+  }
+
+  return cookieBaseUrl;
+}
+
 function deriveBaseUrlFromUrl(fallbackBaseUrl, candidateUrl) {
   let fallbackOrigin = normalizeBaseUrl(fallbackBaseUrl, DEFAULT_BASE_URL);
   const fallbackHost = normalizeHostname(fallbackOrigin);
@@ -470,8 +485,8 @@ function migrateOldCookieFile(projectRoot) {
 /**
  * 解析最终的 baseUrl，按优先级：
  *   1. OPENYIDA_ENDPOINT 环境变量
- *   2. 当前激活环境配置的 baseUrl
- *   3. cookieData.base_url（历史兼容）
+ *   2. cookieData.base_url（登录后实际跳转域名）
+ *   3. 当前激活环境配置的 baseUrl
  *   4. 默认公有云
  * @param {object} [cookieData]
  * @param {string} [projectRoot]
@@ -483,21 +498,13 @@ function resolveEndpoint(cookieData, projectRoot) {
     return normalizeBaseUrl(process.env.OPENYIDA_ENDPOINT, DEFAULT_BASE_URL);
   }
 
-  // 优先级 2：当前激活环境配置
-  const { config: envConfig } = getCurrentEnvConfig(projectRoot);
-  // 只有当环境配置不是默认公有云，或者没有 cookieData 时才使用环境配置
-  // 这样可以兼容：用户没有配置多环境时，仍从 Cookie 中提取专属域名
-  const isDefaultPublic = envConfig.baseUrl === DEFAULT_BASE_URL;
-  if (!isDefaultPublic && envConfig.baseUrl) {
-    return normalizeBaseUrl(envConfig.baseUrl, DEFAULT_BASE_URL);
-  }
-
-  // 优先级 3：从 Cookie 历史提取（兼容专属域名）
+  // 优先级 2：登录缓存中记录的实际服务域名
   if (cookieData && cookieData.base_url) {
     return normalizeBaseUrl(cookieData.base_url, DEFAULT_BASE_URL);
   }
 
-  // 优先级 4：环境配置（公有云默认）
+  // 优先级 3：当前激活环境配置
+  const { config: envConfig } = getCurrentEnvConfig(projectRoot);
   if (envConfig.baseUrl) {
     return normalizeBaseUrl(envConfig.baseUrl, DEFAULT_BASE_URL);
   }
@@ -560,5 +567,6 @@ module.exports = {
   inferLoginUrlForBaseUrl,
   deriveBaseUrlFromDingtalkOAuthUrl,
   deriveBaseUrlFromCookies,
+  deriveBaseUrlFromLoginState,
   deriveBaseUrlFromUrl,
 };

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -440,8 +440,8 @@ function isCsrfTokenExpired(responseJson) {
  *
  * 优先级（高 → 低）：
  *   1. OPENYIDA_ENDPOINT 环境变量
- *   2. 当前激活的私有化环境配置（非默认公有云时）
- *   3. cookieData.base_url（历史兼容，含专属域名）
+ *   2. cookieData.base_url（登录后实际跳转域名）
+ *   3. 当前激活的私有化环境配置
  *   4. 当前激活的环境配置（公有云默认）
  *   5. defaultBaseUrl 参数 / 公有云兜底
  *

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -240,6 +240,7 @@ describe('saveCookieCache 文件写入', () => {
 describe('cdp-browser-login 工具函数', () => {
   const { deriveBaseUrl, findBrowserExecutable } = require('../lib/auth/cdp-browser-login');
   const {
+    deriveBaseUrlFromLoginState,
     deriveBaseUrlFromUrl,
     inferLoginUrlForBaseUrl,
     resolveLoginUrl,
@@ -281,6 +282,15 @@ describe('cdp-browser-login 工具函数', () => {
     expect(result).toBe('https://yida-group.alibaba-inc.com');
   });
 
+  test('deriveBaseUrlFromLoginState 优先使用登录后实际跳转的阿里内网宜搭域名', () => {
+    const result = deriveBaseUrlFromLoginState([
+      { name: 'tianshu_csrf_token', domain: '.alibaba-inc.com' },
+      { name: 'yida_user_cookie', domain: 'yida-group.alibaba-inc.com' },
+    ], 'https://yida-group.alibaba-inc.com/workPlatform', 'https://yida-aliyun.alibaba-inc.com/home');
+
+    expect(result).toBe('https://yida-aliyun.alibaba-inc.com');
+  });
+
   test('deriveBaseUrl 不把 alibaba-inc 父域误判成服务地址', () => {
     const result = deriveBaseUrl([
       { name: 'tianshu_csrf_token', domain: '.alibaba-inc.com' },
@@ -294,6 +304,13 @@ describe('cdp-browser-login 工具函数', () => {
       'https://yida-group.alibaba-inc.com/workPlatform',
       'https://login.dingtalk.com/oauth2/challenge'
     )).toBe('https://yida-group.alibaba-inc.com');
+  });
+
+  test('deriveBaseUrlFromUrl 识别 yida-aliyun.alibaba-inc.com 成功页', () => {
+    expect(deriveBaseUrlFromUrl(
+      'https://www.aliwork.com/workPlatform',
+      'https://yida-aliyun.alibaba-inc.com/home'
+    )).toBe('https://yida-aliyun.alibaba-inc.com');
   });
 
   test('deriveBaseUrlFromUrl 可从 DingTalk 国际 OAuth redirect_uri 反推 yidaapps base URL', () => {

--- a/tests/qr-login.test.js
+++ b/tests/qr-login.test.js
@@ -579,6 +579,13 @@ describe('DingTalk OAuth organization selection', () => {
     )).toBe('https://yida-group.alibaba-inc.com');
   });
 
+  test('derives actual yida-aliyun Alibaba intranet base URL from OAuth redirect', () => {
+    expect(__test__.deriveAliworkBaseUrl(
+      'https://www.aliwork.com',
+      'https://yida-aliyun.alibaba-inc.com/home'
+    )).toBe('https://yida-aliyun.alibaba-inc.com');
+  });
+
   test('derives yidaapps base URL from DingTalk international OAuth redirect', () => {
     expect(__test__.deriveAliworkBaseUrl(
       'https://login.dingtalk.io/oauth2/auth?redirect_uri=https%3A%2F%2Fwww.yidaapps.com%2Fdingtalk_sso_call_back%3Fcontinue%3Dhttps%253A%252F%252Fwww.yidaapps.com%252FworkPlatform',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -93,6 +93,29 @@ describe('resolveBaseUrl', () => {
     const cookieData = { base_url: 'https://www.aliwork.com///' };
     expect(resolveBaseUrl(cookieData)).toBe('https://www.aliwork.com');
   });
+
+  test('登录缓存中的实际 base_url 优先于内置非默认环境域名', () => {
+    const originalEnv = process.env.OPENYIDA_ENV;
+    const originalEndpoint = process.env.OPENYIDA_ENDPOINT;
+    process.env.OPENYIDA_ENV = 'alibaba';
+    delete process.env.OPENYIDA_ENDPOINT;
+
+    try {
+      const cookieData = { base_url: 'https://yida-aliyun.alibaba-inc.com/home' };
+      expect(resolveBaseUrl(cookieData)).toBe('https://yida-aliyun.alibaba-inc.com');
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.OPENYIDA_ENV;
+      } else {
+        process.env.OPENYIDA_ENV = originalEnv;
+      }
+      if (originalEndpoint === undefined) {
+        delete process.env.OPENYIDA_ENDPOINT;
+      } else {
+        process.env.OPENYIDA_ENDPOINT = originalEndpoint;
+      }
+    }
+  });
 });
 
 // ── isLoginExpired ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Prefer the actual post-login Yida service origin when browser login lands on a host such as `yida-aliyun.alibaba-inc.com`.
- Keep `OPENYIDA_ENDPOINT` as the explicit override, but let cached login `base_url` drive subsequent API calls ahead of built-in environment defaults.
- Add regression coverage for Alibaba intranet redirect and cached base URL resolution.

## Root Cause

The login flow could detect a valid `tianshu_csrf_token` while still deriving or later resolving `baseUrl` from a configured default such as `yida-group.alibaba-inc.com`. For accounts whose successful login lands on another Yida service host, subsequent API calls could be sent to the wrong domain.

## Validation

- `npm test -- tests/login.test.js tests/qr-login.test.js tests/utils.test.js`
- `npx eslint lib/core/env-manager.js lib/core/utils.js lib/auth/login.js lib/auth/cdp-browser-login.js tests/login.test.js tests/qr-login.test.js tests/utils.test.js`
- `npm run check:syntax`