### PR TITLE
fix: preserve UTF-8 response chunks

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -460,6 +460,16 @@ function resolveBaseUrl(cookieData, defaultBaseUrl) {
 
 // ── HTTP 请求工具 ─────────────────────────────────────
 
+function collectResponseText(res, onEnd) {
+  const chunks = [];
+  res.on('data', (chunk) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  res.on('end', () => {
+    onEnd(Buffer.concat(chunks).toString('utf8'));
+  });
+}
+
 /**
  * 发送 HTTP POST 请求（application/x-www-form-urlencoded）
  * @param {string} baseUrl
@@ -508,9 +518,7 @@ function httpPost(baseUrl, requestPath, postData, cookies, optionsOverride = {})
     };
 
     const req = requestModule.request(options, (res) => {
-      let data = '';
-      res.on('data', (chunk) => { data += chunk; });
-      res.on('end', () => {
+      collectResponseText(res, (data) => {
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
         }
@@ -593,9 +601,7 @@ function httpGet(baseUrl, requestPath, queryParams, cookies, optionsOverride = {
     };
 
     const req = requestModule.request(options, (res) => {
-      let data = '';
-      res.on('data', (chunk) => { data += chunk; });
-      res.on('end', () => {
+      collectResponseText(res, (data) => {
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
         }

--- a/tests/http-encoding.test.js
+++ b/tests/http-encoding.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const http = require('http');
+const { httpGet, httpPost } = require('../lib/core/utils');
+
+function writeSplitUtf8Json(res, payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const splitTarget = Buffer.from('解', 'utf8');
+  const splitAt = body.indexOf(splitTarget) + 1;
+
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.write(body.subarray(0, splitAt));
+  res.write(body.subarray(splitAt));
+  res.end();
+}
+
+async function withServer(handler, callback) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+describe('http response encoding', () => {
+  const cookies = [{ name: 'tianshu_csrf_token', value: 'tok123', domain: '127.0.0.1' }];
+  const payload = {
+    success: true,
+    content: {
+      text: '测试、解码相关内容',
+    },
+  };
+
+  test('httpGet preserves UTF-8 characters split across chunks', async () => {
+    await withServer((_req, res) => writeSplitUtf8Json(res, payload), async (baseUrl) => {
+      const result = await httpGet(baseUrl, '/api', {}, cookies, { silentStatus: true });
+
+      expect(result.content.text).toBe('测试、解码相关内容');
+      expect(result.content.text).not.toContain('�');
+    });
+  });
+
+  test('httpPost preserves UTF-8 characters split across chunks', async () => {
+    await withServer((_req, res) => writeSplitUtf8Json(res, payload), async (baseUrl) => {
+      const result = await httpPost(baseUrl, '/api', 'value=1', cookies, { silentStatus: true });
+
+      expect(result.content.text).toBe('测试、解码相关内容');
+      expect(result.content.text).not.toContain('�');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Collect HTTP response chunks as buffers and decode once as UTF-8 after the response ends.
- Add regression coverage for Chinese text split across response chunks in both `httpGet` and `httpPost`.

## Root Cause

`httpGet` and `httpPost` appended each response `Buffer` chunk directly to a string. When a multi-byte UTF-8 character was split across chunks, Node decoded the incomplete bytes independently and produced `�`, matching the process `TableField` garbled text reported in #361.

## Validation

- `node --check lib/core/utils.js`
- `npx jest tests/utils.test.js tests/query-data.test.js tests/http-encoding.test.js --runInBand`
- `npm test -- --runInBand` (65 suites / 740 tests)

Fixes #361