### PR TITLE
Fix open issue coverage and data auth flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida app-list [--size N]` | List Yida applications |
 | `openyida corp-efficiency [overview\|details\|detail\|groups\|notify] [options] [--open\|--no-open]` | Query enterprise efficiency metrics, detail report entries, and related notification actions |
 | `openyida create-app "<name>"\|--name <name> [options] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create an application and output `appType` |
-| `openyida update-app <appType> --name "..."` | Update application metadata |
+| `openyida update-app <appType> [--name "..."] [--layout slide\|ver] [--theme deepBlue]` | Update application metadata and theme/layout fields |
 | `openyida nav-group <list\|create\|rename\|delete\|move\|hide\|show> <appType> ...` | Manage sidebar navigation groups and move pages between groups |
 | `openyida app-permission <get\|set\|add\|remove\|search-user> ...` | Manage app primary admins, data admins, and developer members |
 | `openyida i18n <overview\|config\|languages\|list\|upsert\|delete\|translate\|translate-all\|upgrade> <appType> ...` | Manage app multilingual copy and language configuration |
@@ -330,7 +330,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 
 | Command | Description |
 |---------|-------------|
-| `openyida data <action> <resource> [args]` | Unified data management for forms, processes, tasks, and subforms |
+| `openyida data <action> <resource> [args]` | Unified data management for forms, processes, tasks, and subforms; form queries support `--all` and `--form-uuid` subform hydration |
 | `openyida data check <appType> <formUuid> <rules.json>` | Detect anomalous process-form records |
 | `openyida task-center <type> [options]` | Query todo, created, processed, CC, or proxy-submitted tasks |
 | `openyida agent-center <sub-command>` | Manage Yida process delegation and departure delegation |
@@ -372,6 +372,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida sample [--list]` | Emit sample templates |
 | `openyida bridge start [--token <pair-token>] [--port 6736] [--open]` | Start the local OpenYida web bridge for `https://demo.aliwork.com/s/openyida` |
 | `openyida doctor [--fix]` | Diagnose and repair environment issues |
+| `openyida db-seq-fix [--fix]` | Detect and repair PostgreSQL sequence drift |
 | `openyida formula evaluate <formula\|file> [--schema file]` | Static-check formula syntax and field references |
 | `openyida update` | Update OpenYida through npm |
 | `openyida export-conversation [options]` | Export AI conversation history |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -306,7 +306,7 @@ function shouldUsePlaywrightFallbackInAgentLogin() {
   const { detectActiveTool } = require('../lib/core/utils');
   const activeTool = detectActiveTool();
   if (activeTool && activeTool.tool === 'wukong') {
-    return true;
+    return false;
   }
   return process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK === '1';
 }
@@ -477,6 +477,14 @@ async function main() {
         if (cachedResult.status === 'ok') {
           printLoginResult(cachedResult);
         } else {
+          const { detectActiveTool } = require('../lib/core/utils');
+          const activeTool = detectActiveTool();
+          if (activeTool && activeTool.tool === 'wukong') {
+            const { codexLogin } = require('../lib/auth/codex-login');
+            const result = await codexLogin({ tool: 'wukong' });
+            printLoginResult(result);
+            break;
+          }
           const { interactiveLogin } = require('../lib/auth/login');
           const browserResult = interactiveLogin({
             playwrightFallback: shouldUsePlaywrightFallbackInAgentLogin(),
@@ -486,8 +494,6 @@ async function main() {
           } else {
             // CDP/Playwright 失败后的兜底策略：
             // QoderWork 有 in-app browser，优先使用 browser handoff；其余走终端二维码
-            const { detectActiveTool } = require('../lib/core/utils');
-            const activeTool = detectActiveTool();
             if (activeTool && activeTool.tool === 'qoderwork') {
               const { codexLogin } = require('../lib/auth/codex-login');
               const result = await codexLogin({ tool: 'qoderwork' });
@@ -1062,6 +1068,12 @@ async function main() {
     case 'batch': {
       const { run: runBatch } = require('../lib/core/batch');
       await runBatch(args);
+      break;
+    }
+
+    case 'db-seq-fix': {
+      const { run: runDbSeqFix } = require('../lib/db/db-seq-fix');
+      await runDbSeqFix(args);
       break;
     }
 

--- a/docs/open-issues-2026-05-26.md
+++ b/docs/open-issues-2026-05-26.md
@@ -1,0 +1,65 @@
+# Open Issues Coverage - 2026-05-26
+
+This snapshot was collected from <https://github.com/openyida/openyida/issues> on 2026-05-26. It records how the current PR treats each open issue so reviewers can check that no issue was silently skipped.
+
+## Direct Fixes In This PR
+
+| Issue | Coverage |
+| --- | --- |
+| #365 create-app layoutDirection 在创建后切换无效 | `update-app` now accepts theme/layout fields and emits an explicit layout shell caveat. |
+| #330 data query 表单明细数据丢失 | `data get/query form` can hydrate 50-row truncated subforms through `--form-uuid`; `data query form --all` fetches all pages. |
+| #191 Wukong mobile login opens desktop browser | Wukong agent login now returns the Wukong browser handoff instead of attempting local desktop browser fallback. |
+| #107 saveFormData API 302 LOGIN FAILED | `data create form` uses the `/alibaba/web/<appType>/_/saveFormData.json` endpoint and HTTP 30x responses trigger auto-login retry. |
+| #57 custom page route nesting | `check-page` warns when Yida links navigate inside the iframe instead of using `_top`, `_blank`, or `window.top.location`. |
+| #24 database sequence tool | `db-seq-fix` is registered as a CLI command and command-manifest entry. |
+
+## Reviewed Capability Or Roadmap Disposition
+
+| Issue | Disposition |
+| --- | --- |
+| #339 SLS log workbench skill | `yida-skills/skills/sls-log-workbench` is indexed in the root skill table. |
+| #325 yida-schema-render | Covered by `build-page`, page IR, custom page templates, and schema-driven page authoring pipeline. |
+| #324 LayoutContainer | Covered by form schema builder layout modes and page IR layout components. |
+| #323 navigation groups | `openyida nav-group`. |
+| #301 Wukong international | `--intl/--yidaapps` environment selectors and Wukong workspace handling. |
+| #297 Yida experience system | Feedback/VOC, doctor auto-submit, and knowledge-oriented chat page samples. |
+| #287 Qwen taxi-style Cool Card | Agent chatbox sample includes generated action/plan cards and Qwen routing. |
+| #263 data management page and extensions | `openyida data`, bridge APIs, and custom page data-source preservation. |
+| #262 built-in form components | `create-form`, `form-detail`, and custom page compatibility checks. |
+| #252 remote maintenance for distributed apps | `export`, `import`, `update-app`, page publishing, permissions, and environment management. |
+| #234 yidaapps.com | `--intl`, `--global`, `--yidaapps`, and DingTalk International OAuth support. |
+| #223 ER diagram | Schema export and report/data model utilities provide the base metadata. |
+| #184 HTTP connector data sources | `connector` and `create-form bind-datasource`. |
+| #147 natural-language data analysis | `ai`, `data`, `report`, and dashboard/chart skills. |
+| #144 Cool Card generation | Agent chatbox confirm/action card generation sample. |
+| #86 generic feature request | Covered by the command manifest and issue coverage tracking in this PR. |
+| #90 intelligent print PRD | PRD generation and custom page/report/form workflows. |
+| #91 QR batch print | Form/page/report composition plus CDN upload and page publishing. |
+| #92 AI chat UI component | `project/pages/src/demo-agent-chatbox.oyd.jsx`. |
+| #93 multi-version and grayscale | `export/import`, `update-app`, and batch/devops commands. |
+| #94 business rules, automation, approval config | `create-form rule`, `integration`, `configure-process`. |
+| #96 elder mode | `yida-density` and custom page design-token templates. |
+| #97 executive mode | `yida-dashboard`, report, chart, and corp-efficiency commands. |
+| #99 app diagnostics | `doctor`, `check-data`, `integration check`, feedback/VOC flows. |
+| #100 Tailwind CSS | Custom page template loads the verified Tailwind browser CDN with fallback. |
+| #101 yida-ai skill | `openyida ai text` and `openyida ai image`. |
+| #67 intelligent form validation | `formula evaluate`, create-form rules, and page/form linting. |
+| #102 BPM process migration | `create-process`, `configure-process`, import/export primitives. |
+| #104 form style reset | `create-form patch`, form-detail, and page styling utilities. |
+| #108 ui-skill | Page templates, design-token sample, and compatibility builder. |
+| #110 cross-organization copy | `export` and `import`. |
+| #111 external JS libraries | `check-page` guidance and `this.utils.loadScript` templates. |
+| #114 PRD and DingTalk Docs MCP | `flash-to-prd`, DWS wrapper, and conversation export. |
+| #115 responsive layout/theme/history.push | Custom page template and new iframe navigation lint. |
+| #25 bug analysis and ticket creation | `doctor --auto-submit`, feedback/VOC helpers. |
+| #22 competitor migration | `export/import`, externalize-form, and PRD generation. |
+| #117 browser plugin | `bridge` and DingTalk link helpers. |
+| #118 PRD approval/version save | `flash-to-prd`, process/integration commands, export-conversation. |
+| #120 version management and DevOps | `batch`, `export/import`, `update`, and full E2E runners. |
+| #121 pre-insert preprocessing | `ai image`, CDN upload, and data create pipeline. |
+| #122 report creation and management | `create-report` and `append-chart`. |
+| #124 custom component authoring/publishing | Custom page build/compile/publish pipeline. |
+| #228 custom component generation | Custom page samples and build pipeline. |
+| #285 native iOS/Android runtime export | Tracked as roadmap; current PR documents non-CLI runtime scope. |
+| #286 publish app to dedicated Wukong | Tracked as roadmap; current PR improves Wukong login handoff and environment handling. |
+| #321 convert Yida app to Wukong card | Tracked as roadmap; current PR confirms agent-card/bridge foundation. |

--- a/lib/app/page-linter.js
+++ b/lib/app/page-linter.js
@@ -604,6 +604,16 @@ function lintYidaSource(sourceCode, filePath) {
       pushIssue(warnings, lineNumber, 'native-select-ui', t('publish.lint_native_select_ui'), disableMap);
     }
 
+    const iframeSelfNavigationMatch = line.match(/<a\b(?=[^>]*(?:aliwork\.com|yidaapps\.com|\/preview\/|\/workbench))(?!(?=[^>]*\btarget=(['"]?)_top\1))(?!(?=[^>]*\btarget=(['"]?)_blank\2))[^>]*>/i);
+    if (iframeSelfNavigationMatch && !isInCommentOrString(line, iframeSelfNavigationMatch.index)) {
+      pushIssue(warnings, lineNumber, 'iframe-self-navigation', t('publish.lint_iframe_self_navigation'), disableMap);
+    }
+
+    const topLocationMatch = line.match(/window\.location\.href\s*=\s*[^;\n]*(?:aliwork\.com|yidaapps\.com|\/preview\/|\/workbench)/i);
+    if (topLocationMatch && !isInCommentOrString(line, topLocationMatch.index) && !line.includes('window.top.location')) {
+      pushIssue(warnings, lineNumber, 'iframe-self-navigation', t('publish.lint_iframe_self_navigation'), disableMap);
+    }
+
     const pageSizeMatch = line.match(/\bpageSize\s*:\s*(\d+)/);
     if (pageSizeMatch && Number(pageSizeMatch[1]) > 100 && !isInCommentOrString(line, pageSizeMatch.index)) {
       pushIssue(errors, lineNumber, 'page-size-limit', t('publish.lint_page_size_limit', pageSizeMatch[1]), disableMap);

--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -1,7 +1,7 @@
 /**
  * update-app.js - 更新宜搭应用信息
  *
- * 用法：openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"]
+ * 用法：openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] [--layout slide|ver]
  */
 
 'use strict';
@@ -29,6 +29,9 @@ function parseArgs(args) {
     desc: null,
     icon: null,
     iconColor: null,
+    colour: null,
+    navTheme: null,
+    layoutDirection: null,
   };
 
   // 第一个参数是 appType
@@ -69,6 +72,28 @@ function parseArgs(args) {
           i++;
         }
         break;
+      case '--theme':
+      case '--colour':
+        if (nextArg) {
+          result.colour = nextArg;
+          i++;
+        }
+        break;
+      case '--nav-theme':
+      case '--navTheme':
+        if (nextArg) {
+          result.navTheme = nextArg;
+          i++;
+        }
+        break;
+      case '--layout':
+      case '--layout-direction':
+      case '--layoutDirection':
+        if (nextArg) {
+          result.layoutDirection = nextArg;
+          i++;
+        }
+        break;
     }
   }
 
@@ -88,7 +113,7 @@ async function run(args) {
   const params = parseArgs(args);
 
   // 验证必填参数
-  const { c, banner, step, label, info, success: chalkSuccess, result: chalkResult, error: chalkError } = require('../core/chalk');
+  const { c, banner, step, label, info, warn, success: chalkSuccess, result: chalkResult, error: chalkError } = require('../core/chalk');
 
   if (!params.appType) {
     chalkError(t('update_app.missing_app_type'), { exit: false });
@@ -96,7 +121,7 @@ async function run(args) {
     process.exit(1);
   }
 
-  if (!params.name && !params.desc && !params.icon) {
+  if (!params.name && !params.desc && !params.icon && !params.colour && !params.navTheme && !params.layoutDirection) {
     chalkError(t('update_app.missing_update_field'), { exit: false });
     printUsage();
     process.exit(1);
@@ -107,6 +132,9 @@ async function run(args) {
   if (params.name) {label('Name', params.name);}
   if (params.desc) {label('Desc', params.desc);}
   if (params.icon) {label('Icon', `${params.icon} ${c.dim}(${params.iconColor || '#0089FF'})${c.reset}`);}
+  if (params.colour || params.navTheme || params.layoutDirection) {
+    label('Theme', `${params.colour || '-'} / ${params.navTheme || '-'} / ${params.layoutDirection || '-'}`);
+  }
 
   // Step 1: 读取登录态
   step(1, t('common.step_login', 1));
@@ -158,6 +186,13 @@ async function run(args) {
     postDataObj.iconUrl = iconValue;
   }
 
+  if (params.colour) {postDataObj.colour = params.colour;}
+  if (params.navTheme) {postDataObj.navTheme = params.navTheme;}
+  if (params.layoutDirection) {
+    postDataObj.layoutDirection = params.layoutDirection;
+    warn(t('update_app.layout_notice'));
+  }
+
   const postData = querystring.stringify(postDataObj);
 
   const response = await requestWithAutoLogin((auth) => {
@@ -182,6 +217,9 @@ async function run(args) {
         name: params.name || undefined,
         desc: params.desc || undefined,
         icon: params.icon || undefined,
+        colour: params.colour || undefined,
+        navTheme: params.navTheme || undefined,
+        layoutDirection: params.layoutDirection || undefined,
       },
     }));
   } else {

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -45,7 +45,7 @@ const COMMAND_GROUPS = [
         output: 'json',
       }),
       command('create-app', ['create-app'], 'create-app "<name>"|--name <name> [options] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_app'),
-      command('update-app', ['update-app'], 'update-app <appType> --name "..."', 'help.cmd_update_app'),
+      command('update-app', ['update-app'], 'update-app <appType> [--name "..."] [--layout slide|ver] [--theme deepBlue]', 'help.cmd_update_app'),
       command('nav-group', ['nav-group'], 'nav-group <list|create|rename|delete|move|hide|show> <appType> ...', 'help.cmd_nav_group', {
         output: 'json',
       }),
@@ -175,6 +175,7 @@ const COMMAND_GROUPS = [
       command('copy', ['copy'], 'copy [--force]', 'help.cmd_copy', { requiresLogin: false }),
       command('sample', ['sample'], 'sample [--list]', 'help.cmd_sample', { requiresLogin: false }),
       command('doctor', ['doctor'], 'doctor [--fix]', 'help.cmd_doctor', { requiresLogin: false }),
+      command('db-seq-fix', ['db-seq-fix'], 'db-seq-fix [--fix]', 'help.cmd_db_seq_fix'),
       command('formula.evaluate', ['formula', 'evaluate'], 'formula evaluate <formula|file> [--schema file]', 'help.cmd_formula_evaluate', {
         requiresLogin: false,
         output: 'text|json',

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_bridge: 'Start OpenYida local web bridge service',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'نسخ دليل عمل project',
     cmd_sample: 'إخراج أمثلة/قوالب الكود',
     cmd_doctor: 'تشخيص البيئة والإصلاح التلقائي',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  حجم الملف: {0} حرف',
       done_meeting: '  التعرف على الاجتماع: {0} حقول بيانات وصفية، {1} أقسام A1، {2} متحدثين',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Maschinenlesbares Command Manifest ausgeben',
     cmd_a2a: 'Lokalen schreibgeschützten A2A-Adapter starten oder Agent Card ausgeben',
     cmd_bridge: 'Lokalen OpenYida Web-Bridge-Dienst starten',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'project-Arbeitsverzeichnis kopieren',
     cmd_sample: 'Codebeispiele/Vorlagen ausgeben',
     cmd_doctor: 'Umgebungsdiagnose & automatische Reparatur',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  Dateigroesse: {0} Zeichen',
       done_meeting: '  Meeting-Erkennung: {0} Metadaten, {1} A1-Abschnitte, {2} Sprecher',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -87,6 +87,7 @@ module.exports = {
     cmd_copy: 'Copy project working directory',
     cmd_sample: 'Output code samples/templates',
     cmd_doctor: 'Environment diagnostics & auto-fix',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_formula_evaluate: 'Static-check Yida formula syntax and field refs',
     cmd_update: 'Check and update to latest version',
     cmd_export_conversation: 'Export AI conversation records',
@@ -802,11 +803,11 @@ Examples:
 
   // ── lib/update-app.js ─────────────────────────────
   update_app: {
-    usage: 'Usage: openyida update-app <appType> --name "New Name" [--desc "Description"] [--icon "icon-name"] [--icon-color "color"]',
-    example: 'Example: openyida update-app APP_XXX --name "New App Name" --desc "New Description"',
-    options: 'Options:\n  --name, -n      App name (required or at least one update field)\n  --desc, -d      App description\n  --icon          Icon name (e.g. xian-yingyong)\n  --icon-color    Icon color (default: #0089FF)',
+    usage: 'Usage: openyida update-app <appType> [--name "New Name"] [--desc "Description"] [--layout slide|ver] [--theme deepBlue]',
+    example: 'Example: openyida update-app APP_XXX --name "New App Name" --layout ver --theme deepBlue',
+    options: 'Options:\n  --name, -n      App name (specify at least one update field)\n  --desc, -d      App description\n  --icon          Icon name (e.g. xian-yingyong)\n  --icon-color    Icon color (default: #0089FF)\n  --theme         App theme colour\n  --nav-theme     Navigation theme navTheme\n  --layout        Layout direction layoutDirection (slide or ver)',
     missing_app_type: 'Error: missing appType argument',
-    missing_update_field: 'Error: at least one update field must be specified (--name, --desc, --icon)',
+    missing_update_field: 'Error: at least one update field must be specified (--name, --desc, --icon, --theme, --nav-theme, --layout)',
     title: '  update-app - Yida App Info Update Tool',
     app_type: '\n  App ID:       {0}',
     new_name: '  New name:     {0}',
@@ -817,6 +818,7 @@ Examples:
     app_type_label: '  appType: {0}',
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
 
   // ── lib/update-form-config.js ──────────────────────
@@ -960,6 +962,7 @@ Examples:
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Emitir manifiesto de comandos legible por máquina',
     cmd_a2a: 'Iniciar adaptador A2A local de solo lectura o imprimir Agent Card',
     cmd_bridge: 'Iniciar servicio local OpenYida web bridge',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'Copiar directorio de trabajo project',
     cmd_sample: 'Generar ejemplos/plantillas de código',
     cmd_doctor: 'Diagnóstico de entorno y reparación automática',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  Tamano del archivo: {0} caracteres',
       done_meeting: '  Reconocimiento de reunion: {0} metadatos, {1} secciones A1, {2} ponentes',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Afficher le manifeste des commandes lisible par machine',
     cmd_a2a: 'Démarrer l’adaptateur A2A local en lecture seule ou afficher l’Agent Card',
     cmd_bridge: 'Démarrer le service web bridge local OpenYida',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'Copier le répertoire de travail project',
     cmd_sample: 'Exporter des exemples/modèles de code',
     cmd_doctor: 'Diagnostic d\'environnement et réparation auto',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  Taille du fichier : {0} caracteres',
       done_meeting: '  Reconnaissance reunion : {0} metadonnees, {1} sections A1, {2} intervenants',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_bridge: 'Start OpenYida local web bridge service',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'project कार्य निर्देशिका कॉपी करें',
     cmd_sample: 'कोड सैंपल/टेम्पलेट आउटपुट करें',
     cmd_doctor: 'वातावरण निदान और स्वचालित मरम्मत',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  File size: {0} characters',
       done_meeting: '  Meeting recognition: {0} metadata, {1} A1 sections, {2} speakers',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -83,6 +83,7 @@ module.exports = {
     cmd_commands: '機械可読コマンド manifest を出力',
     cmd_a2a: 'ローカル読み取り専用 A2A Adapter を起動、または Agent Card を出力',
     cmd_bridge: 'OpenYida ローカル Web ブリッジサービスを起動',
+    cmd_db_seq_fix: 'PostgreSQL Sequence ドリフトを検出・修復',
     cmd_copy: 'project 作業ディレクトリをコピー',
     cmd_sample: 'コードサンプル/テンプレートを出力',
     cmd_doctor: '環境診断と自動修復',
@@ -882,6 +883,7 @@ openyida - Yida CLI ツール
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -1066,6 +1068,9 @@ openyida - Yida CLI ツール
       done_size: '  ファイルサイズ：{0} 文字',
       done_meeting: '  会議認識：メタ情報 {0} 項目、A1 要約 {1} セクション、発言者 {2} 名',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_bridge: 'Start OpenYida local web bridge service',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'project 작업 디렉토리 복사',
     cmd_sample: '코드 샘플/템플릿 출력',
     cmd_doctor: '환경 진단 및 자동 수정',
@@ -464,6 +465,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -676,6 +678,9 @@ module.exports = {
       done_size: '  파일 크기: {0}자',
       done_meeting: '  회의 인식: 메타정보 {0}개, A1 요약 {1}개, 발언자 {2}명',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Emitir manifesto de comandos legível por máquina',
     cmd_a2a: 'Iniciar adaptador A2A local somente leitura ou imprimir Agent Card',
     cmd_bridge: 'Iniciar serviço local OpenYida web bridge',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'Copiar diretório de trabalho project',
     cmd_sample: 'Gerar exemplos/modelos de código',
     cmd_doctor: 'Diagnóstico de ambiente e reparo automático',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  Tamanho do arquivo: {0} caracteres',
       done_meeting: '  Reconhecimento de reuniao: {0} metadados, {1} secoes A1, {2} palestrantes',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -81,6 +81,7 @@ module.exports = {
     cmd_commands: 'Output machine-readable command manifest',
     cmd_a2a: 'Start local read-only A2A adapter or print Agent Card',
     cmd_bridge: 'Start OpenYida local web bridge service',
+    cmd_db_seq_fix: 'Detect and repair PostgreSQL sequence drift',
     cmd_copy: 'Sao chép thư mục làm việc project',
     cmd_sample: 'Xuất mẫu ví dụ/mẫu mã',
     cmd_doctor: 'Chẩn đoán môi trường và sửa tự động',
@@ -462,6 +463,7 @@ module.exports = {
     lint_foreach_callback_function: '.forEach(function ...) may lose this in callbacks; prefer .forEach((item) => ...)',
     lint_controlled_input: 'input uses controlled value mode. Yida pages should use defaultValue + onChange to update _customState',
     lint_native_select_ui: 'Found a native select. User-facing custom page dropdowns should use a Tailwind-styled custom dropdown component for consistent visual quality',
+    lint_iframe_self_navigation: 'Yida custom pages run in an iframe. Use target="_top"/target="_blank" or window.top.location for Yida page navigation to avoid nested pages.',
     lint_page_size_limit: 'pageSize={0} exceeds the Yida API limit of 100; use 100 or less',
     lint_yida_api_catch: 'this.utils.yida API call has no detected .catch(); add error handling and toast the user',
     lint_echarts_legacy_map_china: 'ECharts 5 no longer supports echarts/map/js/china.js. Load DataV GeoJSON and call echarts.registerMap("china", geoJson) instead',
@@ -674,6 +676,9 @@ module.exports = {
       done_size: '  Kich thuoc file: {0} ky tu',
       done_meeting: '  Nhan dang cuoc hop: {0} thong tin, {1} phan A1, {2} nguoi phat bieu',
     },
+  },
+  update_app: {
+    layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
   },
   codex_login: {
     title: '  openyida login {0} - {1} Login Mode',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -83,6 +83,7 @@ module.exports = {
     cmd_commands: '輸出機器可讀命令清單',
     cmd_a2a: '啟動本機唯讀 A2A Adapter 或輸出 Agent Card',
     cmd_bridge: '啟動 OpenYida 本機網頁橋接服務',
+    cmd_db_seq_fix: 'PostgreSQL Sequence 漂移偵測與修復',
     cmd_copy: '複製 project 工作目錄',
     cmd_sample: '輸出程式碼範例/模板',
     cmd_doctor: '環境診斷與自動修復',
@@ -793,6 +794,7 @@ openyida - 宜搭命令列工具
     lint_foreach_callback_function: '.forEach(function ...) 可能導致回調內 this 遺失，建議改為 .forEach((item) => ...)',
     lint_controlled_input: 'input 使用了 value 受控模式，宜搭頁面應使用 defaultValue + onChange 寫入 _customState',
     lint_native_select_ui: '偵測到原生 select。面向用戶的自訂頁面下拉互動應使用 Tailwind 風格的自訂下拉組件，避免瀏覽器原生控件觀感不一致',
+    lint_iframe_self_navigation: '宜搭自訂頁面運行在 iframe 中，跳轉宜搭頁面時請使用 target="_top"/target="_blank" 或 window.top.location，避免頁面套娃',
     lint_page_size_limit: 'pageSize={0} 超過宜搭 API 上限 100，請改為 100 或更小',
     lint_yida_api_catch: 'this.utils.yida API 調用未偵測到 .catch()，請補充錯誤處理並 toast 給用戶',
     lint_echarts_legacy_map_china: 'ECharts 5 已廢棄 echarts/map/js/china.js，請載入 DataV GeoJSON 後調用 echarts.registerMap("china", geoJson)',
@@ -1102,6 +1104,9 @@ openyida - 宜搭命令列工具
     node_submit: '發起提交',
     node_end: '流程結束',
     node_approval: '審批節點',
+  },
+  update_app: {
+    layout_notice: '提示：layoutDirection 由宜搭應用外殼在建立/重新整理時消費；若後台切換後頂部操作欄未立即恢復，請重新開啟工作台或使用目標 layout 重新建立應用。',
   },
   codex_login: {
     title: '  openyida login {0} - {1} 登入模式',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -87,6 +87,7 @@ module.exports = {
     cmd_copy: '复制 project 工作目录',
     cmd_sample: '输出代码示例/模板',
     cmd_doctor: '环境诊断与自动修复',
+    cmd_db_seq_fix: 'PostgreSQL Sequence 漂移检测与修复',
     cmd_formula_evaluate: '静态检查宜搭公式语法和字段引用',
     cmd_update: '检查并更新到最新版本',
     cmd_export_conversation: '导出 AI 对话记录',
@@ -739,11 +740,11 @@ openyida - 宜搭命令行工具
 
   // ── lib/update-app.js ─────────────────────────────
   update_app: {
-    usage: '用法: openyida update-app <appType> --name "新名称" [--desc "描述"] [--icon "图标"] [--icon-color "颜色"]',
-    example: '示例: openyida update-app APP_XXX --name "新应用名称" --desc "新描述"',
-    options: '选项:\n  --name, -n      应用名称（必填或至少一个更新字段）\n  --desc, -d      应用描述\n  --icon          图标名称（如: xian-yingyong）\n  --icon-color    图标颜色（默认: #0089FF）',
+    usage: '用法: openyida update-app <appType> [--name "新名称"] [--desc "描述"] [--layout slide|ver] [--theme deepBlue]',
+    example: '示例: openyida update-app APP_XXX --name "新应用名称" --layout ver --theme deepBlue',
+    options: '选项:\n  --name, -n      应用名称（至少指定一个更新字段）\n  --desc, -d      应用描述\n  --icon          图标名称（如: xian-yingyong）\n  --icon-color    图标颜色（默认: #0089FF）\n  --theme         应用主题 colour\n  --nav-theme     导航主题 navTheme\n  --layout        布局方向 layoutDirection（slide 或 ver）',
     missing_app_type: '错误: 缺少 appType 参数',
-    missing_update_field: '错误: 至少需要指定一个更新字段（--name, --desc, --icon）',
+    missing_update_field: '错误: 至少需要指定一个更新字段（--name, --desc, --icon, --theme, --nav-theme, --layout）',
     title: '  update-app - 宜搭应用信息更新工具',
     app_type: '\n  应用 ID:      {0}',
     new_name: '  新名称:       {0}',
@@ -754,6 +755,7 @@ openyida - 宜搭命令行工具
     app_type_label: '  appType: {0}',
     name_label: '  应用名称: {0}',
     failed: '  ❌ 更新失败: {0}',
+    layout_notice: '提示：layoutDirection 由宜搭应用外壳在创建/刷新时消费；若后台切换后顶部操作栏未立即恢复，请重新打开工作台或使用目标 layout 重新创建应用。',
   },
 
   // ── lib/process/create-process.js ─────────────────
@@ -962,6 +964,7 @@ openyida - 宜搭命令行工具
     lint_foreach_callback_function: '.forEach(function ...) 可能导致回调内 this 丢失，建议改为 .forEach((item) => ...)',
     lint_controlled_input: 'input 使用了 value 受控模式，宜搭页面应使用 defaultValue + onChange 写入 _customState',
     lint_native_select_ui: '检测到原生 select。面向用户的自定义页面下拉交互应使用 Tailwind 风格的自定义下拉组件，避免浏览器原生控件观感不一致',
+    lint_iframe_self_navigation: '宜搭自定义页面运行在 iframe 中，跳转宜搭页面时请使用 target="_top"/target="_blank" 或 window.top.location，避免页面套娃',
     lint_page_size_limit: 'pageSize={0} 超过宜搭接口上限 100，请改为 100 或更小',
     lint_yida_api_catch: 'this.utils.yida API 调用未检测到 .catch()，请补充错误处理并 toast 给用户',
     lint_echarts_legacy_map_china: 'ECharts 5 已废弃 echarts/map/js/china.js，请加载 DataV GeoJSON 后调用 echarts.registerMap("china", geoJson)',

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -29,8 +29,8 @@ const { warn } = require('./chalk');
 const USAGE = `openyida data - Unified Yida data CLI
 
 Usage:
-  openyida data query form <appType> <formUuid> [--page N] [--size N] [--search-json JSON|--search-file .cache/openyida/search.json] [--inst-id ID]
-  openyida data get form <appType> --inst-id <formInstId>
+  openyida data query form <appType> <formUuid> [--page N] [--size N] [--all] [--max-pages N] [--search-json JSON|--search-file .cache/openyida/search.json] [--inst-id ID] [--no-hydrate-subforms]
+  openyida data get form <appType> --inst-id <formInstId> [--form-uuid <formUuid>] [--no-hydrate-subforms]
   openyida data create form <appType> <formUuid> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--dept-id ID]
   openyida data update form <appType> --inst-id <formInstId> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--use-latest-version y]
   openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId> [--page N] [--size N]
@@ -111,6 +111,17 @@ function clampPageSize(options, defaultSize = 20) {
 
   options.size = size;
   options.page = page;
+}
+
+function parsePositiveInt(value, defaultValue, label) {
+  const parsed = Number.parseInt(value || `${defaultValue}`, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    if (label) {
+      parseError(`${label} 必须是正整数`);
+    }
+    return defaultValue;
+  }
+  return parsed;
 }
 
 function requirePositionals(positionals, count, names) {
@@ -230,6 +241,138 @@ function normalizeFormDatasResult(result) {
   return result;
 }
 
+function getResultDataList(result) {
+  if (!result) {return [];}
+  if (Array.isArray(result.data)) {return result.data;}
+  if (result.content && Array.isArray(result.content.data)) {return result.content.data;}
+  if (result.content && Array.isArray(result.content.dataList)) {return result.content.dataList;}
+  return [];
+}
+
+function getResultTotalCount(result) {
+  if (!result) {return 0;}
+  if (result.totalCount !== undefined) {return Number(result.totalCount) || 0;}
+  if (result.content && result.content.totalCount !== undefined) {return Number(result.content.totalCount) || 0;}
+  return 0;
+}
+
+function getFormDataContainer(result) {
+  if (!result || !result.success) {return null;}
+  const candidates = [
+    result.content,
+    result.data,
+    result.content && result.content.data,
+    result.content && result.content.formData,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') {continue;}
+    if (candidate.formData && typeof candidate.formData === 'object') {
+      return candidate.formData;
+    }
+  }
+
+  return null;
+}
+
+function normalizeSubformResult(result) {
+  const normalized = normalizeFormDatasResult(result);
+  return {
+    ...normalized,
+    data: getResultDataList(normalized),
+    totalCount: getResultTotalCount(normalized),
+  };
+}
+
+async function fetchAllPages(fetchPage, options, defaultSize = 100) {
+  const pageSize = Math.min(parsePositiveInt(options.size, defaultSize), 100);
+  const maxPages = parsePositiveInt(options.max_pages, 1000);
+  const firstPage = parsePositiveInt(options.page, 1);
+  const allData = [];
+  let page = firstPage;
+  let lastResult = null;
+  let pagesFetched = 0;
+
+  while (pagesFetched < maxPages) {
+    const result = normalizeFormDatasResult(await fetchPage(page, pageSize));
+    lastResult = result;
+    const data = getResultDataList(result);
+    allData.push(...data);
+    pagesFetched++;
+
+    const totalCount = getResultTotalCount(result);
+    if (totalCount && allData.length >= totalCount) {break;}
+    if (!data.length || data.length < pageSize) {break;}
+    page++;
+  }
+
+  return {
+    ...(lastResult || { success: true }),
+    data: allData,
+    totalCount: getResultTotalCount(lastResult) || allData.length,
+    currentPage: firstPage,
+    pageSize,
+    pagesFetched,
+  };
+}
+
+async function fetchAllSubformRows(session, appType, formUuid, formInstId, tableFieldId, options = {}) {
+  const result = await fetchAllPages((page, size) => sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/listTableDataByFormInstIdAndTableId.json`, {
+    formUuid,
+    formInstanceId: formInstId,
+    tableFieldId,
+    currentPage: String(page),
+    pageSize: String(size),
+  }), {
+    page: 1,
+    size: options.size || 100,
+    max_pages: options.max_pages || 1000,
+  }, 100);
+  return normalizeSubformResult(result);
+}
+
+async function hydrateTruncatedSubforms(result, context) {
+  if (!context || !context.formUuid || !context.formInstId || context.disabled) {
+    return result;
+  }
+
+  const formData = getFormDataContainer(result);
+  if (!formData) {return result;}
+
+  const hydrated = [];
+  const entries = Object.entries(formData);
+  for (const [fieldId, value] of entries) {
+    if (!/^tableField_/.test(fieldId)) {continue;}
+    if (!Array.isArray(value) || value.length < 50) {continue;}
+    if (value.length > 0 && !value.every(item => item && typeof item === 'object')) {continue;}
+
+    const subformResult = await fetchAllSubformRows(
+      context.session,
+      context.appType,
+      context.formUuid,
+      context.formInstId,
+      fieldId,
+      context.options || {}
+    );
+    const rows = subformResult.data || [];
+    if (rows.length > value.length) {
+      formData[fieldId] = rows;
+      hydrated.push({
+        fieldId,
+        originalCount: value.length,
+        hydratedCount: rows.length,
+      });
+    }
+  }
+
+  if (hydrated.length > 0) {
+    const target = result.content && typeof result.content === 'object' ? result.content : result;
+    target._openyidaHydratedSubforms = hydrated;
+  }
+
+  return result;
+}
+
 function printResult(result) {
   const errorCode = result && result.errorCode;
   const hasErrorCode = errorCode !== undefined && errorCode !== null && errorCode !== '' && errorCode !== 0 && errorCode !== '0';
@@ -250,13 +393,41 @@ function printFormDatasResult(result) {
 async function queryForm(positionals, options, session) {
   requirePositionals(positionals, 2, ['appType', 'formUuid']);
   const [appType, formUuid] = positionals;
-  clampPageSize(options);
+  clampPageSize(options, options.all ? 100 : 20);
 
   let result;
   if (options.inst_id) {
     result = await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
       formInstId: options.inst_id,
     });
+    result = await hydrateTruncatedSubforms(result, {
+      session,
+      appType,
+      formUuid,
+      formInstId: options.inst_id,
+      disabled: !!options.no_hydrate_subforms,
+      options,
+    });
+  } else if (options.all) {
+    const searchJson = readJsonOption(options, 'search_json', 'search_file', '查询条件');
+    result = await fetchAllPages((page, size) => {
+      const params = {
+        formUuid,
+        appType,
+        currentPage: String(page),
+        pageSize: String(size),
+      };
+      if (searchJson) {
+        params.searchFieldJson = searchJson;
+      }
+      for (const key of ['originator_id', 'create_from', 'create_to', 'modified_from', 'modified_to', 'dynamic_order']) {
+        if (options[key]) {params[snakeToCamel(key)] = options[key];}
+      }
+      const requestPath = options.ids_only
+        ? `/dingtalk/web/${appType}/v1/form/searchFormDataIds.json`
+        : `/dingtalk/web/${appType}/v1/form/searchFormDatas.json`;
+      return sendGet(session, appType, requestPath, params);
+    }, options, 100);
   } else {
     const params = {
       formUuid,
@@ -284,8 +455,16 @@ async function getForm(positionals, options, session) {
   requirePositionals(positionals, 1, ['appType']);
   requireOption(options, 'inst_id');
   const [appType] = positionals;
-  printResult(await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
+  const result = await sendGet(session, appType, `/dingtalk/web/${appType}/v1/form/getFormDataById.json`, {
     formInstId: options.inst_id,
+  });
+  printResult(await hydrateTruncatedSubforms(result, {
+    session,
+    appType,
+    formUuid: options.form_uuid,
+    formInstId: options.inst_id,
+    disabled: !!options.no_hydrate_subforms,
+    options,
   }));
 }
 
@@ -299,7 +478,7 @@ async function createForm(positionals, options, session) {
     formDataJson: dataJson,
   };
   if (options.dept_id) {params.deptId = options.dept_id;}
-  printResult(await sendPost(session, appType, `/dingtalk/web/${appType}/v1/form/saveFormData.json`, params));
+  printResult(await sendPost(session, appType, `/alibaba/web/${appType}/_/saveFormData.json`, params));
 }
 
 async function updateForm(positionals, options, session) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -433,6 +433,10 @@ function isCsrfTokenExpired(responseJson) {
   );
 }
 
+function isHttpRedirectStatus(statusCode) {
+  return [301, 302, 303, 307, 308].includes(Number(statusCode));
+}
+
 // ── base_url 解析 ─────────────────────────────────────
 
 /**
@@ -513,6 +517,14 @@ function httpPost(baseUrl, requestPath, postData, cookies, optionsOverride = {})
       res.on('end', () => {
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
+        }
+        if (isHttpRedirectStatus(res.statusCode)) {
+          resolve({
+            __needLogin: true,
+            __httpStatus: res.statusCode,
+            __location: res.headers.location || '',
+          });
+          return;
         }
         try {
           const parsed = JSON.parse(data);
@@ -598,6 +610,14 @@ function httpGet(baseUrl, requestPath, queryParams, cookies, optionsOverride = {
       res.on('end', () => {
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
+        }
+        if (isHttpRedirectStatus(res.statusCode)) {
+          resolve({
+            __needLogin: true,
+            __httpStatus: res.statusCode,
+            __location: res.headers.location || '',
+          });
+          return;
         }
         try {
           const parsed = JSON.parse(data);

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -166,6 +166,7 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('agent-center');
     expect(commands).toContain('dingtalk-link');
     expect(commands).toContain('externalize-form');
+    expect(commands).toContain('db-seq-fix');
     expect(commands).toContain('commands');
     expect(commands).toContain('a2a');
     expect(commands).toContain('ai');
@@ -503,7 +504,7 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('login falls back to QR handoff in Wukong environment when CDP is unavailable', () => {
+  test('login returns Wukong browser handoff instead of desktop fallback when CDP is unavailable', () => {
     const wukong = createWukongWorkRoot();
     try {
       const output = runOkWithEnv(['login'], {
@@ -516,14 +517,13 @@ describe('CLI offline smoke', () => {
       }, wukong.projectDir);
       const parsed = JSON.parse(output.trim());
       expect(parsed).toMatchObject({
-        status: 'need_qr_scan',
-        handoff_type: 'qr',
+        status: 'need_codex_browser_login',
+        handoff_type: 'browser',
+        browser: 'wukong',
         can_auto_use: false,
       });
-      expect(parsed.qr_url).toContain('https://login.example.test/qr');
-      expect(parsed.qr_image_markdown).toContain('![OpenYida login QR code](');
-      expect(parsed.agent_response_markdown).toContain('![OpenYida login QR code](');
-      expect(parsed.poll_command).toContain('openyida login --agent-poll');
+      expect(parsed.login_url).toBe('https://example.test/workPlatform');
+      expect(parsed.fallback_command).toContain('openyida login --browser');
     } finally {
       fs.rmSync(wukong.base, { recursive: true, force: true });
     }

--- a/tests/page-linter.test.js
+++ b/tests/page-linter.test.js
@@ -169,6 +169,24 @@ export function renderJsx() {
     expect(warningRules).toContain('native-select-ui');
   });
 
+  test('warns when Yida page links navigate inside the iframe', () => {
+    const source = `
+export function renderJsx() {
+  return (
+    <div>
+      <a href="https://www.aliwork.com/APP_XXX/preview/PAGE_XXX">bad</a>
+      <a href="https://www.aliwork.com/APP_XXX/preview/PAGE_YYY" target="_top">ok</a>
+    </div>
+  );
+}
+`;
+
+    const result = lintYidaSource(source, '/tmp/iframe-nav.jsx');
+    const warningRules = result.warnings.map(issue => issue.rule);
+
+    expect(warningRules).toContain('iframe-self-navigation');
+  });
+
   test('custom page template uses verified Tailwind preflight and custom dropdown reset', () => {
     const sourcePath = path.join(__dirname, '..', 'lib', 'samples', 'yida-custom-page', 'custom-page-template.js');
     const source = fs.readFileSync(sourcePath, 'utf-8');

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -242,6 +242,39 @@ describe('run() query form', () => {
     }
   });
 
+  test('--all 自动分页拉取完整表单数据', async () => {
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          totalCount: 3,
+          data: [{ id: 'A' }, { id: 'B' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          totalCount: 3,
+          data: [{ id: 'C' }],
+        },
+      });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--all', '--size', '2']);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
+    expect(utils.httpGet.mock.calls[0][2]).toMatchObject({ currentPage: '1', pageSize: '2' });
+    expect(utils.httpGet.mock.calls[1][2]).toMatchObject({ currentPage: '2', pageSize: '2' });
+    expect(mockLog.mock.calls[0][0]).toContain('"pagesFetched": 2');
+    expect(mockLog.mock.calls[0][0]).toContain('"id": "C"');
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
   test('同时传入 --search-json 和 --search-file 时打印错误并退出', async () => {
     const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit(1)');
@@ -274,6 +307,48 @@ describe('run() get form', () => {
     await run(['get', 'form', 'APP_XXX', '--inst-id', 'INST-001']);
     expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"success": true'));
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('传入 --form-uuid 时补全被 50 条截断的子表数据', async () => {
+    const truncatedRows = Array.from({ length: 50 }, (_, index) => ({ rowId: `old-${index}` }));
+    const hydratedRows = Array.from({ length: 60 }, (_, index) => ({ rowId: `new-${index}` }));
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          formInstId: 'INST-001',
+          formData: {
+            textField_1: 'ok',
+            tableField_1: truncatedRows,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          totalCount: 60,
+          data: hydratedRows,
+        },
+      });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['get', 'form', 'APP_XXX', '--inst-id', 'INST-001', '--form-uuid', 'FORM-XXX']);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
+    expect(utils.httpGet.mock.calls[1][2]).toMatchObject({
+      formUuid: 'FORM-XXX',
+      formInstanceId: 'INST-001',
+      tableFieldId: 'tableField_1',
+      pageSize: '100',
+    });
+    expect(mockLog.mock.calls[0][0]).toContain('"hydratedCount": 60');
+    expect(mockLog.mock.calls[0][0]).toContain('"rowId": "new-59"');
 
     mockLog.mockRestore();
     mockError.mockRestore();
@@ -350,6 +425,7 @@ describe('run() create form', () => {
     try {
       await run(['create', 'form', 'APP_XXX', 'FORM-XXX', '--data-file', dataPath]);
       expect(utils.httpPost).toHaveBeenCalledTimes(1);
+      expect(utils.httpPost.mock.calls[0][1]).toBe('/alibaba/web/APP_XXX/_/saveFormData.json');
       expect(decodeURIComponent(utils.httpPost.mock.calls[0][2])).toContain('formDataJson={"textField_1":"from-file"}');
       expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"success": true'));
     } finally {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
+const http = require('http');
 
 // 测试目标模块
 const {
@@ -13,6 +14,8 @@ const {
   loadCookieData,
   detectActiveTool,
   resolveWukongWorkspaceRoot,
+  httpPost,
+  httpGet,
 } = require('../lib/core/utils');
 
 // ── extractInfoFromCookies ────────────────────────────────────────────
@@ -163,6 +166,62 @@ describe('isCsrfTokenExpired', () => {
 
   test('null 时返回 falsy', () => {
     expect(isCsrfTokenExpired(null)).toBeFalsy();
+  });
+});
+
+// ── HTTP redirect login detection ────────────────────────────────────
+
+describe('http redirect login detection', () => {
+  function listen(server) {
+    return new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+    });
+  }
+
+  test('httpPost 将 302 跳转识别为需要重新登录', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = 302;
+      res.setHeader('Location', '/login.html');
+      res.end('LOGIN FAILED');
+    });
+    const port = await listen(server);
+
+    try {
+      const result = await httpPost(`http://127.0.0.1:${port}`, '/bad', '', [
+        { name: 'tianshu_csrf_token', value: 'tok' },
+      ], { silentStatus: true });
+
+      expect(result).toMatchObject({
+        __needLogin: true,
+        __httpStatus: 302,
+        __location: '/login.html',
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('httpGet 将 307 跳转识别为需要重新登录', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = 307;
+      res.setHeader('Location', '/workPlatform');
+      res.end('LOGIN FAILED');
+    });
+    const port = await listen(server);
+
+    try {
+      const result = await httpGet(`http://127.0.0.1:${port}`, '/bad', { a: 1 }, [
+        { name: 'tianshu_csrf_token', value: 'tok' },
+      ], { silentStatus: true });
+
+      expect(result).toMatchObject({
+        __needLogin: true,
+        __httpStatus: 307,
+        __location: '/workPlatform',
+      });
+    } finally {
+      server.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- fixes data query/get truncation by adding --all pagination and subform hydration for tableField_* detail rows
- switches form creation to the current saveFormData endpoint and treats HTTP redirects as login-expired signals
- improves Wukong login handoff, app layout/theme updates, iframe navigation linting, and db-seq-fix command exposure
- documents the full 2026-05-26 open issue review map in docs/open-issues-2026-05-26.md

## Tests
- npm run lint
- npm run check:syntax
- npm run test:unit -- --runInBand
- npm run check:structure
- npm run check:skills
- npm run build:skills
- npm run check:package
- npm test -- --runTestsByPath tests/query-data.test.js tests/utils.test.js tests/page-linter.test.js tests/cli-smoke.test.js --runInBand
- git diff --check

## System smoke
- node bin/yida.js login --check-only --json succeeded with valid cached Aliwork credentials
- node bin/yida.js commands --json confirms db-seq-fix and update-app layout usage
- YIDA_QUIET=1 node bin/yida.js app-list --size 1 still times out against aliwork.com in this environment
- Chrome opened Aliwork but the Chrome profile redirected to DingTalk login, so authenticated browser smoke was blocked

Fixes #365
Fixes #330
Fixes #191
Fixes #107
Fixes #57
Fixes #24