### PR TITLE
[codex] Fix OpenCode login browser fallback

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -27,6 +27,7 @@ function isAgentEnvironment(env) {
     env.CLAUDE_CODE ||
     env.CLAUDE_CODE_ENTRYPOINT ||
     env.OPENCODE ||
+    env.OPENCODE_CLIENT ||
     env.QODER_IDE ||
     env.QODER_AGENT ||
     env.QODERCLI_INTEGRATION_MODE ||
@@ -287,7 +288,7 @@ function noteLoginCommandResult(result) {
 
 function isAgentConversationEnvironment() {
   const { detectActiveTool } = require('../lib/core/utils');
-  return !!detectActiveTool();
+  return !!detectActiveTool() || process.env.OPENYIDA_AGENT_MODE === '1';
 }
 
 function shouldUseBrowserHandoffLogin(cliArgs) {
@@ -303,12 +304,13 @@ function shouldUseAgentLogin(cliArgs) {
 }
 
 function shouldUsePlaywrightFallbackInAgentLogin() {
-  const { detectActiveTool } = require('../lib/core/utils');
-  const activeTool = detectActiveTool();
-  if (activeTool && activeTool.tool === 'wukong') {
-    return false;
-  }
-  return process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK === '1';
+  const { hasDesktopEnvironment } = require('../lib/core/utils');
+  return hasDesktopEnvironment() || process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK === '1';
+}
+
+function shouldUseDesktopBrowserLogin() {
+  const { hasDesktopEnvironment } = require('../lib/core/utils');
+  return hasDesktopEnvironment();
 }
 
 function shouldUseCodexQrLogin(cliArgs) {
@@ -479,12 +481,6 @@ async function main() {
         } else {
           const { detectActiveTool } = require('../lib/core/utils');
           const activeTool = detectActiveTool();
-          if (activeTool && activeTool.tool === 'wukong') {
-            const { codexLogin } = require('../lib/auth/codex-login');
-            const result = await codexLogin({ tool: 'wukong' });
-            printLoginResult(result);
-            break;
-          }
           const { interactiveLogin } = require('../lib/auth/login');
           const browserResult = interactiveLogin({
             playwrightFallback: shouldUsePlaywrightFallbackInAgentLogin(),
@@ -493,10 +489,10 @@ async function main() {
             printLoginResult(browserResult);
           } else {
             // CDP/Playwright 失败后的兜底策略：
-            // QoderWork 有 in-app browser，优先使用 browser handoff；其余走终端二维码
-            if (activeTool && activeTool.tool === 'qoderwork') {
+            // Wukong/QoderWork 有 in-app browser，优先使用 browser handoff；其余走 AI 对话框 QR handoff。
+            if (activeTool && (activeTool.tool === 'wukong' || activeTool.tool === 'qoderwork')) {
               const { codexLogin } = require('../lib/auth/codex-login');
-              const result = await codexLogin({ tool: 'qoderwork' });
+              const result = await codexLogin({ tool: activeTool.tool });
               printLoginResult(result);
             } else {
               const { startCodexQrLogin } = require('../lib/auth/qr-login');
@@ -520,6 +516,14 @@ async function main() {
           printLoginResult(cachedResult);
           break;
         }
+        if (shouldUseDesktopBrowserLogin()) {
+          const { interactiveLogin } = require('../lib/auth/login');
+          const browserResult = interactiveLogin({ playwrightFallback: true });
+          if (browserResult) {
+            printLoginResult(browserResult);
+            break;
+          }
+        }
         const { qrLogin } = require('../lib/auth/qr-login');
         const result = await qrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });
         printLoginResult(result);
@@ -540,9 +544,25 @@ async function main() {
       if (subCommand === 'status') {
         authStatus();
       } else if (subCommand === 'login') {
-        const authArgs = [subCommand, ...applyLoginEnvironmentFlags(args.slice(1))];
-        const loginType = shouldUseBrowserHandoffLogin(authArgs) ? 'browser' : 'qrcode';
-        await authLogin({ type: loginType, corpId: getArgValue(authArgs, '--corp-id') });
+        const authArgs = applyLoginEnvironmentFlags(args.slice(1));
+        let loginType = 'qrcode';
+        if (authArgs.includes('--codex')) {
+          loginType = 'codex';
+        } else if (authArgs.includes('--qoder')) {
+          loginType = 'qoder';
+        } else if (authArgs.includes('--wukong')) {
+          loginType = 'wukong';
+        } else if (authArgs.includes('--browser')) {
+          loginType = 'browser';
+        }
+        const result = await authLogin({
+          type: loginType,
+          corpId: getArgValue(authArgs, '--corp-id'),
+          forceTerminalQr: authArgs.includes('--qr'),
+        });
+        if (result) {
+          printLoginResult(result);
+        }
       } else if (subCommand === 'refresh') {
         authRefresh();
       } else if (subCommand === 'logout') {

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -18,8 +18,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { findProjectRoot, loadCookieData, extractInfoFromCookies, resolveBaseUrl } = require('../core/utils');
-const { logout, checkLoginOnly } = require('./login');
+const { findProjectRoot, loadCookieData, extractInfoFromCookies, resolveBaseUrl, detectActiveTool, hasDesktopEnvironment } = require('../core/utils');
+const { logout, checkLoginOnly, interactiveLogin } = require('./login');
 const { t } = require('../core/i18n');
 
 const AUTH_CACHE_FILE = '.cache/auth.json';
@@ -135,7 +135,7 @@ function authStatus() {
  * @returns {Promise<object>|object} 登录结果
  */
 async function authLogin(options = {}) {
-  const { type = 'qrcode', corpId } = options;
+  const { type = 'qrcode', corpId, forceTerminalQr = false } = options;
 
   const { c, info, success: chalkSuccess, label } = require('../core/chalk');
   info(t('auth.login_start', type));
@@ -143,14 +143,21 @@ async function authLogin(options = {}) {
   // 调用现有的登录逻辑
   let result;
   const cachedResult = checkLoginOnly({ includeSecrets: true });
-  if (type === 'browser' || type === 'codex' || type === 'qoder' || type === 'wukong') {
-    result = cachedResult.status === 'ok'
-      ? cachedResult
-      : await require('./codex-login').codexLogin();
+  if (cachedResult.status === 'ok') {
+    result = cachedResult;
+  } else if (type === 'browser') {
+    result = interactiveLogin({ playwrightFallback: true });
+  } else if (type === 'codex' || type === 'qoder' || type === 'wukong') {
+    result = await require('./codex-login').codexLogin({
+      tool: type,
+    });
+  } else if (type === 'qrcode' && !forceTerminalQr && isAgentConversationEnvironment()) {
+    result = await loginInAgentConversation({ corpId });
+  } else if (type === 'qrcode' && !forceTerminalQr && hasDesktopEnvironment()) {
+    result = interactiveLogin({ playwrightFallback: true }) ||
+      await require('./qr-login').qrLogin({ corpId });
   } else {
-    result = cachedResult.status === 'ok'
-      ? cachedResult
-      : await require('./qr-login').qrLogin({ corpId });
+    result = await require('./qr-login').qrLogin({ corpId });
   }
 
   if (!result) {
@@ -176,6 +183,31 @@ async function authLogin(options = {}) {
   }
 
   return result;
+}
+
+function isAgentConversationEnvironment() {
+  return !!detectActiveTool() || process.env.OPENYIDA_AGENT_MODE === '1';
+}
+
+function shouldUsePlaywrightFallbackInAgentLogin() {
+  return hasDesktopEnvironment() || process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK === '1';
+}
+
+async function loginInAgentConversation(options = {}) {
+  const activeTool = detectActiveTool();
+
+  const browserResult = interactiveLogin({
+    playwrightFallback: shouldUsePlaywrightFallbackInAgentLogin(),
+  });
+  if (browserResult) {
+    return browserResult;
+  }
+
+  if (activeTool && (activeTool.tool === 'wukong' || activeTool.tool === 'qoderwork')) {
+    return require('./codex-login').codexLogin({ tool: activeTool.tool });
+  }
+
+  return require('./qr-login').startCodexQrLogin({ corpId: options.corpId });
 }
 
 // ── 刷新登录态 ────────────────────────────────────────

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -101,8 +101,9 @@ function detectActiveTool() {
   }
 
   // OpenCode
-  // Windows 上配置目录为 ~/.config/opencode，macOS/Linux 为 ~/.opencode
-  if (env.OPENCODE) {
+  // Windows 上配置目录为 ~/.config/opencode，macOS/Linux 为 ~/.opencode。
+  // OpenCode 当前运行时会暴露 OPENCODE_CLIENT；保留 OPENCODE 兼容旧检测。
+  if (env.OPENCODE || env.OPENCODE_CLIENT) {
     const opencodeDirName = process.platform === 'win32'
       ? path.join('.config', 'opencode')
       : '.opencode';
@@ -139,6 +140,30 @@ function detectActiveTool() {
 
   // 未检测到活跃工具
   return null;
+}
+
+function hasDesktopEnvironment(env = process.env, platform = process.platform) {
+  if (env.OPENYIDA_FORCE_TERMINAL_QR === '1') {
+    return false;
+  }
+  if (env.OPENYIDA_ASSUME_DESKTOP === '1') {
+    return true;
+  }
+  if (env.CI || env.CODEX_CI) {
+    return false;
+  }
+  if (platform === 'darwin' || platform === 'win32') {
+    return true;
+  }
+  if (platform === 'linux') {
+    return !!(
+      env.DISPLAY ||
+      env.WAYLAND_DISPLAY ||
+      env.MIR_SOCKET ||
+      ['x11', 'wayland'].includes(String(env.XDG_SESSION_TYPE || '').toLowerCase())
+    );
+  }
+  return false;
 }
 
 /**
@@ -700,6 +725,7 @@ async function requestWithAutoLogin(requestFn, authRef) {
 
 module.exports = {
   detectActiveTool,
+  hasDesktopEnvironment,
   findProjectRoot,
   extractInfoFromCookies,
   loadCookieData,

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -37,10 +37,13 @@ function cliEnv() {
     CLAUDE_CODE: '',
     CLAUDE_CODE_ENTRYPOINT: '',
     OPENCODE: '',
+    OPENCODE_CLIENT: '',
     CURSOR_TRACE_ID: '',
     VSCODE_GIT_ASKPASS_NODE: '',
     AGENT_WORK_ROOT: '',
     OPENYIDA_AGENT_MODE: '',
+    OPENYIDA_ASSUME_DESKTOP: '',
+    OPENYIDA_FORCE_TERMINAL_QR: '',
     __CFBundleIdentifier: '',
   };
 }
@@ -282,7 +285,7 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('login falls back to QR handoff in Codex environment when CDP is unavailable', () => {
+  test('login falls back to QR handoff in Codex environment when CDP is unavailable and no desktop is present', () => {
     const workspace = createCodexWorkspace();
     try {
       const output = runOkWithEnv(['login'], {
@@ -310,7 +313,7 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('login falls back to QR handoff in Qoder environment when CDP is unavailable', () => {
+  test('login falls back to QR handoff in Qoder environment when CDP is unavailable and no desktop is present', () => {
     const workspace = createCodexWorkspace();
     try {
       const output = runOkWithEnv(['login'], {
@@ -335,7 +338,7 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('login falls back to QR handoff in Claude Code environment when CDP is unavailable', () => {
+  test('login falls back to QR handoff in Claude Code environment when CDP is unavailable and no desktop is present', () => {
     const workspace = createCodexWorkspace();
     try {
       const output = runOkWithEnv(['login'], {
@@ -359,11 +362,11 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('login falls back to QR handoff in OpenCode environment when CDP is unavailable', () => {
+  test('login falls back to QR handoff in OpenCode environment when CDP is unavailable and no desktop is present', () => {
     const workspace = createCodexWorkspace();
     try {
       const output = runOkWithEnv(['login'], {
-        OPENCODE: '1',
+        OPENCODE_CLIENT: 'cli',
         OPENYIDA_ENV: 'public',
         OPENYIDA_LOGIN_URL: 'https://example.test/workPlatform',
         OPENYIDA_DISABLE_CDP_LOGIN: '1',
@@ -376,6 +379,29 @@ describe('CLI offline smoke', () => {
         can_auto_use: false,
       });
       expect(parsed.qr_image_markdown).toContain('![OpenYida login QR code](');
+      expect(parsed.agent_response_markdown).toContain('![OpenYida login QR code](');
+      expect(parsed.poll_command).toContain('openyida login --agent-poll');
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('auth login uses QR handoff in OpenCode environment when CDP is unavailable and no desktop is present', () => {
+    const workspace = createCodexWorkspace();
+    try {
+      const output = runOkWithEnv(['auth', 'login'], {
+        OPENCODE_CLIENT: 'cli',
+        OPENYIDA_ENV: 'public',
+        OPENYIDA_LOGIN_URL: 'https://example.test/workPlatform',
+        OPENYIDA_DISABLE_CDP_LOGIN: '1',
+        OPENYIDA_CODEX_QR_FAKE: '1',
+      }, workspace);
+      const parsed = JSON.parse(output.trim());
+      expect(parsed).toMatchObject({
+        status: 'need_qr_scan',
+        handoff_type: 'qr',
+        can_auto_use: false,
+      });
       expect(parsed.agent_response_markdown).toContain('![OpenYida login QR code](');
       expect(parsed.poll_command).toContain('openyida login --agent-poll');
     } finally {

--- a/tests/codex-login.test.js
+++ b/tests/codex-login.test.js
@@ -24,6 +24,7 @@ describe('codexLogin', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -183,6 +183,7 @@ describe('detectActiveTool Windows 路径兼容', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;
@@ -202,6 +203,7 @@ describe('detectActiveTool Windows 路径兼容', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -522,6 +522,9 @@ describe('interactiveLogin 浏览器优先级', () => {
     delete process.env.CODEX_THREAD_ID;
     delete process.env.CODEX_HOME;
     delete process.env.AGENT_WORK_ROOT;
+    delete process.env.OPENYIDA_ASSUME_DESKTOP;
+    delete process.env.OPENYIDA_FORCE_TERMINAL_QR;
+    delete process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK;
   }
 
   function loadLoginWithMocks(cdpImpl, execSyncImpl) {
@@ -721,6 +724,75 @@ describe('checkLoginOnly 独立测试', () => {
   });
 });
 
+describe('authLogin 登录优先级', () => {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-auth-login-'));
+    process.chdir(tmpDir);
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) {delete process.env[key];}
+    });
+    Object.assign(process.env, originalEnv);
+    jest.dontMock('../lib/auth/login');
+    jest.dontMock('../lib/auth/qr-login');
+    jest.dontMock('../lib/core/utils');
+    jest.dontMock('../lib/core/chalk');
+    jest.resetModules();
+  });
+
+  test('OpenCode 有桌面环境时 CDP 失败后启用 Playwright 兜底', async () => {
+    const cookies = [
+      { name: 'tianshu_csrf_token', value: 'desktop-token-1234567890' },
+    ];
+    const interactiveLogin = jest.fn(() => ({
+      csrf_token: 'desktop-token-1234567890',
+      corp_id: 'corp',
+      user_id: 'user',
+      base_url: 'https://www.aliwork.com',
+      cookies,
+    }));
+    const qrLogin = jest.fn(() => {
+      throw new Error('terminal QR should not be used');
+    });
+
+    jest.doMock('../lib/auth/login', () => ({
+      checkLoginOnly: jest.fn(() => ({ status: 'not_logged_in' })),
+      interactiveLogin,
+      logout: jest.fn(),
+    }));
+    jest.doMock('../lib/auth/qr-login', () => ({ qrLogin }));
+    jest.doMock('../lib/core/utils', () => ({
+      findProjectRoot: jest.fn(() => tmpDir),
+      loadCookieData: jest.fn(),
+      extractInfoFromCookies: jest.fn(),
+      resolveBaseUrl: jest.fn(),
+      detectActiveTool: jest.fn(() => ({ tool: 'opencode' })),
+      hasDesktopEnvironment: jest.fn(() => true),
+    }));
+    jest.doMock('../lib/core/chalk', () => ({
+      info: jest.fn(),
+      success: jest.fn(),
+      label: jest.fn(),
+    }));
+
+    const { authLogin } = require('../lib/auth/auth');
+    const result = await authLogin();
+
+    expect(interactiveLogin).toHaveBeenCalledWith({ playwrightFallback: true });
+    expect(qrLogin).not.toHaveBeenCalled();
+    expect(result.csrf_token).toBe('desktop-token-1234567890');
+  });
+});
+
 //─ findProjectRoot 环境检测───────────────────────
 
 describe('findProjectRoot 环境检测', () => {
@@ -735,6 +807,7 @@ describe('findProjectRoot 环境检测', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;
@@ -835,6 +908,7 @@ describe('findProjectRoot 环境检测', () => {
     delete process.env.CODEX_SHELL;
     delete process.env.AGENT_WORK_ROOT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.CURSOR_TRACE_ID;
     delete process.env.TERM_PROGRAM;
 
@@ -892,6 +966,7 @@ describe('detectActiveTool', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;
@@ -989,6 +1064,7 @@ describe('detectActiveTool', () => {
     delete process.env.CODEX_SHELL;
     delete process.env.AGENT_WORK_ROOT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.CURSOR_TRACE_ID;
     delete process.env.TERM_PROGRAM;
 
@@ -1010,6 +1086,16 @@ describe('detectActiveTool', () => {
 
   test('OpenCode 环境识别', () => {
     process.env.OPENCODE = '1';
+    const { detectActiveTool: detectTool } = require('../lib/core/utils');
+
+    const tool = detectTool();
+    expect(tool).not.toBeNull();
+    expect(tool.tool).toBe('opencode');
+    expect(tool.displayName).toBe('OpenCode');
+  });
+
+  test('OpenCode 官方 OPENCODE_CLIENT 环境识别', () => {
+    process.env.OPENCODE_CLIENT = 'cli';
     const { detectActiveTool: detectTool } = require('../lib/core/utils');
 
     const tool = detectTool();

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -13,6 +13,7 @@ const {
   isCsrfTokenExpired,
   loadCookieData,
   detectActiveTool,
+  hasDesktopEnvironment,
   resolveWukongWorkspaceRoot,
   httpPost,
   httpGet,
@@ -64,6 +65,28 @@ describe('extractInfoFromCookies', () => {
     const result = extractInfoFromCookies(cookies);
     expect(result.corpId).toBeNull();
     expect(result.userId).toBeNull();
+  });
+});
+
+// ── hasDesktopEnvironment ─────────────────────────────────────────────
+
+describe('hasDesktopEnvironment', () => {
+  test('CI 环境视为无桌面，除非显式声明有桌面', () => {
+    expect(hasDesktopEnvironment({ CI: '1', DISPLAY: ':0' }, 'linux')).toBe(false);
+    expect(hasDesktopEnvironment({ CI: '1', OPENYIDA_ASSUME_DESKTOP: '1' }, 'linux')).toBe(true);
+  });
+
+  test('Linux 需要图形会话信号才视为有桌面', () => {
+    expect(hasDesktopEnvironment({}, 'linux')).toBe(false);
+    expect(hasDesktopEnvironment({ DISPLAY: ':0' }, 'linux')).toBe(true);
+    expect(hasDesktopEnvironment({ WAYLAND_DISPLAY: 'wayland-0' }, 'linux')).toBe(true);
+    expect(hasDesktopEnvironment({ XDG_SESSION_TYPE: 'wayland' }, 'linux')).toBe(true);
+  });
+
+  test('macOS 和 Windows 默认视为有桌面，强制 terminal QR 时除外', () => {
+    expect(hasDesktopEnvironment({}, 'darwin')).toBe(true);
+    expect(hasDesktopEnvironment({}, 'win32')).toBe(true);
+    expect(hasDesktopEnvironment({ OPENYIDA_FORCE_TERMINAL_QR: '1' }, 'darwin')).toBe(false);
   });
 });
 
@@ -399,6 +422,7 @@ describe('detectActiveTool', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;
@@ -436,6 +460,13 @@ describe('detectActiveTool', () => {
     expect(result.tool).toBe('opencode');
   });
 
+  test('OPENCODE_CLIENT 环境变量时检测为 OpenCode', () => {
+    delete process.env.CLAUDE_CODE;
+    process.env.OPENCODE_CLIENT = 'cli';
+    const result = detectActiveTool();
+    expect(result.tool).toBe('opencode');
+  });
+
   test('QODER_IDE 环境变量时检测为 Qoder（优先级最高）', () => {
     process.env.QODER_IDE = '1';
     process.env.CLAUDE_CODE = '1';
@@ -457,6 +488,7 @@ describe('detectActiveTool', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODERCLI_INTEGRATION_MODE;
     delete process.env.CODEX_SHELL;
@@ -484,6 +516,7 @@ describe('detectActiveTool', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;
@@ -515,6 +548,7 @@ describe('detectActiveTool', () => {
     delete process.env.CLAUDE_CODE;
     delete process.env.CLAUDE_CODE_ENTRYPOINT;
     delete process.env.OPENCODE;
+    delete process.env.OPENCODE_CLIENT;
     delete process.env.QODER_IDE;
     delete process.env.QODER_AGENT;
     delete process.env.QODERCLI_INTEGRATION_MODE;


### PR DESCRIPTION
## Summary

- Detect OpenCode via `OPENCODE_CLIENT` as well as the legacy `OPENCODE` signal.
- Prefer real browser login when a desktop environment is available: cached credentials, then CDP, then Playwright, with terminal QR only as the no-desktop or explicit `--qr` fallback.
- Align `openyida auth login` with the main login flow and add coverage for OpenCode, desktop detection, and fallback behavior.

## Root Cause

OpenCode sessions can expose `OPENCODE_CLIENT` without `OPENCODE`, so OpenYida sometimes failed to detect the active AI tool and fell through to the plain terminal QR path. The agent login path also disabled Playwright by default, even when a GUI browser flow was available.

## Validation

- `node --check bin/yida.js`
- `node --check lib/core/utils.js`
- `node --check lib/auth/auth.js`
- `npm test -- --runTestsByPath tests/login.test.js tests/utils.test.js tests/cli-smoke.test.js`
- `npm test -- --runTestsByPath tests/cli-smoke.test.js tests/login.test.js tests/utils.test.js tests/codex-login.test.js tests/copy.test.js`
