### PR TITLE
[codex] 支持表单智能校验能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida create-form update <appType> <formUuid> <changes.json> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Update a form page |
 | `openyida create-form patch <appType> <formUuid> <patch.json> [--open\|--no-open]` | Apply controlled schema patches for designer-only form settings |
 | `openyida create-form rule <appType> <formUuid> <rules.json> [--open\|--no-open]` | Configure field show/hide linkage and onChange auto-assignment rules |
-| `openyida create-form validation <appType> <formUuid> <validations.json> [--open\|--no-open]` | Configure form validations using Yida-native settings: TextField `validationType` plus field `props.validation` / `customValidate` JSExpression rules for regex, bank card, cross-field, conditional, or async checks |
+| `openyida create-form validation <appType> <formUuid> <validations.json> [--open\|--no-open]` | Configure form validations using Yida-visible field `props.validation` rules and `customValidate` JSExpression functions for regex, bank card, cross-field, conditional, or async checks |
 | `openyida add-validation <appType> <formUuid> --field <labelOrId> --type <phone\|regex\|idCard\|email\|...> [--message <text>]` | Add one smart validation rule without writing a JSON file |
 | `openyida create-form bind-datasource <appType> <formUuid> <fieldLabelOrId> <datasource.json> [--open\|--no-open]` | Bind URL/search data sources to SelectField/MultiSelectField-style option fields |
 | `openyida create-form add-option <appType> <formUuid> <fieldLabel> <option1> [option2] ...` | Append options to a SelectField/RadioField/CheckboxField/MultiSelectField |
@@ -326,7 +326,7 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida publish <sourceFile> <appType> <formUuid> [--compat] [--health-check] [--force] [--open\|--no-open]` | Compile and publish a custom display page; by default the target must be `formType=display` |
 | `openyida update-form-config <appType> <formUuid> <isRenderNav> <title> [--locale zh_CN\|en_US\|ja_JP]` | Update page/form display configuration |
 
-Form field definitions can include `alias` or `componentAlias` to populate Yida designer component aliases, stored as `pages[0].componentAlias.items`.
+Form field definitions can include `alias` or `componentAlias` to populate Yida designer component aliases, stored as `pages[0].componentAlias.items`. Yida runtime resolves these aliases in page JS, so `this.$('phone')` can be used instead of `this.$('textField_xxx')`; OpenYida form rules and validations also accept aliases as field references. For server-side DingTalk OpenAPI calls, use `GET /v2.0/yida/forms/component/alias/{appType}/{formUuid}` to read the `{ fieldId, alias }` mapping, then translate aliases before sending form data/search JSON. That endpoint requires `systemToken`, `userId`, an access token, and the Yida form data read permission; grant that permission in DingTalk developer console API permissions and publish the DingTalk app. Yida app code and app secret are available under app settings > deployment/maintenance.
 
 `openyida publish` preserves existing custom page data sources by default. Before saving the new compiled JSX Schema, it reads the current page Schema and merges the Page-level `dataSource` with the built-in `urlParams` and `timestamp` sources, so manually configured data sources are not deleted during republish.
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida create-form update <appType> <formUuid> <changes.json> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Update a form page |
 | `openyida create-form patch <appType> <formUuid> <patch.json> [--open\|--no-open]` | Apply controlled schema patches for designer-only form settings |
 | `openyida create-form rule <appType> <formUuid> <rules.json> [--open\|--no-open]` | Configure field show/hide linkage and onChange auto-assignment rules |
+| `openyida create-form validation <appType> <formUuid> <validations.json> [--open\|--no-open]` | Configure form validations using Yida-native settings: TextField `validationType` plus field `props.validation` / `customValidate` JSExpression rules for regex, bank card, cross-field, conditional, or async checks |
+| `openyida add-validation <appType> <formUuid> --field <labelOrId> --type <phone\|regex\|idCard\|email\|...> [--message <text>]` | Add one smart validation rule without writing a JSON file |
 | `openyida create-form bind-datasource <appType> <formUuid> <fieldLabelOrId> <datasource.json> [--open\|--no-open]` | Bind URL/search data sources to SelectField/MultiSelectField-style option fields |
 | `openyida create-form add-option <appType> <formUuid> <fieldLabel> <option1> [option2] ...` | Append options to a SelectField/RadioField/CheckboxField/MultiSelectField |
 | `openyida list-forms <appType> [--keyword <text>]` | List forms in an application |
@@ -323,6 +325,8 @@ For overseas apps, pass `--locale en_US` or `--locale ja_JP` on creation command
 | `openyida compile <sourceFile> [--compat]` | Compile a custom page locally; `.oyd.jsx` sources are compatibility-built first |
 | `openyida publish <sourceFile> <appType> <formUuid> [--compat] [--health-check] [--force] [--open\|--no-open]` | Compile and publish a custom display page; by default the target must be `formType=display` |
 | `openyida update-form-config <appType> <formUuid> <isRenderNav> <title> [--locale zh_CN\|en_US\|ja_JP]` | Update page/form display configuration |
+
+Form field definitions can include `alias` or `componentAlias` to populate Yida designer component aliases, stored as `pages[0].componentAlias.items`.
 
 `openyida publish` preserves existing custom page data sources by default. Before saving the new compiled JSX Schema, it reads the current page Schema and merges the Page-level `dataSource` with the built-in `urlParams` and `timestamp` sources, so manually configured data sources are not deleted during republish.
 

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -642,6 +642,12 @@ async function main() {
       break;
     }
 
+    case 'add-validation': {
+      process.argv = [process.argv[0], process.argv[1], 'validation', ...args];
+      require('../lib/app/create-form');
+      break;
+    }
+
     case 'list-forms': {
       const { run } = require('../lib/app/list-forms');
       await run(args);

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -201,6 +201,26 @@ function parseArgs() {
     };
   }
 
+  if (mode === 'validation' || mode === 'validate' || mode === 'validations') {
+    const inlineRule = parseInlineValidationOptions(args.slice(3));
+    if (args.length < 4 && !inlineRule) {
+      usage(
+        'openyida create-form validation <appType> <formUuid> <validationsJsonOrFile>',
+        'openyida create-form validation APP_XXX FORM-XXX .cache/openyida/forms/form-validations.json'
+      );
+      hint('openyida add-validation APP_XXX FORM-XXX --field "手机号" --type phone --message "请输入正确的手机号"');
+      process.exit(1);
+    }
+    return {
+      mode: 'validation',
+      appType: args[1],
+      formUuid: args[2],
+      validationJsonOrFile: inlineRule ? '' : args[3],
+      inlineValidationRule: inlineRule,
+      ...options
+    };
+  }
+
   if (mode === 'bind-datasource' || mode === 'datasource' || mode === 'data-source') {
     if (args.length < 5) {
       usage(
@@ -238,7 +258,7 @@ function parseArgs() {
   }
 
   // 兼容旧用法（无 mode 参数，默认 create 模式）
-  if (args.length >= 3 && mode !== 'create' && mode !== 'update' && mode !== 'patch' && mode !== 'rule' && mode !== 'rules' && mode !== 'bind-datasource' && mode !== 'datasource' && mode !== 'data-source') {
+  if (args.length >= 3 && mode !== 'create' && mode !== 'update' && mode !== 'patch' && mode !== 'rule' && mode !== 'rules' && mode !== 'validation' && mode !== 'validate' && mode !== 'validations' && mode !== 'bind-datasource' && mode !== 'datasource' && mode !== 'data-source') {
     return {
       mode: 'create',
       appType: args[0],
@@ -285,6 +305,7 @@ function readFieldsDefinition(fieldsJsonOrFile) {
     // 1. 数组格式: [{type: "TextField", label: "姓名"}, ...]
     // 2. 对象格式: { columns: 2, fields: [{type: "TextField", label: "姓名"}, ...] }
     let fields;
+    let validations = [];
     let columns = 1; // 默认单列
 
     if (Array.isArray(parsed)) {
@@ -292,6 +313,11 @@ function readFieldsDefinition(fieldsJsonOrFile) {
     } else if (typeof parsed === 'object' && parsed !== null) {
       fields = parsed.fields || [];
       columns = parsed.columns !== undefined ? parsed.columns : 1;
+      validations = Array.isArray(parsed.validations)
+        ? parsed.validations
+        : Array.isArray(parsed.rules)
+          ? parsed.rules
+          : [];
     } else {
       throw new Error(t('create_form.fields_format_invalid'));
     }
@@ -300,7 +326,7 @@ function readFieldsDefinition(fieldsJsonOrFile) {
       throw new Error(t('create_form.fields_must_be_array'));
     }
 
-    return { fields, columns };
+    return { fields, columns, validations };
   } catch (parseError) {
     error(t('create_form.fields_parse_failed') + parseError.message);
   }
@@ -407,6 +433,117 @@ function readRuleDefinition(rulesJsonOrFile) {
     throw new Error('规则必须是数组、{rules: []} 或单个规则对象');
   } catch (parseError) {
     error('规则 JSON 解析失败: ' + parseError.message);
+  }
+}
+
+function parseMaybeJsonValue(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+function parseInlineValidationOptions(tokens) {
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    return null;
+  }
+
+  const rule = {};
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (!token || !token.startsWith('--')) {
+      continue;
+    }
+    const key = token.slice(2).replace(/-/g, '_');
+    const next = tokens[index + 1];
+    if (next && !next.startsWith('--')) {
+      rule[key] = parseMaybeJsonValue(next);
+      index++;
+    } else {
+      rule[key] = true;
+    }
+  }
+
+  if (!rule.field && !rule.field_id && !rule.label && !rule.target && !rule.type) {
+    return null;
+  }
+
+  if (rule.field_id && !rule.fieldId) {
+    rule.fieldId = rule.field_id;
+  }
+  if (rule.domain_whitelist && !rule.domainWhitelist) {
+    rule.domainWhitelist = String(rule.domain_whitelist).split(',').map(function (item) {
+      return item.trim();
+    }).filter(Boolean);
+  }
+  if (rule.compare_to && !rule.compareTo) {
+    rule.compareTo = rule.compare_to;
+  }
+  if (rule.other_field && !rule.otherField) {
+    rule.otherField = rule.other_field;
+  }
+
+  return rule;
+}
+
+function readValidationDefinition(validationJsonOrFile, inlineRule) {
+  if (inlineRule) {
+    return [inlineRule];
+  }
+
+  let rawContent;
+  if (validationJsonOrFile.trimStart().startsWith('[') || validationJsonOrFile.trimStart().startsWith('{')) {
+    rawContent = validationJsonOrFile;
+  } else {
+    const resolvedPath = path.resolve(validationJsonOrFile);
+    if (!fs.existsSync(resolvedPath)) {
+      error('校验规则文件不存在: ' + resolvedPath);
+    }
+    rawContent = fs.readFileSync(resolvedPath, 'utf-8');
+  }
+
+  try {
+    const parsed = JSON.parse(rawContent);
+    if (Array.isArray(parsed)) {
+      if (parsed.length === 0) {
+        throw new Error('校验规则数组不能为空');
+      }
+      return parsed;
+    }
+    if (parsed && typeof parsed === 'object') {
+      if (Array.isArray(parsed.validations)) {
+        if (parsed.validations.length === 0) {
+          throw new Error('validations 数组不能为空');
+        }
+        return parsed.validations;
+      }
+      if (Array.isArray(parsed.rules)) {
+        if (parsed.rules.length === 0) {
+          throw new Error('rules 数组不能为空');
+        }
+        return parsed.rules;
+      }
+      if (parsed.type || parsed.field || parsed.fieldId || parsed.target || parsed.when) {
+        return [parsed];
+      }
+    }
+    throw new Error('校验规则必须是数组、{validations: []}、{rules: []} 或单个规则对象');
+  } catch (parseError) {
+    error('校验规则 JSON 解析失败: ' + parseError.message);
   }
 }
 
@@ -653,6 +790,205 @@ function applySelectDataSourceConfig(props, config) {
   return normalized;
 }
 
+function normalizeValidationType(type) {
+  const normalized = String(type || '').trim();
+  const lower = normalized.toLowerCase();
+  const typeMap = {
+    mobile: 'mobile',
+    phone: 'mobile',
+    tel: 'mobile',
+    cellphone: 'mobile',
+    regex: 'regex',
+    regexp: 'regex',
+    pattern: 'regex',
+    idcard: 'chineseID',
+    id_card: 'chineseID',
+    identitycard: 'chineseID',
+    identity_card: 'chineseID',
+    chineseid: 'chineseID',
+    chinese_id: 'chineseID',
+    bankcard: 'bankCard',
+    bank_card: 'bankCard',
+    luhn: 'bankCard',
+    uscc: 'unifiedSocialCreditCode',
+    creditcode: 'unifiedSocialCreditCode',
+    credit_code: 'unifiedSocialCreditCode',
+    unifiedsocialcreditcode: 'unifiedSocialCreditCode',
+    unified_social_credit_code: 'unifiedSocialCreditCode',
+    mail: 'email',
+    e_mail: 'email',
+    required: 'required',
+    compare: 'compare',
+    crossfield: 'compare',
+    cross_field: 'compare',
+    daterange: 'compare',
+    date_range: 'compare',
+    dateorder: 'compare',
+    date_order: 'compare',
+    conditionalrequired: 'conditionalRequired',
+    conditional_required: 'conditionalRequired',
+    expression: 'custom',
+    javascript: 'custom',
+    js: 'custom',
+    customvalidate: 'customValidate',
+    custom_validate: 'customValidate',
+    async: 'async',
+    remote: 'async',
+  };
+  return typeMap[lower] || normalized;
+}
+
+function defaultValidationMessage(type) {
+  const messages = {
+    required: i18n('此项为必填项', 'This field is required', 'この項目は必須です'),
+    regex: i18n('格式不正确', 'Invalid format', '形式が正しくありません'),
+    mobile: i18n('请输入正确的手机号', 'Please enter a valid phone number', '正しい電話番号を入力してください'),
+    phone: i18n('请输入正确的手机号', 'Please enter a valid phone number', '正しい電話番号を入力してください'),
+    idCard: i18n('身份证号不合法', 'Invalid ID card number', '身分証番号が正しくありません'),
+    chineseID: i18n('身份证号不合法', 'Invalid ID card number', '身分証番号が正しくありません'),
+    bankCard: i18n('银行卡号不合法', 'Invalid bank card number', '銀行カード番号が正しくありません'),
+    unifiedSocialCreditCode: i18n('统一社会信用代码不合法', 'Invalid unified social credit code', '統一社会信用コードが正しくありません'),
+    email: i18n('请输入正确的邮箱地址', 'Please enter a valid email address', '正しいメールアドレスを入力してください'),
+    compare: i18n('字段间逻辑校验未通过', 'Cross-field validation failed', 'フィールド間検証に失敗しました'),
+    conditionalRequired: i18n('此项在当前条件下为必填项', 'This field is required for the current condition', '現在の条件ではこの項目は必須です'),
+    custom: i18n('自定义校验未通过', 'Custom validation failed', 'カスタム検証に失敗しました'),
+    customValidate: i18n('自定义校验未通过', 'Custom validation failed', 'カスタム検証に失敗しました'),
+    async: i18n('异步校验未通过', 'Async validation failed', '非同期検証に失敗しました'),
+  };
+  return messages[type] || i18n('校验未通过', 'Validation failed', '検証に失敗しました');
+}
+
+function normalizeDesignerValidationRule(rule) {
+  if (!rule) {
+    return null;
+  }
+  if (typeof rule === 'string') {
+    return { type: normalizeValidationType(rule), message: defaultValidationMessage(normalizeValidationType(rule)) };
+  }
+  if (typeof rule !== 'object') {
+    return null;
+  }
+
+  const type = normalizeValidationType(rule.type || rule.validator || rule.kind || (rule.pattern ? 'regex' : ''));
+  if (!type) {
+    return null;
+  }
+
+  const normalized = Object.assign({}, rule, {
+    type,
+    message: rule.message || rule.errorMessage || rule.tips || defaultValidationMessage(type),
+  });
+
+  if (rule.regex !== undefined && normalized.pattern === undefined) {
+    normalized.pattern = rule.regex;
+  }
+  if (rule.domain_whitelist && !normalized.domainWhitelist) {
+    normalized.domainWhitelist = String(rule.domain_whitelist).split(',').map(function (item) {
+      return item.trim();
+    }).filter(Boolean);
+  }
+
+  return normalized;
+}
+
+function isNativeFieldValidationRule(rule) {
+  if (!rule || rule.condition || rule.when || rule.api || rule.url || rule.endpoint || rule.targetFieldId) {
+    return false;
+  }
+  if (rule.type === 'email' && rule.domainWhitelist && rule.domainWhitelist.length) {
+    return false;
+  }
+  return [
+    'required',
+    'number',
+    'email',
+    'mobile',
+    'url',
+    'maxLength',
+    'minLength',
+    'minValue',
+    'maxValue',
+    'date',
+    'money',
+    'zipcode',
+    'phone',
+    'ip',
+    'mac',
+    'chineseID',
+    'customValidate',
+  ].indexOf(rule.type) !== -1;
+}
+
+function validationRuleSignature(rule) {
+  const param = rule && rule.param && typeof rule.param === 'object'
+    ? JSON.stringify(rule.param)
+    : rule && rule.param;
+  return [
+    rule && rule.type,
+    rule && rule.pattern,
+    param,
+    rule && rule.targetFieldId,
+    rule && rule.operator,
+    rule && rule.api,
+    rule && rule.expression,
+    rule && rule.condition ? JSON.stringify(rule.condition) : '',
+  ].map(function (value) {
+    return value === undefined ? '' : String(value);
+  }).join('|');
+}
+
+function dedupeValidationRules(rules) {
+  const seen = new Set();
+  return (rules || []).filter(function (rule) {
+    const signature = validationRuleSignature(rule);
+    if (seen.has(signature)) {
+      return false;
+    }
+    seen.add(signature);
+    return true;
+  });
+}
+
+function collectInputValidationRules(field, options) {
+  const rules = [];
+  const includeAdvanced = !!(options && options.includeAdvanced);
+  const sourceRules = Array.isArray(field && field.validation)
+    ? field.validation
+    : Array.isArray(field && field.validations)
+      ? field.validations
+      : [];
+
+  if (field && field.required) {
+    rules.push({
+      type: 'required',
+      message: field.requiredMessage || field.message || defaultValidationMessage('required'),
+    });
+  }
+
+  if (field && (field.pattern || field.regex)) {
+    rules.push({
+      type: 'regex',
+      pattern: field.pattern || field.regex,
+      message: field.message || defaultValidationMessage('regex'),
+    });
+  }
+
+  sourceRules.forEach(function (rule) {
+    const normalized = normalizeDesignerValidationRule(rule);
+    if (normalized && (includeAdvanced || isNativeFieldValidationRule(normalized))) {
+      rules.push(normalized);
+    }
+  });
+
+  return dedupeValidationRules(rules);
+}
+
+function normalizeFieldValidationRules(field, options) {
+  return dedupeValidationRules(collectInputValidationRules(field, options).map(function (rule) {
+    return toDesignerValidationRule(rule);
+  }).filter(Boolean));
+}
+
 // ── 字段类型名容错映射 ───────────────────────────────
 // 宜搭后端枚举对大小写敏感，此映射自动纠正常见的拼写差异
 const FIELD_TYPE_ALIAS = {
@@ -690,6 +1026,26 @@ const FIELD_TYPE_ALIAS = {
   serialnumberfield: 'SerialNumberField',
 };
 
+const COMPONENT_ALIAS_META = Symbol('openyida.componentAlias');
+
+function normalizeComponentAlias(field) {
+  if (!field || typeof field !== 'object') {
+    return '';
+  }
+  const rawAlias = field.componentAlias !== undefined
+    ? field.componentAlias
+    : field.component_alias !== undefined
+      ? field.component_alias
+      : field.alias;
+  if (rawAlias === undefined || rawAlias === null || rawAlias === false) {
+    return '';
+  }
+  if (typeof rawAlias === 'object') {
+    return String(rawAlias.alias || rawAlias.name || '').trim();
+  }
+  return String(rawAlias).trim();
+}
+
 // ── 生成字段组件 ─────────────────────────────────────
 
 function buildFieldComponent(field) {
@@ -698,10 +1054,7 @@ function buildFieldComponent(field) {
   const nodeId = nextNodeId();
 
   // 基础 validation
-  const validation = [];
-  if (field.required) {
-    validation.push({ type: 'required' });
-  }
+  const validation = normalizeFieldValidationRules(field);
 
   // 基础 props（所有字段通用）
   const props = {
@@ -1267,6 +1620,11 @@ function buildFieldComponent(field) {
     conditionGroup: '',
   };
 
+  const componentAlias = normalizeComponentAlias(field);
+  if (componentAlias) {
+    component[COMPONENT_ALIAS_META] = componentAlias;
+  }
+
   // TableField：递归处理子字段
   if (componentName === 'TableField' && field.children) {
     component.children = field.children.map(function (childField) {
@@ -1302,6 +1660,33 @@ function buildComponentsMap(componentNames) {
       componentName: name,
     };
   });
+}
+
+function buildComponentAliasItems(components) {
+  const items = [];
+  const usedAliases = Object.create(null);
+
+  function visit(component) {
+    if (!component || typeof component !== 'object') {
+      return;
+    }
+    const fieldId = component.fieldId || (component.props && component.props.fieldId);
+    const alias = component[COMPONENT_ALIAS_META];
+    if (fieldId && alias) {
+      let finalAlias = alias;
+      if (usedAliases[finalAlias] && usedAliases[finalAlias] !== fieldId) {
+        finalAlias = finalAlias + '_' + fieldId;
+      }
+      usedAliases[finalAlias] = fieldId;
+      items.push({ fieldId, alias: finalAlias });
+    }
+    if (Array.isArray(component.children)) {
+      component.children.forEach(visit);
+    }
+  }
+
+  (components || []).forEach(visit);
+  return items;
 }
 
 // ── 从 fieldId 前缀推断组件类型 ─────────────────────
@@ -1618,31 +2003,16 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
   const fieldComponents = fields.map(function (field) {
     return buildFieldComponent(field);
   });
+  const formContainerChildren = layoutConfig.groupFields
+    ? buildGroupedFieldComponents(fields, layoutConfig.formLayout)
+    : fieldComponents;
 
   // 为 SerialNumberField 设置 formula（需要 corpId、appType 和 formUuid）
-  fieldComponents.forEach(function (component) {
-    if (component.componentName === 'SerialNumberField' && component.props) {
-      const fieldId = component.props.fieldId;
-      const serialNumberRule = component.props.serialNumberRule;
-
-      // 直接使用 serialNumberRule 构建 formula.expression
-      // value 的值就是 serialNumberRule 数组本身
-      const ruleJson = JSON.stringify({
-        type: 'custom',
-        value: serialNumberRule
-      });
-
-      // 转义 JSON 字符串中的引号和反斜杠，用于嵌入到 expression 字符串中
-      const escapedRuleJson = ruleJson.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-
-      component.props.formula = {
-        expression: 'SERIALNUMBER("' + corpId + '", "' + appType + '", "' + formUuid + '", "' + fieldId + '", "' + escapedRuleJson + '")'
-      };
-    }
-  });
+  fillSerialNumberFormulas(formContainerChildren, corpId, appType, formUuid);
 
   // 解析 @label:字段名 引用（必须在所有字段构建完成后执行）
-  resolveFieldIdReferences(fieldComponents);
+  resolveFieldIdReferences(formContainerChildren);
+  const componentAliasItems = buildComponentAliasItems(formContainerChildren);
 
   const componentNames = collectComponentNames(fields);
 
@@ -1761,9 +2131,7 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
               title: '',
               isLocked: false,
               conditionGroup: '',
-              children: layoutConfig.groupFields
-                ? buildGroupedFieldComponents(fields, layoutConfig.formLayout)
-                : fieldComponents,
+              children: formContainerChildren,
             },
           ],
         },
@@ -1818,7 +2186,7 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
     componentsMap: buildComponentsMap(componentNames),
     componentsTree: pageComponentsTree,
     componentAlias: {
-      items: [],
+      items: componentAliasItems,
     },
     id: formUuid,
     connectComponent: [],
@@ -2749,14 +3117,33 @@ function isValidActionIdentifier(value) {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(String(value || ''));
 }
 
-function upsertGeneratedSourceBlock(existingSource, generatedSource) {
+function upsertGeneratedSourceBlockWithBounds(existingSource, generatedSource, blockStart, blockEnd) {
   const source = existingSource || '';
-  const startIndex = source.indexOf(FORM_RULES_BLOCK_START);
-  const endIndex = source.indexOf(FORM_RULES_BLOCK_END);
+  const startIndex = source.indexOf(blockStart);
+  const endIndex = source.indexOf(blockEnd);
   const cleanSource = startIndex !== -1 && endIndex !== -1 && endIndex > startIndex
-    ? source.slice(0, startIndex).trimEnd() + source.slice(endIndex + FORM_RULES_BLOCK_END.length)
+    ? source.slice(0, startIndex).trimEnd() + source.slice(endIndex + blockEnd.length)
     : source;
-  return cleanSource.trimEnd() + '\n\n' + FORM_RULES_BLOCK_START + '\n' + generatedSource.trim() + '\n' + FORM_RULES_BLOCK_END + '\n';
+  return cleanSource.trimEnd() + '\n\n' + blockStart + '\n' + generatedSource.trim() + '\n' + blockEnd + '\n';
+}
+
+function removeGeneratedSourceBlockWithBounds(existingSource, blockStart, blockEnd) {
+  const source = existingSource || '';
+  const startIndex = source.indexOf(blockStart);
+  const endIndex = source.indexOf(blockEnd);
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+    return source;
+  }
+  return (source.slice(0, startIndex).trimEnd() + source.slice(endIndex + blockEnd.length)).trim();
+}
+
+function upsertGeneratedSourceBlock(existingSource, generatedSource) {
+  return upsertGeneratedSourceBlockWithBounds(
+    existingSource,
+    generatedSource,
+    FORM_RULES_BLOCK_START,
+    FORM_RULES_BLOCK_END
+  );
 }
 
 function upsertActionListEntry(actions, entry) {
@@ -3043,11 +3430,619 @@ function applyFormRules(schema, rawRules) {
   };
 }
 
+// ── 表单智能校验（validation 模式 / add-validation）──────────────────
+
+const SMART_VALIDATION_BLOCK_START = '/* openyida:smart-validation:start */';
+const SMART_VALIDATION_BLOCK_END = '/* openyida:smart-validation:end */';
+
+function normalizeSmartValidationCondition(fieldLookup, condition) {
+  if (!condition || typeof condition !== 'object') {
+    return null;
+  }
+  return normalizeRuntimeCondition(fieldLookup, condition, '条件字段');
+}
+
+function resolveSmartRuleField(fieldLookup, rule, role) {
+  const fieldRef = rule.fieldId || rule.field || rule.label || rule.target || rule.name;
+  return resolveRuleField(fieldLookup, fieldRef, role || '校验字段');
+}
+
+function normalizeSmartValidationRule(fieldLookup, rule, index) {
+  if (!rule || typeof rule !== 'object') {
+    throw new Error('校验规则[' + (index + 1) + '] 必须是对象');
+  }
+
+  let type = normalizeValidationType(rule.type || rule.validator || rule.kind || (rule.pattern ? 'regex' : ''));
+  if (type === 'required' && rule.when) {
+    type = 'conditionalRequired';
+  }
+  if (!type) {
+    throw new Error('校验规则[' + (index + 1) + '] 缺少 type');
+  }
+
+  if (type === 'compare') {
+    const leftRef = rule.fieldId || rule.field || rule.source || rule.left || rule.start;
+    const rightRef = rule.targetFieldId || rule.target || rule.compareTo || rule.compare_to || rule.otherField || rule.other_field || rule.right || rule.end;
+    const left = resolveRuleField(fieldLookup, leftRef, '比较字段');
+    const right = resolveRuleField(fieldLookup, rightRef, '被比较字段');
+    return {
+      id: rule.id || 'validation_' + (index + 1),
+      type,
+      fieldId: left.fieldId,
+      fieldLabel: left.label,
+      targetFieldId: right.fieldId,
+      targetLabel: right.label,
+      operator: rule.operator || rule.op || rule.compare || '<=',
+      message: rule.message || rule.errorMessage || defaultValidationMessage(type),
+    };
+  }
+
+  if (type === 'conditionalRequired') {
+    const target = resolveSmartRuleField(fieldLookup, rule, '必填字段');
+    const when = rule.when || rule.condition || {};
+    const condition = normalizeSmartValidationCondition(fieldLookup, when);
+    if (!condition || condition.operator === 'always') {
+      throw new Error('条件必填规则[' + (index + 1) + '] 必须提供 when.field');
+    }
+    return {
+      id: rule.id || 'validation_' + (index + 1),
+      type,
+      fieldId: target.fieldId,
+      fieldLabel: target.label,
+      condition,
+      message: rule.message || rule.errorMessage || defaultValidationMessage(type),
+    };
+  }
+
+  const field = resolveSmartRuleField(fieldLookup, rule, '校验字段');
+  const normalized = {
+    id: rule.id || 'validation_' + (index + 1),
+    type,
+    fieldId: field.fieldId,
+    fieldLabel: field.label,
+    componentName: field.componentName,
+    message: rule.message || rule.errorMessage || rule.tips || defaultValidationMessage(type),
+  };
+
+  if (rule.pattern !== undefined || rule.regex !== undefined) {
+    normalized.pattern = String(rule.pattern !== undefined ? rule.pattern : rule.regex);
+  }
+  if (Array.isArray(rule.domainWhitelist)) {
+    normalized.domainWhitelist = rule.domainWhitelist;
+  } else if (rule.domain_whitelist) {
+    normalized.domainWhitelist = String(rule.domain_whitelist).split(',').map(function (item) {
+      return item.trim();
+    }).filter(Boolean);
+  }
+  if (rule.region !== undefined) {
+    normalized.region = rule.region;
+  }
+  if (rule.expression !== undefined || rule.formula !== undefined || rule.source !== undefined) {
+    normalized.expression = String(rule.expression !== undefined ? rule.expression : rule.formula !== undefined ? rule.formula : rule.source);
+  }
+  if (rule.api || rule.url || rule.endpoint) {
+    normalized.api = rule.api || rule.url || rule.endpoint;
+    normalized.method = rule.method || 'POST';
+    normalized.headers = rule.headers || {};
+    normalized.body = rule.body;
+    normalized.validPath = rule.validPath || rule.valid_path || '';
+  }
+  if (type === 'async' && !normalized.api) {
+    throw new Error('异步校验规则[' + (index + 1) + '] 必须提供 api/url/endpoint');
+  }
+  if (rule.when || rule.condition) {
+    normalized.condition = normalizeSmartValidationCondition(fieldLookup, rule.when || rule.condition);
+  }
+
+  return normalized;
+}
+
+function normalizeSmartValidationRules(formContainer, rawRules) {
+  if (!formContainer || !Array.isArray(formContainer.children)) {
+    throw new Error('未找到 FormContainer');
+  }
+  const fieldLookup = buildFieldLookup(formContainer.children);
+  const normalizedRules = rawRules.map(function (rule, index) {
+    return normalizeSmartValidationRule(fieldLookup, rule, index);
+  });
+
+  const fieldMap = {};
+  fieldLookup.descriptors.forEach(function (descriptor) {
+    fieldMap[descriptor.fieldId] = descriptor.fieldId;
+    if (descriptor.label) {
+      fieldMap[descriptor.label] = descriptor.fieldId;
+    }
+  });
+
+  return {
+    rules: normalizedRules,
+    fieldLookup,
+    fieldMap,
+  };
+}
+
+function toDesignerValidationRule(rule) {
+  if (!rule) {
+    return null;
+  }
+
+  if (rule.type === 'regex') {
+    return {
+      type: 'customValidate',
+      param: buildCustomValidateExpressionParam(rule),
+      message: rule.message,
+    };
+  }
+
+  if (isAdvancedValidationRule(rule)) {
+    return {
+      type: 'customValidate',
+      param: buildCustomValidateExpressionParam(rule),
+      message: rule.message,
+    };
+  }
+
+  if (!isNativeFieldValidationRule(rule)) {
+    return null;
+  }
+  if (rule.type === 'customValidate' && !rule.param) {
+    return null;
+  }
+
+  const designerRule = {
+    type: rule.type,
+    message: rule.message,
+  };
+  ['param', 'minLength', 'maxLength', 'minValue', 'maxValue'].forEach(function (key) {
+    if (rule[key] !== undefined) {
+      designerRule[key] = key === 'param' && rule.type === 'customValidate'
+        ? normalizeCustomValidateParam(rule[key])
+        : rule[key];
+    }
+  });
+  return designerRule;
+}
+
+function isAdvancedValidationRule(rule) {
+  if (!rule || isNativeFieldValidationRule(rule)) {
+    return false;
+  }
+  return ['bankCard', 'unifiedSocialCreditCode', 'email', 'compare', 'conditionalRequired', 'custom', 'async'].indexOf(rule.type) !== -1;
+}
+
+function applyTextFieldValidationType(field, rule) {
+  if (!field || field.componentName !== 'TextField' || !field.props || !rule) {
+    return;
+  }
+  const formatValidationTypes = ['mobile', 'email', 'url', 'chineseID'];
+  if (formatValidationTypes.indexOf(rule.type) !== -1) {
+    field.props.validationType = rule.type;
+  }
+}
+
+function jsString(value) {
+  return JSON.stringify(value === undefined ? '' : value);
+}
+
+function normalizeCustomValidateParam(param) {
+  if (param && typeof param === 'object' && param.type === 'JSExpression') {
+    return param;
+  }
+  return {
+    type: 'JSExpression',
+    value: String(param || 'function validateRule(value) { return true; }'),
+  };
+}
+
+function buildCustomValidateExpressionParam(rule) {
+  return normalizeCustomValidateParam(buildCustomValidateParam(rule));
+}
+
+function buildCustomValidateParam(rule) {
+  if (rule.type === 'customValidate' && rule.param) {
+    return typeof rule.param === 'object' && rule.param.type === 'JSExpression'
+      ? String(rule.param.value || '')
+      : String(rule.param);
+  }
+
+  const fieldId = jsString(rule.fieldId);
+  const targetFieldId = jsString(rule.targetFieldId || '');
+  const operator = jsString(rule.operator || '<=');
+  const pattern = jsString(rule.pattern || '');
+  const expression = jsString(rule.expression || 'true');
+  const condition = JSON.stringify(rule.condition || null);
+  const domainWhitelist = JSON.stringify(rule.domainWhitelist || []);
+  const api = jsString(rule.api || '');
+  const method = jsString(rule.method || 'POST');
+  const headers = JSON.stringify(rule.headers || {});
+  const body = JSON.stringify(rule.body === undefined ? null : rule.body);
+  const validPath = jsString(rule.validPath || '');
+
+  return `function validateRule(value, currentRule) {
+  var FIELD_ID = ${fieldId};
+  var TARGET_FIELD_ID = ${targetFieldId};
+  var OPERATOR = ${operator};
+  var PATTERN = ${pattern};
+  var EXPRESSION = ${expression};
+  var CONDITION = ${condition};
+  var DOMAIN_WHITELIST = ${domainWhitelist};
+  var API = ${api};
+  var METHOD = ${method};
+  var HEADERS = ${headers};
+  var BODY = ${body};
+  var VALID_PATH = ${validPath};
+  var self = this;
+  var state = currentRule && currentRule.values || {};
+  var ctx = currentRule || {};
+
+  function isEmpty(input) {
+    return input === undefined || input === null || input === '' || (Array.isArray(input) && input.length === 0);
+  }
+
+  function text(input) {
+    if (input === undefined || input === null) { return ''; }
+    if (Array.isArray(input)) { return input.join(','); }
+    if (typeof input === 'object') {
+      if (input.value !== undefined) { return String(input.value).trim(); }
+      if (input.label !== undefined) { return String(input.label).trim(); }
+      try { return JSON.stringify(input); } catch (err) { return String(input); }
+    }
+    return String(input).trim();
+  }
+
+  function getFieldValue(id) {
+    if (!id) { return undefined; }
+    try {
+      if (ctx && ctx.store && typeof ctx.store.get === 'function') {
+        var model = ctx.store.get(id);
+        if (model) {
+          if (typeof model.getVal === 'function') { return model.getVal(); }
+          if (typeof model.getValue === 'function') { return model.getValue(); }
+          if (typeof model.get === 'function') { return model.get('value'); }
+        }
+      }
+    } catch (err) {}
+    try {
+      if (self && typeof self.$ === 'function') {
+        var component = self.$(id);
+        if (component) {
+          if (typeof component.getValue === 'function') { return component.getValue(); }
+          if (typeof component.get === 'function') { return component.get('value'); }
+        }
+      }
+    } catch (err) {}
+    try {
+      if (typeof $ === 'function') {
+        var globalComponent = $(id);
+        if (globalComponent) {
+          if (typeof globalComponent.getValue === 'function') { return globalComponent.getValue(); }
+          if (typeof globalComponent.get === 'function') { return globalComponent.get('value'); }
+        }
+      }
+    } catch (err) {}
+    if (state && Object.prototype.hasOwnProperty.call(state, id)) { return state[id]; }
+    return undefined;
+  }
+
+  function comparable(input) {
+    if (input instanceof Date) { return input.getTime(); }
+    if (typeof input === 'number') { return input; }
+    var source = text(input);
+    if (/^\\d{13}$/.test(source)) { return Number(source); }
+    var parsedDate = Date.parse(source);
+    if (!isNaN(parsedDate)) { return parsedDate; }
+    var parsedNumber = Number(source);
+    return isNaN(parsedNumber) ? source : parsedNumber;
+  }
+
+  function match(input, condition) {
+    if (!condition || condition.operator === 'always') { return true; }
+    var conditionValue = condition.value;
+    var op = condition.operator || 'eq';
+    if (op === 'empty') { return isEmpty(input); }
+    if (op === 'notEmpty') { return !isEmpty(input); }
+    if (op === 'in') { return (condition.values || []).indexOf(input) !== -1 || (condition.values || []).indexOf(text(input)) !== -1; }
+    if (op === 'notIn') { return (condition.values || []).indexOf(input) === -1 && (condition.values || []).indexOf(text(input)) === -1; }
+    if (op === 'contains') { return Array.isArray(input) ? input.indexOf(conditionValue) !== -1 : text(input).indexOf(String(conditionValue)) !== -1; }
+    if (op === 'notContains') { return Array.isArray(input) ? input.indexOf(conditionValue) === -1 : text(input).indexOf(String(conditionValue)) === -1; }
+    if (op === 'ne') { return input !== conditionValue && text(input) !== String(conditionValue); }
+    if (op === 'gt') { return Number(input) > Number(conditionValue); }
+    if (op === 'gte') { return Number(input) >= Number(conditionValue); }
+    if (op === 'lt') { return Number(input) < Number(conditionValue); }
+    if (op === 'lte') { return Number(input) <= Number(conditionValue); }
+    return input === conditionValue || text(input) === String(conditionValue);
+  }
+
+  function luhn(input) {
+    var digits = text(input).replace(/\\s+/g, '');
+    if (!/^\\d{12,19}$/.test(digits)) { return false; }
+    var sum = 0;
+    var shouldDouble = false;
+    for (var i = digits.length - 1; i >= 0; i--) {
+      var digit = Number(digits.charAt(i));
+      if (shouldDouble) {
+        digit *= 2;
+        if (digit > 9) { digit -= 9; }
+      }
+      sum += digit;
+      shouldDouble = !shouldDouble;
+    }
+    return sum % 10 === 0;
+  }
+
+  function idCard(input) {
+    var valueText = text(input).toUpperCase();
+    if (!/^\\d{17}[\\dX]$/.test(valueText)) { return false; }
+    var year = Number(valueText.slice(6, 10));
+    var month = Number(valueText.slice(10, 12));
+    var day = Number(valueText.slice(12, 14));
+    var date = new Date(year, month - 1, day);
+    if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) { return false; }
+    var weights = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+    var checks = ['1', '0', 'X', '9', '8', '7', '6', '5', '4', '3', '2'];
+    var sum = 0;
+    for (var index = 0; index < 17; index++) {
+      sum += Number(valueText.charAt(index)) * weights[index];
+    }
+    return checks[sum % 11] === valueText.charAt(17);
+  }
+
+  function uscc(input) {
+    var valueText = text(input).toUpperCase();
+    var chars = '0123456789ABCDEFGHJKLMNPQRTUWXY';
+    if (!/^[0-9ABCDEFGHJKLMNPQRTUWXY]{18}$/.test(valueText)) { return false; }
+    var weights = [1, 3, 9, 27, 19, 26, 16, 17, 20, 29, 25, 13, 8, 24, 10, 30, 28];
+    var sum = 0;
+    for (var index = 0; index < 17; index++) {
+      var charIndex = chars.indexOf(valueText.charAt(index));
+      if (charIndex === -1) { return false; }
+      sum += charIndex * weights[index];
+    }
+    return chars.charAt((31 - (sum % 31)) % 31) === valueText.charAt(17);
+  }
+
+  if (CONDITION) {
+    var conditionValue = getFieldValue(CONDITION.fieldId);
+    if (!match(conditionValue, CONDITION)) { return true; }
+  }
+  if (${jsString(rule.type)} !== 'required' && ${jsString(rule.type)} !== 'conditionalRequired' && isEmpty(value)) {
+    return true;
+  }
+  if (${jsString(rule.type)} === 'regex') { return new RegExp(PATTERN).test(text(value)); }
+  if (${jsString(rule.type)} === 'idCard' || ${jsString(rule.type)} === 'chineseID') { return idCard(value); }
+  if (${jsString(rule.type)} === 'bankCard') { return luhn(value); }
+  if (${jsString(rule.type)} === 'unifiedSocialCreditCode') { return uscc(value); }
+  if (${jsString(rule.type)} === 'email') {
+    var email = text(value);
+    if (!/^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(email)) { return false; }
+    if (DOMAIN_WHITELIST.length) {
+      return DOMAIN_WHITELIST.indexOf(email.split('@').pop()) !== -1;
+    }
+    return true;
+  }
+  if (${jsString(rule.type)} === 'compare') {
+    var targetValue = getFieldValue(TARGET_FIELD_ID);
+    if (isEmpty(value) || isEmpty(targetValue)) { return true; }
+    var left = comparable(value);
+    var right = comparable(targetValue);
+    if (OPERATOR === '<' || OPERATOR === 'lt') { return left < right; }
+    if (OPERATOR === '<=' || OPERATOR === 'lte') { return left <= right; }
+    if (OPERATOR === '>' || OPERATOR === 'gt') { return left > right; }
+    if (OPERATOR === '>=' || OPERATOR === 'gte') { return left >= right; }
+    if (OPERATOR === '!=' || OPERATOR === '!==' || OPERATOR === 'ne') { return left !== right; }
+    return left === right;
+  }
+  if (${jsString(rule.type)} === 'conditionalRequired') { return !isEmpty(value); }
+  if (${jsString(rule.type)} === 'custom') {
+    var fields = {};
+    if (FIELD_ID) { fields[FIELD_ID] = value; }
+    try {
+      var result = (new Function('value', 'fields', 'state', 'ctx', 'getFieldValue', 'return (' + EXPRESSION + ');'))(value, fields, state || {}, ctx || {}, getFieldValue);
+      return result === true || (result && result.valid === true);
+    } catch (err) {
+      return false;
+    }
+  }
+  if (${jsString(rule.type)} === 'async') {
+    if (!API) { return true; }
+    var payload = BODY || { fieldId: FIELD_ID, value: value };
+    return fetch(API, {
+      method: METHOD || 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, HEADERS || {}),
+      body: String(METHOD || 'POST').toUpperCase() === 'GET' ? undefined : JSON.stringify(payload)
+    }).then(function(response) {
+      return response.json();
+    }).then(function(data) {
+      if (VALID_PATH) {
+        var current = data;
+        String(VALID_PATH).split('.').forEach(function(part) {
+          current = current && current[part];
+        });
+        return current !== false;
+      }
+      return data.valid !== false && data.success !== false && !data.error;
+    }).catch(function() {
+      return false;
+    });
+  }
+  return true;
+}`;
+}
+
+function smartValidationSignature(rule) {
+  return [
+    rule && rule.type,
+    rule && rule.fieldId,
+    rule && rule.targetFieldId,
+    rule && rule.operator,
+    rule && rule.pattern,
+    rule && rule.api,
+    rule && rule.expression,
+    rule && rule.condition ? JSON.stringify(rule.condition) : '',
+  ].map(function (value) {
+    return value === undefined ? '' : String(value);
+  }).join('|');
+}
+
+function dedupeSmartValidationRules(rules) {
+  const seen = new Set();
+  return (rules || []).filter(function (rule) {
+    const signature = smartValidationSignature(rule);
+    if (seen.has(signature)) {
+      return false;
+    }
+    seen.add(signature);
+    return true;
+  });
+}
+
+function actionListHasName(actions, name) {
+  return !!(actions && Array.isArray(actions.list) && actions.list.some(function (item) {
+    return item && (item.name === name || item.id === name);
+  }));
+}
+
+function removeGeneratedActionListEntries(actions, names) {
+  if (!actions || !Array.isArray(actions.list)) {
+    return 0;
+  }
+  const nameSet = new Set(names);
+  const beforeCount = actions.list.length;
+  actions.list = actions.list.filter(function (item) {
+    return !item || (!nameSet.has(item.id) && !nameSet.has(item.name));
+  });
+  return beforeCount - actions.list.length;
+}
+
+function cleanupLegacySmartValidationArtifacts(schema, root, formContainer) {
+  const cleanup = {
+    removedMetadata: false,
+    removedBeforeSubmit: false,
+    restoredDidMount: false,
+    removedActions: 0,
+    removedActionSource: false,
+  };
+
+  if (formContainer && formContainer.props && formContainer.props.openyidaSmartValidations !== undefined) {
+    delete formContainer.props.openyidaSmartValidations;
+    cleanup.removedMetadata = true;
+  }
+
+  if (
+    formContainer &&
+    formContainer.props &&
+    formContainer.props.beforeSubmit &&
+    formContainer.props.beforeSubmit.type === 'actionRef' &&
+    formContainer.props.beforeSubmit.name === 'openyidaSmartValidateBeforeSubmit'
+  ) {
+    delete formContainer.props.beforeSubmit;
+    cleanup.removedBeforeSubmit = true;
+  }
+
+  const actions = schema.actions;
+  if (
+    root &&
+    root.lifeCycles &&
+    root.lifeCycles.componentDidMount &&
+    root.lifeCycles.componentDidMount.type === 'actionRef' &&
+    root.lifeCycles.componentDidMount.name === 'openyidaSmartValidationDidMount'
+  ) {
+    if (actionListHasName(actions, 'didMount')) {
+      root.lifeCycles.componentDidMount = {
+        name: 'didMount',
+        id: 'didMount',
+        params: {},
+        type: 'actionRef',
+      };
+    } else {
+      delete root.lifeCycles.componentDidMount;
+    }
+    cleanup.restoredDidMount = true;
+  }
+
+  cleanup.removedActions = removeGeneratedActionListEntries(actions, [
+    'openyidaSmartValidationDidMount',
+    'openyidaSmartValidateBeforeSubmit',
+  ]);
+
+  if (actions && actions.module && typeof actions.module.source === 'string') {
+    const nextSource = removeGeneratedSourceBlockWithBounds(
+      actions.module.source,
+      SMART_VALIDATION_BLOCK_START,
+      SMART_VALIDATION_BLOCK_END
+    );
+    if (nextSource !== actions.module.source) {
+      actions.module.source = nextSource;
+      actions.module.compiled = nextSource ? compileActionSource(nextSource) : '';
+      cleanup.removedActionSource = true;
+    }
+  }
+
+  return cleanup;
+}
+
+function applySmartValidations(schema, rawRules) {
+  if (!schema.pages || !Array.isArray(schema.pages) || schema.pages.length === 0) {
+    throw new Error('Schema 为空，无法配置智能校验');
+  }
+  const root = schema.pages[0].componentsTree && schema.pages[0].componentsTree[0];
+  const formContainer = root ? findFormContainer(root) : null;
+  const normalized = normalizeSmartValidationRules(formContainer, rawRules || []);
+  normalized.rules = dedupeSmartValidationRules(normalized.rules);
+  const cleanup = cleanupLegacySmartValidationArtifacts(schema, root, formContainer);
+  const appliedRules = [];
+  const skippedRules = [];
+
+  normalized.rules.forEach(function (rule) {
+    const designerRule = toDesignerValidationRule(rule);
+    if (!designerRule) {
+      skippedRules.push(rule);
+      return;
+    }
+    const found = findFieldByIdOrLabelDeep(formContainer.children, rule.fieldId);
+    if (!found || !found.field) {
+      skippedRules.push(rule);
+      return;
+    }
+    found.field.props = found.field.props || {};
+    found.field.props.validation = dedupeValidationRules((found.field.props.validation || []).concat([designerRule]));
+    applyTextFieldValidationType(found.field, designerRule);
+    appliedRules.push(Object.assign({}, rule, {
+      designerValidationType: designerRule.type,
+    }));
+  });
+
+  return {
+    rules: normalized.rules,
+    appliedRules,
+    skippedRules,
+    cleanup,
+  };
+}
+
+function collectSmartValidationRulesFromFields(fields, output) {
+  const rules = output || [];
+  (fields || []).forEach(function (field) {
+    const fieldRules = collectInputValidationRules(field, { includeAdvanced: true });
+    const fieldLabel = field.label;
+    fieldRules.forEach(function (rule) {
+      if (rule.type === 'required' && !field.required && !field.validation && !field.validations) {
+        return;
+      }
+      rules.push(Object.assign({ field: fieldLabel }, rule));
+    });
+    if (field.type === 'TableField' && Array.isArray(field.children)) {
+      collectSmartValidationRulesFromFields(field.children, rules);
+    }
+  });
+  return rules;
+}
+
 function applyFieldChanges(component, changes) {
   const props = component.props;
 
   // 需要特殊处理的属性 key 集合（不走通用透传）
-  const specialKeys = ['label', 'required', 'placeholder', 'options', 'dataSource', 'associationForm',
+  const specialKeys = ['label', 'required', 'validation', 'validations', 'pattern', 'regex', 'placeholder', 'options', 'dataSource', 'associationForm',
     'linkageFields', 'mainFieldId', 'mainComponentName', 'mainFieldLabel',
     'subFieldId', 'subComponentName', 'dataFillingRules',
     'remoteDataSource', 'searchDataSource', 'dataSourceConfig', 'dataSourceUrl',
@@ -3075,6 +4070,21 @@ function applyFieldChanges(component, changes) {
         return rule.type !== 'required';
       });
     }
+  }
+
+  // ── 特殊处理：validation / pattern（规范化后写入字段校验配置）
+  if (changes.validation !== undefined || changes.validations !== undefined) {
+    props.validation = normalizeFieldValidationRules({
+      required: changes.required,
+      validation: changes.validation !== undefined ? changes.validation : changes.validations,
+    });
+  }
+
+  if (changes.pattern !== undefined || changes.regex !== undefined) {
+    props.validation = dedupeValidationRules((props.validation || []).concat(normalizeFieldValidationRules({
+      pattern: changes.pattern !== undefined ? changes.pattern : changes.regex,
+      message: changes.message,
+    })));
   }
 
   // ── 特殊处理：placeholder（需要 i18n 包装）
@@ -3597,7 +4607,7 @@ async function mainCreate(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
   const authRef = { csrfToken: csrfToken, cookies: cookies, baseUrl: baseUrl, cookieData: cookieData };
 
   step(2, t('create_form.step_read_fields', 2));
-  const { fields, columns } = readFieldsDefinition(fieldsJsonOrFile);
+  const { fields, columns, validations } = readFieldsDefinition(fieldsJsonOrFile);
   success(t('create_form.fields_loaded', fields.length));
   label('Columns:', String(columns));
   fields.forEach(function (field, index) {
@@ -3633,6 +4643,11 @@ async function mainCreate(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
   }
 
   const schema = buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, theme, labelAlign);
+  const createValidationRules = collectSmartValidationRulesFromFields(fields).concat(validations || []);
+  if (createValidationRules.length > 0) {
+    const appliedValidations = applySmartValidations(schema, createValidationRules);
+    info('已为创建表单写入 ' + appliedValidations.appliedRules.length + ' 条字段校验');
+  }
   const { configResult } = await saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, 1, 4);
 
   // 输出结果
@@ -3694,8 +4709,8 @@ function fillSerialNumberFormulas(components, corpId, appType, formUuid) {
         }
       }
     }
-    // 递归处理子表内的字段
-    if (component.componentName === 'TableField' && Array.isArray(component.children)) {
+    // 递归处理子表、分组、卡片等容器内的字段
+    if (Array.isArray(component.children)) {
       fillSerialNumberFormulas(component.children, corpId, appType, formUuid);
     }
   });
@@ -4210,6 +5225,125 @@ async function mainPatch(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
   )));
 }
 
+// ── validation 模式主流程：字段原生校验 ───────────────
+
+async function mainValidation(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
+  const { appType, formUuid, validationJsonOrFile, inlineValidationRule } = parsedArgs;
+
+  banner(t('create_form.update_title'));
+  label('App ID:', appType);
+  label('Form UUID:', formUuid);
+  label('Validation:', inlineValidationRule ? JSON.stringify(inlineValidationRule) : validationJsonOrFile);
+
+  const authRef = { csrfToken, cookies, baseUrl, cookieData };
+
+  step(2, t('create_form.step_get_schema', 2));
+  info(t('create_form.sending_get_schema'));
+  const schemaResult = await requestWithAutoLogin(function (auth) {
+    return sendGetRequest(
+      auth.baseUrl, auth.cookies,
+      buildApiPath(appType, 'getFormSchema', { prefix: '_view', namespace: 'alibaba' }),
+      { formUuid: formUuid, schemaVersion: 'V5' }
+    );
+  }, authRef);
+
+  if (!schemaResult || schemaResult.success === false || schemaResult.__needLogin) {
+    const errorMsg = schemaResult ? schemaResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
+    fail(t('create_form.get_schema_failed', errorMsg));
+    console.log(JSON.stringify({ success: false, error: errorMsg }));
+    process.exit(1);
+  }
+
+  let schema;
+  let version = 1;
+  if (schemaResult.content && typeof schemaResult.content === 'object' && schemaResult.content.version !== undefined) {
+    version = schemaResult.content.version;
+  } else if (schemaResult.version !== undefined) {
+    version = schemaResult.version;
+  }
+
+  if (schemaResult.content) {
+    schema = typeof schemaResult.content === 'string' ? JSON.parse(schemaResult.content) : schemaResult.content;
+  } else if (schemaResult.pages) {
+    schema = schemaResult;
+  } else {
+    fail(t('create_form.schema_extract_failed'));
+    hint(t('create_form.schema_response_structure', JSON.stringify(Object.keys(schemaResult))));
+    console.log(JSON.stringify({ success: false, error: t('create_form.schema_parse_failed') }));
+    process.exit(1);
+  }
+
+  step(3, '读取并应用智能校验规则');
+  const validations = readValidationDefinition(validationJsonOrFile, inlineValidationRule);
+  let applied;
+  try {
+    applied = applySmartValidations(schema, validations);
+  } catch (validationError) {
+    fail('智能校验规则应用失败: ' + validationError.message);
+    console.log(JSON.stringify({
+      success: false,
+      error: validationError.message,
+      formUuid,
+      appType,
+    }));
+    process.exit(1);
+  }
+
+  success('已应用 ' + applied.appliedRules.length + ' 条字段校验规则');
+  applied.appliedRules.forEach(function (rule, index) {
+    listItem((index + 1) + '. ' + rule.type + ' -> ' + (rule.fieldLabel || rule.fieldId));
+  });
+
+  const corpId = resolveCorpId(authRef.cookieData);
+  const formContainer = schema.pages && schema.pages[0] && schema.pages[0].componentsTree
+    ? findFormContainer(schema.pages[0].componentsTree[0])
+    : null;
+  if (formContainer && formContainer.children) {
+    fillSerialNumberFormulas(formContainer.children, corpId, appType, formUuid);
+  }
+
+  const { configResult } = await saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, version, 4);
+
+  const formUrl = authRef.baseUrl + '/' + appType + '/workbench/' + formUuid;
+  if (configResult && configResult.success) {
+    result(true, '智能校验规则保存成功', [
+      ['Form UUID', formUuid],
+      ['URL', formUrl],
+      ['Validations', String(applied.appliedRules.length)],
+    ]);
+  } else {
+    const configErrorMsg = configResult ? configResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
+    result(false, t('create_form.config_failed', configErrorMsg), [
+      ['Form UUID', formUuid],
+      ['URL', formUrl],
+      ['Validations', String(applied.appliedRules.length)],
+    ]);
+    hint(t('create_form.schema_ok_config_failed'));
+  }
+
+  console.log(JSON.stringify(withBrowserHandoff(
+    {
+      success: true,
+      formUuid,
+      appType,
+      validationsApplied: applied.appliedRules.length,
+      rules: applied.appliedRules.map(function (rule) {
+        return {
+          type: rule.type,
+          fieldId: rule.fieldId,
+          fieldLabel: rule.fieldLabel,
+          targetFieldId: rule.targetFieldId,
+          targetLabel: rule.targetLabel,
+        };
+      }),
+      url: formUrl,
+    },
+    formUrl,
+    { stage: 'validation_form_success', title: formUuid },
+    parsedArgs.browserOpenMode
+  )));
+}
+
 // ── update 模式主流程 ─────────────────────────────────
 
 async function mainUpdate(parsedArgs, csrfToken, cookies, baseUrl, cookieData) {
@@ -4399,6 +5533,8 @@ async function main() {
     await mainPatch(parsedArgs, csrfToken, cookies, baseUrl, cookieData);
   } else if (parsedArgs.mode === 'rule') {
     await mainRule(parsedArgs, csrfToken, cookies, baseUrl, cookieData);
+  } else if (parsedArgs.mode === 'validation') {
+    await mainValidation(parsedArgs, csrfToken, cookies, baseUrl, cookieData);
   } else if (parsedArgs.mode === 'bind-datasource') {
     await mainBindDataSource(parsedArgs, csrfToken, cookies, baseUrl, cookieData);
   } else if (parsedArgs.mode === 'add-option') {

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -2429,6 +2429,26 @@ function extractLabelText(component) {
   return label.zh_CN || label.ja_JP || label.en_US || label.pureEn_US || '';
 }
 
+function buildComponentAliasMaps(page) {
+  const aliasByFieldId = {};
+  const fieldIdByAlias = {};
+  const items = page &&
+    page.componentAlias &&
+    Array.isArray(page.componentAlias.items)
+    ? page.componentAlias.items
+    : [];
+  items.forEach(function (item) {
+    const fieldId = item && item.fieldId ? String(item.fieldId).trim() : '';
+    const alias = item && item.alias ? String(item.alias).trim() : '';
+    if (!fieldId || !alias) {
+      return;
+    }
+    aliasByFieldId[fieldId] = alias;
+    fieldIdByAlias[alias] = fieldId;
+  });
+  return { aliasByFieldId, fieldIdByAlias };
+}
+
 function findFormContainer(node) {
   if (node.componentName === 'FormContainer') {
     return node;
@@ -2855,7 +2875,7 @@ function normalizeConditionOperator(operator, condition) {
   return operatorMap[normalized] || operatorMap[normalized.toLowerCase()] || normalized;
 }
 
-function collectFieldDescriptors(fields, output) {
+function collectFieldDescriptors(fields, output, aliasByFieldId) {
   const descriptors = output || [];
   if (!Array.isArray(fields)) {
     return descriptors;
@@ -2866,27 +2886,32 @@ function collectFieldDescriptors(fields, output) {
     if (fieldId) {
       descriptors.push({
         fieldId,
+        alias: aliasByFieldId && aliasByFieldId[fieldId] || '',
         label: extractLabelText(field),
         componentName: field.componentName || '',
         nodeId: field.id || '',
         field,
       });
     }
-    collectFieldDescriptors(field.children, descriptors);
+    collectFieldDescriptors(field.children, descriptors, aliasByFieldId);
   });
   return descriptors;
 }
 
-function buildFieldLookup(fields) {
-  const descriptors = collectFieldDescriptors(fields);
+function buildFieldLookup(fields, page) {
+  const aliasMaps = buildComponentAliasMaps(page);
+  const descriptors = collectFieldDescriptors(fields, [], aliasMaps.aliasByFieldId);
   const byRef = {};
   descriptors.forEach(function (descriptor) {
     byRef[descriptor.fieldId] = descriptor;
+    if (descriptor.alias) {
+      byRef[descriptor.alias] = descriptor;
+    }
     if (descriptor.label) {
       byRef[descriptor.label] = descriptor;
     }
   });
-  return { descriptors, byRef };
+  return { descriptors, byRef, aliasByFieldId: aliasMaps.aliasByFieldId, fieldIdByAlias: aliasMaps.fieldIdByAlias };
 }
 
 function resolveRuleField(fieldLookup, fieldRef, role) {
@@ -2896,7 +2921,7 @@ function resolveRuleField(fieldLookup, fieldRef, role) {
   const found = fieldLookup.byRef[fieldRef];
   if (!found) {
     const availableFields = fieldLookup.descriptors
-      .map(function (descriptor) { return descriptor.label || descriptor.fieldId; })
+      .map(function (descriptor) { return descriptor.alias || descriptor.label || descriptor.fieldId; })
       .filter(Boolean)
       .join(', ');
     throw new Error('未找到' + role + ': ' + fieldRef + (availableFields ? '；可用字段: ' + availableFields : ''));
@@ -3074,11 +3099,11 @@ function normalizeSetValueRule(fieldLookup, rule, index) {
   return normalized;
 }
 
-function normalizeFormRules(formContainer, rules) {
+function normalizeFormRules(formContainer, rules, page) {
   if (!formContainer || !Array.isArray(formContainer.children)) {
     throw new Error('未找到 FormContainer');
   }
-  const fieldLookup = buildFieldLookup(formContainer.children);
+  const fieldLookup = buildFieldLookup(formContainer.children, page);
   const normalizedRules = rules.map(function (rule, index) {
     const type = String(rule.type || rule.action || '').trim();
     const normalizedType = type.toLowerCase();
@@ -3094,6 +3119,9 @@ function normalizeFormRules(formContainer, rules) {
   const fieldMap = {};
   fieldLookup.descriptors.forEach(function (descriptor) {
     fieldMap[descriptor.fieldId] = descriptor.fieldId;
+    if (descriptor.alias) {
+      fieldMap[descriptor.alias] = descriptor.fieldId;
+    }
     if (descriptor.label) {
       fieldMap[descriptor.label] = descriptor.fieldId;
     }
@@ -3328,7 +3356,7 @@ function applyFormRules(schema, rawRules) {
   }
   const root = schema.pages[0].componentsTree && schema.pages[0].componentsTree[0];
   const formContainer = root ? findFormContainer(root) : null;
-  const normalized = normalizeFormRules(formContainer, rawRules);
+  const normalized = normalizeFormRules(formContainer, rawRules, schema.pages[0]);
   const actions = ensureActionModule(schema);
 
   const sourceFieldIds = new Set();
@@ -3537,11 +3565,11 @@ function normalizeSmartValidationRule(fieldLookup, rule, index) {
   return normalized;
 }
 
-function normalizeSmartValidationRules(formContainer, rawRules) {
+function normalizeSmartValidationRules(formContainer, rawRules, page) {
   if (!formContainer || !Array.isArray(formContainer.children)) {
     throw new Error('未找到 FormContainer');
   }
-  const fieldLookup = buildFieldLookup(formContainer.children);
+  const fieldLookup = buildFieldLookup(formContainer.children, page);
   const normalizedRules = rawRules.map(function (rule, index) {
     return normalizeSmartValidationRule(fieldLookup, rule, index);
   });
@@ -3549,6 +3577,9 @@ function normalizeSmartValidationRules(formContainer, rawRules) {
   const fieldMap = {};
   fieldLookup.descriptors.forEach(function (descriptor) {
     fieldMap[descriptor.fieldId] = descriptor.fieldId;
+    if (descriptor.alias) {
+      fieldMap[descriptor.alias] = descriptor.fieldId;
+    }
     if (descriptor.label) {
       fieldMap[descriptor.label] = descriptor.fieldId;
     }
@@ -3610,14 +3641,23 @@ function isAdvancedValidationRule(rule) {
   return ['bankCard', 'unifiedSocialCreditCode', 'email', 'compare', 'conditionalRequired', 'custom', 'async'].indexOf(rule.type) !== -1;
 }
 
-function applyTextFieldValidationType(field, rule) {
-  if (!field || field.componentName !== 'TextField' || !field.props || !rule) {
+function resetGeneratedTextFieldValidationType(field) {
+  if (!field || field.componentName !== 'TextField' || !field.props) {
     return;
   }
-  const formatValidationTypes = ['mobile', 'email', 'url', 'chineseID'];
-  if (formatValidationTypes.indexOf(rule.type) !== -1) {
-    field.props.validationType = rule.type;
+  if (['mobile', 'email', 'url', 'chineseID'].indexOf(field.props.validationType) !== -1) {
+    field.props.validationType = 'text';
   }
+}
+
+function cleanupLegacyGeneratedValidationRules(validation, designerRule) {
+  const rules = Array.isArray(validation) ? validation : [];
+  if (designerRule && designerRule.type === 'mobile') {
+    return rules.filter(function (rule) {
+      return !rule || rule.type !== 'phone';
+    });
+  }
+  return rules;
 }
 
 function jsString(value) {
@@ -3987,7 +4027,7 @@ function applySmartValidations(schema, rawRules) {
   }
   const root = schema.pages[0].componentsTree && schema.pages[0].componentsTree[0];
   const formContainer = root ? findFormContainer(root) : null;
-  const normalized = normalizeSmartValidationRules(formContainer, rawRules || []);
+  const normalized = normalizeSmartValidationRules(formContainer, rawRules || [], schema.pages[0]);
   normalized.rules = dedupeSmartValidationRules(normalized.rules);
   const cleanup = cleanupLegacySmartValidationArtifacts(schema, root, formContainer);
   const appliedRules = [];
@@ -4005,8 +4045,9 @@ function applySmartValidations(schema, rawRules) {
       return;
     }
     found.field.props = found.field.props || {};
-    found.field.props.validation = dedupeValidationRules((found.field.props.validation || []).concat([designerRule]));
-    applyTextFieldValidationType(found.field, designerRule);
+    resetGeneratedTextFieldValidationType(found.field);
+    const existingValidation = cleanupLegacyGeneratedValidationRules(found.field.props.validation, designerRule);
+    found.field.props.validation = dedupeValidationRules(existingValidation.concat([designerRule]));
     appliedRules.push(Object.assign({}, rule, {
       designerValidationType: designerRule.type,
     }));

--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -29,9 +29,9 @@ const FIELD_TYPES_NEEDING_VALUE_SUFFIX = new Set([
 ]);
 
 /**
- * 从 Schema 中提取字段摘要，列出每个字段的真实 fieldId 和报表用 reportFieldCode。
+ * 从 Schema 中提取字段摘要，列出每个字段的真实 fieldId、组件别名和报表用 reportFieldCode。
  * @param {object} schemaResult - getFormSchema API 返回结果
- * @returns {Array<{label, componentName, fieldId, reportFieldCode}>}
+ * @returns {Array<{label, componentName, fieldId, alias, reportFieldCode}>}
  */
 function extractFieldSummary(schemaResult) {
   const fields = [];
@@ -39,6 +39,7 @@ function extractFieldSummary(schemaResult) {
   if (!pages || pages.length === 0) {
     return fields;
   }
+  const aliasMaps = buildComponentAliasMaps(schemaResult);
 
   const FIELD_COMPONENT_NAMES = new Set([
     'TextField', 'TextareaField', 'SelectField', 'DateField', 'NumberField',
@@ -61,7 +62,13 @@ function extractFieldSummary(schemaResult) {
         ? `${fieldId}_value`
         : fieldId;
       if (fieldId) {
-        fields.push({ label, componentName: node.componentName, fieldId, reportFieldCode });
+        fields.push({
+          label,
+          componentName: node.componentName,
+          fieldId,
+          alias: aliasMaps.aliasByFieldId[fieldId] || '',
+          reportFieldCode,
+        });
       }
     }
     if (node.children) {
@@ -78,6 +85,34 @@ function extractFieldSummary(schemaResult) {
   }
 
   return fields;
+}
+
+function buildComponentAliasMaps(schemaResult) {
+  const aliasByFieldId = {};
+  const fieldIdByAlias = {};
+  const pages = schemaResult && schemaResult.content && schemaResult.content.pages;
+  if (!Array.isArray(pages)) {
+    return { aliasByFieldId, fieldIdByAlias };
+  }
+
+  pages.forEach((page) => {
+    const items = page &&
+      page.componentAlias &&
+      Array.isArray(page.componentAlias.items)
+      ? page.componentAlias.items
+      : [];
+    items.forEach((item) => {
+      const fieldId = item && item.fieldId ? String(item.fieldId).trim() : '';
+      const alias = item && item.alias ? String(item.alias).trim() : '';
+      if (!fieldId || !alias) {
+        return;
+      }
+      aliasByFieldId[fieldId] = alias;
+      fieldIdByAlias[alias] = fieldId;
+    });
+  });
+
+  return { aliasByFieldId, fieldIdByAlias };
 }
 
 function parsePositiveInt(value, fallback, min, max) {
@@ -152,7 +187,7 @@ function ensureUsage(parsed) {
  * @param {Array<object>} fieldNodes - 来自 collectFieldNodes 的原始字段节点数组
  * @param {string} keyword - label（如「优先级」）或 fieldId（如 selectField_qkm136vkr）
  */
-function findFieldNode(fieldNodes, keyword) {
+function findFieldNode(fieldNodes, keyword, aliasByFieldId = {}) {
   if (!keyword) {return null;}
   const target = String(keyword).trim();
 
@@ -163,6 +198,10 @@ function findFieldNode(fieldNodes, keyword) {
       ? (typeof labelRaw === 'object' ? (labelRaw.zh_CN || labelRaw.en_US || '') : String(labelRaw))
       : '';
     if (label === target) {return node;}
+  }
+  for (const node of fieldNodes) {
+    const props = node.props || {};
+    if (props.fieldId && aliasByFieldId[props.fieldId] === target) {return node;}
   }
   for (const node of fieldNodes) {
     const props = node.props || {};
@@ -252,12 +291,12 @@ function printFieldSummary(result) {
   process.stderr.write(`\n  ${c.bold}${c.cyan}📋 字段摘要${c.reset} ${c.dim}（报表配置请使用 reportFieldCode）${c.reset}\n`);
   process.stderr.write(`  ${c.dim}${'─'.repeat(80)}${c.reset}\n`);
   process.stderr.write(
-    `  ${c.bold}${'label'.padEnd(16)}${'componentName'.padEnd(20)}${'fieldId'.padEnd(28)}reportFieldCode${c.reset}\n`
+    `  ${c.bold}${'label'.padEnd(16)}${'alias'.padEnd(18)}${'componentName'.padEnd(20)}${'fieldId'.padEnd(28)}reportFieldCode${c.reset}\n`
   );
   process.stderr.write(`  ${c.dim}${'─'.repeat(80)}${c.reset}\n`);
   for (const field of fieldSummary) {
     process.stderr.write(
-      `  ${c.green}${field.label.padEnd(16)}${c.reset}${c.dim}${field.componentName.padEnd(20)}${c.reset}${field.fieldId.padEnd(28)}${c.cyan}${field.reportFieldCode}${c.reset}\n`
+      `  ${c.green}${field.label.padEnd(16)}${c.reset}${c.yellow}${(field.alias || '').padEnd(18)}${c.reset}${c.dim}${field.componentName.padEnd(20)}${c.reset}${field.fieldId.padEnd(28)}${c.cyan}${field.reportFieldCode}${c.reset}\n`
     );
   }
   process.stderr.write(`  ${c.dim}${'─'.repeat(80)}${c.reset}\n`);
@@ -387,7 +426,8 @@ async function runSingle(parsed, authRef) {
   // --field 模式：只返回单个字段的详细 props（含 SelectField.dataSource 等）
   if (parsed.field) {
     const allFieldNodes = collectFieldNodes(result);
-    const matched = findFieldNode(allFieldNodes, parsed.field);
+    const aliasMaps = buildComponentAliasMaps(result);
+    const matched = findFieldNode(allFieldNodes, parsed.field, aliasMaps.aliasByFieldId);
     if (!matched) {
       const { error: chalkError } = require('../core/chalk');
       chalkError(`未找到字段：${parsed.field}`, {
@@ -403,6 +443,7 @@ async function runSingle(parsed, authRef) {
     const compact = {
       componentName: matched.componentName,
       fieldId: props.fieldId || '',
+      alias: aliasMaps.aliasByFieldId[props.fieldId] || '',
       label,
       props,
     };
@@ -486,6 +527,7 @@ async function run(args) {
 
 module.exports = {
   extractFieldSummary,
+  buildComponentAliasMaps,
   parseArgs,
   filterForms,
   mapLimit,

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -67,6 +67,8 @@ const COMMAND_GROUPS = [
       command('create-form.update', ['create-form', 'update'], 'create-form update <appType> ... [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_update_form'),
       command('create-form.patch', ['create-form', 'patch'], 'create-form patch <appType> <formUuid> <patchJsonOrFile> [--open|--no-open]', 'help.cmd_update_form'),
       command('create-form.rule', ['create-form', 'rule'], 'create-form rule <appType> <formUuid> <rulesJsonOrFile> [--open|--no-open]', 'help.cmd_update_form'),
+      command('create-form.validation', ['create-form', 'validation'], 'create-form validation <appType> <formUuid> <validationsJsonOrFile> [--open|--no-open]', 'help.cmd_update_form'),
+      command('add-validation', ['add-validation'], 'add-validation <appType> <formUuid> --field <labelOrId> --type <phone|regex|idCard|email|...> [--message <text>]', 'help.cmd_update_form'),
       command('create-form.bind-datasource', ['create-form', 'bind-datasource'], 'create-form bind-datasource <appType> <formUuid> <fieldLabelOrId> <dataSourceJsonOrFile> [--open|--no-open]', 'help.cmd_update_form'),
       command('list-forms', ['list-forms'], 'list-forms <appType> [--keyword <text>]', 'help.cmd_list_forms'),
       command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all>', 'help.cmd_get_schema'),

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -478,7 +478,7 @@ async function createForm(positionals, options, session) {
     formDataJson: dataJson,
   };
   if (options.dept_id) {params.deptId = options.dept_id;}
-  printResult(await sendPost(session, appType, `/alibaba/web/${appType}/_/saveFormData.json`, params));
+  printResult(await sendPost(session, appType, `/dingtalk/web/${appType}/v1/form/saveFormData.json`, params));
 }
 
 async function updateForm(positionals, options, session) {

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -161,6 +161,8 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('create-form.create');
     expect(commands).toContain('create-form.patch');
     expect(commands).toContain('create-form.rule');
+    expect(commands).toContain('create-form.validation');
+    expect(commands).toContain('add-validation');
     expect(commands).toContain('create-form.bind-datasource');
     expect(commands).toContain('list-forms');
     expect(commands).toContain('build-page');

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -111,6 +111,14 @@ describe('component alias schema support', () => {
     expect(sourceCode).toContain('field.alias');
     expect(sourceCode).toContain('component[COMPONENT_ALIAS_META]');
   });
+
+  test('rules and validations can resolve component aliases as field refs', () => {
+    expect(sourceCode).toContain('function buildComponentAliasMaps(');
+    expect(sourceCode).toContain('aliasByFieldId');
+    expect(sourceCode).toContain('fieldIdByAlias');
+    expect(sourceCode).toContain('byRef[descriptor.alias]');
+    expect(sourceCode).toContain('fieldMap[descriptor.alias]');
+  });
 });
 
 // ── JS 语法检查 ──
@@ -235,8 +243,9 @@ describe('validation mode in source code', () => {
   test('validation mode uses native field validation first', () => {
     expect(sourceCode).toContain('function applySmartValidations(');
     expect(sourceCode).toContain('isNativeFieldValidationRule');
-    expect(sourceCode).toContain('function applyTextFieldValidationType');
-    expect(sourceCode).toContain('field.props.validationType = rule.type');
+    expect(sourceCode).toContain('function resetGeneratedTextFieldValidationType');
+    expect(sourceCode).toContain("field.props.validationType = 'text'");
+    expect(sourceCode).not.toContain('field.props.validationType = rule.type');
     expect(sourceCode).toContain('found.field.props.validation = dedupeValidationRules');
     expect(sourceCode).toContain('customValidate');
     expect(sourceCode).toContain('cleanupLegacySmartValidationArtifacts');

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -95,6 +95,24 @@ describe('buildFormSchema FormContainer structure', () => {
   });
 });
 
+describe('component alias schema support', () => {
+  test('buildFormSchema writes component alias metadata at page level', () => {
+    const formSchemaFunction = extractFunctionBody(sourceCode, 'buildFormSchema');
+    expect(formSchemaFunction).toBeDefined();
+    expect(sourceCode).toContain('function normalizeComponentAlias(');
+    expect(sourceCode).toContain('function buildComponentAliasItems(');
+    expect(formSchemaFunction).toContain('componentAliasItems');
+    expect(formSchemaFunction).toContain('items: componentAliasItems');
+  });
+
+  test('field definitions accept alias and componentAlias without writing them into props', () => {
+    expect(sourceCode).toContain('field.componentAlias');
+    expect(sourceCode).toContain('field.component_alias');
+    expect(sourceCode).toContain('field.alias');
+    expect(sourceCode).toContain('component[COMPONENT_ALIAS_META]');
+  });
+});
+
 // ── JS 语法检查 ──
 
 describe('create-form.js syntax', () => {
@@ -204,6 +222,41 @@ describe('rule mode in source code', () => {
     expect(sourceCode).toContain('openyidaRuleSetBehavior');
     expect(sourceCode).toContain('openyidaRuleSetValue');
     expect(sourceCode).toContain("operator: 'always'");
+  });
+});
+
+describe('validation mode in source code', () => {
+  test('parseArgs recognizes validation mode and add-validation inline options', () => {
+    expect(sourceCode).toContain("mode === 'validation'");
+    expect(sourceCode).toContain('inlineValidationRule');
+    expect(sourceCode).toContain('parseInlineValidationOptions');
+  });
+
+  test('validation mode uses native field validation first', () => {
+    expect(sourceCode).toContain('function applySmartValidations(');
+    expect(sourceCode).toContain('isNativeFieldValidationRule');
+    expect(sourceCode).toContain('function applyTextFieldValidationType');
+    expect(sourceCode).toContain('field.props.validationType = rule.type');
+    expect(sourceCode).toContain('found.field.props.validation = dedupeValidationRules');
+    expect(sourceCode).toContain('customValidate');
+    expect(sourceCode).toContain('cleanupLegacySmartValidationArtifacts');
+  });
+
+  test('smart validation emits native customValidate functions without submit hooks', () => {
+    expect(sourceCode).toContain('function buildCustomValidateParam');
+    expect(sourceCode).toContain("type: 'JSExpression'");
+    expect(sourceCode).toContain('function validateRule(value, currentRule)');
+    expect(sourceCode).toContain("=== 'idCard'");
+    expect(sourceCode).toContain("=== 'bankCard'");
+    expect(sourceCode).toContain("=== 'unifiedSocialCreditCode'");
+    expect(sourceCode).toContain("=== 'compare'");
+    expect(sourceCode).toContain("=== 'async'");
+    expect(sourceCode).not.toContain('function buildSmartValidationActionSource');
+  });
+
+  test('create fields preserve validation definitions', () => {
+    expect(sourceCode).toContain('normalizeFieldValidationRules(field)');
+    expect(sourceCode).toContain('normalizeDesignerValidationRule');
   });
 });
 

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -20,9 +20,12 @@ const utils = require('../lib/core/utils');
 const { fetchFormPageList } = require('../lib/app/form-navigation');
 const {
   extractFieldSummary,
+  buildComponentAliasMaps,
   parseArgs,
   filterForms,
   fetchSchemaRecord,
+  collectFieldNodes,
+  findFieldNode,
   run,
 } = require('../lib/app/get-schema');
 
@@ -74,6 +77,11 @@ describe('extractFieldSummary', () => {
       content: {
         pages: [
           {
+            componentAlias: {
+              items: [
+                { fieldId: 'textField_name', alias: 'customerName' },
+              ],
+            },
             componentsTree: [
               {
                 componentName: 'FormContainer',
@@ -104,15 +112,51 @@ describe('extractFieldSummary', () => {
         label: '姓名',
         componentName: 'TextField',
         fieldId: 'textField_name',
+        alias: 'customerName',
         reportFieldCode: 'textField_name',
       },
       {
         label: 'Status',
         componentName: 'SelectField',
         fieldId: 'selectField_status',
+        alias: '',
         reportFieldCode: 'selectField_status_value',
       },
     ]);
+  });
+
+  test('builds alias maps and finds fields by alias', () => {
+    const schema = {
+      content: {
+        pages: [
+          {
+            componentAlias: {
+              items: [
+                { fieldId: 'textField_name', alias: 'customerName' },
+              ],
+            },
+            componentsTree: [
+              {
+                componentName: 'FormContainer',
+                children: [
+                  {
+                    componentName: 'TextField',
+                    props: { fieldId: 'textField_name', label: { zh_CN: '姓名' } },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const aliasMaps = buildComponentAliasMaps(schema);
+    const nodes = collectFieldNodes(schema);
+
+    expect(aliasMaps.aliasByFieldId.textField_name).toBe('customerName');
+    expect(aliasMaps.fieldIdByAlias.customerName).toBe('textField_name');
+    expect(findFieldNode(nodes, 'customerName', aliasMaps.aliasByFieldId).props.fieldId).toBe('textField_name');
   });
 });
 

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -425,7 +425,7 @@ describe('run() create form', () => {
     try {
       await run(['create', 'form', 'APP_XXX', 'FORM-XXX', '--data-file', dataPath]);
       expect(utils.httpPost).toHaveBeenCalledTimes(1);
-      expect(utils.httpPost.mock.calls[0][1]).toBe('/alibaba/web/APP_XXX/_/saveFormData.json');
+      expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/v1/form/saveFormData.json');
       expect(decodeURIComponent(utils.httpPost.mock.calls[0][2])).toContain('formDataJson={"textField_1":"from-file"}');
       expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"success": true'));
     } finally {


### PR DESCRIPTION
## Summary

- add `create-form validation` and `add-validation` commands for configuring form validation rules
- write validation through Yida-visible schema settings: field `props.validation` and `customValidate` JSExpression rules
- keep TextField `validationType` at the normal `text` value; do not emit hidden/internal `validationType: "mobile"` / `"chineseID"` settings
- normalize CLI `phone`/`mobile` input to the visible mobile-phone validation rule `props.validation[].type = "mobile"`
- support built-in and advanced validators including mobile phone, Chinese ID, bank card, unified social credit code, email domain whitelist, cross-field compare, conditional required, custom expression, and async validation
- clean up earlier generated submit/lifecycle hook artifacts and old hidden `validationType` artifacts
- align form data create API with the real Yida submit endpoint
- preserve and resolve generated form component aliases for form rules, validations, and schema inspection

Closes #67

## Real Environment Verification

Created and tested a real Yida app/form:

- App: `APP_O0QC9137RUFVEAZNYNJL`
- Form: `FORM-70FAC1553EC6474AB5E6FB82BA4948E1OH1K`
- URL: https://www.aliwork.com/APP_O0QC9137RUFVEAZNYNJL/workbench/FORM-70FAC1553EC6474AB5E6FB82BA4948E1OH1K

Schema after correction:

- 手机号: `validationType: "text"`, `props.validation[].type: "mobile"`
- 身份证号: `validationType: "text"`, `props.validation[].type: "chineseID"`
- 开始日期: `props.validation[].type: "customValidate"`, `param.type: "JSExpression"`
- 公司名称: `props.validation[].type: "customValidate"`, `param.type: "JSExpression"`

Chrome submit-state checks:

- invalid phone `123` is blocked with `请输入正确的手机号`
- invalid ID card and start date after end date are blocked with field errors
- `主体类型 = 企业` with empty company name is blocked
- valid phone, valid ID card, valid date order, and company name submit successfully

## Checks

- `node --check lib/app/create-form.js`
- `npm test -- --runInBand tests/get-schema.test.js tests/create-form.test.js tests/query-data.test.js tests/cli-smoke.test.js`
- `npm run check:ci`
- `git diff --check`