### PR TITLE
feat: 导出应用 ER 图 / export app ER diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida list-forms <appType> [--keyword <text>]` | List forms/pages in an app |
 | `openyida aggregate-table <list\|create-empty\|inspect\|preview\|save\|publish\|status> <appType> ...` | Manage aggregate tables (virtualView) |
 | `openyida get-schema <appType> <formUuid\|--all>` | Get one form Schema or all form Schemas |
+| `openyida er <appType> [--format mermaid\|json] [--output file] [--include-system] [--include-pages]` | Export app entity relationship diagram |
 | `openyida create-page <appType> "<name>" [--mode dashboard] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a custom display page |
 | `openyida generate-page <template>` | Generate page from curated template |
 | `openyida build-page <sourceFile> [--output file\|--write]` | Build Yida-compatible page source |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -674,6 +674,12 @@ async function main() {
       break;
     }
 
+    case 'er': {
+      const { run } = require('../lib/app/er');
+      await run(args);
+      break;
+    }
+
     case 'formula': {
       const subCommand = args[0];
       const subArgs = args.slice(1);

--- a/lib/app/er.js
+++ b/lib/app/er.js
@@ -1,0 +1,679 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  loadCookieData,
+  triggerLogin,
+  resolveBaseUrl,
+} = require('../core/utils');
+const { t } = require('../core/i18n');
+const { fetchFormPageList } = require('./form-navigation');
+const {
+  buildComponentAliasMaps,
+  fetchSchemaRecord,
+  filterForms,
+  mapLimit,
+} = require('./get-schema');
+
+const FIELD_KIND_BY_COMPONENT = {
+  TextField: 'string',
+  TextareaField: 'text',
+  SelectField: 'enum',
+  MultiSelectField: 'enum[]',
+  RadioField: 'enum',
+  CheckboxField: 'enum[]',
+  NumberField: 'number',
+  RateField: 'number',
+  DateField: 'datetime',
+  CascadeDateField: 'datetime',
+  PhoneField: 'phone',
+  EmailField: 'email',
+  EmployeeField: 'user',
+  DepartmentSelectField: 'department',
+  CountrySelectField: 'country',
+  CitySelectField: 'city',
+  CascadeSelectField: 'cascade',
+  AddressField: 'address',
+  ImageField: 'image',
+  AttachmentField: 'attachment',
+  SignatureField: 'signature',
+  SerialNumberField: 'serial',
+  AssociationFormField: 'relation',
+  TableField: 'subtable',
+};
+
+const SYSTEM_ENTITIES = [
+  {
+    id: 'SystemUser',
+    name: 'User',
+    type: 'system',
+    formUuid: 'SystemUser',
+    formType: 'system',
+    fields: [
+      { name: 'userId', fieldId: 'userId', type: 'string', componentName: 'SystemField', label: 'userId' },
+      { name: 'name', fieldId: 'name', type: 'string', componentName: 'SystemField', label: 'name' },
+      { name: 'deptId', fieldId: 'deptId', type: 'string', componentName: 'SystemField', label: 'deptId' },
+      { name: 'roleIds', fieldId: 'roleIds', type: 'string[]', componentName: 'SystemField', label: 'roleIds' },
+    ],
+  },
+  {
+    id: 'SystemDepartment',
+    name: 'Department',
+    type: 'system',
+    formUuid: 'SystemDepartment',
+    formType: 'system',
+    fields: [
+      { name: 'deptId', fieldId: 'deptId', type: 'string', componentName: 'SystemField', label: 'deptId' },
+      { name: 'name', fieldId: 'name', type: 'string', componentName: 'SystemField', label: 'name' },
+      { name: 'parentId', fieldId: 'parentId', type: 'string', componentName: 'SystemField', label: 'parentId' },
+      { name: 'orgId', fieldId: 'orgId', type: 'string', componentName: 'SystemField', label: 'orgId' },
+    ],
+  },
+  {
+    id: 'SystemRole',
+    name: 'Role',
+    type: 'system',
+    formUuid: 'SystemRole',
+    formType: 'system',
+    fields: [
+      { name: 'roleId', fieldId: 'roleId', type: 'string', componentName: 'SystemField', label: 'roleId' },
+      { name: 'name', fieldId: 'name', type: 'string', componentName: 'SystemField', label: 'name' },
+      { name: 'orgId', fieldId: 'orgId', type: 'string', componentName: 'SystemField', label: 'orgId' },
+    ],
+  },
+  {
+    id: 'SystemOrganization',
+    name: 'Organization',
+    type: 'system',
+    formUuid: 'SystemOrganization',
+    formType: 'system',
+    fields: [
+      { name: 'orgId', fieldId: 'orgId', type: 'string', componentName: 'SystemField', label: 'orgId' },
+      { name: 'name', fieldId: 'name', type: 'string', componentName: 'SystemField', label: 'name' },
+    ],
+  },
+];
+
+function parseArgs(args) {
+  const parsed = {
+    appType: '',
+    format: 'mermaid',
+    output: '',
+    includeSystem: false,
+    includePages: false,
+    keyword: '',
+    concurrency: 3,
+    retries: 1,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if ((arg === '--format' || arg === '-f') && args[index + 1]) {
+      parsed.format = args[index + 1].toLowerCase();
+      index++;
+    } else if ((arg === '--output' || arg === '-o') && args[index + 1]) {
+      parsed.output = args[index + 1];
+      index++;
+    } else if (arg === '--include-system') {
+      parsed.includeSystem = true;
+    } else if (arg === '--include-pages') {
+      parsed.includePages = true;
+    } else if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--keyword' && args[index + 1]) {
+      parsed.keyword = args[index + 1];
+      index++;
+    } else if ((arg === '--concurrency' || arg === '--parallel') && args[index + 1]) {
+      parsed.concurrency = parsePositiveInt(args[index + 1], 3, 1, 10);
+      index++;
+    } else if ((arg === '--retries' || arg === '--retry') && args[index + 1]) {
+      parsed.retries = parsePositiveInt(args[index + 1], 1, 0, 5);
+      index++;
+    } else if (arg === '--json') {
+      parsed.format = 'json';
+      parsed.json = true;
+    } else if (!arg.startsWith('-') && !parsed.appType) {
+      parsed.appType = arg;
+    }
+  }
+
+  if (parsed.format === 'mmd') {
+    parsed.format = 'mermaid';
+  }
+
+  return parsed;
+}
+
+function parsePositiveInt(value, fallback, min, max) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < min) {
+    return fallback;
+  }
+  return Math.min(parsed, max);
+}
+
+function filterErSourceForms(forms, options = {}) {
+  const filtered = filterForms(forms, options.keyword || '');
+  if (options.includePages) {
+    return filtered;
+  }
+  return filtered.filter((form) => String(form?.formType || '').toLowerCase() !== 'display');
+}
+
+function normalizeText(value, fallback = '') {
+  if (!value) {
+    return fallback;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    return value.zh_CN || value.en_US || value.zh_TW || value.zh_HK || value.ja_JP || Object.values(value).find(item => typeof item === 'string') || fallback;
+  }
+  return String(value);
+}
+
+function sanitizeEntityId(value) {
+  const raw = String(value || 'Entity').replace(/[^A-Za-z0-9_]/g, '_');
+  const compact = raw.replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+  if (!compact) {
+    return 'Entity';
+  }
+  return /^[A-Za-z_]/.test(compact) ? compact : `E_${compact}`;
+}
+
+function sanitizeFieldName(value, fallback) {
+  const raw = String(value || fallback || 'field').trim() || 'field';
+  const normalized = raw.replace(/\s+/g, '_').replace(/[^\w\u4e00-\u9fa5]/g, '_').replace(/_+/g, '_');
+  return normalized.replace(/^_+|_+$/g, '') || fallback || 'field';
+}
+
+function fieldTypeFor(componentName) {
+  return FIELD_KIND_BY_COMPONENT[componentName] || String(componentName || 'field');
+}
+
+function dedupeByKey(items, keyFn) {
+  const seen = new Set();
+  return items.filter((item) => {
+    const key = keyFn(item);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function getAssociationTarget(props) {
+  const associationForm = props.associationForm || {};
+  return {
+    appType: associationForm.appType || props.appType || '',
+    formUuid: associationForm.formUuid || props.formUuid || '',
+    formTitle: normalizeText(associationForm.formTitle || associationForm.title || props.formTitle || props.title, ''),
+    mainFieldId: associationForm.mainFieldId || '',
+    mainFieldLabel: normalizeText(associationForm.mainFieldLabel, ''),
+    multiple: !!(props.multiple || associationForm.multiple),
+  };
+}
+
+function collectTopLevelFieldNodes(schemaResult) {
+  const nodes = [];
+  const pages = schemaResult && schemaResult.content && schemaResult.content.pages;
+  if (!Array.isArray(pages)) {
+    return nodes;
+  }
+
+  function traverse(node) {
+    if (!node) {
+      return;
+    }
+    if (FIELD_KIND_BY_COMPONENT[node.componentName]) {
+      nodes.push(node);
+      if (node.componentName === 'TableField') {
+        return;
+      }
+    }
+    if (Array.isArray(node.children)) {
+      node.children.forEach(traverse);
+    }
+  }
+
+  pages.forEach((page) => {
+    const roots = page && page.componentsTree ? page.componentsTree : [];
+    roots.forEach(traverse);
+  });
+  return nodes;
+}
+
+function buildFieldFromNode(node, aliasMaps) {
+  const props = node.props || {};
+  const fieldId = props.fieldId || '';
+  if (!fieldId) {
+    return null;
+  }
+
+  const label = normalizeText(props.label, fieldId);
+  const alias = aliasMaps.aliasByFieldId[fieldId] || '';
+  return {
+    name: sanitizeFieldName(alias || fieldId, fieldId),
+    label,
+    alias,
+    fieldId,
+    componentName: node.componentName,
+    type: fieldTypeFor(node.componentName),
+    required: !!props.required,
+  };
+}
+
+function buildRelationshipsForField(entityId, node, label, fieldId) {
+  const props = node.props || {};
+  const relationships = [];
+
+  if (node.componentName === 'EmployeeField') {
+    relationships.push({
+      from: entityId,
+      to: 'SystemUser',
+      fromField: fieldId,
+      label,
+      type: props.multiple ? 'many-to-many' : 'many-to-one',
+      source: 'EmployeeField',
+    });
+  }
+
+  if (node.componentName === 'DepartmentSelectField') {
+    relationships.push({
+      from: entityId,
+      to: 'SystemDepartment',
+      fromField: fieldId,
+      label,
+      type: props.multiple ? 'many-to-many' : 'many-to-one',
+      source: 'DepartmentSelectField',
+    });
+  }
+
+  if (node.componentName === 'AssociationFormField') {
+    const target = getAssociationTarget(props);
+    const targetId = target.formUuid ? sanitizeEntityId(target.formUuid) : '';
+    relationships.push({
+      from: entityId,
+      to: targetId,
+      toFormUuid: target.formUuid,
+      toFormName: target.formTitle,
+      fromField: fieldId,
+      toField: target.mainFieldId,
+      label,
+      type: target.multiple ? 'many-to-many' : 'many-to-one',
+      source: 'AssociationFormField',
+      unresolved: !targetId,
+    });
+  }
+
+  return relationships;
+}
+
+function buildEntityFromRecord(record) {
+  const schema = record.schema;
+  const aliasMaps = buildComponentAliasMaps(schema);
+  const nodes = collectTopLevelFieldNodes(schema);
+  const entityId = sanitizeEntityId(record.formUuid || record.formName);
+  const entity = {
+    id: entityId,
+    name: record.formName || record.formUuid || entityId,
+    type: 'form',
+    formUuid: record.formUuid || '',
+    formType: record.formType || '',
+    pathName: record.pathName || '',
+    fields: [],
+  };
+  const childEntities = [];
+  const relationships = [];
+
+  nodes.forEach((node) => {
+    const props = node.props || {};
+    const fieldId = props.fieldId || '';
+    if (!fieldId) {
+      return;
+    }
+
+    const baseField = buildFieldFromNode(node, aliasMaps);
+    const label = baseField.label;
+
+    entity.fields.push(baseField);
+    relationships.push(...buildRelationshipsForField(entity.id, node, label, fieldId));
+
+    if (node.componentName === 'TableField') {
+      const childEntityId = `${entity.id}_${sanitizeEntityId(fieldId)}`;
+      const childModel = Array.isArray(node.children)
+        ? collectTableChildModel(node.children, aliasMaps, childEntityId)
+        : { fields: [], relationships: [] };
+      const childFields = childModel.fields;
+      relationships.push(...childModel.relationships);
+      childEntities.push({
+        id: childEntityId,
+        name: `${entity.name}.${label || fieldId}`,
+        type: 'subtable',
+        formUuid: `${record.formUuid || entity.id}.${fieldId}`,
+        formType: 'subtable',
+        parentFormUuid: record.formUuid || '',
+        parentFieldId: fieldId,
+        fields: [
+          { name: 'parentInstId', fieldId: 'parentInstId', type: 'string', componentName: 'SystemField', label: 'parentInstId' },
+          ...childFields,
+        ],
+      });
+      relationships.push({
+        from: entity.id,
+        to: childEntityId,
+        fromField: fieldId,
+        label,
+        type: 'one-to-many',
+        source: 'TableField',
+      });
+    }
+  });
+
+  entity.fields = dedupeByKey(entity.fields, item => item.fieldId);
+  entity.fields.unshift({
+    name: 'formInstId',
+    label: 'formInstId',
+    alias: '',
+    fieldId: 'formInstId',
+    componentName: 'SystemField',
+    type: 'string',
+    required: true,
+  });
+  return { entity, childEntities, relationships };
+}
+
+function collectTableChildModel(children, aliasMaps, childEntityId) {
+  const fields = [];
+  const relationships = [];
+
+  function traverse(node) {
+    if (!node) {
+      return;
+    }
+    if (FIELD_KIND_BY_COMPONENT[node.componentName]) {
+      const field = buildFieldFromNode(node, aliasMaps);
+      if (field) {
+        fields.push(field);
+        relationships.push(...buildRelationshipsForField(childEntityId, node, field.label, field.fieldId));
+      }
+    }
+    if (Array.isArray(node.children)) {
+      node.children.forEach(traverse);
+    }
+  }
+
+  children.forEach(traverse);
+  return {
+    fields: dedupeByKey(fields, item => item.fieldId),
+    relationships,
+  };
+}
+
+function buildErModel(records, options = {}) {
+  const entities = [];
+  const relationships = [];
+  const warnings = [];
+
+  records.filter(record => record && record.success).forEach((record) => {
+    const built = buildEntityFromRecord(record);
+    entities.push(built.entity, ...built.childEntities);
+    relationships.push(...built.relationships);
+  });
+
+  const knownEntityIds = new Set(entities.map(entity => entity.id));
+  const needsSystemUser = relationships.some(rel => rel.to === 'SystemUser');
+  const needsSystemDepartment = needsSystemUser || relationships.some(rel => rel.to === 'SystemDepartment');
+
+  if (options.includeSystem || needsSystemUser || needsSystemDepartment) {
+    SYSTEM_ENTITIES.forEach((entity) => {
+      const shouldInclude = options.includeSystem ||
+        (entity.id === 'SystemUser' && needsSystemUser) ||
+        (entity.id === 'SystemDepartment' && needsSystemDepartment);
+      if (shouldInclude && !knownEntityIds.has(entity.id)) {
+        entities.push(entity);
+        knownEntityIds.add(entity.id);
+      }
+    });
+  }
+
+  if (knownEntityIds.has('SystemUser') && knownEntityIds.has('SystemDepartment')) {
+    relationships.push({
+      from: 'SystemUser',
+      to: 'SystemDepartment',
+      fromField: 'deptId',
+      toField: 'deptId',
+      label: 'department',
+      type: 'many-to-one',
+      source: 'SystemEntity',
+    });
+  }
+
+  if (knownEntityIds.has('SystemDepartment')) {
+    relationships.push({
+      from: 'SystemDepartment',
+      to: 'SystemDepartment',
+      fromField: 'parentId',
+      toField: 'deptId',
+      label: 'parent department',
+      type: 'many-to-one',
+      source: 'SystemEntity',
+    });
+  }
+
+  if (knownEntityIds.has('SystemDepartment') && knownEntityIds.has('SystemOrganization')) {
+    relationships.push({
+      from: 'SystemDepartment',
+      to: 'SystemOrganization',
+      fromField: 'orgId',
+      toField: 'orgId',
+      label: 'organization',
+      type: 'many-to-one',
+      source: 'SystemEntity',
+    });
+  }
+
+  if (knownEntityIds.has('SystemRole') && knownEntityIds.has('SystemOrganization')) {
+    relationships.push({
+      from: 'SystemRole',
+      to: 'SystemOrganization',
+      fromField: 'orgId',
+      toField: 'orgId',
+      label: 'organization',
+      type: 'many-to-one',
+      source: 'SystemEntity',
+    });
+  }
+
+  if (knownEntityIds.has('SystemUser') && knownEntityIds.has('SystemRole')) {
+    relationships.push({
+      from: 'SystemUser',
+      to: 'SystemRole',
+      fromField: 'roleIds',
+      toField: 'roleId',
+      label: 'roles',
+      type: 'many-to-many',
+      source: 'SystemEntity',
+    });
+  }
+
+  relationships.forEach((rel) => {
+    if (rel.to && !knownEntityIds.has(rel.to)) {
+      rel.unresolved = true;
+      warnings.push({
+        type: 'unresolved-relationship',
+        from: rel.from,
+        to: rel.to,
+        toFormUuid: rel.toFormUuid || '',
+        message: `Relationship target not found: ${rel.toFormUuid || rel.to}`,
+      });
+    }
+  });
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    appType: options.appType || '',
+    entities: dedupeByKey(entities, item => item.id),
+    relationships: dedupeByKey(relationships, item => `${item.from}->${item.to}:${item.fromField}:${item.source}`),
+    warnings,
+  };
+}
+
+function mermaidTypeFor(field) {
+  return String(field.type || field.componentName || 'field')
+    .replace(/\[\]/g, '_list')
+    .replace(/[^\w\u4e00-\u9fa5]/g, '_');
+}
+
+function mermaidComment(value) {
+  return String(value || '').replace(/["\\\r\n]/g, ' ').trim();
+}
+
+function renderMermaid(model) {
+  const lines = ['erDiagram'];
+
+  model.entities.forEach((entity) => {
+    lines.push(`  ${entity.id} {`);
+    const fields = entity.fields && entity.fields.length > 0
+      ? entity.fields
+      : [{ name: entity.formUuid || entity.id, fieldId: entity.formUuid || entity.id, type: 'entity' }];
+    fields.forEach((field) => {
+      const keyMark = field.fieldId === 'formInstId' || field.fieldId === 'parentInstId' ? ' PK' : '';
+      const commentParts = [field.label, field.alias, field.componentName].map(mermaidComment).filter(Boolean);
+      const comment = commentParts.length > 0 ? ` "${commentParts.join(' / ')}"` : '';
+      lines.push(`    ${mermaidTypeFor(field)} ${sanitizeFieldName(field.name, field.fieldId)}${keyMark}${comment}`);
+    });
+    lines.push('  }');
+  });
+
+  model.relationships
+    .filter(rel => rel.to && !rel.unresolved)
+    .forEach((rel) => {
+      const connector = rel.type === 'one-to-many'
+        ? '||--o{'
+        : rel.type === 'many-to-many'
+          ? '}o--o{'
+          : '}o--||';
+      const label = mermaidComment(rel.label || rel.fromField || rel.source);
+      lines.push(`  ${rel.from} ${connector} ${rel.to} : "${label}"`);
+    });
+
+  return `${lines.join('\n')}\n`;
+}
+
+function formatErOutput(model, format) {
+  if (format === 'json') {
+    return `${JSON.stringify(model, null, 2)}\n`;
+  }
+  if (format === 'mermaid') {
+    return renderMermaid(model);
+  }
+  throw new Error(`Unsupported ER format: ${format}`);
+}
+
+function createAuthRef() {
+  const { step, info, success: chalkSuccess } = require('../core/chalk');
+
+  step(1, t('common.step_login', 1));
+  let cookieData = loadCookieData();
+  if (!cookieData) {
+    info(t('common.login_no_cache'));
+    cookieData = triggerLogin();
+  }
+
+  const authRef = {
+    csrfToken: cookieData.csrf_token,
+    cookies: cookieData.cookies,
+    baseUrl: resolveBaseUrl(cookieData),
+    cookieData,
+  };
+  chalkSuccess(t('common.login_ready', authRef.baseUrl));
+  return authRef;
+}
+
+function ensureUsage(parsed) {
+  if (parsed.help) {
+    process.stderr.write(`${t('er.usage')}\n${t('er.example')}\n`);
+    return false;
+  }
+  if (!parsed.appType) {
+    const { error } = require('../core/chalk');
+    error(t('er.usage'), { hint: t('er.example') });
+  }
+  if (!['mermaid', 'json'].includes(parsed.format)) {
+    const { error } = require('../core/chalk');
+    error(t('er.unsupported_format', parsed.format), { hint: t('er.format_hint') });
+  }
+  return true;
+}
+
+async function collectSchemaRecords(parsed, authRef) {
+  const forms = filterErSourceForms(await fetchFormPageList(parsed.appType, authRef), parsed);
+  return mapLimit(forms, parsed.concurrency, form => fetchSchemaRecord(parsed.appType, form, authRef, parsed.retries));
+}
+
+function writeOutputIfNeeded(content, outputPath) {
+  if (!outputPath) {
+    return '';
+  }
+  const resolved = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, content, 'utf-8');
+  return resolved;
+}
+
+async function run(args) {
+  const parsed = parseArgs(args || []);
+  if (!ensureUsage(parsed)) {
+    return;
+  }
+  const { banner, step, label, info, success } = require('../core/chalk');
+
+  banner(t('er.title'));
+  label('App', parsed.appType);
+  label('Format', parsed.format);
+  if (parsed.output) {label('Output', parsed.output);}
+
+  const authRef = createAuthRef();
+
+  step(2, t('er.step_fetch'));
+  const records = await collectSchemaRecords(parsed, authRef);
+  const successCount = records.filter(record => record.success).length;
+  info(t('er.forms_loaded', successCount, records.length - successCount));
+
+  step(3, t('er.step_build'));
+  const model = buildErModel(records, {
+    appType: parsed.appType,
+    includeSystem: parsed.includeSystem,
+  });
+  const content = formatErOutput(model, parsed.format);
+  const writtenPath = writeOutputIfNeeded(content, parsed.output);
+
+  if (writtenPath) {
+    success(t('er.output_written', writtenPath));
+  } else {
+    process.stdout.write(content);
+  }
+}
+
+module.exports = {
+  SYSTEM_ENTITIES,
+  parseArgs,
+  filterErSourceForms,
+  normalizeText,
+  sanitizeEntityId,
+  sanitizeFieldName,
+  collectTopLevelFieldNodes,
+  buildEntityFromRecord,
+  buildErModel,
+  renderMermaid,
+  formatErOutput,
+  collectSchemaRecords,
+  run,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -78,6 +78,9 @@ const COMMAND_GROUPS = [
         output: 'json',
       }),
       command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all>', 'help.cmd_get_schema'),
+      command('er', ['er'], 'er <appType> [--format mermaid|json] [--output file] [--include-system] [--include-pages]', 'help.cmd_er', {
+        output: 'text|json',
+      }),
       command('create-page', ['create-page'], 'create-page <appType> "<name>" [--mode dashboard] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_page'),
       command('generate-page', ['generate-page'], 'generate-page <template>', 'help.cmd_generate_page'),
       command('build-page', ['build-page'], 'build-page <sourceFile> [--output file|--write]', 'help.cmd_build_page', { requiresLogin: false }),

--- a/lib/core/locales/ar.js
+++ b/lib/core/locales/ar.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'تحديث صفحة نموذج',
     cmd_list_forms: 'List forms/pages in an app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'الحصول على Schema النموذج',
     cmd_create_page: 'إنشاء صفحة عرض مخصصة',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/de.js
+++ b/lib/core/locales/de.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'Formularseite aktualisieren',
     cmd_list_forms: 'Formulare/Seiten einer App auflisten',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'Formular-Schema abrufen',
     cmd_create_page: 'Benutzerdefinierte Anzeigeseite erstellen',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -34,6 +34,7 @@ module.exports = {
     cmd_list_forms: 'List forms/pages in an app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
     cmd_get_schema: 'Get one form Schema or all form Schemas',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_create_page: 'Create a custom display page',
     cmd_generate_page: 'Generate page from curated template',
     cmd_build_page: 'Build Yida-compatible page source',
@@ -602,6 +603,18 @@ Examples:
     sending: '  Sending getFormSchema request...',
     success: '  ✅ Schema retrieved successfully!',
     failed: '  ❌ Failed to get Schema: {0}',
+  },
+
+  er: {
+    title: '  openyida er - Yida Entity Relationship Diagram Export',
+    usage: 'Usage: openyida er <appType> [--format mermaid|json] [--output file] [--include-system] [--include-pages]',
+    example: 'Example: openyida er APP_XXX --format mermaid --output .cache/openyida/er/app.mmd',
+    step_fetch: '\n📋 Step 2: Fetch app schemas',
+    step_build: '\n🧩 Step 3: Build ER model',
+    forms_loaded: '  Loaded {0} schemas, {1} failed',
+    output_written: '  ER diagram written to: {0}',
+    unsupported_format: 'Unsupported ER output format: {0}',
+    format_hint: 'Use --format mermaid or --format json',
   },
 
   list_forms: {

--- a/lib/core/locales/es.js
+++ b/lib/core/locales/es.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'Actualizar página de formulario',
     cmd_list_forms: 'Listar formularios/páginas de una app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'Obtener Schema del formulario',
     cmd_create_page: 'Crear página de visualización personalizada',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/fr.js
+++ b/lib/core/locales/fr.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'Mettre à jour une page de formulaire',
     cmd_list_forms: 'Lister les formulaires/pages d\'une app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'Obtenir le Schema du formulaire',
     cmd_create_page: 'Créer une page d\'affichage personnalisée',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/hi.js
+++ b/lib/core/locales/hi.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'फॉर्म पेज अपडेट करें',
     cmd_list_forms: 'List forms/pages in an app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'फॉर्म Schema प्राप्त करें',
     cmd_create_page: 'कस्टम डिस्प्ले पेज बनाएं',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/ja.js
+++ b/lib/core/locales/ja.js
@@ -33,6 +33,7 @@ module.exports = {
     cmd_update_form: 'フォームページを更新',
     cmd_list_forms: 'アプリ内のフォーム/ページを一覧表示',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'フォーム Schema を取得',
     cmd_create_page: 'カスタム表示ページを作成',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/ko.js
+++ b/lib/core/locales/ko.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: '양식 페이지 업데이트',
     cmd_list_forms: 'List forms/pages in an app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: '양식 Schema 가져오기',
     cmd_create_page: '사용자 정의 표시 페이지 생성',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/pt.js
+++ b/lib/core/locales/pt.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'Atualizar página de formulário',
     cmd_list_forms: 'Listar formulários/páginas de um app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'Obter Schema do formulário',
     cmd_create_page: 'Criar página de exibição personalizada',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/vi.js
+++ b/lib/core/locales/vi.js
@@ -31,6 +31,7 @@ module.exports = {
     cmd_update_form: 'Cập nhật trang biểu mẫu',
     cmd_list_forms: 'List forms/pages in an app',
     cmd_aggregate_table: 'Manage aggregate tables (virtualView)',
+    cmd_er: 'Export app entity relationship diagram',
     cmd_get_schema: 'Lấy Schema biểu mẫu',
     cmd_create_page: 'Tạo trang hiển thị tùy chỉnh',
     cmd_generate_page: 'Generate page from curated template',

--- a/lib/core/locales/zh-HK.js
+++ b/lib/core/locales/zh-HK.js
@@ -33,6 +33,7 @@ module.exports = {
     cmd_update_form: '更新表單頁面',
     cmd_list_forms: '列出應用程式下的表單/頁面',
     cmd_aggregate_table: '管理聚合表（virtualView）',
+    cmd_er: '導出應用實體關係圖',
     cmd_get_schema: '取得表單 Schema',
     cmd_create_page: '建立自訂展示頁面',
     cmd_generate_page: '基於高質素模板生成頁面',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -34,6 +34,7 @@ module.exports = {
     cmd_list_forms: '列出应用下的表单/页面',
     cmd_aggregate_table: '管理聚合表（virtualView）',
     cmd_get_schema: '获取单个或全部表单 Schema',
+    cmd_er: '导出应用实体关系图',
     cmd_create_page: '创建自定义展示页面',
     cmd_generate_page: '基于高质量模板生成页面',
     cmd_build_page: '构建宜搭兼容页面源码',
@@ -574,6 +575,18 @@ openyida - 宜搭命令行工具
     sending: '  发送 getFormSchema 请求...',
     success: '  ✅ Schema 获取成功！',
     failed: '  ❌ 获取 Schema 失败: {0}',
+  },
+
+  er: {
+    title: '  openyida er - 宜搭实体关系图导出工具',
+    usage: '用法: openyida er <appType> [--format mermaid|json] [--output file] [--include-system] [--include-pages]',
+    example: '示例: openyida er APP_XXX --format mermaid --output .cache/openyida/er/app.mmd',
+    step_fetch: '\n📋 Step 2: 获取应用 Schema',
+    step_build: '\n🧩 Step 3: 构建 ER 模型',
+    forms_loaded: '  已加载 {0} 个 Schema，失败 {1} 个',
+    output_written: '  ER 图已写入: {0}',
+    unsupported_format: '不支持的 ER 输出格式: {0}',
+    format_hint: '请使用 --format mermaid 或 --format json',
   },
 
   list_forms: {

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -109,6 +109,7 @@ describe('CLI offline smoke', () => {
     expect(output).toContain('corp-efficiency');
     expect(output).toContain('create-form');
     expect(output).toContain('list-forms');
+    expect(output).toContain('er <appType>');
     expect(output).toContain('aggregate-table');
     expect(output).toContain('ai-form-setting');
     expect(output).toContain('connector');
@@ -148,6 +149,13 @@ describe('CLI offline smoke', () => {
     expect(result.output).not.toContain('读取登录态');
   });
 
+  test('er --help renders usage without requiring login', () => {
+    const result = runAny(['er', '--help']);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('openyida er');
+    expect(result.output).not.toContain('读取登录态');
+  });
+
   test('commands --json renders machine-readable command manifest', () => {
     const output = runOk(['commands', '--json']);
     const parsed = JSON.parse(output);
@@ -167,6 +175,7 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('add-validation');
     expect(commands).toContain('create-form.bind-datasource');
     expect(commands).toContain('list-forms');
+    expect(commands).toContain('er');
     expect(commands).toContain('aggregate-table');
     expect(commands).toContain('ai-form-setting');
     expect(commands).toContain('build-page');
@@ -213,6 +222,11 @@ describe('CLI offline smoke', () => {
     expect(parsed.commands.find(entry => entry.id === 'aggregate-table')).toMatchObject({
       usage: 'openyida aggregate-table <list|create-empty|inspect|preview|save|publish|status> <appType> ...',
       output: 'json',
+      requires_login: true,
+    });
+    expect(parsed.commands.find(entry => entry.id === 'er')).toMatchObject({
+      usage: 'openyida er <appType> [--format mermaid|json] [--output file] [--include-system] [--include-pages]',
+      output: 'text|json',
       requires_login: true,
     });
     expect(parsed.commands.find(entry => entry.id === 'ai-form-setting')).toMatchObject({

--- a/tests/er.test.js
+++ b/tests/er.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+const {
+  parseArgs,
+  filterErSourceForms,
+  collectTopLevelFieldNodes,
+  buildErModel,
+  renderMermaid,
+  formatErOutput,
+} = require('../lib/app/er');
+
+function schemaFrom(children, aliasItems = []) {
+  return {
+    success: true,
+    content: {
+      pages: [
+        {
+          componentAlias: {
+            items: aliasItems,
+          },
+          componentsTree: [
+            {
+              componentName: 'FormContainer',
+              children,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function field(componentName, fieldId, label, props = {}, children = []) {
+  return {
+    componentName,
+    props: {
+      fieldId,
+      label: { zh_CN: label },
+      ...props,
+    },
+    children,
+  };
+}
+
+function record(formUuid, formName, children, aliasItems = []) {
+  return {
+    formUuid,
+    formName,
+    formType: 'receipt',
+    pathName: formName,
+    success: true,
+    schema: schemaFrom(children, aliasItems),
+  };
+}
+
+describe('er argument parsing', () => {
+  test('parses output options and normalizes mmd format', () => {
+    expect(parseArgs([
+      'APP_XXX',
+      '--format',
+      'mmd',
+      '--output',
+      '.cache/openyida/er/app.mmd',
+      '--include-system',
+      '--keyword',
+      '客户',
+      '--concurrency',
+      '8',
+      '--retries',
+      '2',
+    ])).toEqual({
+      appType: 'APP_XXX',
+      format: 'mermaid',
+      output: '.cache/openyida/er/app.mmd',
+      includeSystem: true,
+      includePages: false,
+      keyword: '客户',
+      concurrency: 8,
+      retries: 2,
+      json: false,
+      help: false,
+    });
+  });
+
+  test('--json switches output format', () => {
+    expect(parseArgs(['APP_XXX', '--json'])).toMatchObject({
+      appType: 'APP_XXX',
+      format: 'json',
+      json: true,
+    });
+  });
+
+  test('--include-pages opts display pages into the ER source set', () => {
+    expect(parseArgs(['APP_XXX', '--include-pages'])).toMatchObject({
+      appType: 'APP_XXX',
+      includePages: true,
+    });
+  });
+
+  test('--help is parsed before login is needed', () => {
+    expect(parseArgs(['--help'])).toMatchObject({
+      appType: '',
+      help: true,
+    });
+  });
+});
+
+describe('er source form filtering', () => {
+  test('skips display pages by default and includes them only when requested', () => {
+    const forms = [
+      { formUuid: 'FORM-CUSTOMER', formName: 'Customer', formType: 'receipt' },
+      { formUuid: 'PAGE-DASHBOARD', formName: 'Dashboard', formType: 'display' },
+      { formUuid: 'FORM-APPROVAL', formName: 'Approval', formType: 'process' },
+    ];
+
+    expect(filterErSourceForms(forms, { includePages: false }).map(form => form.formUuid)).toEqual([
+      'FORM-CUSTOMER',
+      'FORM-APPROVAL',
+    ]);
+    expect(filterErSourceForms(forms, { includePages: true }).map(form => form.formUuid)).toEqual([
+      'FORM-CUSTOMER',
+      'PAGE-DASHBOARD',
+      'FORM-APPROVAL',
+    ]);
+  });
+
+  test('applies keyword filtering before display page exclusion', () => {
+    const forms = [
+      { formUuid: 'FORM-CUSTOMER', formName: 'Customer', formType: 'receipt' },
+      { formUuid: 'PAGE-DASHBOARD', formName: 'Dashboard', formType: 'display' },
+    ];
+
+    expect(filterErSourceForms(forms, { keyword: 'Dashboard', includePages: false })).toEqual([]);
+    expect(filterErSourceForms(forms, { keyword: 'Dashboard', includePages: true })).toEqual([
+      forms[1],
+    ]);
+  });
+});
+
+describe('er model extraction', () => {
+  test('keeps table children out of the parent entity field list', () => {
+    const schema = schemaFrom([
+      field('TextField', 'textField_name', '客户名称'),
+      field('TableField', 'tableField_contacts', '联系人', {}, [
+        field('TextField', 'textField_contactName', '联系人姓名'),
+      ]),
+    ]);
+
+    expect(collectTopLevelFieldNodes(schema).map(node => node.props.fieldId)).toEqual([
+      'textField_name',
+      'tableField_contacts',
+    ]);
+  });
+
+  test('builds form, subtable, association, and system relationships', () => {
+    const customerRecord = record('FORM-CUSTOMER', '客户', [
+      field('TextField', 'textField_name', '客户名称', { required: true }),
+      field('DepartmentSelectField', 'departmentSelectField_dept', '归属部门'),
+      field('TableField', 'tableField_contacts', '联系人', {}, [
+        field('TextField', 'textField_contactName', '联系人姓名'),
+        field('EmployeeField', 'employeeField_contactOwner', '联系人负责人'),
+      ]),
+    ], [
+      { fieldId: 'textField_name', alias: 'customerName' },
+      { fieldId: 'tableField_contacts', alias: 'contacts' },
+      { fieldId: 'textField_contactName', alias: 'contactName' },
+    ]);
+
+    const orderRecord = record('FORM-ORDER', '订单', [
+      field('AssociationFormField', 'associationFormField_customer', '关联客户', {
+        associationForm: {
+          appType: 'APP_XXX',
+          formUuid: 'FORM-CUSTOMER',
+          formTitle: '客户',
+          mainFieldId: 'textField_name',
+          mainFieldLabel: { zh_CN: '客户名称' },
+        },
+      }),
+      field('EmployeeField', 'employeeField_owner', '负责人'),
+      field('NumberField', 'numberField_amount', '金额'),
+    ]);
+
+    const model = buildErModel([customerRecord, orderRecord], { appType: 'APP_XXX' });
+    const entityIds = model.entities.map(entity => entity.id);
+    const relationshipKeys = model.relationships.map(rel => `${rel.from}->${rel.to}:${rel.source}`);
+
+    expect(entityIds).toEqual(expect.arrayContaining([
+      'FORM_CUSTOMER',
+      'FORM_ORDER',
+      'FORM_CUSTOMER_tableField_contacts',
+      'SystemUser',
+      'SystemDepartment',
+    ]));
+    expect(entityIds).not.toContain('SystemRole');
+    expect(relationshipKeys).toEqual(expect.arrayContaining([
+      'FORM_ORDER->FORM_CUSTOMER:AssociationFormField',
+      'FORM_ORDER->SystemUser:EmployeeField',
+      'FORM_CUSTOMER->SystemDepartment:DepartmentSelectField',
+      'FORM_CUSTOMER->FORM_CUSTOMER_tableField_contacts:TableField',
+      'FORM_CUSTOMER_tableField_contacts->SystemUser:EmployeeField',
+      'SystemUser->SystemDepartment:SystemEntity',
+      'SystemDepartment->SystemDepartment:SystemEntity',
+    ]));
+    expect(model.warnings).toHaveLength(0);
+
+    const customerEntity = model.entities.find(entity => entity.id === 'FORM_CUSTOMER');
+    expect(customerEntity.fields.map(item => item.name)).toEqual([
+      'formInstId',
+      'customerName',
+      'departmentSelectField_dept',
+      'contacts',
+    ]);
+
+    const contactEntity = model.entities.find(entity => entity.id === 'FORM_CUSTOMER_tableField_contacts');
+    expect(contactEntity.fields.map(item => item.name)).toEqual([
+      'parentInstId',
+      'contactName',
+      'employeeField_contactOwner',
+    ]);
+  });
+
+  test('includeSystem adds optional role and organization entities', () => {
+    const model = buildErModel([
+      record('FORM-CUSTOMER', '客户', [
+        field('TextField', 'textField_name', '客户名称'),
+      ]),
+    ], { includeSystem: true });
+
+    expect(model.entities.map(entity => entity.id)).toEqual(expect.arrayContaining([
+      'SystemUser',
+      'SystemDepartment',
+      'SystemRole',
+      'SystemOrganization',
+    ]));
+    expect(model.relationships.map(rel => `${rel.from}->${rel.to}:${rel.source}`)).toEqual(expect.arrayContaining([
+      'SystemDepartment->SystemOrganization:SystemEntity',
+      'SystemRole->SystemOrganization:SystemEntity',
+      'SystemUser->SystemRole:SystemEntity',
+    ]));
+  });
+
+  test('marks association targets outside the exported app as warnings', () => {
+    const model = buildErModel([
+      record('FORM-ORDER', '订单', [
+        field('AssociationFormField', 'associationFormField_customer', '关联客户', {
+          associationForm: {
+            appType: 'APP_OTHER',
+            formUuid: 'FORM-MISSING',
+            formTitle: '外部客户',
+          },
+        }),
+      ]),
+    ]);
+
+    expect(model.relationships[0]).toMatchObject({
+      from: 'FORM_ORDER',
+      to: 'FORM_MISSING',
+      unresolved: true,
+    });
+    expect(model.warnings).toEqual([
+      expect.objectContaining({
+        type: 'unresolved-relationship',
+        toFormUuid: 'FORM-MISSING',
+      }),
+    ]);
+  });
+});
+
+describe('er output rendering', () => {
+  test('renders Mermaid ER syntax and skips unresolved edges', () => {
+    const model = buildErModel([
+      record('FORM-ORDER', '订单', [
+        field('AssociationFormField', 'associationFormField_customer', '关联客户', {
+          associationForm: {
+            formUuid: 'FORM-CUSTOMER',
+            formTitle: '客户',
+          },
+        }),
+      ]),
+      record('FORM-CUSTOMER', '客户', [
+        field('TextField', 'textField_name', '客户名称'),
+      ]),
+      record('FORM-INVOICE', '发票', [
+        field('AssociationFormField', 'associationFormField_missing', '外部记录', {
+          associationForm: {
+            formUuid: 'FORM-MISSING',
+            formTitle: '外部记录',
+          },
+        }),
+      ]),
+    ]);
+
+    const mermaid = renderMermaid(model);
+    expect(mermaid).toContain('erDiagram');
+    expect(mermaid).toContain('FORM_ORDER {');
+    expect(mermaid).toContain('string formInstId PK');
+    expect(mermaid).toContain('FORM_ORDER }o--|| FORM_CUSTOMER : "关联客户"');
+    expect(mermaid).not.toContain('FORM_INVOICE }o--|| FORM_MISSING');
+  });
+
+  test('formats JSON output', () => {
+    const model = buildErModel([
+      record('FORM-CUSTOMER', '客户', [
+        field('TextField', 'textField_name', '客户名称'),
+      ]),
+    ], { appType: 'APP_XXX' });
+
+    expect(JSON.parse(formatErOutput(model, 'json'))).toMatchObject({
+      schemaVersion: 1,
+      appType: 'APP_XXX',
+      entities: [
+        expect.objectContaining({ id: 'FORM_CUSTOMER' }),
+      ],
+    });
+  });
+});

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -170,6 +170,7 @@ openyida copy
 | `yida-create-process` | `skills/yida-create-process/SKILL.md` | 创建流程表单并配置流程 | `openyida create-process <appType> "<表单名>" <字段JSON> <流程JSON>` |
 | `yida-aggregate-table` | — | 聚合表（virtualView）列表、创建空白页、读取配置、预览、保存草稿和发布 | `openyida aggregate-table <list\|create-empty\|inspect\|preview\|save\|publish\|status> ...` |
 | `yida-get-schema` | `skills/yida-get-schema/SKILL.md` | 获取单个/全部表单 Schema，确认字段 ID | `openyida get-schema <appType> <formUuid>` |
+| `yida-er` | — | 只读导出应用表单实体、子表和系统实体关系图 | `openyida er <appType> [--format mermaid\|json] [--output file] [--include-system] [--include-pages]` |
 | `yida-custom-page` | `skills/yida-custom-page/SKILL.md` | 编写自定义页面 JSX 代码规范 | 详见 SKILL.md |
 | `yida-publish-page` | `skills/yida-publish-page/SKILL.md` | 编译并发布自定义页面 | `openyida publish <源文件路径> <appType> <formUuid> [--health-check]` |
 | `yida-page-config` | `skills/yida-page-config/SKILL.md` | 页面公开访问/组织内分享配置 | `openyida verify-short-url <appType> <formUuid> <url>` |


### PR DESCRIPTION
## 中文说明

- 新增 `openyida er <appType>`，从应用表单 Schema 中导出应用级 ER 模型。
- 默认输出 Mermaid ER 图，也支持 `--format json` / `--json` 输出结构化 JSON。
- 覆盖普通表单实体、子表实体、关联表单关系、成员/部门系统关系、可选系统角色/组织实体，以及未解析关系告警。
- 已注册 CLI 帮助、命令清单和技能文档。

## 范围说明

这个 PR 是 #223 的只读导出基础能力：先提供可验证的 Mermaid/JSON ER 模型，不包含宜搭应用内可视化页面，也不包含 PNG/PDF 图片渲染。

## Summary

- add `openyida er <appType>` to export an app-level ER model from form schemas
- render Mermaid ER diagrams by default and JSON with `--format json` / `--json`
- include form entities, subtable entities, AssociationFormField links, Employee/Department system links, optional system Role/Organization entities, and unresolved relationship warnings
- document the command and register it in help / command manifest / skills index

## Scope

This is a read-only CLI export path for #223. It does not create a visual in-app ER page or image/PDF renderer yet, but provides a verifiable Mermaid/JSON foundation for that work.

## Tests

- `npm.cmd test -- --runInBand`
- `npm.cmd test -- --runTestsByPath tests\\er.test.js tests\\cli-smoke.test.js --runInBand`
- `npx.cmd eslint lib\\app\\er.js tests\\er.test.js tests\\cli-smoke.test.js bin\\yida.js lib\\core\\command-manifest.js --ext .js`
- `npm.cmd run check:syntax`
- `npm.cmd run check:skills`
- `git diff --check`

Refs #223