### PR TITLE
feat: 支持受控批量更新表单数据 / support guarded form batch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ openyida configure-process APP_XXX FORM_XXX .cache/openyida/process/process.json
 openyida process preview APP_XXX PROC_INST_XXX --output .cache/openyida/process/process.html
 openyida data query form APP_XXX FORM_XXX --page 1 --size 20
 openyida data create form APP_XXX FORM_XXX --data-file .cache/openyida/data-import/record.json
+openyida data batch-update form APP_XXX --file .cache/openyida/data-import/batch-update.json --max 30
 openyida get-permission APP_XXX FORM_XXX
 ```
 
@@ -335,7 +336,7 @@ Form field definitions can include `alias` or `componentAlias` to populate Yida 
 
 | Command | Description |
 |---------|-------------|
-| `openyida data <action> <resource> [args]` | Unified data management for forms, processes, tasks, and subforms; form queries support `--all`, `--form-uuid` subform hydration, and `--resolve-aliases` for component alias JSON keys |
+| `openyida data <action> <resource> [args]` | Unified data management for forms, processes, tasks, and subforms; form queries support `--all`, form updates support guarded `batch-update`, and JSON inputs support `--resolve-aliases` for component alias keys |
 | `openyida data check <appType> <formUuid> <rules.json>` | Detect anomalous process-form records |
 | `openyida task-center <type> [options]` | Query todo, created, processed, CC, or proxy-submitted tasks |
 | `openyida agent-center <sub-command>` | Manage Yida process delegation and departure delegation |

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -5,7 +5,7 @@
  *   openyida data <action> <resource> [参数]
  *
  * 支持的操作：
- *   query form / get form / create form / update form / query subform
+ *   query form / get form / create form / update form / batch-update form / query subform
  *   query process / get process / create process / update process
  *   query operation-records / execute task / query tasks
  */
@@ -34,6 +34,7 @@ Usage:
   openyida data get form <appType> --inst-id <formInstId> [--form-uuid <formUuid>] [--no-hydrate-subforms]
   openyida data create form <appType> <formUuid> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--dept-id ID] [--resolve-aliases]
   openyida data update form <appType> --inst-id <formInstId> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--form-uuid <formUuid>] [--use-latest-version y] [--resolve-aliases]
+  openyida data batch-update form <appType> --file .cache/openyida/batch-update.json [--max 30] [--form-uuid <formUuid>] [--use-latest-version y] [--resolve-aliases] [--stop-on-error]
   openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId|alias> [--page N] [--size N] [--resolve-aliases]
 
   openyida data query process <appType> <formUuid> [--page N] [--size N] [--search-json JSON|--search-file .cache/openyida/search.json] [--resolve-aliases] [--task-id ID] [--instance-status STATUS] [--approved-result RESULT]
@@ -153,6 +154,16 @@ function readJsonFileOption(filePath, label) {
   } catch (err) {
     parseError(`${label} 文件必须是合法 JSON：${resolvedPath} (${err.message})`);
   }
+}
+
+function readJsonFileValue(filePath, label) {
+  const jsonValue = readJsonFileOption(filePath, label);
+  try {
+    return JSON.parse(jsonValue);
+  } catch (err) {
+    parseError(`${label} 文件必须是合法 JSON：${path.resolve(filePath)} (${err.message})`);
+  }
+  return null;
 }
 
 function readJsonOption(options, jsonKey, fileKey, label) {
@@ -520,6 +531,22 @@ function printResult(result) {
   process.exit(1);
 }
 
+function isSuccessResult(result) {
+  const errorCode = result && result.errorCode;
+  const hasErrorCode = errorCode !== undefined && errorCode !== null && errorCode !== '' && errorCode !== 0 && errorCode !== '0';
+  return !!(result && result.success && !hasErrorCode);
+}
+
+function printBatchResult(result) {
+  const output = JSON.stringify(result, null, 2);
+  if (result && result.success) {
+    console.log(output);
+    return;
+  }
+  console.error(output);
+  process.exit(1);
+}
+
 function printFormDatasResult(result) {
   printResult(normalizeFormDatasResult(result));
 }
@@ -637,6 +664,93 @@ async function updateForm(positionals, options, session) {
   };
   if (options.use_latest_version) {params.useLatestVersion = options.use_latest_version;}
   printResult(await sendPost(session, appType, `/dingtalk/web/${appType}/v1/form/updateFormData.json`, params));
+}
+
+function normalizeBatchUpdateRecord(record, index) {
+  if (!isPlainObject(record)) {
+    parseError(`批量更新第 ${index + 1} 条记录必须是对象`);
+  }
+  const formInstId = record.formInstId || record.formInstanceId || record.instId || record.inst_id;
+  const formData = record.formData || record.data || record.updateFormData;
+  if (!formInstId || typeof formInstId !== 'string') {
+    parseError(`批量更新第 ${index + 1} 条记录缺少 formInstId`);
+  }
+  if (!isPlainObject(formData)) {
+    parseError(`批量更新第 ${index + 1} 条记录缺少 formData 对象`);
+  }
+  return { formInstId, formData };
+}
+
+function loadBatchUpdateRecords(options) {
+  requireOption(options, 'file');
+  const value = readJsonFileValue(options.file, '批量更新');
+  if (!Array.isArray(value)) {
+    parseError('批量更新文件必须是 JSON 数组');
+  }
+  return value.map(normalizeBatchUpdateRecord);
+}
+
+async function batchUpdateForm(positionals, options, session) {
+  requirePositionals(positionals, 1, ['appType']);
+  const [appType] = positionals;
+  const records = loadBatchUpdateRecords(options);
+  const max = parsePositiveInt(options.max, 30, '--max');
+
+  if (records.length > max) {
+    parseError(`批量更新记录数 ${records.length} 超过上限 ${max}，请拆分文件或调大 --max`);
+  }
+
+  const rawDataList = records.map((record) => JSON.stringify(record.formData));
+  const aliasContext = await resolveAliasContextIfNeeded(session, appType, options.form_uuid, options, rawDataList.join('\n'));
+  const results = [];
+  let successCount = 0;
+  let failureCount = 0;
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    const translatedDataJson = translateJsonWithAliases(rawDataList[index], aliasContext, translateFormDataObject);
+    const params = {
+      formInstId: record.formInstId,
+      updateFormDataJson: translatedDataJson,
+    };
+    if (options.use_latest_version) {params.useLatestVersion = options.use_latest_version;}
+
+    let response;
+    try {
+      response = await sendPost(session, appType, `/dingtalk/web/${appType}/v1/form/updateFormData.json`, params);
+    } catch (err) {
+      response = { success: false, errorMsg: err.message || String(err) };
+    }
+
+    const success = isSuccessResult(response);
+    if (success) {
+      successCount += 1;
+    } else {
+      failureCount += 1;
+    }
+
+    results.push({
+      index,
+      formInstId: record.formInstId,
+      success,
+      response,
+    });
+
+    if (!success && options.stop_on_error) {
+      break;
+    }
+  }
+
+  printBatchResult({
+    success: failureCount === 0,
+    total: records.length,
+    attempted: results.length,
+    successCount,
+    failureCount,
+    stoppedOnError: !!(options.stop_on_error && failureCount > 0 && results.length < records.length),
+    max,
+    results,
+  });
 }
 
 async function querySubform(positionals, options, session) {
@@ -784,6 +898,7 @@ async function run(args) {
   if (action === 'get' && resource === 'form') {return getForm(positionals, options, session);}
   if (action === 'create' && resource === 'form') {return createForm(positionals, options, session);}
   if (action === 'update' && resource === 'form') {return updateForm(positionals, options, session);}
+  if (action === 'batch-update' && resource === 'form') {return batchUpdateForm(positionals, options, session);}
   if (action === 'query' && resource === 'subform') {return querySubform(positionals, options, session);}
   if (action === 'query' && resource === 'process') {return queryProcess(positionals, options, session);}
   if (action === 'get' && resource === 'process') {return getProcess(positionals, options, session);}

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -612,6 +612,120 @@ describe('run() update form alias resolution', () => {
   });
 });
 
+describe('run() batch-update form', () => {
+  function writeBatchFile(records) {
+    const tmpFile = path.join(os.tmpdir(), 'openyida-batch-update-' + Date.now() + '-' + Math.random().toString(36).slice(2) + '.json');
+    fs.writeFileSync(tmpFile, JSON.stringify(records), 'utf8');
+    return tmpFile;
+  }
+
+  test('按文件顺序批量更新并输出汇总结果', async () => {
+    const batchFile = writeBatchFile([
+      { formInstId: 'INST-001', formData: { textField_status: '已处理' } },
+      { formInstId: 'INST-002', formData: { textField_status: '已关闭' } },
+    ]);
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpPost
+      .mockResolvedValueOnce({ success: true, content: { formInstId: 'INST-001' } })
+      .mockResolvedValueOnce({ success: true, content: { formInstId: 'INST-002' } });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['batch-update', 'form', 'APP_XXX', '--file', batchFile, '--max', '2']);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(2);
+    expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/v1/form/updateFormData.json');
+    expect(decodeURIComponent(utils.httpPost.mock.calls[0][2])).toContain('formInstId=INST-001');
+    expect(decodeURIComponent(utils.httpPost.mock.calls[1][2])).toContain('formInstId=INST-002');
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      total: 2,
+      attempted: 2,
+      successCount: 2,
+      failureCount: 0,
+      max: 2,
+    });
+
+    fs.unlinkSync(batchFile);
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('记录数超过 --max 时拦截且不发送请求', async () => {
+    const batchFile = writeBatchFile([
+      { formInstId: 'INST-001', formData: { textField_status: '已处理' } },
+      { formInstId: 'INST-002', formData: { textField_status: '已关闭' } },
+    ]);
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit(1)');
+    });
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run(['batch-update', 'form', 'APP_XXX', '--file', batchFile, '--max', '1'])).rejects.toThrow('process.exit(1)');
+
+    expect(utils.httpPost).not.toHaveBeenCalled();
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('超过上限 1'));
+
+    fs.unlinkSync(batchFile);
+    mockExit.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('--stop-on-error 遇到失败后停止后续记录', async () => {
+    const batchFile = writeBatchFile([
+      { formInstId: 'INST-001', formData: { textField_status: '已处理' } },
+      { formInstId: 'INST-002', formData: { textField_status: '已关闭' } },
+      { formInstId: 'INST-003', formData: { textField_status: '已取消' } },
+    ]);
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpPost
+      .mockResolvedValueOnce({ success: true, content: { formInstId: 'INST-001' } })
+      .mockResolvedValueOnce({ success: false, errorMsg: '更新失败' });
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit(1)');
+    });
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run(['batch-update', 'form', 'APP_XXX', '--file', batchFile, '--stop-on-error'])).rejects.toThrow('process.exit(1)');
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(2);
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"success": false'));
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"total": 3'));
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"attempted": 2'));
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"successCount": 1'));
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"failureCount": 1'));
+    expect(mockError).toHaveBeenCalledWith(expect.stringContaining('"stoppedOnError": true'));
+
+    fs.unlinkSync(batchFile);
+    mockExit.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('--resolve-aliases 会转换每条记录的 formData 字段别名', async () => {
+    const batchFile = writeBatchFile([
+      { formInstId: 'INST-001', formData: { phone: '123' } },
+    ]);
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet.mockResolvedValueOnce(buildAliasSchema());
+    utils.httpPost.mockResolvedValueOnce({ success: true });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['batch-update', 'form', 'APP_XXX', '--file', batchFile, '--form-uuid', 'FORM-XXX', '--resolve-aliases']);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(decodeURIComponent(utils.httpPost.mock.calls[0][2])).toContain('updateFormDataJson={"textField_phone":"123"}');
+
+    fs.unlinkSync(batchFile);
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+});
+
 describe('run() query subform alias resolution', () => {
   test('--resolve-aliases 会把子表组件别名转换为 tableFieldId', async () => {
     utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));

--- a/yida-skills/skills/yida-data-management/SKILL.md
+++ b/yida-skills/skills/yida-data-management/SKILL.md
@@ -69,10 +69,13 @@ openyida data create form <appType> <formUuid> --data-json '<json>' [--resolve-a
 openyida data create form <appType> <formUuid> --data-file .cache/openyida/data-import/record.json [--resolve-aliases]
 openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-json '<json>' [--resolve-aliases]
 openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-file .cache/openyida/data-import/patch.json [--resolve-aliases]
+openyida data batch-update form <appType> --file .cache/openyida/data-import/batch-update.json [--max 30] [--form-uuid <formUuid>] [--resolve-aliases] [--stop-on-error]
 openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId|alias> [--resolve-aliases]
 ```
 
 当 JSON 使用宜搭组件别名作为 key 时，追加 `--resolve-aliases`，OpenYida 会先读取表单 Schema 中的 `componentAlias.items`，再将别名转换为真实 `fieldId` 后调用数据接口。更新类命令若要解析别名，必须额外传 `--form-uuid <formUuid>`。
+
+批量更新文件必须是数组，每条记录包含 `formInstId` 和 `formData`。命令会顺序调用表单更新接口，默认最多 30 条；超过 `--max` 会直接拦截，并输出总数、成功数、失败数和每条记录结果。该能力不是事务，已成功的记录不会自动回滚。
 
 ### 流程实例
 
@@ -202,7 +205,7 @@ openyida sample yida-data-management form-field-template   # 表单字段定义�
 - `pageSize` 最大 100，QPS 限制约 40 次/秒
 - `searchFieldJson` 和 `dynamicOrder` 必须传字符串
 - 字段 ID 通过 `openyida get-schema` 获取，不要手写猜测
-- 批量脚本可以用 Python `subprocess` 调用 `openyida data ...`，也可以用 JS 复用 Node 工具；脚本必须放在 `.cache/openyida/scripts/`，导入数据放在 `.cache/openyida/data-import/`
+- 批量更新优先使用 `openyida data batch-update form ... --max 30`；更复杂的批处理脚本必须放在 `.cache/openyida/scripts/`，导入数据放在 `.cache/openyida/data-import/`
 
 ## 异常处理
 


### PR DESCRIPTION
## 中文说明

- 新增 `openyida data batch-update form`，用于受控地批量更新表单实例数据。
- 支持读取批量 JSON 文件，执行前用 `--max` 限制单次更新数量，默认 30 条，超过上限直接拦截。
- 顺序调用现有表单更新接口，输出每条记录的成功/失败结果，以及总数、成功数、失败数和实际尝试数。
- 支持 `--stop-on-error`、`--use-latest-version`，并复用现有 `--resolve-aliases + --form-uuid` 字段别名转换能力。
- 已更新 README 和 `yida-data-management` 技能文档。

Closes #400.

## 范围说明

这是基于现有 `updateFormData.json` 接口的受控顺序批处理能力，不是事务型批量接口。若中途失败，已经成功更新的记录不会自动回滚；命令会返回逐条结果，方便调用方重试或补偿。

## Summary

- add `openyida data batch-update form` for guarded sequential form record updates
- validate batch JSON files, enforce `--max` before sending requests, and collect per-record success/failure results
- support `--stop-on-error`, `--use-latest-version`, and existing `--resolve-aliases` translation via `--form-uuid`
- document the batch update command in README and the yida-data-management skill

## Notes

This implements a controlled sequential batch wrapper around the existing `updateFormData.json` endpoint. It is not a transactional batch API: records updated before a later failure are not rolled back. The command reports attempted count and per-record responses so callers can retry or compensate safely.

## Tests

- `node --check lib/core/query-data.js`
- `cmd /c npm test -- --runInBand tests/query-data.test.js`
- `cmd /c npm test -- --runInBand`