### PR TITLE
feat: 支持集成自动化结构化编排

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 
 | Command | Description |
 |---------|-------------|
-| `openyida integration create <appType> ...` | Create integration automation flow |
+| `openyida integration create <appType> ... [--spec file.json]` | Create integration automation flow |
 | `openyida integration list <appType> [--form-uuid <uuid>] [--status y\|n] [--json]` | List integration automation flows |
 | `openyida integration enable <appType> <formUuid> <processCode>` | Enable integration automation flow |
 | `openyida integration disable <appType> <formUuid> <processCode>` | Disable integration automation flow |

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -158,7 +158,7 @@ const COMMAND_GROUPS = [
     id: 'integration',
     titleKey: 'help.group_integration',
     commands: [
-      command('integration.create', ['integration', 'create'], 'integration create <appType> ...', 'help.cmd_integration'),
+      command('integration.create', ['integration', 'create'], 'integration create <appType> ... [--spec file.json]', 'help.cmd_integration'),
       command('integration.list', ['integration', 'list'], 'integration list <appType> [--form-uuid <uuid>] [--status y|n] [--json]', 'help.cmd_integration_list', {
         output: 'json',
       }),

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -356,6 +356,7 @@ Examples:
     create_opt_title: '  --title <text>                Notification title, supports #{fieldId-ComponentType}#',
     create_opt_content: '  --content <text>              Notification content, supports #{fieldId-ComponentType}#',
     create_opt_events: '  --events <list>               Trigger events: insert/update/delete/comment/processFinish/activityTask',
+    create_opt_spec: '  --spec <file.json>            Use a structured flow spec for complex automation nodes (dataUpdate/route, etc.)',
     create_opt_data_form_uuid: '  --data-form-uuid <uuid>     Target form UUID for a get-single-data node',
     create_opt_data_condition: '  --data-condition <rule>     Get-data condition: targetField:label:triggerField[:component[:opCode[:valueType]]]',
     create_opt_get_self: '  --get-self                    Insert a get-self node (pid equals trigger form instance ID)',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -353,6 +353,7 @@ openyida - 宜搭命令行工具
     create_opt_title: '  --title <text>                通知标题，支持 #{fieldId-ComponentType}#',
     create_opt_content: '  --content <text>              通知内容，支持 #{fieldId-ComponentType}#',
     create_opt_events: '  --events <list>               触发事件，insert/update/delete/comment/processFinish/activityTask',
+    create_opt_spec: '  --spec <file.json>            使用结构化编排文件创建复杂自动化（dataUpdate/route 等）',
     create_opt_data_form_uuid: '  --data-form-uuid <uuid>     插入获取单条数据节点的目标表单 UUID',
     create_opt_data_condition: '  --data-condition <rule>     获取数据过滤条件：目标字段:字段名:触发字段[:组件[:操作符[:值类型]]]',
     create_opt_get_self: '  --get-self                    自动插入获取自身节点（pid 等于触发事件表单实例ID）',

--- a/lib/integration/integration-create.js
+++ b/lib/integration/integration-create.js
@@ -5,6 +5,12 @@ const { generateNodeId } = require('./integration-node-ids');
 const { getFormSchema, createLogicflow, saveProcess } = require('./integration-api');
 const { mapEventTypes, buildProcessJson } = require('./integration-process-builder');
 const { buildViewJson } = require('./integration-view-builder');
+const {
+  readIntegrationSpec,
+  validateIntegrationSpec,
+  buildSpecProcessAndViewJson,
+  collectAddDataFormUuids,
+} = require('./integration-spec-builder');
 const { t } = require('../core/i18n');
 const { warn } = require('../core/chalk');
 
@@ -50,6 +56,7 @@ async function run(args) {
     warn(t('integration.create_opt_title'));
     warn(t('integration.create_opt_content'));
     warn(t('integration.create_opt_events'));
+    warn(t('integration.create_opt_spec'));
     warn(t('integration.create_opt_data_form_uuid'));
     warn(t('integration.create_opt_data_condition'));
     warn(t('integration.create_opt_get_self'));
@@ -86,6 +93,7 @@ async function run(args) {
   const eventsRaw = parseFlag(subArgs, '--events') || 'insert';
   const approvalActionsRaw = parseFlag(subArgs, '--approval-actions') || '';
   const approvalNodeIdsRaw = parseFlag(subArgs, '--approval-node-ids') || '';
+  const specPath = parseFlag(subArgs, '--spec');
   const triggerRecursively = hasFlag(subArgs, '--trigger-recursively');
   const getSelf = hasFlag(subArgs, '--get-self');
   const getSelfTriggerField = parseFlag(subArgs, '--get-self-field')
@@ -93,6 +101,15 @@ async function run(args) {
     || '__masterdata_form_inst_id';
   const getSelfQueryField = parseFlag(subArgs, '--get-self-query-field') || 'pid';
   const shouldPublish = hasFlag(subArgs, '--publish');
+  let integrationSpec = null;
+  if (specPath) {
+    try {
+      integrationSpec = readIntegrationSpec(specPath);
+    } catch (error) {
+      warn(`读取 --spec 失败：${error.message}`);
+      process.exit(1);
+    }
+  }
 
   const receiverUserIds = receiversRaw
     ? receiversRaw.split(',').map((id) => id.trim()).filter(Boolean)
@@ -115,6 +132,15 @@ async function run(args) {
   if (formEventTypes.length === 0) {
     warn(t('integration.create_invalid_events'));
     process.exit(1);
+  }
+
+  if (integrationSpec) {
+    try {
+      validateIntegrationSpec(integrationSpec, formEventTypes);
+    } catch (error) {
+      warn(`读取 --spec 失败：${error.message}`);
+      process.exit(1);
+    }
   }
 
   if (formEventTypes.includes('processFinish') && approvalActions.length === 0) {
@@ -290,6 +316,12 @@ async function run(args) {
   if (triggerConditions.length > 0) {
     warn(`触发过滤条件: ${triggerConditions.length}`);
   }
+  if (integrationSpec) {
+    const specNodes = Array.isArray(integrationSpec.nodes || integrationSpec.flow || integrationSpec.steps)
+      ? (integrationSpec.nodes || integrationSpec.flow || integrationSpec.steps).length
+      : 0;
+    warn(`结构化编排: ${specPath} (${specNodes} 个顶层节点)`);
+  }
   warn(t('integration.create_receivers', receiverUserIds.length > 0 ? receiverUserIds.join(', ') : t('integration.create_receivers_empty')));
   warn(t('integration.create_notify_title', notificationTitle));
   warn(t('integration.create_notify_content', notificationContent));
@@ -311,7 +343,14 @@ async function run(args) {
   if (addDataFormUuid) {
     totalSteps++;
   } // 获取目标表单 Schema
+  const specAddDataFormUuids = integrationSpec
+    ? collectAddDataFormUuids(integrationSpec).filter((uuid) => uuid !== addDataFormUuid)
+    : [];
+  totalSteps += specAddDataFormUuids.length;
   totalSteps++;                         // 保存/发布
+  if (shouldPublish) {
+    totalSteps++;
+  }
   let currentStep = 0;
   const step = (label) => {
     currentStep++;
@@ -382,69 +421,106 @@ async function run(args) {
 
   // 若有新增数据节点，获取目标表单 Schema（用于 viewJson 中的 inputs/rules 字段）
   let addDataFormSchema = [];
+  const formSchemasByUuid = new Map();
   if (addDataFormUuid) {
     try {
       warn(t('integration.create_step_get_schema'));
       addDataFormSchema = await getFormSchema(authRef, { appType, formUuid: addDataFormUuid.toString() });
+      formSchemasByUuid.set(addDataFormUuid.toString(), addDataFormSchema);
       warn(t('integration.create_get_schema_ok', String(addDataFormSchema.length)));
+    } catch (error) {
+      warn(t('integration.create_get_schema_warn', error.message));
+    }
+  }
+  for (const specFormUuid of specAddDataFormUuids) {
+    try {
+      step(`获取 ${specFormUuid} 表单 Schema`);
+      const schema = await getFormSchema(authRef, { appType, formUuid: specFormUuid.toString() });
+      formSchemasByUuid.set(specFormUuid.toString(), schema);
+      warn(t('integration.create_get_schema_ok', String(schema.length)));
     } catch (error) {
       warn(t('integration.create_get_schema_warn', error.message));
     }
   }
 
   // 构建 json 和 viewJson 参数
-  const processJson = buildProcessJson({
-    processCode,
-    formUuid,
-    appType,
-    formEventTypes,
-    notificationTitle,
-    notificationContent,
-    toUsers,
-    userFields,
-    nodeIds: processNodeIds,
-    addDataFormUuid: addDataFormUuid ?? undefined,
-    addDataAssignments,
-    dataFormUuid: dataFormUuid ?? undefined,
-    dataConditions,
-    hasMessageNode,
-    approvalActions,
-    approvalNodeIds,
-    triggerRecursively,
-    triggerConditions,
-    connectorId: connectorIdArg,
-    actionId: actionIdArg,
-    connectorAssignments,
-    connectorDescription: connectorNameArg || undefined,
-  });
+  let processJson;
+  let viewJson;
+  let outputFormEventTypes = formEventTypes;
+  let specNodeIdMap = null;
 
-  const viewJson = buildViewJson({
-    formUuid,
-    formEventTypes,
-    notificationTitle,
-    notificationContent,
-    toUsers,
-    userFields,
-    appType,
-    nodeIds: viewNodeIds,
-    addDataFormUuid: addDataFormUuid ?? undefined,
-    addDataAssignments,
-    addDataFormSchema,
-    addDataFormName: '',
-    dataFormUuid: dataFormUuid ?? undefined,
-    dataConditions,
-    hasMessageNode,
-    approvalActions,
-    approvalNodeIds,
-    triggerRecursively,
-    triggerConditions,
-    connectorId: connectorIdArg,
-    actionId: actionIdArg,
-    connectorAssignments,
-    connectorName: connectorNameArg,
-    connectorIcon: connectorIconArg,
-    connectorInputs: connectorInputsJson,
-  });
+  if (integrationSpec) {
+    const built = buildSpecProcessAndViewJson({
+      spec: integrationSpec,
+      processCode,
+      formUuid,
+      appType,
+      flowName,
+      formEventTypes,
+      notificationTitle,
+      notificationContent,
+      toUsers,
+      userFields,
+      formSchemasByUuid,
+    });
+    processJson = built.processJson;
+    viewJson = built.viewJson;
+    outputFormEventTypes = built.formEventTypes;
+    specNodeIdMap = built.nodeIdMap;
+  } else {
+    processJson = buildProcessJson({
+      processCode,
+      formUuid,
+      appType,
+      formEventTypes,
+      notificationTitle,
+      notificationContent,
+      toUsers,
+      userFields,
+      nodeIds: processNodeIds,
+      addDataFormUuid: addDataFormUuid ?? undefined,
+      addDataAssignments,
+      dataFormUuid: dataFormUuid ?? undefined,
+      dataConditions,
+      hasMessageNode,
+      approvalActions,
+      approvalNodeIds,
+      triggerRecursively,
+      triggerConditions,
+      connectorId: connectorIdArg,
+      actionId: actionIdArg,
+      connectorAssignments,
+      connectorDescription: connectorNameArg || undefined,
+    });
+
+    viewJson = buildViewJson({
+      formUuid,
+      formEventTypes,
+      notificationTitle,
+      notificationContent,
+      toUsers,
+      userFields,
+      appType,
+      nodeIds: viewNodeIds,
+      addDataFormUuid: addDataFormUuid ?? undefined,
+      addDataAssignments,
+      addDataFormSchema,
+      addDataFormName: '',
+      dataFormUuid: dataFormUuid ?? undefined,
+      dataConditions,
+      hasMessageNode,
+      approvalActions,
+      approvalNodeIds,
+      triggerRecursively,
+      triggerConditions,
+      connectorId: connectorIdArg,
+      actionId: actionIdArg,
+      connectorAssignments,
+      connectorName: connectorNameArg,
+      connectorIcon: connectorIconArg,
+      connectorInputs: connectorInputsJson,
+    });
+  }
 
   // 保存逻辑流（草稿）
   step(t('integration.create_step_save'));
@@ -512,7 +588,8 @@ async function run(args) {
       flowName,
       appType,
       formUuid,
-      formEventTypes,
+      formEventTypes: outputFormEventTypes,
+      specNodeIdMap,
     }));
     return;
   }
@@ -531,7 +608,8 @@ async function run(args) {
     flowName,
     appType,
     formUuid,
-    formEventTypes,
+    formEventTypes: outputFormEventTypes,
+    specNodeIdMap,
   }));
 }
 

--- a/lib/integration/integration-process-builder.js
+++ b/lib/integration/integration-process-builder.js
@@ -44,6 +44,8 @@ function mapTriggerOperator(opCode) {
     NotContain: '不包含',
     HasValue: '有值',
     NoValue: '没有值',
+    ExistValue: '有值',
+    NotExistValue: '没有值',
     GreaterThan: '大于',
     LessThan: '小于',
     GreaterThanOrEqual: '大于等于',
@@ -58,7 +60,7 @@ function mapDataRetrieveOperator(opCode) {
   return mapTriggerOperator(opCode || 'Contain');
 }
 
-function buildTriggerCondition(triggerConditions) {
+function buildTriggerCondition(triggerConditions, logic = 'AND') {
   const groupId = generateRuleGroupId();
   const rules = (triggerConditions || []).map((condition) => {
     const opCode = condition.opCode || 'Equal';
@@ -83,18 +85,19 @@ function buildTriggerCondition(triggerConditions) {
       opCode,
     };
   });
+  const normalizedLogic = String(logic || 'AND').toUpperCase() === 'OR' ? 'OR' : 'AND';
   return {
-    condition: 'AND',
+    condition: normalizedLogic,
     rules,
     ruleId: groupId,
-    conditionCode: '&&',
+    conditionCode: normalizedLogic === 'OR' ? '||' : '&&',
   };
 }
 
 /**
  * 构建获取单条数据节点的过滤条件对象
  */
-function buildDataRetrieveCondition(dataConditions) {
+function buildDataRetrieveCondition(dataConditions, logic = 'AND') {
   const groupId = generateRuleGroupId();
   const rules = dataConditions.map((condition) => {
     const opCode = condition.opCode || 'Contain';
@@ -119,11 +122,12 @@ function buildDataRetrieveCondition(dataConditions) {
       opCode,
     };
   });
+  const normalizedLogic = String(logic || 'AND').toUpperCase() === 'OR' ? 'OR' : 'AND';
   return {
-    condition: 'AND',
+    condition: normalizedLogic,
     rules,
     ruleId: groupId,
-    conditionCode: '&&',
+    conditionCode: normalizedLogic === 'OR' ? '||' : '&&',
   };
 }
 

--- a/lib/integration/integration-spec-builder.js
+++ b/lib/integration/integration-spec-builder.js
@@ -69,7 +69,7 @@ function conditionCodeFor(logic) {
 }
 
 function getNodeAlias(node, fallback) {
-  return node.id || node.key || node.name || fallback;
+  return node.id || node.key || fallback;
 }
 
 function registerNodeId(node, context, prefix) {
@@ -79,8 +79,7 @@ function registerNodeId(node, context, prefix) {
   const alias = getNodeAlias(node, `${prefix}_${context.generatedIndex++}`);
   const existing = context.aliasToNodeId.get(alias);
   if (existing) {
-    node._nodeId = existing;
-    return existing;
+    throw new Error(`Duplicate integration spec node alias: ${alias}`);
   }
   const nodeId = node.nodeId || generateNodeId();
   node._nodeId = nodeId;
@@ -135,11 +134,11 @@ function normalizeToUsers(value, fallback = []) {
   }).filter(Boolean);
 }
 
-function normalizeDataConditions(conditions) {
+function normalizeDataConditions(conditions, context) {
   return asArray(conditions).map((condition) => ({
-    bFieldId: condition.bFieldId || condition.fieldId || condition.id,
+    bFieldId: resolveNodeRefs(condition.bFieldId || condition.fieldId || condition.id, context),
     bFieldName: condition.bFieldName || condition.fieldName || condition.name || condition.label || condition.bFieldId || condition.fieldId,
-    aFieldId: condition.aFieldId || condition.value || condition.ruleValue,
+    aFieldId: resolveNodeRefs(condition.aFieldId || condition.value || condition.ruleValue, context),
     componentType: condition.componentType || 'TextField',
     opCode: condition.opCode || condition.op || 'Contain',
     valueType: condition.valueType || 'processVar',
@@ -292,7 +291,7 @@ function buildDataRetrieveProcessNode(node, nodeId, nextNodeId, context) {
       opCode: 'Equal',
       valueType: 'processVar',
     }]
-    : normalizeDataConditions(node.conditions || node.dataConditions);
+    : normalizeDataConditions(node.conditions || node.dataConditions, context);
   const conditions = rawConditions.length > 0
     ? buildDataRetrieveCondition(rawConditions, node.logic || node.conditionLogic)
     : { condition: 'AND', rules: [], ruleId: generateRuleGroupId(), conditionCode: '&&' };

--- a/lib/integration/integration-spec-builder.js
+++ b/lib/integration/integration-spec-builder.js
@@ -1,0 +1,978 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { generateNodeId, generateRuleGroupId, generateDataRuleId, generateButtonUuid } = require('./integration-node-ids');
+const {
+  mapEventTypes,
+  buildTriggerCondition,
+  buildDataRetrieveCondition,
+  buildDataCreateAssignments,
+  buildConnectorCallAssignments,
+} = require('./integration-process-builder');
+const { buildAddDataChildList } = require('./integration-view-builder');
+const {
+  lookupConnectorPreset,
+  buildConnectorRulesFromInputs,
+  buildFallbackInputsFromAssignments,
+} = require('./connector-presets');
+
+function readIntegrationSpec(filePath) {
+  const resolved = path.resolve(filePath);
+  const raw = fs.readFileSync(resolved, 'utf8').replace(/^\uFEFF/u, '');
+  const spec = JSON.parse(raw);
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('--spec must point to a JSON object');
+  }
+  return spec;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getSpecNodes(spec) {
+  return asArray(spec.nodes || spec.flow || spec.steps);
+}
+
+function getSpecEventInput(spec, fallbackEvents = ['insert']) {
+  const events = Array.isArray(spec.events)
+    ? spec.events
+    : Array.isArray(spec.formEventTypes)
+      ? spec.formEventTypes
+      : fallbackEvents;
+  return asArray(events).map((event) => String(event).trim()).filter(Boolean);
+}
+
+function mapSpecEventTypes(spec, fallbackEvents) {
+  return mapEventTypes(getSpecEventInput(spec, fallbackEvents));
+}
+
+function validateIntegrationSpec(spec, fallbackEvents = ['insert']) {
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('--spec must point to a JSON object');
+  }
+  if (getSpecNodes(spec).length === 0) {
+    throw new Error('integration spec must contain a non-empty nodes array');
+  }
+  if (mapSpecEventTypes(spec, fallbackEvents).length === 0) {
+    throw new Error('integration spec must contain at least one valid event');
+  }
+}
+
+function normalizeLogic(logic) {
+  return String(logic || 'AND').toUpperCase() === 'OR' ? 'OR' : 'AND';
+}
+
+function conditionCodeFor(logic) {
+  return normalizeLogic(logic) === 'OR' ? '||' : '&&';
+}
+
+function getNodeAlias(node, fallback) {
+  return node.id || node.key || node.name || fallback;
+}
+
+function registerNodeId(node, context, prefix) {
+  if (node._nodeId) {
+    return node._nodeId;
+  }
+  const alias = getNodeAlias(node, `${prefix}_${context.generatedIndex++}`);
+  const existing = context.aliasToNodeId.get(alias);
+  if (existing) {
+    node._nodeId = existing;
+    return existing;
+  }
+  const nodeId = node.nodeId || generateNodeId();
+  node._nodeId = nodeId;
+  context.aliasToNodeId.set(alias, nodeId);
+  context.nodeIdToAlias.set(nodeId, alias);
+  return nodeId;
+}
+
+function preRegisterSpecNodes(nodes, context) {
+  for (const node of asArray(nodes)) {
+    const type = normalizeNodeType(node.type || node.componentName) || 'node';
+    registerNodeId(node, context, type);
+    if (type === 'route') {
+      for (const branch of asArray(node.branches || node.conditions)) {
+        registerNodeId(branch, context, 'condition');
+        preRegisterSpecNodes(branch.nodes || branch.childNodes || branch.children, context);
+      }
+    }
+  }
+}
+
+function resolveAlias(value, context) {
+  if (!value) {
+    return value;
+  }
+  return context.aliasToNodeId.get(value) || value;
+}
+
+function resolveNodeRefs(value, context) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  return value.replace(/\$\{([^}.]+)\}/g, (match, alias) => {
+    const nodeId = context.aliasToNodeId.get(alias);
+    return nodeId ? `\${${nodeId}}` : match;
+  });
+}
+
+function normalizeToUsers(value, fallback = []) {
+  const raw = value === undefined ? fallback : value;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((item) => {
+    if (typeof item === 'string') {
+      return { userId: item, userName: '' };
+    }
+    if (item && typeof item === 'object' && item.userId) {
+      return { userId: item.userId, userName: item.userName || '' };
+    }
+    return null;
+  }).filter(Boolean);
+}
+
+function normalizeDataConditions(conditions) {
+  return asArray(conditions).map((condition) => ({
+    bFieldId: condition.bFieldId || condition.fieldId || condition.id,
+    bFieldName: condition.bFieldName || condition.fieldName || condition.name || condition.label || condition.bFieldId || condition.fieldId,
+    aFieldId: condition.aFieldId || condition.value || condition.ruleValue,
+    componentType: condition.componentType || 'TextField',
+    opCode: condition.opCode || condition.op || 'Contain',
+    valueType: condition.valueType || 'processVar',
+  })).filter((condition) => condition.bFieldId && condition.aFieldId);
+}
+
+function normalizeTriggerConditions(conditions, context) {
+  return asArray(conditions).map((condition) => ({
+    fieldId: resolveNodeRefs(condition.fieldId || condition.id, context),
+    fieldName: condition.fieldName || condition.name || condition.label || condition.fieldId || condition.id,
+    opCode: condition.opCode || condition.op || 'Equal',
+    value: resolveNodeRefs(condition.value, context),
+    componentType: condition.componentType || 'TextField',
+    valueType: condition.valueType || 'literal',
+  })).filter((condition) => condition.fieldId);
+}
+
+function buildConditionObject(conditions, logic, context) {
+  let conditionRules = conditions;
+  let conditionLogic = logic;
+  if (conditions && typeof conditions === 'object' && !Array.isArray(conditions)) {
+    conditionRules = conditions.rules || conditions.conditions || [];
+    conditionLogic = conditions.logic || conditions.condition || logic;
+  }
+  const normalized = normalizeTriggerConditions(conditionRules, context);
+  if (normalized.length === 0) {
+    return {
+      condition: normalizeLogic(conditionLogic),
+      rules: [],
+      ruleId: generateRuleGroupId(),
+      conditionCode: conditionCodeFor(conditionLogic),
+    };
+  }
+  return buildTriggerCondition(normalized, conditionLogic);
+}
+
+function normalizeAssignments(assignments, context) {
+  return asArray(assignments).map((assignment) => ({
+    column: assignment.column || assignment.fieldId || assignment.targetField,
+    valueType: assignment.valueType || 'literal',
+    value: resolveNodeRefs(assignment.value, context),
+    __display: assignment.__display,
+    __source: assignment.__source ? resolveNodeRefs(assignment.__source, context) : undefined,
+  })).filter((assignment) => assignment.column);
+}
+
+function buildUpdateAssignments(assignments, context) {
+  return normalizeAssignments(assignments, context).map((assignment) => {
+    const value = assignment.valueType === 'literal' && !isNaN(Number(assignment.value))
+      ? Number(assignment.value)
+      : assignment.value;
+    const result = {
+      column: assignment.column,
+      valueType: assignment.valueType,
+      value,
+      assignments: [],
+    };
+    if (assignment.__display) {
+      result.__display = assignment.__display;
+    }
+    if (assignment.__source) {
+      result.__source = assignment.__source;
+    }
+    return result;
+  });
+}
+
+function buildMessageProcessNode(node, nodeId, nextNodeId, context) {
+  const title = node.title || context.defaultNotificationTitle || context.flowName;
+  const content = node.content || context.defaultNotificationContent || '表单有新记录提交，请及时查看。';
+  const toUsers = normalizeToUsers(node.receivers || node.toUsers, context.defaultToUsers);
+  const userFields = Array.isArray(node.userFields) ? node.userFields : context.defaultUserFields;
+  return {
+    name: { zh_CN: node.name || '消息通知', en_US: '' },
+    description: node.description || '请设置消息通知',
+    type: 'sendMessage',
+    nodeId,
+    prevId: '',
+    nextId: [nextNodeId],
+    props: {
+      template: { templateName: '' },
+      messageType: node.messageType || 'NORMAL',
+      messageInfo: {
+        title,
+        content,
+        buttons: [
+          {
+            name: node.buttonName || '查看详情',
+            type: 'commit',
+            value: node.buttonUrl || `//yidalogin.aliwork.com/${context.appType}/formDetail/${context.formUuid}?formInstId=\${formInstId}`,
+            buttonUuid: generateButtonUuid(),
+          },
+        ],
+      },
+      appType: context.appType,
+      toRoles: [],
+      toUsers,
+      userFields: Array.isArray(userFields) && userFields.length > 0 ? userFields : ['form_inst_creator'],
+    },
+    childNodes: [],
+  };
+}
+
+function buildMessageViewNode(node, nodeId, context) {
+  const title = node.title || context.defaultNotificationTitle || context.flowName;
+  const content = node.content || context.defaultNotificationContent || '表单有新记录提交，请及时查看。';
+  const toUsers = normalizeToUsers(node.receivers || node.toUsers, context.defaultToUsers);
+  const userFields = Array.isArray(node.userFields) ? node.userFields : context.defaultUserFields;
+  return {
+    componentName: 'SendMessageNode',
+    id: nodeId,
+    props: {
+      nodeName: 'SendMessageNode',
+      name: node.name || '消息通知',
+      description: node.description || '请设置消息通知',
+      sendMessageRules: {
+        template: { templateName: '' },
+        messageType: node.messageType || 'NORMAL',
+        messageInfo: {
+          title,
+          content,
+          buttons: [
+            {
+              name: node.buttonName || '查看详情',
+              type: 'commit',
+              value: node.buttonUrl || `//yidalogin.aliwork.com/${context.appType}/formDetail/${context.formUuid}?formInstId=\${formInstId}`,
+              buttonUuid: generateButtonUuid(),
+            },
+          ],
+        },
+        appType: context.appType,
+        toRoles: [],
+        toUsers,
+        userFields: Array.isArray(userFields) && userFields.length > 0 ? userFields : ['form_inst_modifier'],
+        description: node.description || '发送工作通知',
+      },
+    },
+    title: node.name || '消息通知',
+  };
+}
+
+function buildDataRetrieveProcessNode(node, nodeId, nextNodeId, context) {
+  const formUuid = node.formUuid || node.sourceId || (node.type === 'getSelf' ? context.formUuid : undefined);
+  const rawConditions = node.type === 'getSelf' || node.getSelf
+    ? [{
+      bFieldId: node.queryField || 'pid',
+      bFieldName: '表单实例ID',
+      aFieldId: node.triggerField || '__masterdata_form_inst_id',
+      componentType: 'TextField',
+      opCode: 'Equal',
+      valueType: 'processVar',
+    }]
+    : normalizeDataConditions(node.conditions || node.dataConditions);
+  const conditions = rawConditions.length > 0
+    ? buildDataRetrieveCondition(rawConditions, node.logic || node.conditionLogic)
+    : { condition: 'AND', rules: [], ruleId: generateRuleGroupId(), conditionCode: '&&' };
+  return {
+    name: { zh_CN: node.name || '获取单条数据', en_US: '' },
+    description: node.description || '请设置想要获取的数据',
+    type: 'dataRetrieve',
+    nodeId,
+    prevId: '',
+    nextId: [nextNodeId],
+    props: {
+      type: 'single',
+      filterType: 'condition',
+      sort: node.sort || { type: 'none', column: '' },
+      sourceId: formUuid,
+      appType: context.appType,
+      originalType: node.originalType || 'form',
+      subSourceId: node.subSourceId || '',
+      condition: conditions,
+      quantity: String(node.quantity || '1'),
+      dataRules: {
+        rules: [
+          {
+            componentName: '',
+            labe: '',
+            name: '',
+            required: false,
+            ruleId: generateDataRuleId(),
+            value: '',
+            valueType: 'literal',
+          },
+        ],
+      },
+      assignments: [],
+    },
+    childNodes: [],
+  };
+}
+
+function buildDataRetrieveViewNode(node, nodeId, context) {
+  const processNode = buildDataRetrieveProcessNode(node, nodeId, nodeId, context);
+  const props = processNode.props;
+  return {
+    componentName: 'GetSingleDataNode',
+    id: nodeId,
+    props: {
+      nodeName: 'GetSingleDataNode',
+      name: node.name || '获取单条数据',
+      description: node.description || '请设置想要获取的数据',
+      type: 'single',
+      getData: {
+        type: 'single',
+        originalType: props.originalType,
+        appType: context.appType,
+        sourceId: props.sourceId,
+        targetItem: {
+          appType: context.appType,
+          appName: '',
+          formItem: {
+            formType: 'receipt',
+            advanceProc: 'n',
+            formUuid: props.sourceId,
+            title: '',
+            fields: null,
+            hasTableField: null,
+          },
+        },
+        subSourceId: props.subSourceId,
+        relativeItem: {},
+        filterType: 'condition',
+        condition: props.condition,
+        sort: props.sort,
+        rulesFilter: [],
+        outputs: [],
+        quantity: Number(props.quantity || 1),
+        dataRules: props.dataRules,
+        assignments: [],
+      },
+      title: node.name || '获取单条数据',
+    },
+  };
+}
+
+function buildDataCreateProcessNode(node, nodeId, nextNodeId, context) {
+  const formUuid = node.formUuid || node.targetFormUuid;
+  return {
+    name: { zh_CN: node.name || '新增数据', en_US: '' },
+    description: node.description || '请设置新增数据',
+    type: 'dataCreate',
+    nodeId,
+    prevId: '',
+    nextId: [nextNodeId],
+    props: {
+      formUuid,
+      appType: context.appType,
+      subFormUuid: node.subFormUuid || '',
+      insertType: node.insertType || 'form',
+      type: node.createType || 'single',
+      sourceId: node.sourceId || '',
+      assignments: buildDataCreateAssignments(normalizeAssignments(node.assignments, context)),
+    },
+    childNodes: [],
+  };
+}
+
+function buildDataCreateViewNode(node, nodeId, context) {
+  const formUuid = node.formUuid || node.targetFormUuid;
+  const schemaComponents = context.formSchemasByUuid.get(formUuid) || [];
+  const childList = buildAddDataChildList(schemaComponents);
+  const componentOptionMap = {};
+  childList.forEach((item) => {
+    componentOptionMap[item.fieldId] = '[]';
+  });
+  const assignmentRules = normalizeAssignments(node.assignments, context).map((assignment) => {
+    const matchedField = childList.find((item) => item.fieldId === assignment.column);
+    return {
+      name: assignment.column,
+      componentName: matchedField ? matchedField.componentName : 'TextField',
+      valueType: assignment.valueType,
+      value: assignment.valueType === 'literal' && !isNaN(Number(assignment.value))
+        ? Number(assignment.value)
+        : assignment.value,
+      required: false,
+      ruleId: generateDataRuleId(),
+      componentOption: '[]',
+      label: matchedField ? matchedField.label : assignment.column,
+      componentProps: {
+        defaultDataSource: {},
+        relateAppType: '',
+        relateOrderEnable: false,
+        relateOrderConfig: [],
+      },
+    };
+  });
+  return {
+    componentName: 'AddDataNode',
+    id: nodeId,
+    props: {
+      nodeName: 'AddDataNode',
+      name: node.name || '新增数据',
+      description: node.description || `在[${node.formName || '目标表单'}]中新增数据`,
+      addDataRules: {
+        formUuid,
+        appType: context.appType,
+        insertType: node.insertType || 'form',
+        type: node.createType || 'single',
+        subFormUuid: node.subFormUuid || '',
+        sourceId: node.sourceId || '',
+        assignments: [],
+        inputs: { childList, componentOptionMap },
+        rules: {
+          childList,
+          componentOptionMap,
+          ruleId: generateDataRuleId(),
+          rules: assignmentRules,
+        },
+      },
+    },
+    title: node.name || '新增数据',
+  };
+}
+
+function buildDataUpdateRules(node, context) {
+  const sourceId = resolveAlias(node.source || node.sourceId || node.from, context) || '';
+  const updateType = node.updateType || node.updateMode || (sourceId ? 'node' : 'condition');
+  const condition = node.condition
+    ? buildConditionObject(node.condition, node.logic, context)
+    : {};
+  return {
+    type: updateType,
+    sourceId,
+    subSourceId: node.subSourceId || '',
+    condition,
+    subCondition: node.subCondition || {},
+    assignments: buildUpdateAssignments(node.assignments || node.updateAssignments, context),
+    noneOperation: node.noneOperation || 'ignored',
+    rulesFilter: node.rulesFilter || [],
+    tableRulesFilter: node.tableRulesFilter || [],
+  };
+}
+
+function buildDataUpdateProcessNode(node, nodeId, nextNodeId, context) {
+  return {
+    name: { zh_CN: node.name || '更新数据', en_US: '' },
+    description: node.description || '请设置更新数据',
+    type: 'dataUpdate',
+    nodeId,
+    prevId: '',
+    nextId: [nextNodeId],
+    props: buildDataUpdateRules(node, context),
+    childNodes: [],
+  };
+}
+
+function buildDataUpdateViewNode(node, nodeId, context) {
+  const rules = buildDataUpdateRules(node, context);
+  return {
+    componentName: 'UpdateDataNode',
+    id: nodeId,
+    props: {
+      nodeName: 'UpdateDataNode',
+      name: node.name || '更新数据',
+      description: node.description || '请设置更新数据',
+      updateDataRules: rules,
+    },
+    title: node.name || '更新数据',
+  };
+}
+
+function buildConnectorProcessNode(node, nodeId, nextNodeId, context) {
+  return {
+    name: { zh_CN: node.name || '连接器', en_US: '' },
+    description: node.description || '请选择连接器',
+    type: 'innerConnector',
+    nodeId,
+    prevId: '',
+    nextId: [nextNodeId],
+    props: {
+      inputs: {
+        url: '',
+        method: '',
+        body: '',
+        connection: '',
+        connectorId: node.connectorId,
+        actionId: node.actionId,
+        assignments: buildConnectorCallAssignments(normalizeAssignments(node.assignments || node.connectorAssignments, context)),
+      },
+    },
+    childNodes: [],
+  };
+}
+
+function buildConnectorViewNode(node, nodeId, context) {
+  let normalizedInputs = Array.isArray(node.inputs) ? node.inputs : [];
+  let normalizedOutputs = [];
+  let presetDescription = '';
+  let presetSchemaType = 'normal';
+  if (normalizedInputs.length === 0) {
+    const preset = lookupConnectorPreset(node.connectorId, node.actionId);
+    if (preset && preset.inputs && preset.inputs.length > 0) {
+      normalizedInputs = preset.inputs;
+      normalizedOutputs = preset.outputs || [];
+      presetDescription = preset.description || '';
+      presetSchemaType = preset.openDevSchemaType || 'normal';
+    } else {
+      normalizedInputs = buildFallbackInputsFromAssignments(normalizeAssignments(node.assignments || node.connectorAssignments, context));
+    }
+  }
+  const assignments = normalizeAssignments(node.assignments || node.connectorAssignments, context);
+  const connectorRulesArray = buildConnectorRulesFromInputs(normalizedInputs, assignments);
+  const connectorDisplayName = node.name || '连接器';
+  return {
+    componentName: 'ConnectorNode',
+    id: nodeId,
+    props: {
+      nodeName: 'ConnectorNode',
+      connectorRules: {
+        allStepCounts: 2,
+        currentStep: 1,
+        connectorId: node.connectorId,
+        connectionId: '',
+        actionId: node.actionId,
+        connector: {
+          config: null,
+          connectorCorpId: '',
+          connectorId: node.connectorId,
+          containTriggers: null,
+          description: connectorDisplayName,
+          iconUrl: node.icon || '',
+          mode: 1,
+          name: connectorDisplayName,
+          orgId: 0,
+          prioirty: 0,
+          subscribed: null,
+          underControl: null,
+        },
+        inputs: normalizedInputs,
+        outputs: normalizedOutputs,
+        url: '',
+        method: '',
+        body: '',
+        rules: connectorRulesArray,
+        description: presetDescription || connectorDisplayName,
+        openDevSchemaType: presetSchemaType,
+        totalLevel: 0,
+        categoryListMap: {},
+        selectedCategoryList: [],
+        integrationObjectPath: [],
+        integrationObjectName: '',
+      },
+      name: connectorDisplayName,
+      description: node.description || '请选择连接器',
+      step: 0,
+      status: 'edit',
+    },
+    title: connectorDisplayName,
+  };
+}
+
+function buildRouteNode(node, nodeId, exitNodeId, context) {
+  const branches = asArray(node.branches || node.conditions);
+  const conditionIds = [];
+  const conditionProcessNodes = [];
+  const conditionViewNodes = [];
+  let hasDefault = false;
+
+  branches.forEach((branch, index) => {
+    const branchNode = { ...branch, id: branch.id || branch.name || `branch_${index + 1}` };
+    const branchId = registerNodeId(branchNode, context, 'condition');
+    conditionIds.push(branchId);
+
+    const childResult = buildSpecNodeList(asArray(branch.nodes || branch.childNodes || branch.children), exitNodeId, context);
+    const isDefault = Boolean(branch.default || branch.isDefault);
+    hasDefault = hasDefault || isDefault;
+    const priority = isDefault ? 2147483647 : (branch.priority || index + 1);
+    const branchName = branch.name || (isDefault ? '其他情况' : '条件');
+    const conditionObject = isDefault
+      ? null
+      : buildConditionObject(branch.condition || branch.conditions || branch.rules, branch.logic || branch.conditionLogic, context);
+    const nextId = childResult.processNodes.length > 0 ? childResult.processNodes[0].nodeId : exitNodeId;
+
+    const props = {
+      priority,
+      isDefault,
+    };
+    if (!isDefault) {
+      props.conditions = conditionObject;
+      props.calculate = 'condition';
+    }
+
+    conditionProcessNodes.push({
+      name: { zh_CN: branchName, en_US: branchName },
+      description: branch.description || '',
+      type: 'condition',
+      nodeId: branchId,
+      prevId: nodeId,
+      nextId: [nextId],
+      props,
+      childNodes: childResult.processNodes,
+    });
+
+    const viewProps = isDefault
+      ? {
+        isDefault: true,
+        buttons: [{ name: '关闭' }],
+        name: { zh_CN: branchName, en_US: branchName },
+        description: branch.description || '',
+      }
+      : {
+        name: { zh_CN: branchName, en_US: branchName },
+        description: branch.description || '',
+        conditions: {
+          calculate: 'condition',
+          conditions: conditionObject,
+          isDefault: false,
+          priority,
+          description: branch.description || branchName,
+        },
+      };
+    const viewNode = {
+      componentName: 'ConditionNode',
+      id: branchId,
+      props: viewProps,
+    };
+    if (childResult.viewNodes.length > 0) {
+      viewNode.children = childResult.viewNodes;
+    }
+    conditionViewNodes.push(viewNode);
+  });
+
+  if (!hasDefault) {
+    const defaultId = generateNodeId();
+    conditionIds.push(defaultId);
+    conditionProcessNodes.push({
+      name: { zh_CN: '其他情况', en_US: 'Other situations' },
+      description: '',
+      type: 'condition',
+      nodeId: defaultId,
+      prevId: nodeId,
+      nextId: [exitNodeId],
+      props: {
+        priority: 2147483647,
+        isDefault: true,
+      },
+      childNodes: [],
+    });
+    conditionViewNodes.push({
+      componentName: 'ConditionNode',
+      id: defaultId,
+      props: {
+        isDefault: true,
+        buttons: [{ name: '关闭' }],
+        name: { zh_CN: '其他情况', en_US: 'Other situations' },
+        description: '',
+      },
+    });
+  }
+
+  return {
+    processNode: {
+      name: { zh_CN: node.name || '条件分支', en_US: node.name || 'Condition' },
+      description: node.description || '',
+      type: 'route',
+      nodeId,
+      prevId: '',
+      nextId: conditionIds,
+      props: { outgoingType: node.outgoingType || 'priority' },
+      childNodes: conditionProcessNodes,
+    },
+    viewNode: {
+      componentName: 'ConditionContainer',
+      id: nodeId,
+      props: {},
+      title: node.name || '条件分支',
+      children: conditionViewNodes,
+    },
+  };
+}
+
+function normalizeNodeType(type) {
+  const normalized = String(type || '').toLowerCase();
+  const mapping = {
+    getself: 'getSelf',
+    'get-self': 'getSelf',
+    getdata: 'dataRetrieve',
+    dataretrieve: 'dataRetrieve',
+    dataretrievenode: 'dataRetrieve',
+    createdata: 'dataCreate',
+    adddata: 'dataCreate',
+    datacreate: 'dataCreate',
+    updatedata: 'dataUpdate',
+    dataupdate: 'dataUpdate',
+    message: 'sendMessage',
+    sendmessage: 'sendMessage',
+    connector: 'connector',
+    innerconnector: 'connector',
+    route: 'route',
+    condition: 'route',
+  };
+  return mapping[normalized] || type;
+}
+
+function buildSpecNode(node, nextNodeId, context) {
+  const type = normalizeNodeType(node.type || node.componentName);
+  const nodeId = registerNodeId(node, context, type || 'node');
+  if (type === 'getSelf' || type === 'dataRetrieve') {
+    return {
+      processNode: buildDataRetrieveProcessNode({ ...node, type }, nodeId, nextNodeId, context),
+      viewNode: buildDataRetrieveViewNode({ ...node, type }, nodeId, context),
+    };
+  }
+  if (type === 'dataCreate') {
+    return {
+      processNode: buildDataCreateProcessNode(node, nodeId, nextNodeId, context),
+      viewNode: buildDataCreateViewNode(node, nodeId, context),
+    };
+  }
+  if (type === 'dataUpdate') {
+    return {
+      processNode: buildDataUpdateProcessNode(node, nodeId, nextNodeId, context),
+      viewNode: buildDataUpdateViewNode(node, nodeId, context),
+    };
+  }
+  if (type === 'sendMessage') {
+    return {
+      processNode: buildMessageProcessNode(node, nodeId, nextNodeId, context),
+      viewNode: buildMessageViewNode(node, nodeId, context),
+    };
+  }
+  if (type === 'connector') {
+    return {
+      processNode: buildConnectorProcessNode(node, nodeId, nextNodeId, context),
+      viewNode: buildConnectorViewNode(node, nodeId, context),
+    };
+  }
+  if (type === 'route') {
+    return buildRouteNode(node, nodeId, nextNodeId, context);
+  }
+  throw new Error(`Unsupported integration spec node type: ${node.type || node.componentName}`);
+}
+
+function buildSpecNodeList(nodes, exitNodeId, context) {
+  const normalizedNodes = asArray(nodes);
+  const processNodes = [];
+  const viewNodes = [];
+  for (let index = normalizedNodes.length - 1; index >= 0; index--) {
+    const node = normalizedNodes[index];
+    const nextNodeId = processNodes.length > 0 ? processNodes[0].nodeId : exitNodeId;
+    const built = buildSpecNode(node, nextNodeId, context);
+    processNodes.unshift(built.processNode);
+    viewNodes.unshift(built.viewNode);
+  }
+  return { processNodes, viewNodes };
+}
+
+function buildStartNodes(spec, context, triggerNodeId, firstNodeId) {
+  const formEventTypes = mapSpecEventTypes(spec, context.defaultFormEventTypes);
+  if (formEventTypes.length === 0) {
+    throw new Error('integration spec must contain at least one valid event');
+  }
+  const triggerConditions = asArray(spec.triggerConditions);
+  const triggerConditionObject = triggerConditions.length > 0
+    ? buildTriggerCondition(normalizeTriggerConditions(triggerConditions, context), spec.triggerConditionLogic || 'AND')
+    : null;
+  const startFormEventTypes = formEventTypes;
+  const processNode = {
+    name: {
+      en_US: 'Form event trigger',
+      zh_CN: '表单事件触发',
+      type: 'i18n',
+    },
+    description: '',
+    type: 'trigger',
+    nodeId: triggerNodeId,
+    prevId: '',
+    nextId: [firstNodeId],
+    props: {
+      inputs: {
+        formEventType: formEventTypes,
+        formEventField: '',
+        formUuid: context.formUuid,
+        conditions: triggerConditionObject,
+        activityAction: asArray(spec.approvalActions),
+        triggerFormEventRecursively: Boolean(spec.triggerRecursively),
+        activityId: asArray(spec.approvalNodeIds),
+        activityTask: [],
+      },
+      triggerType: 'FormEvent',
+    },
+    childNodes: [],
+  };
+  const viewNode = {
+    componentName: 'StartNode',
+    id: triggerNodeId,
+    props: {
+      nodeName: 'StartNode',
+      name: {
+        en_US: 'Form event trigger',
+        zh_CN: '表单事件触发',
+        type: 'i18n',
+      },
+      nodeError: '',
+      start: {
+        examineApproveType: 'processFinish',
+        formEventType: startFormEventTypes,
+        formEventField: '',
+        dataFilterType: triggerConditions.length > 0 ? 'byRule' : 'all',
+        fieldType: 'all',
+        conditions: triggerConditionObject || {
+          condition: 'AND',
+          rules: [
+            {
+              id: '',
+              op: '等于',
+              operators: [],
+              componentType: 'TextField',
+            },
+          ],
+        },
+        formUuid: context.formUuid,
+        triggerType: 'FormEvent',
+        type: 'form',
+        triggerFormEventRecursively: Boolean(spec.triggerRecursively),
+        examineApproveNode: '',
+        examineApproveActiveList: asArray(spec.approvalActions),
+        examineApproveActiveTask: [],
+      },
+    },
+  };
+  return { processNode, viewNode, formEventTypes };
+}
+
+function buildFinishNodes(endNodeId) {
+  return {
+    processNode: {
+      name: { en_US: 'end', zh_CN: '结束', type: 'i18n' },
+      description: '',
+      type: 'finish',
+      nodeId: endNodeId,
+      prevId: '',
+      nextId: [],
+      props: {},
+      childNodes: [],
+    },
+    viewNode: {
+      componentName: 'EndNode',
+      id: endNodeId,
+      props: {
+        name: { en_US: 'end', zh_CN: '结束', type: 'i18n' },
+      },
+    },
+  };
+}
+
+function buildSpecProcessAndViewJson(options) {
+  const spec = options.spec || {};
+  validateIntegrationSpec(spec, options.formEventTypes || ['insert']);
+  const nodes = getSpecNodes(spec);
+
+  const context = {
+    appType: options.appType,
+    formUuid: options.formUuid,
+    flowName: options.flowName || '',
+    defaultFormEventTypes: options.formEventTypes || ['insert'],
+    defaultNotificationTitle: options.notificationTitle,
+    defaultNotificationContent: options.notificationContent,
+    defaultToUsers: options.toUsers || [],
+    defaultUserFields: options.userFields || [],
+    formSchemasByUuid: options.formSchemasByUuid || new Map(),
+    aliasToNodeId: new Map(),
+    nodeIdToAlias: new Map(),
+    generatedIndex: 1,
+  };
+  const canvasId = options.canvasId || generateNodeId();
+  const triggerNodeId = options.triggerNodeId || generateNodeId();
+  const endNodeId = options.endNodeId || generateNodeId();
+
+  preRegisterSpecNodes(nodes, context);
+  const middle = buildSpecNodeList(nodes, endNodeId, context);
+  const firstNodeId = middle.processNodes.length > 0 ? middle.processNodes[0].nodeId : endNodeId;
+  const start = buildStartNodes(spec, context, triggerNodeId, firstNodeId);
+  const finish = buildFinishNodes(endNodeId);
+
+  return {
+    processJson: {
+      props: {
+        allowWithdraw: true,
+        allowCollaboration: true,
+        allowTemporaryStorage: true,
+        processCode: options.processCode,
+      },
+      nodes: [start.processNode, ...middle.processNodes, finish.processNode],
+    },
+    viewJson: {
+      schema: {
+        componentName: 'CanvasEngine',
+        id: canvasId,
+        props: {},
+        children: [start.viewNode, ...middle.viewNodes, finish.viewNode],
+      },
+      globalSetting: {},
+    },
+    formEventTypes: start.formEventTypes,
+    nodeIdMap: Object.fromEntries(context.aliasToNodeId.entries()),
+  };
+}
+
+function collectAddDataFormUuids(spec) {
+  const result = new Set();
+  function visit(nodes) {
+    for (const node of asArray(nodes)) {
+      const type = normalizeNodeType(node.type || node.componentName);
+      if (type === 'dataCreate') {
+        const formUuid = node.formUuid || node.targetFormUuid;
+        if (formUuid) {
+          result.add(formUuid);
+        }
+      }
+      if (type === 'route') {
+        for (const branch of asArray(node.branches || node.conditions)) {
+          visit(branch.nodes || branch.childNodes || branch.children);
+        }
+      }
+    }
+  }
+  visit(getSpecNodes(spec));
+  return Array.from(result);
+}
+
+module.exports = {
+  readIntegrationSpec,
+  validateIntegrationSpec,
+  buildSpecProcessAndViewJson,
+  collectAddDataFormUuids,
+  _private: {
+    getSpecNodes,
+    mapSpecEventTypes,
+    normalizeNodeType,
+    resolveNodeRefs,
+    buildSpecNodeList,
+    buildDataUpdateRules,
+  },
+};

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -205,6 +205,7 @@ describe('CLI offline smoke', () => {
       output: 'text|json',
       requires_login: false,
     });
+    expect(parsed.commands.find(entry => entry.id === 'integration.create').usage).toContain('--spec file.json');
     expect(parsed.commands.find(entry => entry.id === 'externalize-form')).toMatchObject({
       usage: 'openyida externalize-form <appType> <formUuid> [--schema-file file]',
       output: 'json|markdown',

--- a/tests/integration-spec-builder.test.js
+++ b/tests/integration-spec-builder.test.js
@@ -217,6 +217,112 @@ describe('integration spec builder', () => {
     expect(route.childNodes[0].props.conditions.rules).toHaveLength(2);
   });
 
+  test('does not use duplicate display names as node aliases', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          { type: 'sendMessage', name: 'Notify', content: 'first' },
+          { type: 'sendMessage', name: 'Notify', content: 'second' },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+    });
+
+    const messages = built.processJson.nodes.filter((node) => node.type === 'sendMessage');
+    expect(messages).toHaveLength(2);
+    expect(messages[0].nodeId).not.toBe(messages[1].nodeId);
+    expect(messages[0].nextId).toEqual([messages[1].nodeId]);
+    expect(messages[0].nextId).not.toEqual([messages[0].nodeId]);
+    expect(built.nodeIdMap).not.toHaveProperty('Notify');
+  });
+
+  test('rejects duplicate explicit node aliases', () => {
+    expect(() => buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          { id: 'notify', type: 'sendMessage', content: 'first' },
+          { id: 'notify', type: 'sendMessage', content: 'second' },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+    })).toThrow(/Duplicate integration spec node alias: notify/);
+  });
+
+  test('does not use duplicate route branch names as aliases', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          {
+            type: 'route',
+            branches: [
+              {
+                name: 'Matched',
+                conditions: [{ fieldId: 'textField_a', opCode: 'ExistValue' }],
+                nodes: [{ type: 'sendMessage', content: 'first' }],
+              },
+              {
+                name: 'Matched',
+                conditions: [{ fieldId: 'textField_b', opCode: 'ExistValue' }],
+                nodes: [{ type: 'sendMessage', content: 'second' }],
+              },
+            ],
+          },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+    });
+
+    const route = built.processJson.nodes.find((node) => node.type === 'route');
+    expect(route.nextId).toHaveLength(3);
+    expect(new Set(route.nextId).size).toBe(3);
+    expect(route.nextId).not.toContain(undefined);
+    expect(built.nodeIdMap).not.toHaveProperty('Matched');
+  });
+
+  test('resolves node references inside dataRetrieve conditions', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          { id: 'self', type: 'getSelf' },
+          {
+            id: 'lookup',
+            type: 'dataRetrieve',
+            formUuid: 'FORM-B',
+            conditions: [
+              {
+                fieldId: 'textField_b',
+                value: '${self}.textField_a',
+              },
+            ],
+          },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+    });
+
+    const lookup = built.processJson.nodes.find((node) => node.nodeId === built.nodeIdMap.lookup);
+    expect(lookup.props.condition.rules[0]).toMatchObject({
+      id: 'textField_b',
+      value: `\${${built.nodeIdMap.self}}.textField_a`,
+    });
+  });
+
   test('resolveNodeRefs replaces spec aliases only inside ${alias}', () => {
     const context = {
       aliasToNodeId: new Map([['self', 'node-self']]),

--- a/tests/integration-spec-builder.test.js
+++ b/tests/integration-spec-builder.test.js
@@ -1,0 +1,239 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.mock('../lib/integration/integration-node-ids', () => {
+  let counter = 0;
+  return {
+    generateNodeId: jest.fn(() => `node_${++counter}`),
+    generateRuleGroupId: jest.fn(() => 'group-fixed'),
+    generateRuleItemId: jest.fn(() => 'item-fixed'),
+    generateDataRuleId: jest.fn(() => 'rule-fixed'),
+    generateButtonUuid: jest.fn(() => 'button-fixed'),
+  };
+});
+
+const {
+  buildSpecProcessAndViewJson,
+  collectAddDataFormUuids,
+  readIntegrationSpec,
+  validateIntegrationSpec,
+  _private,
+} = require('../lib/integration/integration-spec-builder');
+
+describe('integration spec builder', () => {
+  test('builds dataRetrieve -> route -> dataUpdate/dataCreate flow from spec', () => {
+    const spec = {
+      events: ['insert'],
+      nodes: [
+        {
+          id: 'self',
+          type: 'getSelf',
+        },
+        {
+          id: 'branch',
+          type: 'route',
+          branches: [
+            {
+              id: 'hasData',
+              name: '有自身数据',
+              conditions: [
+                {
+                  fieldId: '${self}.pid',
+                  fieldName: '表单实例ID',
+                  opCode: 'ExistValue',
+                  componentType: 'TextField',
+                },
+              ],
+              nodes: [
+                {
+                  id: 'updateSelf',
+                  type: 'dataUpdate',
+                  source: 'self',
+                  assignments: [
+                    {
+                      column: 'textareaField_result',
+                      valueType: 'literal',
+                      value: '已更新',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'fallback',
+              name: '其他情况',
+              default: true,
+              nodes: [
+                {
+                  id: 'createBackup',
+                  type: 'dataCreate',
+                  formUuid: 'FORM-B',
+                  assignments: [
+                    {
+                      column: 'textField_name',
+                      valueType: 'processVar',
+                      value: 'textField_name',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const built = buildSpecProcessAndViewJson({
+      spec,
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+      formEventTypes: ['insert'],
+      formSchemasByUuid: new Map([
+        ['FORM-B', [
+          { componentName: 'TextField', props: { fieldId: 'textField_name', label: { zh_CN: '名称' } } },
+        ]],
+      ]),
+    });
+
+    expect(built.processJson.props.processCode).toBe('LPROC-SPEC');
+    expect(built.processJson.nodes.map((node) => node.type)).toEqual([
+      'trigger',
+      'dataRetrieve',
+      'route',
+      'finish',
+    ]);
+    expect(built.processJson.nodes[1].props.condition.rules[0]).toMatchObject({
+      id: 'pid',
+      value: '__masterdata_form_inst_id',
+      opCode: 'Equal',
+    });
+
+    const route = built.processJson.nodes[2];
+    expect(route.childNodes.map((node) => node.type)).toEqual(['condition', 'condition']);
+    expect(route.childNodes[0].props.conditions.rules[0]).toMatchObject({
+      id: `\${${built.nodeIdMap.self}}.pid`,
+      opCode: 'ExistValue',
+      op: '有值',
+    });
+    expect(route.childNodes[0].childNodes[0]).toMatchObject({
+      type: 'dataUpdate',
+      props: {
+        type: 'node',
+        sourceId: built.nodeIdMap.self,
+      },
+    });
+    expect(route.childNodes[1].props.isDefault).toBe(true);
+    expect(route.childNodes[1].childNodes[0]).toMatchObject({
+      type: 'dataCreate',
+      props: {
+        formUuid: 'FORM-B',
+      },
+    });
+
+    expect(built.viewJson.schema.children.map((node) => node.componentName)).toEqual([
+      'StartNode',
+      'GetSingleDataNode',
+      'ConditionContainer',
+      'EndNode',
+    ]);
+    expect(built.viewJson.schema.children[2].children[0].children[0].componentName).toBe('UpdateDataNode');
+    expect(Object.keys(built.nodeIdMap).sort()).toEqual([
+      'branch',
+      'createBackup',
+      'fallback',
+      'hasData',
+      'self',
+      'updateSelf',
+    ]);
+  });
+
+  test('collectAddDataFormUuids walks branch child nodes', () => {
+    expect(collectAddDataFormUuids({
+      nodes: [
+        {
+          type: 'route',
+          branches: [
+            { nodes: [{ type: 'dataCreate', formUuid: 'FORM-A' }] },
+            { nodes: [{ type: 'dataCreate', targetFormUuid: 'FORM-B' }] },
+          ],
+        },
+      ],
+    }).sort()).toEqual(['FORM-A', 'FORM-B']);
+  });
+
+  test('validates spec shape before remote calls are needed', () => {
+    expect(() => validateIntegrationSpec({ nodes: [{ type: 'getSelf' }] }, ['insert'])).not.toThrow();
+    expect(() => validateIntegrationSpec({ events: ['insert'], nodes: [] })).toThrow(/non-empty nodes array/);
+    expect(() => validateIntegrationSpec({ events: ['unknown'], nodes: [{ type: 'getSelf' }] })).toThrow(/valid event/);
+  });
+
+  test('accepts route condition objects with explicit logic', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          { id: 'self', type: 'getSelf' },
+          {
+            type: 'route',
+            branches: [
+              {
+                id: 'matched',
+                condition: {
+                  logic: 'OR',
+                  rules: [
+                    {
+                      fieldId: '${self}.textField_a',
+                      fieldName: 'A',
+                      opCode: 'ExistValue',
+                    },
+                    {
+                      fieldId: '${self}.textField_b',
+                      fieldName: 'B',
+                      opCode: 'ExistValue',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'Spec Flow',
+    });
+
+    const route = built.processJson.nodes.find((node) => node.type === 'route');
+    expect(route.childNodes[0].props.conditions).toMatchObject({
+      condition: 'OR',
+      conditionCode: '||',
+    });
+    expect(route.childNodes[0].props.conditions.rules).toHaveLength(2);
+  });
+
+  test('resolveNodeRefs replaces spec aliases only inside ${alias}', () => {
+    const context = {
+      aliasToNodeId: new Map([['self', 'node-self']]),
+    };
+
+    expect(_private.resolveNodeRefs('${self}.numberField_count+1', context)).toBe('${node-self}.numberField_count+1');
+    expect(_private.resolveNodeRefs('literal-self', context)).toBe('literal-self');
+  });
+
+  test('readIntegrationSpec accepts UTF-8 BOM files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-integration-spec-'));
+    const file = path.join(dir, 'flow.json');
+    fs.writeFileSync(file, '\uFEFF{"nodes":[{"type":"getSelf"}]}', 'utf8');
+    try {
+      expect(readIntegrationSpec(file).nodes[0].type).toBe('getSelf');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -91,6 +91,7 @@ openyida integration check <appType...> [--json] [--output result.xlsx] [--no-pr
 | `--approval-node-ids <nodeId,...>` | 空 | 当 `--events activityTask` 时必填；审批节点 ID，多个用逗号分隔 |
 | `--trigger-condition <fieldId:fieldName:opCode:value[:componentType[:valueType]]>` | 空 | 触发器过滤条件，可多次传入；示例：`radioField_xxx:采购类型:Equal:材料采购:RadioField:literal` |
 | `--trigger-recursively` | 关闭 | 允许自动触发，对应设计器里的“允许自动触发” |
+| `--spec <file.json>` | 不启用 | 使用结构化编排文件创建复杂自动化，支持 `getSelf`、`dataRetrieve`、`dataCreate`、`dataUpdate`、`route`、`sendMessage`、`connector` |
 | `--get-self` | 关闭 | 自动插入“获取自身”节点：来源表单为当前触发表，过滤条件为 `pid 等于 字段 __masterdata_form_inst_id` |
 | `--get-self-field <field>` | `__masterdata_form_inst_id` | 覆盖右侧触发事件系统字段；仅在确认环境变量名不同后使用 |
 | `--get-self-query-field <field>` | `pid` | 覆盖左侧查询系统字段；仅在确认平台查询字段名不同后使用 |
@@ -149,6 +150,70 @@ openyida integration create APP_XXX FORM-A-XXX "表单A新增后同步到表单B
   --add-data-assignment "textField_b1:processVar:textField_a1" \
   --add-data-assignment "numberField_b2:literal:0" \
   --add-data-assignment "textareaField_b3:column:CONCATENATE(#{textField_a1},#{textField_a2})" \
+  --publish
+```
+
+### 结构化编排 `--spec`
+
+复杂自动化优先使用 `--spec`，不要手写 `saveProcess` payload。spec 的节点可以用 `id` 作为别名，后续用 `${别名}.fieldId` 引用上游节点输出，OpenYida 会在保存前替换成真实 `node_xxx`。
+
+```json
+{
+  "events": ["insert"],
+  "nodes": [
+    { "id": "self", "type": "getSelf" },
+    {
+      "id": "branch",
+      "type": "route",
+      "branches": [
+        {
+          "id": "hasSelf",
+          "name": "已获取自身",
+          "conditions": [
+            {
+              "fieldId": "${self}.pid",
+              "fieldName": "表单实例ID",
+              "opCode": "ExistValue",
+              "componentType": "TextField"
+            }
+          ],
+          "nodes": [
+            {
+              "id": "updateSelf",
+              "type": "dataUpdate",
+              "source": "self",
+              "assignments": [
+                {
+                  "column": "textareaField_result",
+                  "valueType": "literal",
+                  "value": "已处理"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "fallback",
+          "name": "其他情况",
+          "default": true,
+          "nodes": [
+            {
+              "id": "notice",
+              "type": "sendMessage",
+              "title": "未获取到记录",
+              "content": "获取自身节点无匹配结果，请检查过滤条件。"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+```bash
+openyida integration create APP_XXX FORM-XXX "获取自身后分支更新" \
+  --spec project/integration/get-self-update.json \
   --publish
 ```
 


### PR DESCRIPTION
## 依赖关系

依赖 #404。本 PR 是基于 `feat/integration-automation-diagnostics` 的堆叠分支；其中第一笔提交来自 #404，本 PR 新增提交为 `0ef73a4`。

## 改动内容

- 为 `openyida integration create` 新增 `--spec <file.json>`，支持用结构化 JSON 描述复杂集成自动化。
- 新增 spec builder，生成真实可保存/发布的 `processJson` 和 `viewJson`。
- 支持 `getSelf`、`dataRetrieve`、`dataCreate`、`dataUpdate`、`route/condition`、`sendMessage`、`connector` 节点。
- 支持节点别名引用，例如 `${self}.fieldId`，构建时会自动替换为真实 `node_xxx`。
- 在构建前预注册节点别名，解决分支内节点提前引用上游节点的问题。
- 在 CLI 输出中返回 `specNodeIdMap`，方便真实排查。
- 增加 spec 本地校验：空节点、无效事件会在远端创建前失败，避免产生无效逻辑流壳子。
- 更新 CLI 帮助、中文/英文文案、单测和 `yida-integration` 技能文档。

## 验证结果

- `npm.cmd test -- --runInBand`
- `npm.cmd run lint`，结果为 0 errors，仍有项目历史遗留 warnings
- `git diff --check`
- 真实宜搭回归验证：
  - 测试应用：`APP_W4S4FPGN8LPFXEGF62PP`
  - 测试表单：`FORM-8F4560BC5B024B39AC4131FC3DCDB5F283YA`
  - 创建并发布测试流：`spec回归143635`
  - 触发测试记录：`FINST-ZDD66AA1NG46XE1CNXIAY6G3QSUA2JOXVJQPMII6`
  - 确认字段 `textareaField_5ihd6nth1` 被更新为 `spec-route-update-ok`
  - 已禁用测试流：`LPROC-J9766ED1PQ36PX1XLNV9FDB206HY2ERVTJQPMB8`
