### PR TITLE
[codex] fix connector operation schema handling

### DIFF
--- a/lib/connector/api.js
+++ b/lib/connector/api.js
@@ -78,7 +78,13 @@ function printTable(headers, rows) {
 function buildOperationsSummary(operations) {
   if (!Array.isArray(operations) || operations.length === 0) {return '';}
 
-  const summaries = operations.map(op => op.summary || op.operationId);
+  const summaries = operations
+    .map(op => op.summary || op.name || op.operationId || op.id || op.url || op.path)
+    .filter(Boolean);
+
+  if (summaries.length === 0) {
+    return '';
+  }
 
   if (summaries.length === 1) {
     return `支持${summaries[0]}`;

--- a/lib/connector/connector-add-action.js
+++ b/lib/connector/connector-add-action.js
@@ -23,6 +23,7 @@ const {
   getConnectorDetail,
   saveConnector,
 } = require('./api');
+const { normalizeOperations } = require('./operation-normalizer');
 
 function showUsage() {
   console.log(`
@@ -99,6 +100,7 @@ async function run(args) {
     if (!Array.isArray(newOperations)) {
       newOperations = [newOperations];
     }
+    newOperations = normalizeOperations(newOperations);
     console.log(`✓ 已加载 ${newOperations.length} 个执行动作`);
     newOperations.forEach((operation, index) => {
       console.log(`  [${index + 1}] ${operation.operationId}: ${operation.summary}`);
@@ -123,7 +125,7 @@ async function run(args) {
     const detail = await getConnectorDetail(connector.connectorName, authRef);
     targetConnector = { ...connector, detail };
 
-    const existingOps = JSON.parse(targetConnector.detail.operations || '[]');
+    const existingOps = normalizeOperations(JSON.parse(targetConnector.detail.operations || '[]'));
     console.log('📋 即将追加到以下连接器:');
     console.log(`   名称: ${targetConnector.displayName}`);
     console.log(`   ID: ${targetConnector.id}`);
@@ -164,7 +166,7 @@ async function run(args) {
   }
 
   // 合并执行动作
-  const existingOperations = JSON.parse(targetConnector.detail.operations || '[]');
+  const existingOperations = normalizeOperations(JSON.parse(targetConnector.detail.operations || '[]'));
   const existingIds = new Set(existingOperations.map(op => op.operationId));
   const duplicates = newOperations.filter(op => existingIds.has(op.operationId));
 

--- a/lib/connector/connector-create.js
+++ b/lib/connector/connector-create.js
@@ -31,6 +31,7 @@ const {
   getConnectorDetail,
   saveConnector,
 } = require('./api');
+const { normalizeOperations } = require('./operation-normalizer');
 
 function showUsage() {
   console.log(`
@@ -232,11 +233,11 @@ async function run(args) {
     console.log(`当前描述: ${connector.connectorDesc || '(空)'}\n`);
 
     const detail = await getConnectorDetail(connector.connectorName, authRef);
-    const currentOperations = JSON.parse(detail.operations || '[]');
+    const currentOperations = normalizeOperations(JSON.parse(detail.operations || '[]'));
     const newDesc = buildConnectorDesc(options.description, connector.connectorDesc, authRef, currentOperations);
 
     await saveConnector({
-      operations: detail.operations || '[]',
+      operations: JSON.stringify(currentOperations),
       displayName: detail.displayName,
       iconUrl: detail.iconUrl || 'chaxun%%#FFA200',
       connectorDesc: newDesc,
@@ -278,6 +279,7 @@ async function run(args) {
       fail('错误: operations 文件不能为空数组');
       process.exit(1);
     }
+    operations = normalizeOperations(operations);
     console.log(`✓ 已加载 ${operations.length} 个执行动作`);
   } catch (e) {
     fail(`读取执行动作配置文件失败: ${e.message}`);

--- a/lib/connector/connector-delete-action.js
+++ b/lib/connector/connector-delete-action.js
@@ -17,6 +17,7 @@ const {
   getConnectorDetail,
   saveConnector,
 } = require('./api');
+const { normalizeOperations } = require('./operation-normalizer');
 
 function showUsage() {
   console.log(`
@@ -63,7 +64,7 @@ async function run(args) {
   }
 
   const detail = await getConnectorDetail(connector.connectorName, authRef);
-  const currentOperations = JSON.parse(detail.operations || '[]');
+  const currentOperations = normalizeOperations(JSON.parse(detail.operations || '[]'));
   const targetOperation = currentOperations.find(op => op.operationId === operationId);
 
   if (!targetOperation) {

--- a/lib/connector/doc-parser.js
+++ b/lib/connector/doc-parser.js
@@ -104,21 +104,22 @@ class MarkdownParser extends BaseDocParser {
   }
 
   parseRequestHeaders() {
-    const headerSection = this.extractSection('请求头', '请求参数');
+    const headerSection = this.extractSection('请求头', ['查询参数', '请求参数', '请求体', '响应']);
     if (headerSection) {
       this.result.requestInfo.headers = this.parseTable(headerSection);
     }
   }
 
   parseQueryParams() {
-    const querySection = this.extractSection('查询参数', '请求体');
+    const querySection = this.extractSection('查询参数', ['请求体', '响应', '错误码']) ||
+      this.extractSection('请求参数', ['请求体', '响应', '错误码']);
     if (querySection) {
       this.result.requestInfo.query = this.parseTable(querySection);
     }
   }
 
   parseRequestBody() {
-    const bodySection = this.extractSection('请求体', '响应');
+    const bodySection = this.extractSection('请求体', ['响应', '返回', '错误码']);
     if (!bodySection) {return;}
 
     const jsonMatch = bodySection.match(/```json\s*([\s\S]*?)```/);
@@ -289,10 +290,13 @@ class MarkdownParser extends BaseDocParser {
 
     let endIndex = this.content.length;
     if (endMarker) {
-      const endMatch = this.content.indexOf(endMarker, startIndex + startMarker.length);
-      if (endMatch !== -1) {
-        endIndex = endMatch;
-      }
+      const markers = Array.isArray(endMarker) ? endMarker : [endMarker];
+      markers.forEach(marker => {
+        const endMatch = this.content.indexOf(marker, startIndex + startMarker.length);
+        if (endMatch !== -1 && endMatch < endIndex) {
+          endIndex = endMatch;
+        }
+      });
     }
 
     return this.content.substring(startIndex, endIndex);
@@ -341,6 +345,15 @@ class MarkdownParser extends BaseDocParser {
 
     return headerMap[header] || header.toLowerCase();
   }
+}
+
+function applyParamLocation(nodes, paramLocation) {
+  (Array.isArray(nodes) ? nodes : []).forEach(node => {
+    node.paramLocation = paramLocation;
+    applyParamLocation(node.childList, paramLocation);
+    applyParamLocation(node.children, paramLocation);
+  });
+  return nodes;
 }
 
 /**
@@ -424,6 +437,7 @@ function convertToOperationConfig(parseResult) {
       childList: [],
       __level: 0,
       hidden: false,
+      paramLocation: 'header',
       required: h.required === 'true' || h.required === '是' || h.required === '**' || h.required === true,
       defaultValue: h.example || h.value || ''
     }));
@@ -433,7 +447,8 @@ function convertToOperationConfig(parseResult) {
       desc: '请求头',
       name: 'Headers',
       paramType: 'Object',
-      required: false
+      required: false,
+      paramLocation: 'header'
     });
 
     operation.parameters.header = parseResult.requestInfo.headers.map(h => ({
@@ -452,7 +467,8 @@ function convertToOperationConfig(parseResult) {
       children: [],
       childList: [],
       __level: 0,
-      hidden: false
+      hidden: false,
+      paramLocation: 'query'
     }));
 
     operation.inputs.push({
@@ -460,7 +476,8 @@ function convertToOperationConfig(parseResult) {
       desc: '查询参数',
       name: 'Query',
       paramType: 'Object',
-      required: false
+      required: false,
+      paramLocation: 'query'
     });
 
     operation.parameters.query = parseResult.requestInfo.query.map(q => ({
@@ -478,7 +495,7 @@ function convertToOperationConfig(parseResult) {
       default: JSON.stringify(requestExample)
     };
 
-    const requestChildList = generateChildList(requestSchema, operation.operationId);
+    const requestChildList = applyParamLocation(generateChildList(requestSchema, operation.operationId), 'body');
     if (requestChildList.length > 0) {
       operation.inputs.push({
         defaultValue: JSON.stringify(requestExample),
@@ -486,7 +503,8 @@ function convertToOperationConfig(parseResult) {
         name: 'Body',
         paramType: 'Object',
         required: false,
-        childList: requestChildList
+        childList: requestChildList,
+        paramLocation: 'body'
       });
     }
   }
@@ -495,13 +513,6 @@ function convertToOperationConfig(parseResult) {
   if (parseResult.responseInfo.schema) {
     const responseSchema = parseResult.responseInfo.schema;
     operation.responses = responseSchema;
-
-    if (!operation.parameters.body) {
-      const example = generateExample(responseSchema);
-      operation.parameters.body = {
-        default: JSON.stringify(example)
-      };
-    }
 
     operation.outputs = [generateOutputs(responseSchema, operation.operationId)];
   } else {

--- a/lib/connector/operation-normalizer.js
+++ b/lib/connector/operation-normalizer.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const { generateOutputs } = require('./response-parser');
+
+function slugifyOperationId(value, fallback) {
+  const slug = String(value || '')
+    .trim()
+    .replace(/^\//, '')
+    .replace(/[^A-Za-z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  return slug || fallback;
+}
+
+function deriveOperationId(operation, index) {
+  const explicitId = String(operation.operationId || '').trim();
+  if (explicitId) {
+    return explicitId;
+  }
+
+  const fallback = `operation_${index + 1}`;
+  const candidates = [operation.url, operation.path, operation.id, operation.name, operation.summary];
+  for (const candidate of candidates) {
+    const operationId = slugifyOperationId(candidate, '');
+    if (operationId) {
+      return operationId;
+    }
+  }
+
+  return fallback;
+}
+
+function normalizeUrl(value) {
+  return String(value || '').trim().replace(/^\/+/, '');
+}
+
+function inferParamLocation(input) {
+  if (input.paramLocation) {
+    return input.paramLocation;
+  }
+
+  const name = String(input.name || '').toLowerCase();
+  if (name === 'headers' || name === 'header') {
+    return 'header';
+  }
+  if (name === 'query' || name === 'queries') {
+    return 'query';
+  }
+  if (name === 'path' || name === 'paths') {
+    return 'path';
+  }
+  if (name === 'body') {
+    return 'body';
+  }
+
+  return null;
+}
+
+function normalizeParamNode(node, paramLocation) {
+  if (!node || typeof node !== 'object') {
+    return node;
+  }
+
+  const normalized = { ...node };
+  if (paramLocation && !normalized.paramLocation) {
+    normalized.paramLocation = paramLocation;
+  }
+  if (!Array.isArray(normalized.children)) {
+    normalized.children = [];
+  }
+  if (!Array.isArray(normalized.childList)) {
+    normalized.childList = [];
+  }
+  normalized.children = normalized.children.map(child => normalizeParamNode(child, paramLocation));
+  normalized.childList = normalized.childList.map(child => normalizeParamNode(child, paramLocation));
+  return normalized;
+}
+
+function normalizeInput(input) {
+  if (!input || typeof input !== 'object') {
+    return input;
+  }
+
+  const paramLocation = inferParamLocation(input);
+  const normalized = { ...input };
+  if (paramLocation && !normalized.paramLocation) {
+    normalized.paramLocation = paramLocation;
+  }
+  if (!Array.isArray(normalized.childList)) {
+    normalized.childList = [];
+  }
+  normalized.childList = normalized.childList.map(child => normalizeParamNode(child, paramLocation));
+  return normalized;
+}
+
+function buildParametersFromInputs(inputs) {
+  const parameters = { header: [] };
+
+  for (const input of inputs) {
+    if (!input || typeof input !== 'object') {
+      continue;
+    }
+
+    const location = inferParamLocation(input);
+    const childList = Array.isArray(input.childList) ? input.childList : [];
+
+    if (location === 'header') {
+      parameters.header = childList.map(child => ({
+        name: child.name,
+        value: child.defaultValue || '',
+      }));
+    } else if (location === 'query') {
+      parameters.query = childList.map(child => ({
+        name: child.name,
+        value: child.defaultValue || '',
+      }));
+    } else if (location === 'body' && input.defaultValue !== undefined) {
+      parameters.body = { default: input.defaultValue };
+    }
+  }
+
+  return parameters;
+}
+
+function normalizeParameters(parameters, inputs) {
+  const normalized = parameters && typeof parameters === 'object' && !Array.isArray(parameters)
+    ? { ...parameters }
+    : buildParametersFromInputs(inputs);
+
+  if (!Array.isArray(normalized.header)) {
+    normalized.header = [];
+  }
+
+  return normalized;
+}
+
+function normalizeOutput(output) {
+  if (!output || typeof output !== 'object') {
+    return output;
+  }
+
+  const normalized = { ...output };
+  if (!Array.isArray(normalized.childList)) {
+    normalized.childList = [];
+  }
+  return normalized;
+}
+
+function normalizeOperation(operation, index) {
+  if (!operation || typeof operation !== 'object' || Array.isArray(operation)) {
+    throw new Error(`第 ${index + 1} 个执行动作必须是对象`);
+  }
+
+  const operationId = deriveOperationId(operation, index);
+  const rawUrl = operation.url !== undefined && operation.url !== null ? operation.url : operation.path;
+  const hasUrl = rawUrl !== undefined && rawUrl !== null && String(rawUrl).trim() !== '';
+  const url = normalizeUrl(rawUrl);
+
+  if (!hasUrl) {
+    throw new Error(`第 ${index + 1} 个执行动作缺少 url/path`);
+  }
+
+  const summary = operation.summary || operation.name || operationId;
+  const description = operation.description || operation.desc || summary;
+  const method = String(operation.method || 'get').toLowerCase();
+  const inputs = Array.isArray(operation.inputs)
+    ? operation.inputs.map(normalizeInput)
+    : [];
+  const responses = operation.responses || { type: 'object', properties: {} };
+  const outputs = Array.isArray(operation.outputs) && operation.outputs.length > 0
+    ? operation.outputs.map(normalizeOutput)
+    : [generateOutputs(responses, operationId)];
+
+  return {
+    ...operation,
+    id: operation.id || `operation-${operationId}`,
+    operationId,
+    summary,
+    description,
+    url,
+    method,
+    inputs,
+    parameters: normalizeParameters(operation.parameters, inputs),
+    responses,
+    outputs,
+    origin: operation.origin !== undefined ? operation.origin : true,
+  };
+}
+
+function normalizeOperations(operations) {
+  const list = Array.isArray(operations) ? operations : [operations];
+  return list.map(normalizeOperation);
+}
+
+module.exports = {
+  normalizeOperation,
+  normalizeOperations,
+};

--- a/tests/connector.test.js
+++ b/tests/connector.test.js
@@ -24,6 +24,8 @@ const {
   DocParserFactory,
 } = require('../lib/connector/doc-parser');
 const { generateConnectorDesc } = require('../lib/connector/desc-generator');
+const { normalizeOperations } = require('../lib/connector/operation-normalizer');
+const { buildOperationsSummary } = require('../lib/connector/api');
 
 describe('connector curl parsing and action generation', () => {
   test('parseCurl extracts URL, method, headers, query path, and JSON body', () => {
@@ -180,11 +182,43 @@ describe('connector response and API document parsing', () => {
     });
     expect(operation.summary).toBe('Search Users');
     expect(operation.method).toBe('post');
+    const headersInput = operation.inputs.find((input) => input.name === 'Headers');
+    const queryInput = operation.inputs.find((input) => input.name === 'Query');
+    const bodyInput = operation.inputs.find((input) => input.name === 'Body');
+    expect(headersInput.paramLocation).toBe('header');
+    expect(headersInput.childList.map((node) => node.name)).toEqual(['Authorization']);
+    expect(headersInput.childList[0].paramLocation).toBe('header');
+    expect(queryInput.paramLocation).toBe('query');
+    expect(queryInput.childList[0].paramLocation).toBe('query');
+    expect(bodyInput.paramLocation).toBe('body');
+    expect(bodyInput.childList.map((node) => node.paramLocation)).toEqual(['body', 'body']);
     expect(operation.parameters.header[0]).toEqual({
       name: 'Authorization',
       value: 'Bearer token',
     });
     expect(operation.parameters.query[0]).toEqual({ name: 'page', value: '1' });
+    expect(operation.outputs[0].childList.map((node) => node.name)).toContain('data');
+  });
+
+  test('convertToOperationConfig does not synthesize request body from response schema', () => {
+    const markdown = [
+      '# List Users',
+      '',
+      '- URL',
+      'https://api.example.com/v1/users',
+      '- Method',
+      'GET',
+      '',
+      '## 响应',
+      '```json',
+      '{"success":true,"data":[{"id":1}]}',
+      '```',
+    ].join('\n');
+
+    const operation = convertToOperationConfig(new MarkdownParser(markdown).parse());
+
+    expect(operation.inputs.map((input) => input.name)).not.toContain('Body');
+    expect(operation.parameters.body).toBeUndefined();
     expect(operation.outputs[0].childList.map((node) => node.name)).toContain('data');
   });
 
@@ -199,5 +233,41 @@ describe('connector response and API document parsing', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('connector operation normalization', () => {
+  test('normalizes legacy name/path actions before saving to Yida', () => {
+    const [operation] = normalizeOperations([
+      {
+        name: '测试接口',
+        path: '/test',
+        method: 'GET',
+        description: '测试用接口',
+      },
+    ]);
+
+    expect(operation).toMatchObject({
+      id: 'operation-test',
+      operationId: 'test',
+      summary: '测试接口',
+      description: '测试用接口',
+      url: 'test',
+      method: 'get',
+      parameters: { header: [] },
+      responses: { type: 'object', properties: {} },
+      origin: true,
+    });
+    expect(operation.outputs[0]).toMatchObject({
+      name: 'Response',
+      paramType: 'Object',
+      childList: [],
+    });
+  });
+
+  test('buildOperationsSummary falls back to legacy action names', () => {
+    expect(buildOperationsSummary([
+      { name: '测试接口', path: '/test', method: 'get' },
+    ])).toBe('支持测试接口');
   });
 });


### PR DESCRIPTION
## Summary

Fixes connector action payload handling so OpenYida no longer saves malformed HTTP connector operations that the Yida editor cannot reliably render or preserve.

## Root Cause

Connector save paths use `ConnectorFactory.createOrUpdateConnector`, which replaces the full `operations` payload. If an operation is saved in a legacy or partial shape such as `{ name, path, method, description }`, the platform editor can open with missing action configuration and later save an incomplete or empty action list.

The markdown API doc parser also had two schema issues:

- `请求头` section extraction could swallow following query/body tables.
- Response schemas could be incorrectly synthesized into request body parameters for GET-style docs.

## Changes

- Add `lib/connector/operation-normalizer.js` to normalize legacy connector actions before saving.
- Apply operation normalization in create, update-description, add-action, and delete-action save paths.
- Add `paramLocation` to parsed header/query/body inputs and children.
- Stop generating request body parameters from response schemas.
- Improve connector description fallback so legacy actions no longer produce `支持undefined`.
- Add connector tests for doc parsing, body synthesis prevention, legacy action normalization, and description fallback.

## Real Device Notes

Tested against the `AI宜搭体验中心` org after QR login. Read-only connector detail/list APIs worked, and an existing connector showed the legacy partial operation shape that matches the customer symptom.

Creating a new smoke-test connector still failed in the platform API with `数据库操作超时，请稍后重试` from `ConnectorFactory.createOrUpdateConnector`, even with canonical payloads and ASCII-only descriptions. No `OY_CONNECTOR_TEST` connector was left behind. That remaining create timeout needs platform-side log follow-up, but the client-side malformed operation risk is covered here.

## Validation

- `npm test -- --runInBand tests/connector.test.js`
- `npm test -- --runInBand tests/connector.test.js tests/publish-precheck.test.js tests/publish-args.test.js`
- `node --check` on modified connector files
