### PR TITLE
[codex] Add OpenYida publish guard skill

### DIFF
--- a/scripts/e2e-real/skill-coverage.js
+++ b/scripts/e2e-real/skill-coverage.js
@@ -43,6 +43,7 @@ const SKILL_COVERAGE = {
   'yida-login': { level: 'real-e2e', stages: ['auth'], commands: ['login --check-only --json'] },
   'yida-logout': { level: 'offline-unit', tests: ['login/auth unit coverage'], reason: 'real logout would destroy the shared E2E session' },
   'yida-nav-group': { level: 'offline-unit', tests: ['tests/nav-group.test.js'], reason: 'navigation grouping mutates app sidebar order; unit coverage validates payloads and tree operations until a dedicated cleanup-safe nav stage exists' },
+  'yida-openyida-publish-guard': { level: 'offline-unit', tests: ['skill metadata and packaging validation'], reason: 'publish guard is an agent workflow safety rule for comparing live schema before publish; real page publish behavior remains covered by yida-publish-page E2E stages' },
   'yida-page-config': { level: 'real-e2e', stages: ['share'], commands: ['get-page-config', 'verify-short-url', 'save-share-config'] },
   'yida-ppt': { level: 'deprecated', reason: 'skill is deprecated in favor of yida-ppt-slider' },
   'yida-ppt-slider': { level: 'offline-unit', reason: 'presentation-style custom page skill should be validated by page generation/check-page fixtures' },

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -174,6 +174,7 @@ openyida copy
 | `yida-get-schema` | `skills/yida-get-schema/SKILL.md` | 获取单个/全部表单 Schema，确认字段 ID | `openyida get-schema <appType> <formUuid>` |
 | `yida-custom-page` | `skills/yida-custom-page/SKILL.md` | 编写自定义页面 JSX 代码规范 | 详见 SKILL.md |
 | `yida-publish-page` | `skills/yida-publish-page/SKILL.md` | 编译并发布自定义页面 | `openyida publish <源文件路径> <appType> <formUuid> [--health-check]` |
+| `yida-openyida-publish-guard` | `skills/yida-openyida-publish-guard/SKILL.md` | 发布既有自定义页面前拉取线上 schema 并对比现状，避免本地旧代码覆盖设计器即时修改 | `openyida get-schema <appType> <formUuid> --json` |
 | `yida-page-config` | `skills/yida-page-config/SKILL.md` | 页面公开访问/组织内分享配置 | `openyida verify-short-url <appType> <formUuid> <url>` |
 | `yida-basic-info` | `skills/yida-basic-info/SKILL.md` | 组织基本信息、资源容量、额度和域名设置查询 | `openyida basic-info overview` |
 | `yida-nav-group` | `skills/yida-nav-group/SKILL.md` | 应用左侧导航分组管理（查询/创建/重命名/删除/移动/显隐） | `openyida nav-group list <appType>` |

--- a/yida-skills/skills/yida-openyida-publish-guard/SKILL.md
+++ b/yida-skills/skills/yida-openyida-publish-guard/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: yida-openyida-publish-guard
+description: Prevent stale local OpenYida custom page source from overwriting live designer edits. Use before modifying, compiling, or publishing an existing Yida custom page, display page, pageDesigner URL, or formUuid with openyida publish, especially when users may have edited the page in the designer after local source was last copied.
+---
+
+# OpenYida Publish Guard
+
+## Purpose
+
+Use this skill whenever an existing OpenYida custom page is about to be edited or published from local source.
+
+The Yida designer is also a source of truth. Users can make small live edits in the designer, such as deleting a query button, while the local `.oyd.jsx` file still contains older code. Publishing that stale local file will silently restore the deleted UI or roll back other live changes.
+
+This skill adds a mandatory online-state check before publishing so agents merge requested changes onto the current live page instead of overwriting it.
+
+## When To Use
+
+Use this skill for:
+
+- Any `openyida publish` to an existing custom page.
+- Any request that mentions a `pageDesigner` URL, display page, custom page JSX, or `formUuid`.
+- Any targeted page edit where the user says "only change X" or "do not touch other code".
+- Any situation where the user or another editor may have changed the page in the Yida designer after the local source was created.
+
+Do not use this skill for creating a brand-new page that has no existing live schema.
+
+## Required Workflow
+
+1. Confirm the target `appType`, `formUuid`, and local source path.
+2. Check the OpenYida environment and login state:
+
+```bash
+openyida env --json
+openyida login --check-only --json
+```
+
+3. Fetch the live schema before editing or publishing:
+
+```bash
+openyida get-schema <appType> <formUuid> --json > project/.cache/openyida/live-<formUuid>.json
+```
+
+4. Inspect the fetched live page for current code and configuration. For custom display pages, check at least:
+
+- `pages[].componentsTree[].methods.__initMethods__.source`
+- `pages[].componentsTree[].methods.__initMethods__.compiled`
+- JSX render source under `componentsTree` when present
+- `dataSource.online` and existing connector or page-level data source definitions
+- Any visible component tree change that could represent a designer edit
+
+5. Compare the live source with the local source before publishing.
+
+- If the local source is older or missing a user-visible live change, merge the requested change into the live/current behavior.
+- If the user explicitly says "only change X", verify the final diff only touches X and strictly required helper or style code.
+- If live and local differ in unrelated user-visible areas, pause and ask whether to preserve the live changes unless the preservation is obvious.
+- If the user explicitly says "use local source", you may skip live-source merging, but still run environment checks, page checks, compile, and health-checked publish.
+
+6. Only after the merge is scoped and reviewed, run:
+
+```bash
+openyida check-page <source>
+openyida compile <source>
+openyida publish <source> <appType> <formUuid> --health-check
+```
+
+## Minimal Diff Discipline
+
+- Do not reformat the file.
+- Do not regenerate the entire page unless explicitly requested.
+- Do not replace a page with an older local copy.
+- Keep deleted live UI deleted unless the user asks to restore it.
+- Preserve existing page data sources; confirm publish output reports retained data sources.
+- Search the final local source for accidentally restored labels or controls from the bug report, such as `查询`, `queryButton`, or other recently removed UI.
+
+## Incident That Motivated This Skill
+
+While editing a Junjie Yida ranking page, a user had deleted the query button directly in the Yida designer. A later targeted change was published from an older local `.oyd.jsx` file without first checking the live designer schema. The stale publish restored the deleted query button and overwrote the user's immediate designer edit.
+
+The fix was to restore the deleted UI state and add this guardrail: before future OpenYida page edits or publishes, fetch the live schema, compare the current live source with local source, and merge the requested change onto the latest live behavior.
+
+## Recovery If An Overwrite Happens
+
+1. Acknowledge the overwrite plainly.
+2. Restore the overwritten live change immediately, without broad refactors.
+3. Re-run `openyida check-page`, `openyida compile`, and `openyida publish --health-check`.
+4. Update this skill if the failure mode is not already covered.


### PR DESCRIPTION
## 改动概述

新增 `yida-openyida-publish-guard` agent skill，用于在发布既有 OpenYida / 宜搭自定义页面前强制拉取线上 schema、检查当前 live source 与数据源配置，并在本地源码发布前完成对比和合并，避免本地旧 `.oyd.jsx` 覆盖用户在设计器里的即时修改。

这个 PR 来自一次真实问题：用户在宜搭设计器里删除了查询按钮，随后 agent 从本地旧源码发布一个局部改动，导致已删除的按钮被恢复，覆盖了用户刚在设计器中的修改。该 skill 将这个事故沉淀成发布前 guardrail。

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [x] 文档更新
- [ ] 代码重构
- [ ] 配置 / CI 变更
- [ ] 依赖升级
- [ ] 国际化（i18n）
- [ ] UI / 终端输出优化
- [ ] 发布 / 打包流程调整

## 关联 Issue / 需求

无公开 issue。来自 OpenYida 自定义页面发布过程中，本地源码覆盖线上设计器即时改动的实际使用场景。

## 主要变更

- `yida-skills/skills/yida-openyida-publish-guard/SKILL.md`：新增发布保护 skill，定义适用场景、必走流程、最小 diff 纪律和事故恢复步骤。
- `yida-skills/SKILL.md`：在子技能速查表中登记该 skill，方便涉及既有自定义页面发布时被发现。
- `scripts/e2e-real/skill-coverage.js`：为新增 skill 增加显式覆盖策略，避免 E2E skill coverage gate 失败。

## 兼容性与风险

- [x] 无破坏性变更
- [ ] 涉及 CLI 参数或输出格式变更，已说明兼容策略
- [ ] 涉及登录态、Cookie、组织上下文或私有化环境，已确认无敏感信息泄露
- [ ] 涉及宜搭真实数据写入，已说明影响范围和回滚方式

该 PR 新增 agent skill 文档、索引和对应覆盖矩阵条目，不修改 CLI 运行时代码。

## 测试与验证

- [ ] `npm test`
- [ ] `npm run lint`
- [x] `npm run check:syntax`
- [x] `npm run check:skills`
- [ ] `npm run build:skills`
- [ ] `npm run check:package`
- [ ] 已在真实宜搭环境验证相关功能（如适用）
- [ ] 私有化部署场景已验证或确认不受影响（如适用）

额外验证：

```text
npx jest tests/e2e-real-skill-coverage.test.js --runInBand
node scripts/e2e-real/skill-coverage.js --json
```

`check:skills` 仍报告仓库既有的长文档 warning，非本 PR 新增问题。

## 文档与 Agent 技能

- [ ] 新增或调整 CLI 命令时，已更新 `README.md` 命令一览表
- [ ] 新增用户可见文案时，已同步 `lib/core/locales/` 下所有语言包
- [x] 涉及 Agent 工作流变化时，已更新 `yida-skills/` 相关技能说明
- [ ] 涉及 GitHub Release / npm 发布行为时，已更新 `CHANGELOG.md`

## 截图 / 录屏

不适用。

## Reviewer 关注点

请重点看该 skill 是否应该作为单独子技能保留，或是否需要并入 `yida-publish-page`；以及“用户明确要求使用本地源码时可跳过 live-source 合并，但仍需 check/compile/health-check”的例外是否合理。