### PR TITLE
feat: support env cookie auth

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -266,7 +266,7 @@ function printLoginResult(result) {
     corp_id: result && result.corp_id,
     user_id: result && result.user_id,
     csrf_token: result && result.csrf_token ? `${result.csrf_token.slice(0, 16)}...` : undefined,
-    cookies_count: Array.isArray(result && result.cookies) ? result.cookies.length : 0,
+    cookies_count: Array.isArray(result && result.cookies) ? result.cookies.length : (result.cookies_count || 0),
   };
   console.log(JSON.stringify(summary));
 }
@@ -559,7 +559,7 @@ async function main() {
     case 'login': {
       const { checkLoginOnly } = require('../lib/auth/login');
       const loginArgs = applyLoginEnvironmentFlags(args, { inferTargetUrl: true });
-      const { isInjectedAuthMode } = require('../lib/core/utils');
+      const { isEnvAuthMode } = require('../lib/core/utils');
       if (loginArgs.includes('--agent-poll') || loginArgs.includes('--codex-poll')) {
         const sessionFile = getArgValue(loginArgs, '--agent-poll') || getArgValue(loginArgs, '--codex-poll');
         const { pollCodexQrLogin } = require('../lib/auth/qr-login');
@@ -577,7 +577,7 @@ async function main() {
       } else if (loginArgs.includes('--check-only')) {
         const result = checkLoginOnly({ includeSecrets: loginArgs.includes('--with-cookies') });
         console.log(JSON.stringify(result, null, 2));
-      } else if (isInjectedAuthMode()) {
+      } else if (isEnvAuthMode()) {
         const result = checkLoginOnly({ includeSecrets: true });
         printLoginResult(result);
       } else if (shouldUseCodexQrLogin(loginArgs)) {

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -32,6 +32,13 @@ const { t } = require('../core/i18n');
 
 const AUTH_CACHE_FILE = '.cache/auth.json';
 
+function maskIdentifier(value) {
+  const text = String(value || '');
+  if (!text) {return null;}
+  if (text.length <= 8) {return `${text.slice(0, 2)}***${text.slice(-1)}`;}
+  return `${text.slice(0, 4)}***${text.slice(-4)}`;
+}
+
 // ── 配置读取 ──────────────────────────────────────────
 
 function loadAuthConfig() {
@@ -90,6 +97,7 @@ function authStatus() {
   const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
   const authConfig = loadAuthConfig();
+  const isEnvAuth = cookieData.auth_source === 'env';
 
   if (!csrfToken) {
     warn(t('auth.no_csrf_token'), false);
@@ -105,12 +113,12 @@ function authStatus() {
   chalkSuccess(t('auth.logged_in'), false);
   label('Base URL', baseUrl, { stderr: false });
   if (corpId) {
-    label('Corp ID', corpId, { stderr: false });
+    label('Corp ID', isEnvAuth ? maskIdentifier(corpId) : corpId, { stderr: false });
   }
   if (userId) {
-    label('User ID', userId, { stderr: false });
+    label('User ID', isEnvAuth ? maskIdentifier(userId) : userId, { stderr: false });
   }
-  label('CSRF', `${csrfToken.slice(0, 16)}…`, { stderr: false });
+  label('CSRF', isEnvAuth ? '<redacted>' : `${csrfToken.slice(0, 16)}…`, { stderr: false });
 
   // 显示登录信息
   if (authConfig) {

--- a/lib/auth/login.js
+++ b/lib/auth/login.js
@@ -27,7 +27,8 @@ const {
   loadCookieData,
   resolveBaseUrl,
   detectActiveTool,
-  isInjectedAuthMode,
+  isEnvAuthMode,
+  getLastEnvAuthError,
 } = require('../core/utils');
 const { t } = require('../core/i18n');
 
@@ -48,6 +49,9 @@ function loadConfig() {
 // ── Cookie 持久化 ─────────────────────────────────────
 
 function saveCookieCache(cookies, baseUrl) {
+  if (isEnvAuthMode()) {
+    return;
+  }
   const projectRoot = findProjectRoot();
   const cacheDir = path.join(projectRoot, '.cache');
 
@@ -59,6 +63,13 @@ function saveCookieCache(cookies, baseUrl) {
   fs.writeFileSync(cookieFile, JSON.stringify({ cookies, base_url: baseUrl }, null, 2), 'utf-8');
   const { c } = require('../core/chalk');
   process.stderr.write(`  ${c.green}✔${c.reset} Cookie saved to ${c.dim}${cookieFile}${c.reset}\n`);
+}
+
+function maskIdentifier(value) {
+  const text = String(value || '');
+  if (!text) {return null;}
+  if (text.length <= 8) {return `${text.slice(0, 2)}***${text.slice(-1)}`;}
+  return `${text.slice(0, 4)}***${text.slice(-4)}`;
 }
 
 // ── 仅检查登录态 ──────────────────────────────────────
@@ -79,9 +90,12 @@ function checkLoginOnly(options = {}) {
   const legacyCookieFile = path.join(projectRoot, '.cache', 'cookies.json');
   const cookieData = loadCookieData(projectRoot);
   const cookies = cookieData && Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
-  const authMode = isInjectedAuthMode() ? 'injected' : 'default';
+  const envAuthError = getLastEnvAuthError();
+  const isEnvAuth = !!(cookieData && cookieData.auth_source === 'env');
+  const authMode = isEnvAuth || isEnvAuthMode() ? 'env' : 'default';
   const baseDiagnostics = {
     authMode,
+    authSource: authMode === 'env' ? 'env' : 'cache',
     activeTool: activeTool ? activeTool.tool : null,
     isWukong: !!(activeTool && activeTool.tool === 'wukong'),
     projectRoot,
@@ -106,10 +120,12 @@ function checkLoginOnly(options = {}) {
         corp_id_found: false,
         user_id_found: false,
         base_url_found: false,
-        failure_reason: baseDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing',
+        failure_reason: envAuthError
+          ? envAuthError.failure_reason
+          : (baseDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing'),
       },
-      message: authMode === 'injected'
-        ? 'No injected Cookie cache, host page refresh required'
+      message: authMode === 'env'
+        ? 'No env Cookie, host page refresh required'
         : 'No local Cookie cache, QR scan login required',
     };
   }
@@ -119,6 +135,9 @@ function checkLoginOnly(options = {}) {
   const corpId = cookieData.corp_id || cookieData.corpId || cookieInfo.corpId;
   const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
+  const canIncludeSecrets = includeSecrets && !isEnvAuth;
+  const outputCorpId = isEnvAuth ? maskIdentifier(corpId) : corpId;
+  const outputUserId = isEnvAuth ? maskIdentifier(userId) : userId;
   const diagnostics = {
     ...baseDiagnostics,
     cache_readable: true,
@@ -136,8 +155,8 @@ function checkLoginOnly(options = {}) {
       status: 'not_logged_in',
       can_auto_use: false,
       diagnostics,
-      message: authMode === 'injected'
-        ? 'No csrf_token in injected Cookie cache, host page refresh required'
+      message: authMode === 'env'
+        ? 'No csrf_token in env Cookie, host page refresh required'
         : 'No tianshu_csrf_token in Cookie, re-login required',
     };
   }
@@ -145,15 +164,15 @@ function checkLoginOnly(options = {}) {
   const result = {
     status: 'ok',
     can_auto_use: true,
-    csrf_token: includeSecrets ? csrfToken : `${csrfToken.slice(0, 8)}…`,
-    corp_id: corpId,
-    user_id: userId,
+    csrf_token: canIncludeSecrets ? csrfToken : `${csrfToken.slice(0, 8)}…`,
+    corp_id: outputCorpId,
+    user_id: outputUserId,
     base_url: baseUrl,
     cookies_count: cookies.length,
     diagnostics,
-    message: `✅ Valid login credentials found\n  Org: ${corpId}\n  User: ${userId}\n  Domain: ${baseUrl}`,
+    message: `✅ Valid login credentials found\n  Org: ${outputCorpId || ''}\n  User: ${outputUserId || ''}\n  Domain: ${baseUrl}`,
   };
-  if (includeSecrets) {
+  if (canIncludeSecrets) {
     result.cookies = cookies;
   }
   return result;
@@ -209,8 +228,8 @@ function refreshCsrfFromCache() {
  */
 function ensureLogin(options = {}) {
   const force = !!options.force;
-  const injectedAuth = isInjectedAuthMode();
-  if (!force || injectedAuth) {
+  const envAuth = isEnvAuthMode();
+  if (!force || envAuth) {
     const cookieData = loadCookieData();
 
     if (cookieData && cookieData.cookies) {
@@ -235,7 +254,7 @@ function ensureLogin(options = {}) {
     }
   }
 
-  if (injectedAuth) {
+  if (envAuth) {
     return null;
   }
 

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -16,6 +16,7 @@ const {
   resolveBaseUrl,
   extractInfoFromCookies,
   resolveWukongWorkspaceRoot,
+  getLastEnvAuthError,
 } = require('./utils');
 const { t } = require('./i18n');
 
@@ -110,6 +111,7 @@ function detectLoginStatus(projectRoot) {
   const cookieDiagnostics = getCookieDiagnostics(projectRoot);
   const cookieData = loadCookieData(projectRoot);
   const cookies = cookieData && Array.isArray(cookieData.cookies) ? cookieData.cookies : [];
+  const envAuthError = getLastEnvAuthError();
 
   if (!cookieData || !cookieData.cookies) {
     return {
@@ -128,7 +130,9 @@ function detectLoginStatus(projectRoot) {
         corpIdFound: false,
         userIdFound: false,
         baseUrlFound: false,
-        failureReason: cookieDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing',
+        failureReason: envAuthError
+          ? envAuthError.failure_reason
+          : (cookieDiagnostics.cookieFileFound ? 'cookie_cache_unreadable_or_invalid' : 'cookie_cache_missing'),
       },
     };
   }
@@ -139,6 +143,7 @@ function detectLoginStatus(projectRoot) {
   const userId = cookieData.user_id || cookieData.userId || cookieData.staffId || cookieInfo.userId;
   const baseUrl = resolveBaseUrl(cookieData);
   const loggedIn = !!csrfToken;
+  const isEnvAuth = cookieData.auth_source === 'env';
 
   return {
     loggedIn,
@@ -148,8 +153,10 @@ function detectLoginStatus(projectRoot) {
     userId,
     baseUrl,
     cookiesCount: cookies.length,
+    authSource: isEnvAuth ? 'env' : 'cache',
     diagnostics: {
       ...cookieDiagnostics,
+      authSource: isEnvAuth ? 'env' : 'cache',
       cacheReadable: true,
       cookiesArrayFound: Array.isArray(cookieData.cookies),
       csrfTokenFound: !!csrfToken,
@@ -164,6 +171,13 @@ function detectLoginStatus(projectRoot) {
 function maskSecret(value) {
   if (!value) {return null;}
   return `${value.slice(0, 16)}...`;
+}
+
+function maskIdentifier(value) {
+  const text = String(value || '');
+  if (!text) {return null;}
+  if (text.length <= 8) {return `${text.slice(0, 2)}***${text.slice(-1)}`;}
+  return `${text.slice(0, 4)}***${text.slice(-4)}`;
 }
 
 /**
@@ -198,9 +212,10 @@ function buildEnvironmentSnapshot() {
       loggedIn: loginStatus.loggedIn,
       canAutoUse: loginStatus.canAutoUse,
       baseUrl: loginStatus.baseUrl,
-      corpId: loginStatus.corpId,
-      userId: loginStatus.userId,
-      csrfToken: maskSecret(loginStatus.csrfToken),
+      authSource: loginStatus.authSource || null,
+      corpId: loginStatus.authSource === 'env' ? maskIdentifier(loginStatus.corpId) : loginStatus.corpId,
+      userId: loginStatus.authSource === 'env' ? maskIdentifier(loginStatus.userId) : loginStatus.userId,
+      csrfToken: loginStatus.authSource === 'env' ? null : maskSecret(loginStatus.csrfToken),
       cookiesCount: loginStatus.cookiesCount,
       diagnostics: loginStatus.diagnostics,
     },

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -264,6 +264,43 @@ function isInjectedAuthMode(env = process.env) {
   return ['1', 'true', 'yes', 'on'].includes(authEnabled);
 }
 
+function hasEnvCookieAuth(env = process.env) {
+  return !!String(env.OPENYIDA_COOKIE_B64 || '').trim();
+}
+
+function isEnvAuthMode(env = process.env) {
+  return isInjectedAuthMode(env) || hasEnvCookieAuth(env);
+}
+
+let lastEnvAuthError = null;
+
+function getLastEnvAuthError() {
+  return lastEnvAuthError;
+}
+
+function setLastEnvAuthError(code, failureReason, message) {
+  lastEnvAuthError = {
+    code,
+    failure_reason: failureReason,
+    message,
+    authMode: 'env',
+  };
+  return lastEnvAuthError;
+}
+
+function normalizeEnvBaseUrl(baseUrl, fallbackBaseUrl) {
+  const raw = String(baseUrl || fallbackBaseUrl || 'https://www.aliwork.com').trim();
+  try {
+    const parsed = new URL(raw);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+    return raw.replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
+
 /**
  * 查找项目根目录（project 工作区）。
  *
@@ -354,6 +391,123 @@ function extractInfoFromCookies(cookies) {
   return { csrfToken, corpId, userId };
 }
 
+function parseCookieHeader(rawCookieHeader, options = {}) {
+  const raw = String(rawCookieHeader || '').trim();
+  if (!raw) {
+    return [];
+  }
+  let domain = '';
+  if (options.baseUrl) {
+    try {
+      domain = new URL(options.baseUrl).hostname;
+    } catch {
+      domain = '';
+    }
+  }
+  return raw
+    .split(';')
+    .map((part) => {
+      const trimmed = part.trim();
+      const equalsIndex = trimmed.indexOf('=');
+      if (equalsIndex <= 0) {
+        return null;
+      }
+      const name = trimmed.slice(0, equalsIndex).trim();
+      const value = trimmed.slice(equalsIndex + 1).trim();
+      if (!name) {
+        return null;
+      }
+      const cookie = { name, value };
+      if (domain) {
+        cookie.domain = domain;
+      }
+      return cookie;
+    })
+    .filter(Boolean);
+}
+
+function decodeCookieHeaderFromBase64(encodedCookie) {
+  const normalized = String(encodedCookie || '').trim().replace(/\s+/g, '');
+  if (!normalized) {
+    return null;
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    return null;
+  }
+  try {
+    const decoded = Buffer.from(normalized, 'base64').toString('utf8').trim();
+    return decoded && decoded.includes('=') ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+function loadEnvCookieData(defaultBaseUrl, env = process.env) {
+  lastEnvAuthError = null;
+  const encodedCookie = String(env.OPENYIDA_COOKIE_B64 || '').trim();
+  const envAuthEnabled = isInjectedAuthMode(env);
+  if (!encodedCookie) {
+    if (envAuthEnabled) {
+      setLastEnvAuthError(
+        'not_logged_in',
+        'env_cookie_missing',
+        'OPENYIDA_COOKIE_B64 is required when YIDA_AUTH_ENABLED=true'
+      );
+    }
+    return null;
+  }
+
+  const baseUrl = normalizeEnvBaseUrl(env.OPENYIDA_BASE_URL, defaultBaseUrl);
+  if (!baseUrl) {
+    setLastEnvAuthError(
+      'not_logged_in',
+      'base_url_invalid',
+      'OPENYIDA_BASE_URL is invalid'
+    );
+    return null;
+  }
+
+  const rawCookieHeader = decodeCookieHeaderFromBase64(encodedCookie);
+  if (!rawCookieHeader) {
+    setLastEnvAuthError(
+      'not_logged_in',
+      'env_cookie_decode_failed',
+      'OPENYIDA_COOKIE_B64 is not a valid base64 encoded Cookie header'
+    );
+    return null;
+  }
+
+  const cookies = parseCookieHeader(rawCookieHeader, { baseUrl });
+  if (cookies.length === 0) {
+    setLastEnvAuthError(
+      'not_logged_in',
+      'env_cookie_parse_failed',
+      'OPENYIDA_COOKIE_B64 decoded to an empty or invalid Cookie header'
+    );
+    return null;
+  }
+
+  const { csrfToken, corpId, userId } = extractInfoFromCookies(cookies);
+  if (!csrfToken) {
+    setLastEnvAuthError(
+      'csrf_missing',
+      'csrf_token_missing',
+      'Env Cookie header does not contain tianshu_csrf_token'
+    );
+    return null;
+  }
+
+  return {
+    cookies,
+    csrf_token: csrfToken,
+    corp_id: corpId,
+    user_id: userId,
+    base_url: baseUrl,
+    auth_source: 'env',
+    auth_mode: 'env',
+  };
+}
+
 // ── 登录态缓存读取 ────────────────────────────────────
 
 /**
@@ -367,6 +521,14 @@ function extractInfoFromCookies(cookies) {
 function loadCookieData(projectRoot, defaultBaseUrl) {
   const root = projectRoot || findProjectRoot();
   const fallbackBaseUrl = defaultBaseUrl || 'https://www.aliwork.com';
+
+  const envCookieData = loadEnvCookieData(fallbackBaseUrl);
+  if (envCookieData) {
+    return envCookieData;
+  }
+  if (lastEnvAuthError && isEnvAuthMode()) {
+    return null;
+  }
 
   // 尝试迁移旧版 cookies.json（仅在首次使用多环境功能时执行一次）
   const { migrateOldCookieFile, getCookieFilePath } = require('./env-manager');
@@ -428,21 +590,22 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
  * @returns {object} loginResult
  */
 function triggerLogin(options = {}) {
-  if (isInjectedAuthMode()) {
+  if (isEnvAuthMode()) {
     const cookieData = loadCookieData();
     if (cookieData && cookieData.cookies && cookieData.cookies.length > 0 && cookieData.csrf_token) {
       return cookieData;
     }
-    const reason = cookieData && cookieData.cookies
-      ? 'csrf_token_missing'
-      : 'cookie_cache_missing';
+    const envAuthError = getLastEnvAuthError();
+    const reason = envAuthError
+      ? envAuthError.failure_reason
+      : (cookieData && cookieData.cookies ? 'csrf_token_missing' : 'env_cookie_missing');
     const { CliError } = require('./cli-error');
     throw new CliError(
-      `not_logged_in: injected cookie is unavailable (${reason}). Refresh the host page so it can inject a fresh Yida cookie cache.`,
+      `not_logged_in: env cookie is unavailable (${reason}). Refresh the host page so it can inject a fresh Yida cookie.`,
       {
         code: 'INJECTED_AUTH_REQUIRED',
         details: {
-          authMode: 'injected',
+          authMode: 'env',
           failure_reason: reason,
         },
       }
@@ -499,10 +662,16 @@ function refreshCsrfToken() {
  * @returns {boolean}
  */
 function isLoginExpired(responseJson) {
+  if (!responseJson) {return false;}
+  const status = String(responseJson.status || '').toLowerCase();
+  const errorCode = String(responseJson.errorCode || responseJson.code || '').toLowerCase();
+  const errorMsg = String(responseJson.errorMsg || responseJson.message || '').toLowerCase();
+  if (status === 'not_logged_in' || errorCode === 'not_logged_in' || errorMsg.includes('not_logged_in')) {
+    return true;
+  }
   return (
-    responseJson &&
     responseJson.success === false &&
-    (responseJson.errorCode === '307' || responseJson.errorCode === '302')
+    ['307', '302', '401', '403'].includes(errorCode)
   );
 }
 
@@ -521,6 +690,10 @@ function isCsrfTokenExpired(responseJson) {
 
 function isHttpRedirectStatus(statusCode) {
   return [301, 302, 303, 307, 308].includes(Number(statusCode));
+}
+
+function isHttpAuthStatus(statusCode) {
+  return [401, 403].includes(Number(statusCode));
 }
 
 // ── base_url 解析 ─────────────────────────────────────
@@ -612,7 +785,7 @@ function httpPost(baseUrl, requestPath, postData, cookies, optionsOverride = {})
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
         }
-        if (isHttpRedirectStatus(res.statusCode)) {
+        if (isHttpRedirectStatus(res.statusCode) || isHttpAuthStatus(res.statusCode)) {
           resolve({
             __needLogin: true,
             __httpStatus: res.statusCode,
@@ -694,7 +867,7 @@ function httpPostJson(baseUrl, requestPath, payload, cookies, optionsOverride = 
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
         }
-        if (isHttpRedirectStatus(res.statusCode)) {
+        if (isHttpRedirectStatus(res.statusCode) || isHttpAuthStatus(res.statusCode)) {
           resolve({
             __needLogin: true,
             __httpStatus: res.statusCode,
@@ -784,7 +957,7 @@ function httpGet(baseUrl, requestPath, queryParams, cookies, optionsOverride = {
         if (!optionsOverride.silentStatus) {
           warn(t('common.http_status', res.statusCode));
         }
-        if (isHttpRedirectStatus(res.statusCode)) {
+        if (isHttpRedirectStatus(res.statusCode) || isHttpAuthStatus(res.statusCode)) {
           resolve({
             __needLogin: true,
             __httpStatus: res.statusCode,
@@ -830,14 +1003,16 @@ function httpGet(baseUrl, requestPath, queryParams, cookies, optionsOverride = {
  */
 async function requestWithAutoLogin(requestFn, authRef) {
   let result = await requestFn(authRef);
+  const usingEnvAuth = isEnvAuthMode()
+    || !!(authRef && authRef.cookieData && authRef.cookieData.auth_source === 'env');
 
   if (result && result.__csrfExpired) {
-    if (isInjectedAuthMode()) {
+    if (usingEnvAuth) {
       return {
         success: false,
         __needLogin: true,
         errorCode: 'INJECTED_AUTH_REQUIRED',
-        errorMsg: 'not_logged_in: injected cookie csrf_token expired. Refresh the host page so it can inject a fresh Yida cookie cache.',
+        errorMsg: 'not_logged_in: env cookie csrf_token expired. Refresh the host page so it can inject a fresh Yida cookie.',
       };
     }
     const refreshedData = refreshCsrfToken();
@@ -854,12 +1029,12 @@ async function requestWithAutoLogin(requestFn, authRef) {
   }
 
   if (result && result.__needLogin) {
-    if (isInjectedAuthMode()) {
+    if (usingEnvAuth) {
       return {
         success: false,
         __needLogin: true,
         errorCode: 'INJECTED_AUTH_REQUIRED',
-        errorMsg: 'not_logged_in: injected cookie missing or expired. Refresh the host page so it can inject a fresh Yida cookie cache.',
+        errorMsg: 'not_logged_in: env cookie missing or expired. Refresh the host page so it can inject a fresh Yida cookie.',
       };
     }
     const newCookieData = triggerLogin({ force: true });
@@ -886,6 +1061,9 @@ module.exports = {
   hasDesktopEnvironment,
   findProjectRoot,
   extractInfoFromCookies,
+  parseCookieHeader,
+  loadEnvCookieData,
+  getLastEnvAuthError,
   loadCookieData,
   triggerLogin,
   refreshCsrfToken,
@@ -901,4 +1079,6 @@ module.exports = {
   getNodeExecutable,
   resolveWukongWorkspaceRoot,
   isInjectedAuthMode,
+  hasEnvCookieAuth,
+  isEnvAuthMode,
 };

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -520,7 +520,7 @@ describe('CLI offline smoke', () => {
     }
   });
 
-  test('YIDA_AUTH_ENABLED=true login only checks injected cookie cache', () => {
+  test('YIDA_AUTH_ENABLED=true login only checks env cookie', () => {
     const workspace = createCodexWorkspace();
     try {
       const output = runOkWithEnv(['login'], {
@@ -533,15 +533,16 @@ describe('CLI offline smoke', () => {
         status: 'not_logged_in',
         can_auto_use: false,
       });
-      expect(parsed.message).toContain('injected Cookie cache');
-      expect(parsed).toHaveProperty('diagnostics.authMode', 'injected');
+      expect(parsed.message).toContain('No env Cookie');
+      expect(parsed).toHaveProperty('diagnostics.authMode', 'env');
+      expect(parsed).toHaveProperty('diagnostics.failure_reason', 'env_cookie_missing');
       expect(parsed).not.toHaveProperty('handoff_type');
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }
   });
 
-  test('YIDA_AUTH_ENABLED=true login accepts top-level injected auth fields', () => {
+  test('OPENYIDA_COOKIE_B64 login accepts env cookie and ignores stale cache', () => {
     const workspace = createCodexWorkspace();
     const cacheDir = path.join(workspace, 'project', '.cache');
     fs.mkdirSync(cacheDir, { recursive: true });
@@ -549,26 +550,32 @@ describe('CLI offline smoke', () => {
       cookies: [
         { name: 'sid', value: 'cookie-only' },
       ],
-      csrf_token: 'injected-token-1234567890',
-      corp_id: 'corp-injected',
-      user_id: 'user-injected',
-      base_url: 'https://www.aliwork.com',
+      csrf_token: 'stale-token-1234567890',
+      corp_id: 'corp-stale',
+      user_id: 'user-stale',
+      base_url: 'https://stale.aliwork.com',
     }), 'utf8');
+    const rawCookie = 'tianshu_csrf_token=env-token-1234567890; tianshu_corp_user=corpInjected_userInjected';
 
     try {
       const output = runOkWithEnv(['login'], {
         CODEX_SHELL: '1',
         YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_COOKIE_B64: Buffer.from(rawCookie, 'utf8').toString('base64'),
+        OPENYIDA_BASE_URL: 'https://www.aliwork.com',
         OPENYIDA_ENV: 'public',
       }, workspace);
       const parsed = JSON.parse(output.trim());
       expect(parsed).toMatchObject({
         ok: true,
         base_url: 'https://www.aliwork.com',
-        corp_id: 'corp-injected',
-        user_id: 'user-injected',
         cookies_count: 2,
       });
+      expect(parsed.corp_id).toContain('***');
+      expect(parsed.user_id).toContain('***');
+      expect(JSON.stringify(parsed)).not.toContain('env-token-1234567890');
+      expect(JSON.stringify(parsed)).not.toContain('corpInjected');
+      expect(JSON.stringify(parsed)).not.toContain('userInjected');
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -6,6 +6,13 @@ const os = require('os');
 
 const { run, detectEnvironment, detectLoginStatus, buildEnvironmentSnapshot } = require('../lib/core/env');
 
+function restoreEnv(snapshot) {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in snapshot)) {delete process.env[key];}
+  });
+  Object.assign(process.env, snapshot);
+}
+
 // ── detectEnvironment ─────────────────────────────────────────────────
 
 describe('detectEnvironment', () => {
@@ -187,6 +194,31 @@ describe('run', () => {
     expect(snapshot).toHaveProperty('login.csrfToken');
     if (snapshot.login.csrfToken) {
       expect(snapshot.login.csrfToken.endsWith('...')).toBe(true);
+    }
+  });
+
+  test('env auth 下 buildEnvironmentSnapshot 不泄露 cookie/csrf/corp/user 明文', () => {
+    const originalEnv = { ...process.env };
+    const rawCookie = 'tianshu_csrf_token=env-secret-token; tianshu_corp_user=corpSensitive_userSensitive';
+    process.env.YIDA_AUTH_ENABLED = 'true';
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(rawCookie, 'utf8').toString('base64');
+    process.env.OPENYIDA_BASE_URL = 'https://www.aliwork.com';
+
+    try {
+      const snapshot = buildEnvironmentSnapshot();
+      const serialized = JSON.stringify(snapshot);
+
+      expect(snapshot.login.loggedIn).toBe(true);
+      expect(snapshot.login.authSource).toBe('env');
+      expect(snapshot.login.csrfToken).toBeNull();
+      expect(snapshot.login.corpId).toContain('***');
+      expect(snapshot.login.userId).toContain('***');
+      expect(serialized).not.toContain('env-secret-token');
+      expect(serialized).not.toContain('corpSensitive');
+      expect(serialized).not.toContain('userSensitive');
+      expect(serialized).not.toContain(process.env.OPENYIDA_COOKIE_B64);
+    } finally {
+      restoreEnv(originalEnv);
     }
   });
 

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -14,8 +14,25 @@ jest.mock('../lib/core/i18n', () => ({
 
 const {
   extractInfoFromCookies,
+  getLastEnvAuthError,
   loadCookieData,
+  loadEnvCookieData,
+  parseCookieHeader,
+  requestWithAutoLogin,
 } = require('../lib/core/utils');
+
+function restoreEnv(snapshot) {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in snapshot)) {delete process.env[key];}
+  });
+  Object.assign(process.env, snapshot);
+}
+
+function clearEnvAuthVars() {
+  delete process.env.YIDA_AUTH_ENABLED;
+  delete process.env.OPENYIDA_COOKIE_B64;
+  delete process.env.OPENYIDA_BASE_URL;
+}
 
 //─ extractInfoFromCookies─────────────────────────
 
@@ -110,14 +127,121 @@ describe('extractInfoFromCookies', () => {
   });
 });
 
+describe('env cookie auth provider', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    restoreEnv(originalEnv);
+    clearEnvAuthVars();
+  });
+
+  afterEach(() => {
+    restoreEnv(originalEnv);
+  });
+
+  test('parseCookieHeader parses raw HTTP Cookie header', () => {
+    const cookies = parseCookieHeader(
+      'tianshu_csrf_token=env-token; tianshu_corp_user=corp123_user456; other=value=with=equals',
+      { baseUrl: 'https://www.aliwork.com' }
+    );
+
+    expect(cookies).toEqual([
+      { name: 'tianshu_csrf_token', value: 'env-token', domain: 'www.aliwork.com' },
+      { name: 'tianshu_corp_user', value: 'corp123_user456', domain: 'www.aliwork.com' },
+      { name: 'other', value: 'value=with=equals', domain: 'www.aliwork.com' },
+    ]);
+  });
+
+  test('loadEnvCookieData decodes base64 cookie and extracts csrf/corp/user/baseUrl', () => {
+    const rawCookie = 'tianshu_csrf_token=env-token; tianshu_corp_user=corp123_user456';
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(rawCookie, 'utf8').toString('base64');
+    process.env.OPENYIDA_BASE_URL = 'https://custom.aliwork.com/';
+
+    const result = loadEnvCookieData('https://www.aliwork.com');
+
+    expect(result).toMatchObject({
+      csrf_token: 'env-token',
+      corp_id: 'corp123',
+      user_id: 'user456',
+      base_url: 'https://custom.aliwork.com',
+      auth_source: 'env',
+    });
+    expect(result.cookies).toEqual([
+      { name: 'tianshu_csrf_token', value: 'env-token', domain: 'custom.aliwork.com' },
+      { name: 'tianshu_corp_user', value: 'corp123_user456', domain: 'custom.aliwork.com' },
+    ]);
+  });
+
+  test('invalid base64 records structured env auth error', () => {
+    process.env.OPENYIDA_COOKIE_B64 = 'not valid base64!';
+
+    expect(loadEnvCookieData()).toBeNull();
+    expect(getLastEnvAuthError()).toMatchObject({
+      code: 'not_logged_in',
+      failure_reason: 'env_cookie_decode_failed',
+      authMode: 'env',
+    });
+  });
+
+  test('missing csrf records csrf_missing error', () => {
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from('tianshu_corp_user=corp123_user456', 'utf8').toString('base64');
+
+    expect(loadEnvCookieData()).toBeNull();
+    expect(getLastEnvAuthError()).toMatchObject({
+      code: 'csrf_missing',
+      failure_reason: 'csrf_token_missing',
+    });
+  });
+
+  test('env cookie expired response returns structured auth error', async () => {
+    process.env.YIDA_AUTH_ENABLED = 'true';
+    const result = await requestWithAutoLogin(async () => ({ __needLogin: true }), {
+      csrfToken: 'expired',
+      cookies: [],
+      baseUrl: 'https://www.aliwork.com',
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      __needLogin: true,
+      errorCode: 'INJECTED_AUTH_REQUIRED',
+    });
+    expect(result.errorMsg).toContain('not_logged_in');
+    expect(result.errorMsg).toContain('env cookie');
+  });
+
+  test('OPENYIDA_COOKIE_B64 alone keeps expired response in env auth mode', async () => {
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(
+      'tianshu_csrf_token=env-token; tianshu_corp_user=corp123_user456',
+      'utf8'
+    ).toString('base64');
+
+    const result = await requestWithAutoLogin(async () => ({ __needLogin: true }), {
+      csrfToken: 'expired',
+      cookies: [],
+      baseUrl: 'https://www.aliwork.com',
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      __needLogin: true,
+      errorCode: 'INJECTED_AUTH_REQUIRED',
+    });
+    expect(result.errorMsg).toContain('env cookie');
+  });
+});
+
 //─ loadCookieData─────────────────────────────────
 
 describe('loadCookieData', () => {
+  const originalEnv = { ...process.env };
   let tmpDir;
   let cacheDir;
   let cookieFile;
 
   beforeEach(() => {
+    restoreEnv(originalEnv);
+    clearEnvAuthVars();
     tmpDir = path.join(os.tmpdir(), `yida-load-cookie-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     cacheDir = path.join(tmpDir, '.cache');
     cookieFile = path.join(cacheDir, 'cookies.json');
@@ -128,6 +252,7 @@ describe('loadCookieData', () => {
     if (fs.existsSync(tmpDir)) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+    restoreEnv(originalEnv);
   });
 
   test('cookies.json 不存在时返回 null', () => {
@@ -179,16 +304,71 @@ describe('loadCookieData', () => {
     const result = loadCookieData(tmpDir);
     expect(result).toBeNull();
   });
+
+  test('env cookie 优先于 cookies.json', () => {
+    fs.writeFileSync(cookieFile, JSON.stringify({
+      cookies: [
+        { name: 'tianshu_csrf_token', value: 'cache-token' },
+        { name: 'tianshu_corp_user', value: 'cacheCorp_cacheUser' },
+      ],
+      base_url: 'https://cache.aliwork.com',
+    }), 'utf-8');
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(
+      'tianshu_csrf_token=env-token; tianshu_corp_user=envCorp_envUser',
+      'utf8'
+    ).toString('base64');
+
+    const result = loadCookieData(tmpDir);
+
+    expect(result.csrf_token).toBe('env-token');
+    expect(result.corp_id).toBe('envCorp');
+    expect(result.user_id).toBe('envUser');
+    expect(result.auth_source).toBe('env');
+  });
+
+  test('env cookie 不创建或修改 .cache cookie 文件', () => {
+    fs.rmSync(cookieFile, { force: true });
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(
+      'tianshu_csrf_token=env-token; tianshu_corp_user=envCorp_envUser',
+      'utf8'
+    ).toString('base64');
+
+    const beforeExists = fs.existsSync(cookieFile);
+    const result = loadCookieData(tmpDir);
+
+    expect(beforeExists).toBe(false);
+    expect(result.csrf_token).toBe('env-token');
+    expect(fs.existsSync(cookieFile)).toBe(false);
+    expect(fs.existsSync(path.join(cacheDir, 'cookies-public.json'))).toBe(false);
+  });
+
+  test('YIDA_AUTH_ENABLED=true 但缺少 env cookie 时不回退 cookies.json', () => {
+    fs.writeFileSync(cookieFile, JSON.stringify({
+      cookies: [
+        { name: 'tianshu_csrf_token', value: 'cache-token' },
+      ],
+    }), 'utf-8');
+    process.env.YIDA_AUTH_ENABLED = 'true';
+
+    expect(loadCookieData(tmpDir)).toBeNull();
+    expect(getLastEnvAuthError()).toMatchObject({
+      failure_reason: 'env_cookie_missing',
+    });
+  });
 });
 
 //─ saveCookieCache 文件写入测试───────────────────
 
 describe('saveCookieCache 文件写入', () => {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
   let tmpDir;
   let cacheDir;
   let cookieFile;
 
   beforeEach(() => {
+    restoreEnv(originalEnv);
+    clearEnvAuthVars();
     tmpDir = path.join(os.tmpdir(), `yida-save-cookie-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     cacheDir = path.join(tmpDir, '.cache');
     cookieFile = path.join(cacheDir, 'cookies.json');
@@ -196,9 +376,11 @@ describe('saveCookieCache 文件写入', () => {
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     if (fs.existsSync(tmpDir)) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+    restoreEnv(originalEnv);
   });
 
   test('正确写入 cookies.json 文件', () => {
@@ -232,6 +414,20 @@ describe('saveCookieCache 文件写入', () => {
     expect(result).not.toBeNull();
     expect(result.csrf_token).toBe('token123');
     expect(result.base_url).toBe(baseUrl);
+  });
+
+  test('env auth 模式下 saveCookieCache 不写入 cookies.json', () => {
+    process.chdir(tmpDir);
+    process.env.YIDA_AUTH_ENABLED = 'true';
+    const { saveCookieCache } = require('../lib/auth/login');
+
+    saveCookieCache([
+      { name: 'tianshu_csrf_token', value: 'newtoken' },
+      { name: 'tianshu_corp_user', value: 'newcorp_newuser' },
+    ], 'https://www.aliwork.com');
+
+    expect(fs.existsSync(cookieFile)).toBe(false);
+    expect(fs.existsSync(path.join(cacheDir, 'cookies-public.json'))).toBe(false);
   });
 });
 
@@ -729,18 +925,23 @@ describe('interactiveLogin 浏览器优先级', () => {
     });
   });
 
-  test('YIDA_AUTH_ENABLED=true 时 force=true 也只读取注入缓存', () => {
+  test('YIDA_AUTH_ENABLED=true 时 force=true 也只读取进程 env cookie', () => {
     fs.mkdirSync(path.join(tmpDir, '.cache'), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, '.cache', 'cookies-public.json'), JSON.stringify({
       cookies: [
         { name: 'sid', value: 'cookie-only' },
       ],
-      csrf_token: 'injected-token-1234567890',
-      corp_id: 'corp-injected',
-      user_id: 'user-injected',
-      base_url: 'https://www.aliwork.com',
+      csrf_token: 'stale-token-1234567890',
+      corp_id: 'corp-stale',
+      user_id: 'user-stale',
+      base_url: 'https://stale.aliwork.com',
     }), 'utf8');
     process.env.YIDA_AUTH_ENABLED = 'true';
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(
+      'tianshu_csrf_token=env-token-1234567890; tianshu_corp_user=corpEnv_userEnv',
+      'utf8'
+    ).toString('base64');
+    process.env.OPENYIDA_BASE_URL = 'https://env.aliwork.com';
 
     const { loginModule, cdpModule, childProcess } = loadLoginWithMocks(() => {
       throw new Error('interactive login should not run');
@@ -751,10 +952,10 @@ describe('interactiveLogin 浏览器优先级', () => {
     expect(cdpModule.cdpBrowserLogin).not.toHaveBeenCalled();
     expect(childProcess.execSync).not.toHaveBeenCalled();
     expect(result).toMatchObject({
-      csrf_token: 'injected-token-1234567890',
-      corp_id: 'corp-injected',
-      user_id: 'user-injected',
-      base_url: 'https://www.aliwork.com',
+      csrf_token: 'env-token-1234567890',
+      corp_id: 'corpEnv',
+      user_id: 'userEnv',
+      base_url: 'https://env.aliwork.com',
     });
   });
 });
@@ -800,6 +1001,31 @@ describe('checkLoginOnly 独立测试', () => {
     } finally {
       process.chdir(originalCwd);
       fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('env auth 下 checkLoginOnly 不返回完整 cookie 或 csrf', () => {
+    const originalEnv = { ...process.env };
+    const rawCookie = 'tianshu_csrf_token=env-secret-token; tianshu_corp_user=corpSensitive_userSensitive';
+    process.env.YIDA_AUTH_ENABLED = 'true';
+    process.env.OPENYIDA_COOKIE_B64 = Buffer.from(rawCookie, 'utf8').toString('base64');
+    process.env.OPENYIDA_BASE_URL = 'https://www.aliwork.com';
+
+    try {
+      const { checkLoginOnly } = require('../lib/auth/login');
+      const result = checkLoginOnly({ includeSecrets: true });
+      const serialized = JSON.stringify(result);
+
+      expect(result.status).toBe('ok');
+      expect(result.cookies).toBeUndefined();
+      expect(result.csrf_token).toBe('env-secr…');
+      expect(result.corp_id).toContain('***');
+      expect(result.user_id).toContain('***');
+      expect(serialized).not.toContain('env-secret-token');
+      expect(serialized).not.toContain(process.env.OPENYIDA_COOKIE_B64);
+      expect(serialized).not.toContain(rawCookie);
+    } finally {
+      restoreEnv(originalEnv);
     }
   });
 });
@@ -859,6 +1085,7 @@ describe('authLogin 登录优先级', () => {
       detectActiveTool: jest.fn(() => ({ tool: 'opencode' })),
       hasDesktopEnvironment: jest.fn(() => true),
       isInjectedAuthMode: jest.fn(() => false),
+      isEnvAuthMode: jest.fn(() => false),
     }));
     jest.doMock('../lib/core/chalk', () => ({
       info: jest.fn(),

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -16,6 +16,7 @@ const {
   hasDesktopEnvironment,
   resolveWukongWorkspaceRoot,
   httpPost,
+  httpPostJson,
   httpGet,
 } = require('../lib/core/utils');
 
@@ -167,6 +168,16 @@ describe('isLoginExpired', () => {
     expect(isLoginExpired({ success: false, errorCode: '302' })).toBe(true);
   });
 
+  test('HTTP auth errorCode 时返回 true', () => {
+    expect(isLoginExpired({ success: false, errorCode: '401' })).toBe(true);
+    expect(isLoginExpired({ success: false, errorCode: '403' })).toBe(true);
+  });
+
+  test('not_logged_in 状态或错误码时返回 true', () => {
+    expect(isLoginExpired({ status: 'not_logged_in' })).toBe(true);
+    expect(isLoginExpired({ success: false, errorCode: 'not_logged_in' })).toBe(true);
+  });
+
   test('success 为 true 时返回 false', () => {
     expect(isLoginExpired({ success: true, errorCode: '307' })).toBe(false);
   });
@@ -253,6 +264,48 @@ describe('http redirect login detection', () => {
         __needLogin: true,
         __httpStatus: 307,
         __location: '/workPlatform',
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('httpGet 将 401 识别为需要重新登录', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = 401;
+      res.end('Unauthorized');
+    });
+    const port = await listen(server);
+
+    try {
+      const result = await httpGet(`http://127.0.0.1:${port}`, '/bad', { a: 1 }, [
+        { name: 'tianshu_csrf_token', value: 'tok' },
+      ], { silentStatus: true });
+
+      expect(result).toMatchObject({
+        __needLogin: true,
+        __httpStatus: 401,
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('httpPostJson 将 403 识别为需要重新登录', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = 403;
+      res.end(JSON.stringify({ success: false, errorCode: '403' }));
+    });
+    const port = await listen(server);
+
+    try {
+      const result = await httpPostJson(`http://127.0.0.1:${port}`, '/bad', {}, [
+        { name: 'tianshu_csrf_token', value: 'tok' },
+      ], { silentStatus: true });
+
+      expect(result).toMatchObject({
+        __needLogin: true,
+        __httpStatus: 403,
       });
     } finally {
       server.close();


### PR DESCRIPTION
## Summary
- add an env auth provider for OPENYIDA_COOKIE_B64 raw Cookie header injection
- prefer env auth over .cache cookies and avoid writing cookie cache in env auth mode
- redact env-auth cookie/csrf/corp/user values in login/env output
- map 401/403/not_logged_in responses to structured auth failures

## Tests
- npm run check:quick
- npm test -- tests/utils.test.js tests/login.test.js tests/env.test.js tests/cli-smoke.test.js --runInBand
- npm test -- --runInBand --testPathIgnorePatterns=tests/e2e-real-skill-coverage.test.js

Note: full Jest without ignore currently fails only on tests/e2e-real-skill-coverage.test.js because this local workspace has an untracked yida-skills/skills/yida-data-insight directory missing coverage metadata.