### PR TITLE
docs: standardize OpenYida input file guidance

### DIFF
--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -157,6 +157,7 @@ description: >
 1. **先读后执行**：执行任何子技能前，必须先读取其 SKILL.md，不凭记忆猜参数格式。
 2. **corpId 一致性检查**：创建页面前对比 prd 与 `.cache/cookies.json` 的 corpId，不一致必须询问用户（重新登录 or 当前组织新建）。
 3. **发布前本地校验**：自定义页面发布前跑 `openyida check-page` + `openyida compile`；JSON 配置写盘后先解析校验，再调用平台命令。
+4. **命令输入文件禁止 shell 写入**：当 OpenYida 命令需要 JSON/YAML/CSV/config/script 文件参数时，先使用当前 agent 运行时提供的结构化文件写入工具（如 create_file / Write / file edit tool）创建文件，再把路径传给命令；禁止用 shell heredoc、`cat`/`echo`/`printf`/`tee` 加输出重定向，或把命令 stdout 重定向成业务文件。
 
 ### 重要规则（IMPORTANT，影响质量/性能/可维护性）
 
@@ -167,7 +168,7 @@ description: >
 5. **数据性能优先**：统计聚合用 `yida-report` 服务端聚合，不在前端拉全量后自行聚合。
 6. **避免无效重试**：失败先查登录态/组织/参数/字段 ID，无修改不连续重试超 1 次。
 7. **配置分两处存**：业务语义 → `prd/<项目名>.md`；Schema ID → `.cache/<项目名>-schema.json`（prd 不记 ID）。
-8. **临时文件入 `.cache/`**：cookies/schema/配置/脚本一律放 `.cache/openyida/`，不写仓库根目录。
+8. **临时文件入 project `.cache/`**：OpenYida 业务中间文件写入 `<projectRoot>/.cache/openyida/<项目名或任务名>/`；Schema ID 映射仍写 `<projectRoot>/.cache/<项目名>-schema.json`。从 workspace 根执行命令时使用 `project/.cache/...`，从 project 工作目录内执行时使用 `.cache/...`；不要写仓库根目录或系统临时目录。
 9. **报表美化先问方案**：用户说"优化/美化报表"时先问选原生报表(`yida-report`)还是 ECharts(`yida-chart`)。
 10. **按 schema 证据选技能**：先看 `formType`、组件树、`dataSource.online`；`receipt/process/report` 分别落到表单/流程/报表技能。
 11. **官方示例范式优先**：蒸馏官方示例时先理解脱敏 schema 承载方式，不凭截图/标题/视觉判断。

--- a/yida-skills/references/development-rules.md
+++ b/yida-skills/references/development-rules.md
@@ -1,6 +1,6 @@
 # 核心规则详解
 
-> 逐条展开主 SKILL.md「核心规则」的操作细节，编号与主文件一一对应（FATAL 1–3 / IMPORTANT 1–11）。需要更多篇幅的规则指向文末专节。
+> 逐条展开主 SKILL.md「核心规则」的操作细节，编号与主文件一一对应（FATAL 1–4 / IMPORTANT 1–11）。需要更多篇幅的规则指向文末专节。
 
 ## 致命规则（FATAL）
 
@@ -15,6 +15,8 @@
 - 发布时留意"同名双副本内容不一致"警告，必要时加 `--health-check` 做首屏 HTTP 健康检查；
 - 任何 JSON 配置写盘后先做 JSON 解析校验，再调用平台命令。
 
+**F4 命令输入文件禁止 shell 写入**：当 OpenYida 命令需要 JSON/YAML/CSV/config/script 文件参数时，必须先使用当前 agent 运行时提供的结构化文件写入工具（如 create_file / Write / file edit tool）创建文件，再把文件路径传给命令。禁止用 shell heredoc、`cat`/`echo`/`printf`/`tee` 加输出重定向，或把 `openyida` 命令 stdout 重定向成业务配置、Schema、导入数据或一次性脚本。
+
 ## 重要规则（IMPORTANT）
 
 | # | 规则 | 操作细节 |
@@ -26,7 +28,7 @@
 | 5 | 数据性能优先 | 统计聚合用 `yida-report` 服务端聚合；不在自定义页面前端分页拉全量后自行聚合。 |
 | 6 | 避免无效重试 | 失败先按错误信息查登录态/组织/参数/字段 ID；无修改不连续重试超 1 次。 |
 | 7 | 配置分两处存 | 详见 [配置信息分两处存储](#配置信息分两处存储) 与 [PRD 质量门槛](#prd-质量门槛)。 |
-| 8 | 临时文件入 `.cache/` | 详见 [临时文件规范](#临时文件规范)。 |
+| 8 | 临时文件入 project `.cache/` | 详见 [临时文件规范](#临时文件规范)。 |
 | 9 | 报表美化先问方案 | 详见 [报表优化 / 美化提示规则](#报表优化--美化提示规则)。 |
 | 10 | 按 schema 证据选技能 | 先看 `formType`、组件树、`dataSource.online`；`receipt/process/report` 分别落到表单/流程/报表技能，只有默认页是自定义展示页、或确需列表/看板/工具页交互时才落到 `yida-custom-page`。 |
 | 11 | 官方示例范式优先 | 蒸馏宜搭示例中心时，先按 [官方示例 Schema 范式](official-example-schema-patterns.md) 理解脱敏 schema 的承载方式，不凭截图/卡片标题/页面视觉判断。 |
@@ -55,14 +57,16 @@
 
 ## 临时文件规范
 
-所有临时文件（cookies、schema 缓存、字段/报表/流程配置、导入数据、一次性脚本等）**必须写在项目根目录的 `.cache/` 下**，不写仓库根目录或系统其他位置。
+所有 OpenYida 业务中间文件（cookies、schema 缓存、字段/报表/流程配置、导入数据、一次性脚本等）**必须写在 OpenYida project 工作目录的 `.cache/` 下**，不写业务仓库根目录、系统 `/tmp` 或其他位置。源码中的 `<projectRoot>` 指 OpenYida project 工作目录；从 workspace 根执行命令时路径通常是 `project/.cache/...`，从 project 工作目录内执行时路径是 `.cache/...`。
+
+文件必须由 agent 的结构化文件写入工具创建，再传给 OpenYida 命令。不要通过 `execute_shell` 加 heredoc、`cat`/`echo`/`printf`/`tee`、管道或重定向来生成 JSON/YAML/CSV/config/script 文件。`/tmp` 只允许用于外部工具强制要求的系统临时路径，OpenYida 业务配置、schema、导入数据和一次性脚本不写 `/tmp`。
 
 | 工件类型 | 推荐位置 |
 |---------|---------|
-| Schema / ID 映射 | `.cache/<项目名>-schema.json` |
-| 字段 / 报表 / 流程配置 | `.cache/openyida/<项目名>/` |
-| 批量导入数据（JSON/JSONL/CSV） | `.cache/openyida/data-import/` |
-| 一次性 Python / JS 脚本 | `.cache/openyida/scripts/` |
+| Schema / ID 映射 | `<projectRoot>/.cache/<项目名>-schema.json` |
+| 字段 / 报表 / 流程 / 连接器配置 | `<projectRoot>/.cache/openyida/<项目名或任务名>/` |
+| 批量导入数据（JSON/JSONL/CSV） | `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/` |
+| 一次性 Python / JS 脚本 | `<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/` |
 
 > 只有需长期维护的 PRD、页面源码、示例资源才写入 `prd/`、`pages/src/`、`project/` 等正式目录。
 

--- a/yida-skills/skills/large-file-write/SKILL.md
+++ b/yida-skills/skills/large-file-write/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: large-file-write
-description: 解决 heredoc 或 shell 命令写入大文件内容被截断的问题。通过 Node.js 脚本将内容作为模板字符串写入，绕过 shell 截断限制。适用于需要可靠写入超过 100 行文本文件时。
+description: 解决 heredoc 或 shell 命令写入大文件内容被截断的问题。优先使用 agent 结构化文件写入工具；超大文件可用该工具创建 Node.js payload 后执行。适用于需要可靠写入超过 100 行文本文件时。
 ---
 
 # Large File Write Skill
 
 ## 问题背景
 
-在 AI Agent 模式下，使用 heredoc（`<< 'EOF'`）或 shell 命令向文件写入大块内容时，经常出现：
+在 AI Agent 模式下，使用 shell here-document 或其他 shell 命令向文件写入大块内容时，经常出现：
 - 内容被截断（工具输出超过 token 限制）
 - heredoc 内容未生效（zsh 特殊字符转义问题）
 - 多次追加导致重复内容或语法错误
@@ -15,20 +15,22 @@ description: 解决 heredoc 或 shell 命令写入大文件内容被截断的问
 
 ## 解决方案
 
-使用 Node.js 脚本 `scripts/write.js`，将内容作为 JS 字符串变量传入，绕过 shell 截断限制。
+优先使用当前 agent 运行时提供的结构化文件写入工具（如 create_file / Write / file edit tool）直接创建目标文件。内容过大、单次写入可能截断时，再用结构化写入工具创建 Node.js payload 脚本，由 payload 调用 `fs.writeFileSync` 写目标文件。
+
+OpenYida 业务场景下，payload、内容片段和验证脚本必须放在 `<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/`，不要写系统临时目录、仓库根目录或 `.cache/` 顶层。
 
 ## 使用方式
 
 三种写入模式的完整代码示例，详见 [references/write-patterns.md](./references/write-patterns.md)：
 
-- **模式一**：创建内容脚本后执行（推荐）— 用 `create_file` 创建临时 JS 脚本，再 `node` 执行
+- **模式一**：创建内容脚本后执行（推荐）— 用结构化文件写入工具创建临时 JS 脚本，再 `node` 执行
 - **模式二**：追加内容到已有文件 — 用 `fs.appendFileSync` 追加大块内容
-- **模式三**：使用通用写入脚本（stdin 模式）— 通过管道传入内容
+- **模式三**：使用通用写入脚本（content-file 模式）— 内容文件也先由结构化文件写入工具创建
 
 ### 快速示例
 
 ```js
-// /tmp/content-payload.js
+// <projectRoot>/.cache/openyida/<任务名>/scripts/content-payload.js
 const fs = require('fs');
 const content = `// 你的大块内容（支持任意长度）
 export function myFunction() { ... }
@@ -38,17 +40,17 @@ console.log('写入完成，行数：', content.split('\n').length);
 ```
 
 ```bash
-node /tmp/content-payload.js
+node .cache/openyida/<任务名>/scripts/content-payload.js
 wc -l /path/to/target.js   # 验证行数
 ```
 
 ## 核心原则
 
-1. **永远不要用 heredoc 写大文件** — 改用 `create_file` 工具创建临时 JS 脚本
+1. **永远不要用 heredoc 写大文件** — 改用结构化文件写入工具创建临时 JS 脚本
 2. **永远不要用 PowerShell JSON 化大文件** — 禁止 `Get-Content -Raw <file> | ConvertTo-Json`、`ConvertFrom-Json` 处理 `.oyd.jsx/.jsx/.js` 页面源码
 3. **内容放在 JS 模板字符串里** — 支持任意长度，不受 shell 限制
 4. **写完立即验证** — `wc -l` 检查行数，`tail` 检查末尾内容
-5. **分段写入大文件** — 超过 300 行的内容，拆分为多个 `create_file` + `node` 执行
+5. **分段写入大文件** — 超过 300 行的内容，拆分为多个结构化写入 + `node` 执行
 6. **本技能不读写 memory**：文件写入为纯本地操作，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -88,4 +90,4 @@ Get-Content -Raw project\pages\src\vendor-section.oyd.jsx | ConvertTo-Json
 | `node: command not found` | Node.js 未安装 | 先安装 Node.js ≥ 16 |
 | 脚本执行后文件为空 | 模板字符串语法错误 | 检查反引号是否闭合，特殊字符是否转义 |
 | 写入不完整 | 内容超过单次 create_file 限制 | 按「分段写入」方式拆分为多个脚本 |
-| 权限拒绝 | 目标路径无写权限 | 检查目录权限，或改用 `/tmp/` 路径 |
+| 权限拒绝 | 目标路径无写权限 | 检查目标目录权限；OpenYida 业务文件仍应留在 project 工作目录内 |

--- a/yida-skills/skills/large-file-write/references/write-patterns.md
+++ b/yida-skills/skills/large-file-write/references/write-patterns.md
@@ -6,10 +6,10 @@
 
 适用于一次性写入大块内容（>100 行）。
 
-### Step 1：用 `create_file` 工具创建临时内容脚本
+### Step 1：用结构化文件写入工具创建临时内容脚本
 
 ```js
-// /tmp/content-payload.js
+// <projectRoot>/.cache/openyida/<任务名>/scripts/content-payload.js
 const fs = require('fs');
 const content = `
 // 这里放你要写入的大块内容
@@ -25,7 +25,7 @@ console.log('写入完成，行数：', content.split('\n').length);
 ### Step 2：执行脚本
 
 ```bash
-node /tmp/content-payload.js
+node .cache/openyida/<任务名>/scripts/content-payload.js
 ```
 
 ### Step 3：验证写入结果
@@ -42,7 +42,7 @@ tail -5 /path/to/target.js
 适用于向已有文件末尾追加大块内容。
 
 ```js
-// /tmp/append-payload.js
+// <projectRoot>/.cache/openyida/<任务名>/scripts/append-payload.js
 const fs = require('fs');
 const appendContent = `
 // 追加的内容
@@ -57,22 +57,23 @@ console.log('追加完成');
 执行：
 
 ```bash
-node /tmp/append-payload.js
+node .cache/openyida/<任务名>/scripts/append-payload.js
 ```
 
 ---
 
-## 模式三：使用通用写入脚本（stdin 模式）
+## 模式三：使用通用写入脚本（content-file 模式）
 
-适用于通过管道传入内容的场景。
+适用于内容已经由结构化文件写入工具保存为独立文件的场景。
 
 ```bash
 node ~/.agents/skills/large-file-write/scripts/write.js \
   --file /path/to/target.js \
+  --content-file .cache/openyida/<任务名>/scripts/content.txt \
   --mode write   # 或 append
 ```
 
-然后通过 stdin 输入内容（Ctrl+D 结束）。
+不要通过 shell 管道、heredoc 或重定向临时生成 `content.txt`；先使用 create_file / Write / file edit tool 创建它。
 
 ---
 
@@ -80,10 +81,7 @@ node ~/.agents/skills/large-file-write/scripts/write.js \
 
 **不要**用 PowerShell 把大 JSX/JS 文件转成 JSON patch：
 
-```powershell
-# 禁止：会把整个文件读入内存并生成转义后的大字符串
-Get-Content -Raw project\pages\src\vendor-section.oyd.jsx | ConvertTo-Json > vendor-patch.json
-```
+禁止把整个文件读入内存再重定向成 JSON patch，例如 `Get-Content -Raw ... | ConvertTo-Json` 这类流程会制造巨大中间数据，也违反“命令输入文件由结构化写入工具创建”的约定。
 
 这种写法会同时持有原始源码、JSON 转义字符串、管道对象和输出缓冲。对包含 vendor、base64、压缩代码的 `.oyd.jsx` 文件，内存可能被放大到数十 GB。
 
@@ -106,7 +104,7 @@ fs.writeFileSync(target, next, 'utf8');
 当单次内容超过 300 行时，拆分为多个脚本分段写入：
 
 ```js
-// /tmp/part1-payload.js — 写入第一段（文件头 + 前半部分）
+// <projectRoot>/.cache/openyida/<任务名>/scripts/part1-payload.js — 写入第一段（文件头 + 前半部分）
 const fs = require('fs');
 const part1 = `
 // === 第一段内容 ===
@@ -118,7 +116,7 @@ console.log('第一段写入完成');
 ```
 
 ```js
-// /tmp/part2-payload.js — 追加第二段
+// <projectRoot>/.cache/openyida/<任务名>/scripts/part2-payload.js — 追加第二段
 const fs = require('fs');
 const part2 = `
 // === 第二段内容 ===
@@ -145,5 +143,5 @@ tail -5 /path/to/target.js
 |---------|------|---------|
 | 文件为空 | 模板字符串反引号未闭合 | 检查 `` ` `` 是否成对，特殊字符是否转义 |
 | 内容截断 | 单次 create_file 超过 token 限制 | 拆分为多个脚本分段写入 |
-| 权限拒绝 | 目标路径无写权限 | 改用 `/tmp/` 路径，或检查目录权限 |
+| 权限拒绝 | 目标路径无写权限 | 检查目标目录权限；OpenYida 业务文件仍应留在 project 工作目录内 |
 | node 命令未找到 | Node.js 未安装 | 先安装 Node.js ≥ 16 |

--- a/yida-skills/skills/large-file-write/scripts/write.js
+++ b/yida-skills/skills/large-file-write/scripts/write.js
@@ -8,9 +8,9 @@
  *   node write.js --file <目标文件路径> [--mode write|append] [--encoding utf8]
  *
  * 内容来源（三选一）：
- *   1. stdin：echo "content" | node write.js --file out.js
- *   2. --content-file <临时内容文件>：node write.js --file out.js --content-file /tmp/content.txt
- *   3. --payload <JS文件>：node write.js --payload /tmp/payload.js（payload 文件自行调用 fs 写入）
+ *   1. stdin：交互式输入或由调用方传入标准输入
+ *   2. --content-file <内容文件>：node write.js --file out.js --content-file .cache/openyida/task/content.txt
+ *   3. --payload <JS文件>：node write.js --payload .cache/openyida/task/payload.js（payload 文件自行调用 fs 写入）
  */
 
 const fs = require('fs');
@@ -53,15 +53,15 @@ large-file-write - 大文件可靠写入工具
   --help                 显示帮助
 
 示例：
-  # 从 stdin 写入
-  echo "hello world" | node write.js --file /tmp/out.txt
+	  # 从 stdin 写入
+	  node write.js --file .cache/openyida/task/out.txt
 
-  # 从内容文件写入
-  node write.js --file /tmp/out.js --content-file /tmp/content.txt --verify
+	  # 从内容文件写入
+	  node write.js --file .cache/openyida/task/out.js --content-file .cache/openyida/task/content.txt --verify
 
-  # 执行自包含 payload 脚本
-  node write.js --payload /tmp/my-payload.js
-`);
+	  # 执行自包含 payload 脚本
+	  node write.js --payload .cache/openyida/task/my-payload.js
+	`);
   process.exit(0);
 }
 

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -13,6 +13,7 @@ description: 宜搭完整应用开发技能。从零到一搭建完整宜搭应�
 - 不要跳过 `openyida env` 环境检测直接开始开发
 - 不要在未读取各子技能 SKILL.md 的情况下执行对应操作
 - 不要编造任何 ID（appType/formUuid/fieldId），必须从命令返回中提取
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成 OpenYida 命令输入文件
 
 ## 严格要求 (MUST DO)
 
@@ -20,7 +21,7 @@ description: 宜搭完整应用开发技能。从零到一搭建完整宜搭应�
 - 按照本文档的流程编排顺序执行，不要跳步
 - 每个关键 ID 创建后立即记录到 `.cache/<项目名>-schema.json`
 - 业务需求记录到 `prd/<项目名>.md`
-- 临时字段配置、流程配置、报表配置、导入数据和一次性执行脚本统一写入 `.cache/openyida/`，不要写到仓库根目录
+- 临时字段配置、流程配置、报表配置、连接器配置、导入数据和一次性执行脚本统一用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/`；从 workspace 根执行命令时传 `project/.cache/...`，从 OpenYida project 工作目录执行时传 `.cache/...`；不要写到仓库根目录或系统临时目录
 - 首次生成完整应用后，必须基于业务信息架构整理导航顺序：面向决策者的总览/驾驶舱看板作为门面靠前，数据录入/明细表单在后；同级多个专题看板按业务优先级排，不要把所有自定义页面无脑堆最前
 - 导航整理完成后，若应用含表单，默认向核心表单灌入 2-3 条覆盖关键维度的示例数据，让看板首屏有真实聚合效果；`DateField`/`CascadeDateField` 用 13 位毫秒时间戳，灌后 `openyida data query` 抽查至少 1 条确认字段值非空（用户明确说"不要示例数据"时才跳过）
 - **本技能不读写 memory**：所有关键 ID（appType、formUuid 等）通过 `.cache/<项目名>-schema.json` 持久化，不依赖跨会话的 memory 状态
@@ -276,7 +277,9 @@ openyida create-page <appType> "<页面名称>" [--mode dashboard]
 
 **当页面需要收集/存储数据时**，调用 `yida-create-form-page` 技能。
 
-#### 4.1 定义字段，写入 `.cache/openyida/<项目名>/xxx-fields.json`
+#### 4.1 定义字段，写入 `<projectRoot>/.cache/openyida/<项目名或任务名>/xxx-fields.json`
+
+使用 create_file / Write / file edit tool 创建字段定义文件；不要用 shell heredoc 或重定向写 JSON。若从 workspace 根执行命令，路径写作 `project/.cache/openyida/<项目名或任务名>/xxx-fields.json`。
 
 ```json
 [
@@ -290,7 +293,7 @@ openyida create-page <appType> "<页面名称>" [--mode dashboard]
 #### 4.2 创建表单
 
 ```bash
-openyida create-form create <appType> "<表单名称>" .cache/openyida/<项目名>/xxx-fields.json
+openyida create-form create <appType> "<表单名称>" .cache/openyida/<项目名或任务名>/xxx-fields.json
 ```
 
 **输出**：`formUuid` 和各字段的 `fieldId`（如 `textField_xxxxxxxx`）。
@@ -326,8 +329,10 @@ openyida create-form create <appType> "<表单名称>" .cache/openyida/<项目�
 **当需求含「审批」「流程」「申请」「审核」「工单」等关键词时必须执行**。
 
 ```bash
-openyida create-process <appType> --formUuid <formUuid> <流程定义文件>
+openyida create-process <appType> --formUuid <formUuid> .cache/openyida/<项目名或任务名>/process-definition.json
 ```
+
+流程定义文件先用结构化文件写入工具创建；从 workspace 根执行命令时路径加 `project/` 前缀。
 
 > 📖 详见 [`skills/yida-create-process/SKILL.md`](../yida-create-process/SKILL.md)
 
@@ -397,10 +402,11 @@ openyida nav-group order <appType> <总览看板> <专题看板...> <核心表�
 新建应用的表单默认无数据，看板首屏会空。导航整理完成后，默认向核心表单灌入 **2-3 条**覆盖关键维度（不同活动/渠道/日期等）的示例记录，调用 `yida-data-management` 技能：
 
 ```bash
-openyida data create form <appType> <formUuid> --data-json '{"selectField_xxx":"双11","dateField_xxx":1730995200000,"numberField_xxx":1200000}'
+openyida data create form <appType> <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/sample-record-1.json
 ```
 
 **要点**：
+- 示例数据 JSON 先用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/`；从 workspace 根执行命令时路径加 `project/` 前缀。
 - `DateField`/`CascadeDateField` 必须用 13 位毫秒时间戳，不要传 `YYYY-MM-DD`。
 - 字段 ID 从 `.cache/<项目名>-schema.json` 或 `openyida get-schema` 获取，不能猜。
 - 灌完执行 `openyida data query form <appType> <formUuid>` 抽查至少 1 条，确认 `formData` 字段有实际值。
@@ -431,7 +437,7 @@ openyida data create form <appType> <formUuid> --data-json '{"selectField_xxx":"
 
 **测试数据/修数脚本约定**：
 - 一次性造数、旧数据修正、字段迁移可以使用 Python 或 JS，选择更快更清晰的实现即可；不要求为了“宜搭”强行写 JS。
-- 脚本放在 `.cache/openyida/scripts/` 下，导入数据放在 `.cache/openyida/data-import/` 下；执行前先 `openyida get-schema` / `openyida data query` 确认字段和记录，批量更新单次不超过 30 条。
+- 脚本放在 `<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/` 下，导入数据放在 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/` 下，均由结构化文件写入工具创建；执行前先 `openyida get-schema` / `openyida data query` 确认字段和记录，批量更新单次不超过 30 条。
 - 脚本可以通过 `openyida data ...` 命令或宜搭官方接口执行，但字段 ID、formInstId、appType 必须来自真实查询结果，不能猜。
 
 ---

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -87,8 +87,10 @@ openyida publish project/pages/src/<页面名>.canvas.jsx <appType> <formUuid>
 #    扩展名不规范但确为 Canvas 源码时，显式加 --canvas。
 
 # 6. 发布后回读 Schema 验收：确认组件树存在 YidaCodeCanvas，且 runtimeCode 非空
-openyida get-schema <appType> <formUuid> > .cache/openyida/<页面名>-schema.json
+openyida get-schema <appType> <formUuid>
 ```
+
+如需保存完整 Schema，使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/<页面名或任务名>/<页面名>-schema.json`；从 workspace 根执行后续命令时路径加 `project/` 前缀。不要把 `openyida` stdout 通过 shell 重定向保存成 JSON。
 
 ## 与其他技能分工
 

--- a/yida-skills/skills/yida-canvas-upgrade/SKILL.md
+++ b/yida-skills/skills/yida-canvas-upgrade/SKILL.md
@@ -20,7 +20,7 @@ description: 将 OpenYida 原普通自定义页面链路升级/迁移为宜搭 C
 | --- | --- |
 | 登录态只读验证 | `openyida env --json` + `openyida login --check-only --json` |
 | 原页面源码 | 找到 `.oyd.jsx` / `.jsx` 源文件；不要只看 dist 编译产物 |
-| 目标页面 Schema | `openyida get-schema <appType> <formUuid> > .cache/openyida/canvas-upgrade/<name>-schema.json` |
+| 目标页面 Schema | 先执行 `openyida get-schema <appType> <formUuid>`，再用 create_file / Write / file edit tool 按需保存到 `<projectRoot>/.cache/openyida/canvas-upgrade/<name>-schema.json`；不要用 shell 重定向 |
 | Code Canvas 发布能力 | 已内置：产出的 `.canvas.jsx` 用 `openyida publish <源文件> <appType> <formUuid>` 即自动走 Canvas 链路（`.canvas.jsx` 扩展名识别，CLI 本地用 Babel 编译出 `runtimeCode` + `importedModules` 并写 `YidaCodeCanvas` Schema），无需设计器手工添加 |
 | 原页面数据依赖 | 列出 `this.utils.yida.*`、`this.dataSourceMap.*`、连接器、外部脚本、全局变量 |
 

--- a/yida-skills/skills/yida-chart/SKILL.md
+++ b/yida-skills/skills/yida-chart/SKILL.md
@@ -60,8 +60,8 @@ openyida login --check-only --json
 # Step 2: 准备原生报表数据源
 # 无原生报表时先使用 yida-report 创建；已有 URL 时解析 appType/formUuid
 
-# Step 3: 获取报表 Schema，输出到文件避免终端截断
-openyida get-schema <appType> <reportFormUuid> > .cache/report-schema-output.txt 2>&1
+# Step 3: 获取报表 Schema；需要文件时用 CLI 输出目录或结构化文件写入工具保存 stdout
+openyida get-schema <appType> --all --keyword <报表名称> --output-dir .cache/openyida/<项目名或任务名>/schemas
 
 # Step 4: 解析 cid / className / dataSetKey / filterKey / cname
 

--- a/yida-skills/skills/yida-chart/references/echarts-bindding-guide.md
+++ b/yida-skills/skills/yida-chart/references/echarts-bindding-guide.md
@@ -25,7 +25,7 @@ Step 1: 从 URL 中解析 appType 和 formUuid
 Step 2: 执行 openyida env 检测环境和登录态
     ↓
 Step 3: 执行 openyida get-schema <appType> <formUuid> 获取现有报表 Schema
-    ↓  命令：openyida get-schema <appType> <formUuid> > .cache/report-schema-output.txt 2>&1
+    ↓  需要文件时，使用结构化文件写入工具保存 stdout，或用 --all --keyword --output-dir 输出到 project .cache
     ↓
 Step 4: 解析 Schema，提取每个图表组件的 5 个核心参数
     ↓  详见下方「Schema 解析规范」
@@ -58,15 +58,14 @@ Step 11: 输出 ECharts 自定义页面访问链接
 
 ## Schema 获取注意事项
 
-1. **必须将输出重定向到文件**：报表 Schema 通常非常大（数千行），终端输出会被截断
+1. **不要用 shell 重定向保存 Schema**：报表 Schema 通常非常大（数千行），需要文件时用 CLI 自带输出目录或 agent 结构化文件写入工具
    ```bash
-   openyida get-schema <appType> <formUuid> > .cache/report-schema-output.txt 2>&1
+   openyida get-schema <appType> --all --keyword <报表名称> --output-dir .cache/openyida/<项目名或任务名>/schemas
    ```
 
-2. **提取 JSON 部分**：输出文件包含前缀日志信息，需要从 `{` 开始的行提取纯 JSON
+2. **单表回读时保存 stdout**：如必须按 `formUuid` 回读，先执行命令，再用 create_file / Write / file edit tool 保存纯 JSON 到 `<projectRoot>/.cache/openyida/<项目名或任务名>/report-schema.json`
    ```bash
-   grep -n "^{" .cache/report-schema-output.txt
-   tail -n +<行号> .cache/report-schema-output.txt > .cache/report-schema.json
+   openyida get-schema <appType> <formUuid> --json
    ```
 
 ---

--- a/yida-skills/skills/yida-chart/references/examples.md
+++ b/yida-skills/skills/yida-chart/references/examples.md
@@ -15,8 +15,8 @@ https://www.aliwork.com/APP_KNILKT41DC5XXR5D4QEC/admin/REPORT-QA666SC1J3U3TFO9GM
 # Step 1：检测环境和登录态
 openyida env
 
-# Step 2：获取报表 Schema（必须重定向到文件，避免截断）
-openyida get-schema APP_KNILKT41DC5XXR5D4QEC REPORT-QA666SC1J3U3TFO9GM9MJ5400RIW3W83SUYMM5 > .cache/report-schema-output.txt 2>&1
+# Step 2：获取报表 Schema；需要文件时用结构化文件写入工具保存 stdout
+openyida get-schema APP_KNILKT41DC5XXR5D4QEC REPORT-QA666SC1J3U3TFO9GM9MJ5400RIW3W83SUYMM5 --json
 
 # Step 3：创建自定义展示页面
 openyida create-page APP_KNILKT41DC5XXR5D4QEC "任务数据看板" --mode dashboard

--- a/yida-skills/skills/yida-connector-safe-actions/SKILL.md
+++ b/yida-skills/skills/yida-connector-safe-actions/SKILL.md
@@ -26,6 +26,7 @@ description: 从前端 API 文件或后端 Controller 代码中提取接口定�
 - Windows PowerShell 读取中文 JSON 时必须显式使用 UTF-8。
 - 修改后必须执行“添加动作 -> 列表验证 -> CLI 测试 -> 再次列表验证”的闭环。
 - 如果一次错误配置导致动作被清空，应重建完整动作列表，而不是只追加缺失动作。
+- 动作 JSON 必须使用当前 agent 的结构化文件写入工具创建；不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向写文件。
 
 ## 推荐流程
 
@@ -51,11 +52,13 @@ openyida connector list-actions <connector-id>
 
 ### 3. 生成动作 JSON 文件
 
-建议放在当前项目：
+建议放在 OpenYida project 工作目录的任务子目录：
 
 ```text
-.cache/openyida/connector-actions/<业务名>-actions.json
+<projectRoot>/.cache/openyida/<项目名或任务名>/connector-actions/<业务名>-actions.json
 ```
+
+从 workspace 根执行命令时传 `project/.cache/openyida/<项目名或任务名>/connector-actions/<业务名>-actions.json`；从 project 工作目录内执行时传 `.cache/openyida/<项目名或任务名>/connector-actions/<业务名>-actions.json`。
 
 动作 ID 建议使用顺序编号：
 
@@ -74,7 +77,7 @@ openyida connector list-actions <connector-id>
 Windows PowerShell 必须加 `-Encoding UTF8`：
 
 ```powershell
-Get-Content -Raw -Encoding UTF8 .cache\openyida\connector-actions\<业务名>-actions.json | ConvertFrom-Json | Out-Null
+Get-Content -Raw -Encoding UTF8 .cache\openyida\<项目名或任务名>\connector-actions\<业务名>-actions.json | ConvertFrom-Json | Out-Null
 ```
 
 不要使用默认 `Get-Content` 校验中文 JSON，默认编码可能导致误判或乱码。
@@ -82,7 +85,7 @@ Get-Content -Raw -Encoding UTF8 .cache\openyida\connector-actions\<业务名>-ac
 ### 5. 添加动作
 
 ```bash
-openyida connector add-action --operations .cache/openyida/connector-actions/<业务名>-actions.json --connector-id <connector-id> --confirm
+openyida connector add-action --operations .cache/openyida/<项目名或任务名>/connector-actions/<业务名>-actions.json --connector-id <connector-id> --confirm
 ```
 
 ### 6. 验证动作存在

--- a/yida-skills/skills/yida-connector/SKILL.md
+++ b/yida-skills/skills/yida-connector/SKILL.md
@@ -10,11 +10,13 @@ description: 宜搭 HTTP 连接器创建与管理。打通钉钉/自建系统/�
 - 不要在代码中硬编码 API Key、密码等凭证，通过连接器鉴权配置管理
 - 不要编造 connector-id 或 action-id，必须从命令返回中提取
 - 不要删除连接器前确认是否有表单/页面正在使用
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成连接器 action/config JSON
 
 ## 严格要求 (MUST DO)
 
 - 优先使用 `smart-create` 从 curl 命令或接口文档智能创建
 - 创建连接器后，将 connector-id 记录到 `.cache/<项目名>-schema.json`
+- `--operations`、`--action` 等文件参数必须先用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/connector/` 或该技能更具体的目录，再传给命令；不要写仓库根目录或系统临时目录
 - **本技能不读写 memory**：连接器配置通过 CLI 命令写入宜搭平台，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -106,6 +108,8 @@ openyida connector delete-action <connector-id> <action-id>
 # 测试连接器
 openyida connector test --connector-id <id> --action <action-file>
 ```
+
+> `<action-file>` 先用 create_file / Write / file edit tool 创建，例如 `.cache/openyida/<项目名或任务名>/connector/actions.json`；从 workspace 根执行命令时路径加 `project/` 前缀。
 
 ### 鉴权账号管理
 

--- a/yida-skills/skills/yida-create-form-page/SKILL.md
+++ b/yida-skills/skills/yida-create-form-page/SKILL.md
@@ -10,12 +10,13 @@ description: 表单页面创建与更新，支持 19 种字段类型（文本、
 - 不要编造 formUuid，必须从命令返回的 JSON 中提取
 - 不要在 update 模式中使用猜测的 fieldId，必须先用 `yida-get-schema` 获取
 - 不要用此命令操作数据记录（增删改查），应使用 `yida-data-management`
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成字段、变更、补丁、规则、数据源 JSON 文件
 
 ## 严格要求 (MUST DO)
 
 - create 成功后，将 formUuid 记录到 `.cache/<项目名>-schema.json`
 - update 模式修改字段前，必须先用 `openyida get-schema` 确认字段 ID
-- 字段定义或变更定义需要落盘时，必须写入 `.cache/openyida/<项目名>/`，例如 `.cache/openyida/pm/pm-fields-team.json`；不要在仓库根目录生成 `*-fields*.json` 或 `*-changes*.json`
+- 字段定义或变更定义需要落盘时，必须使用 agent 的结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/`，例如 `<projectRoot>/.cache/openyida/pm/pm-fields-team.json`；不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `*-fields*.json`、`*-changes*.json`
 - **本技能不读写 memory**：formUuid 等信息输出到 stdout，通过 `.cache/<项目名>-schema.json` 持久化，不依赖跨会话的 memory 状态
 
 ## 官方表单示例范式
@@ -54,8 +55,10 @@ description: 表单页面创建与更新，支持 19 种字段类型（文本、
 
 ```bash
 openyida create-form create <appType> <formTitle> <fieldsJsonOrFile> [--layout double|card] [--theme compact|comfortable] [--label-align top|left]
-# 文件路径示例：.cache/openyida/<项目名>/<表单名>-fields.json
+# 文件路径示例：.cache/openyida/<项目名或任务名>/<表单名>-fields.json
 ```
+
+> 文件先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；如果从 workspace 根执行命令，传 `project/.cache/openyida/<项目名或任务名>/<表单名>-fields.json`。
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
@@ -73,7 +76,7 @@ openyida create-form create <appType> <formTitle> <fieldsJsonOrFile> [--layout d
 
 ```bash
 openyida create-form update <appType> <formUuid> <changesJsonOrFile>
-# 文件路径示例：.cache/openyida/<项目名>/<表单名>-changes.json
+# 文件路径示例：.cache/openyida/<项目名或任务名>/<表单名>-changes.json
 ```
 
 | 参数 | 必填 | 说明 |
@@ -94,7 +97,7 @@ openyida create-form update <appType> <formUuid> <changesJsonOrFile>
 
 ```bash
 openyida create-form patch <appType> <formUuid> <patchJsonOrFile>
-# 文件路径示例：.cache/openyida/<项目名>/<表单名>-patch.json
+# 文件路径示例：.cache/openyida/<项目名或任务名>/<表单名>-patch.json
 ```
 
 支持的操作：
@@ -121,7 +124,7 @@ openyida create-form patch <appType> <formUuid> <patchJsonOrFile>
 ]
 ```
 
-patch 模式是高级能力：执行前必须先 `openyida get-schema <appType> <formUuid> --json` 确认现有结构，补丁文件必须写在 `.cache/openyida/<项目名>/` 下。
+patch 模式是高级能力：执行前必须先 `openyida get-schema <appType> <formUuid> --json` 确认现有结构，补丁文件必须用结构化文件写入工具写在 `<projectRoot>/.cache/openyida/<项目名或任务名>/` 下。
 
 ### 自定义校验函数（customValidate）
 
@@ -197,7 +200,7 @@ patch 模式是高级能力：执行前必须先 `openyida get-schema <appType> 
 
 ```bash
 openyida create-form rule <appType> <formUuid> <rulesJsonOrFile>
-# 文件路径示例：.cache/openyida/<项目名>/<表单名>-rules.json
+# 文件路径示例：.cache/openyida/<项目名或任务名>/<表单名>-rules.json
 ```
 
 支持的规则类型：
@@ -255,7 +258,7 @@ rule 模式会自动生成宜搭动作代码，绑定触发字段的 `onChange`�
 
 ```bash
 openyida create-form bind-datasource <appType> <formUuid> <fieldLabelOrId> <dataSourceJsonOrFile>
-# 文件路径示例：.cache/openyida/<项目名>/<字段名>-datasource.json
+# 文件路径示例：.cache/openyida/<项目名或任务名>/<字段名>-datasource.json
 ```
 
 数据源配置示例：
@@ -380,7 +383,7 @@ openyida create-form bind-datasource <appType> <formUuid> <fieldLabelOrId> <data
 
 ## 注意事项
 
-- 临时文件写在 `.cache/openyida/` 目录中；不要写到仓库根目录
+- 临时 JSON 文件用结构化文件写入工具写在 `<projectRoot>/.cache/openyida/<项目名或任务名>/` 目录中；不要写到仓库根目录、系统临时目录或 `.cache/` 顶层
 - update 模式操作按顺序执行，注意依赖关系
 - 字段匹配基于中文标签（`label.zh_CN`）
 - 如需创建自定义展示页面（无字段），请使用 `yida-create-page`

--- a/yida-skills/skills/yida-create-process/SKILL.md
+++ b/yida-skills/skills/yida-create-process/SKILL.md
@@ -8,6 +8,7 @@ description: 流程表单一体化创建（创建表单 → 转流程 → 获取
 
 - 不要编造 processCode，必须从命令返回的 JSON 中提取
 - 不要在流程定义中使用猜测的 fieldId，必须先用 `yida-get-schema` 获取
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成字段定义、流程定义 JSON 文件
 
 ## 严格要求 (MUST DO)
 
@@ -15,7 +16,7 @@ description: 流程表单一体化创建（创建表单 → 转流程 → 获取
 - 优先使用用法 2（先创建表单获取字段 ID，再 `--formUuid` 转流程）
 - 创建成功后，将 formUuid 和 processCode 记录到 `.cache/<项目名>-schema.json`
 - 流程定义中字段 ≥ 3 且审批节点 ≥ 2 时，必须自动配置字段权限
-- 字段定义和流程定义文件必须写入 `.cache/openyida/<项目名>/`，不要在仓库根目录生成 `fields.json`、`process-definition.json` 等临时文件
+- 字段定义和流程定义文件必须用 agent 的结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/`；不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `fields.json`、`process-definition.json` 等临时文件
 - **本技能不读写 memory**：formUuid 和 processCode 输出到 stdout，通过 `.cache/<项目名>-schema.json` 持久化，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -66,11 +67,16 @@ openyida create-process <appType> --formUuid <formUuid> <processDefinitionFile>
 
 ## 推荐两步流程
 
-```bash
-# Step 1: 创建表单获取字段 ID
-openyida create-form create "APP_XXX" "订单处理表" .cache/openyida/order/order-fields.json
+1. 使用 create_file / Write / file edit tool 创建字段定义：
+   `<projectRoot>/.cache/openyida/order/order-fields.json`
+2. 执行表单创建命令，获取真实 `formUuid` 和 `fieldId`。
+3. 使用结构化文件写入工具创建流程定义：
+   `<projectRoot>/.cache/openyida/order/process-definition.json`
+4. 执行流程转换命令。
 
-# Step 2: 将已有表单转为流程表单
+```bash
+# 以下命令默认在 OpenYida project 工作目录内执行；从 workspace 根执行时路径加 project/ 前缀。
+openyida create-form create "APP_XXX" "订单处理表" .cache/openyida/order/order-fields.json
 openyida create-process "APP_XXX" --formUuid "FORM-YYY" .cache/openyida/order/process-definition.json
 ```
 

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -73,10 +73,15 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 
 以创建「员工信息查询页」为例，完整流程如下：
 
-```bash
-# Step 1：获取表单 Schema，确认字段 ID
-openyida get-schema APP_XXX FORM-EMPLOYEE > .cache/employee-schema.json 2>&1
+1. 获取表单 Schema，确认字段 ID：
 
+```bash
+openyida get-schema APP_XXX FORM-EMPLOYEE
+```
+
+如需保存完整 Schema，使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/employee-query/employee-schema.json`；ID 映射仍写 `<projectRoot>/.cache/employee-query-schema.json`。
+
+```bash
 # Step 2：创建自定义页面
 openyida create-page APP_XXX "员工信息查询"
 
@@ -96,7 +101,7 @@ openyida publish project/pages/src/employee-query.oyd.jsx APP_XXX FORM-QUERY001
 - **Step 1** 的 get-schema 输出包含所有字段的 fieldId，在代码中必须使用 `FIELDS` 常量映射这些 ID
 - **Step 3** 的页面代码必须遵循 [编码指南](references/coding-guide.md) 和 [运行时护栏](references/runtime-guardrails.md)
 - 优先通过 `openyida generate-page ... --compile` 生成高质量骨架；需要完整交互样板时使用 `todo-mvc`
-- 页面生成 spec、接口调试 JSON、一次性验证脚本等临时工件必须放在 `.cache/openyida/` 下；不要在仓库根目录生成 `page.json`、`data.json` 或脚本文件
+- 页面生成 spec、接口调试 JSON、一次性验证脚本等临时工件必须用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/` 下；不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `page.json`、`data.json` 或脚本文件
 - `check-page` 支持行级禁用：`// openyida-lint-disable-line <rule>` 或 `// openyida-lint-disable-next-line <rule>`。只在确认该行不会触发宜搭运行时问题时使用。
 
 ## 开发规范
@@ -115,12 +120,13 @@ openyida sample yida-custom-page custom-page-template   # 完整页面模板（d
 openyida sample yida-custom-page product-homepage       # 产品/项目首页轻量模板（支持 --var KEY=VALUE）
 openyida sample yida-custom-page todo-mvc               # TodoMVC 完整交互模板（事件/状态/循环/本地存储）
 openyida sample yida-custom-page design-tokens          # 设计 token 参考（颜色/间距/字体规范）
-openyida generate-page product-homepage --spec .cache/openyida/page-specs/home.json --output pages/src/home.oyd.jsx --compile  # 基于 spec/blocks 生成首页并本地编译
+openyida generate-page product-homepage --spec .cache/openyida/<项目名或任务名>/page-specs/home.json --output pages/src/home.oyd.jsx --compile  # 基于 spec/blocks 生成首页并本地编译
 openyida generate-page todo-mvc --output pages/src/todo-mvc.oyd.jsx --compile  # 生成官方 TodoMVC 风格交互样板
 openyida check-page pages/src/home.oyd.jsx --json      # 输出机器可读的规范检查结果；.oyd.jsx 会先兼容构建
 ```
 
 - 完整文件结构、状态管理、全局变量、19 条编码规则见 [编码指南](references/coding-guide.md)
+- `--spec` 文件先用 create_file / Write / file edit tool 创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/page-specs/`
 - 运行时高风险规则、`check-page` 规则和自动修复边界见 [运行时护栏](references/runtime-guardrails.md)
 - 输入控件、筛选栏、下拉、表格、附件等组件骨架见 [组件指南](references/component-jsx-guide.md)
 

--- a/yida-skills/skills/yida-custom-page/references/component-jsx-guide.md
+++ b/yida-skills/skills/yida-custom-page/references/component-jsx-guide.md
@@ -400,5 +400,7 @@ openyida compile pages/src/page.jsx
 如果页面使用字段 ID、提交数据或构造查询条件，发布前还必须重新确认 Schema：
 
 ```bash
-openyida get-schema APP_XXX FORM-XXX > .cache/form-schema.json
+openyida get-schema APP_XXX FORM-XXX
 ```
+
+如需保存完整 Schema，使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/<项目名或任务名>/form-schema.json`；不要使用 shell 重定向。

--- a/yida-skills/skills/yida-data-management/SKILL.md
+++ b/yida-skills/skills/yida-data-management/SKILL.md
@@ -11,6 +11,7 @@ description: 宜搭数据管理。表单实例/子表/流程实例/任务中心�
 - 不要编造 formInstId 或 processInstanceId，必须从查询结果中提取
 - 不要用此命令修改表单结构（字段增删改），应使用 `yida-create-form-page`
 - **绝对禁止猜测或编造字段 ID（fieldId）**，宜搭字段 ID 由平台随机生成（如 `textField_eftt1aa5m`），无法预测，必须通过 `openyida get-schema` 获取
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成 `--data-file`、`--search-file`、CSV 或一次性脚本
 
 ## 严格要求 (MUST DO)
 
@@ -22,8 +23,8 @@ description: 宜搭数据管理。表单实例/子表/流程实例/任务中心�
 - **录入数据后，必须执行 `openyida data query` 抽查至少 1 条记录，确认 `formData` 中字段有实际值（非空），否则说明字段 ID 有误，需重新排查**
 - **读取子表明细超过 50 行时，必须使用 `openyida data query subform` 或 `listTableDataByFormInstIdAndTableId` 分页查询完整子表；不要把 `searchFormDatas.currentPage` 当作子表分页**
 - **本技能不读写 memory**：数据操作通过 CLI 命令写入宜搭平台，不依赖跨会话的 memory 状态
-- 一次性造数、旧数据修正、字段迁移脚本可以使用 Python 或 JS，优先选择更快更清晰的实现；脚本、导入数据、查询条件文件必须放在 `.cache/openyida/` 下，并复用真实查询到的 appType/formUuid/fieldId/formInstId
-- **禁止在仓库根目录生成导入用的 `*.json`、`*.js`、`*.py`、`*.csv` 临时文件**；推荐使用 `.cache/openyida/data-import/` 存放数据文件，`.cache/openyida/scripts/` 存放一次性执行脚本
+- 一次性造数、旧数据修正、字段迁移脚本可以使用 Python 或 JS，优先选择更快更清晰的实现；脚本、导入数据、查询条件文件必须由结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/` 下，并复用真实查询到的 appType/formUuid/fieldId/formInstId
+- **禁止在仓库根目录、系统临时目录或 `.cache/` 顶层生成导入用的 `*.json`、`*.js`、`*.py`、`*.csv` 临时文件**；推荐使用 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/` 存放数据文件，`<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/` 存放一次性执行脚本
 
 ## 适用场景
 
@@ -61,14 +62,16 @@ description: 宜搭数据管理。表单实例/子表/流程实例/任务中心�
 ### 表单实例
 
 ```bash
-openyida data query form <appType> <formUuid> [--page 1 --size 20] [--search-json '<json>'|--search-file .cache/openyida/data-import/search.json] [--resolve-aliases]
+openyida data query form <appType> <formUuid> [--page 1 --size 20] [--search-json '<json>'|--search-file .cache/openyida/<项目名或任务名>/data-import/search.json] [--resolve-aliases]
 openyida data get form <appType> --inst-id <formInstId>
 openyida data create form <appType> <formUuid> --data-json '<json>' [--resolve-aliases]
-openyida data create form <appType> <formUuid> --data-file .cache/openyida/data-import/record.json [--resolve-aliases]
+openyida data create form <appType> <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/record.json [--resolve-aliases]
 openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-json '<json>' [--resolve-aliases]
-openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-file .cache/openyida/data-import/patch.json [--resolve-aliases]
+openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/patch.json [--resolve-aliases]
 openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId|alias> [--page 1 --size 100] [--resolve-aliases]
 ```
+
+> `--data-file` / `--search-file` 指向的文件先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；从 workspace 根执行命令时路径加 `project/` 前缀。
 
 当 JSON 使用宜搭组件别名作为 key 时，追加 `--resolve-aliases`，OpenYida 会先读取表单 Schema 中的 `componentAlias.items`，再将别名转换为真实 `fieldId` 后调用数据接口。更新类命令若要解析别名，必须额外传 `--form-uuid <formUuid>`。
 
@@ -90,14 +93,14 @@ openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-
 ### 流程实例
 
 ```bash
-openyida data query process <appType> <formUuid> [--instance-status RUNNING] [--search-file .cache/openyida/data-import/process-search.json] [--resolve-aliases]
+openyida data query process <appType> <formUuid> [--instance-status RUNNING] [--search-file .cache/openyida/<项目名或任务名>/data-import/process-search.json] [--resolve-aliases]
 openyida data get process <appType> --process-inst-id <processInstanceId>
 openyida data create process <appType> <formUuid> --process-code <processCode> --data-json '<json>' [--resolve-aliases]
-openyida data create process <appType> <formUuid> --process-code <processCode> --data-file .cache/openyida/data-import/process-record.json [--resolve-aliases]
+openyida data create process <appType> <formUuid> --process-code <processCode> --data-file .cache/openyida/<项目名或任务名>/data-import/process-record.json [--resolve-aliases]
 openyida data update process <appType> --process-inst-id <processInstanceId> --form-uuid <formUuid> --data-json '<json>' [--resolve-aliases]
-openyida data update process <appType> --process-inst-id <processInstanceId> --form-uuid <formUuid> --data-file .cache/openyida/data-import/process-patch.json [--resolve-aliases]
+openyida data update process <appType> --process-inst-id <processInstanceId> --form-uuid <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/process-patch.json [--resolve-aliases]
 openyida data query operation-records <appType> --process-inst-id <processInstanceId>
-openyida data execute task <appType> --task-id <taskId> --process-inst-id <processInstanceId> --out-result AGREE --remark '同意' [--data-file .cache/openyida/data-import/task-data.json] [--form-uuid <formUuid>] [--resolve-aliases]
+openyida data execute task <appType> --task-id <taskId> --process-inst-id <processInstanceId> --out-result AGREE --remark '同意' [--data-file .cache/openyida/<项目名或任务名>/data-import/task-data.json] [--form-uuid <formUuid>] [--resolve-aliases]
 ```
 
 ### 任务中心
@@ -156,7 +159,7 @@ openyida data query tasks <appType> --type todo|done|submitted|cc [--page 1 --si
 {"textField_xxx":"文本","numberField_xxx":10,"dateField_xxx":1719705600000,"employeeField_xxx":["userId"]}
 ```
 
-当 JSON 较长或用于批量导入时，写入 `.cache/openyida/data-import/<name>.json`，再使用 `--data-file` 或 `--search-file`；不要为了拼接命令在仓库根目录生成临时脚本。
+当 JSON 较长或用于批量导入时，使用结构化文件写入工具写入 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/<name>.json`，再使用 `--data-file` 或 `--search-file`；不要为了拼接命令在仓库根目录、系统临时目录或 `.cache/` 顶层生成临时脚本。
 
 ### 常见字段格式
 
@@ -215,7 +218,7 @@ openyida sample yida-data-management form-field-template   # 表单字段定义�
 - `pageSize` 最大 100，QPS 限制约 40 次/秒
 - `searchFieldJson` 和 `dynamicOrder` 必须传字符串
 - 字段 ID 通过 `openyida get-schema` 获取，不要手写猜测
-- 批量脚本可以用 Python `subprocess` 调用 `openyida data ...`，也可以用 JS 复用 Node 工具；脚本必须放在 `.cache/openyida/scripts/`，导入数据放在 `.cache/openyida/data-import/`
+- 批量脚本可以用 Python `subprocess` 调用 `openyida data ...`，也可以用 JS 复用 Node 工具；脚本必须由结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/`，导入数据放在 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/`
 
 ## 异常处理
 

--- a/yida-skills/skills/yida-data-source-connectors/SKILL.md
+++ b/yida-skills/skills/yida-data-source-connectors/SKILL.md
@@ -108,8 +108,10 @@ export function loadConnectorDataSource(dataSourceName, headers, query, body) {
 
 ```bash
 openyida publish <src> <appType> <formUuid> --health-check
-openyida get-schema <appType> <formUuid> > .cache/openyida/<page>-schema.json
+openyida get-schema <appType> <formUuid>
 ```
+
+如需保存回读 Schema，使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/<项目名或任务名>/<page>-schema.json`；从 workspace 根执行后续命令时路径加 `project/` 前缀。不要使用 shell 重定向。
 
 检查点：
 

--- a/yida-skills/skills/yida-flash-note-to-prd/references/examples.md
+++ b/yida-skills/skills/yida-flash-note-to-prd/references/examples.md
@@ -24,8 +24,9 @@
 
 ```bash
 # 方式 1：从文件读取
-echo "上述内容" > meeting.txt
-openyida flash-to-prd --file meeting.txt --name 员工积分管理系统
+# 先使用 create_file / Write / file edit tool 创建：
+# <projectRoot>/.cache/openyida/员工积分管理系统/flash-note/meeting.txt
+openyida flash-to-prd --file .cache/openyida/员工积分管理系统/flash-note/meeting.txt --name 员工积分管理系统
 
 # 方式 2：直接发给 AI 智能体（推荐）
 # 将文本直接粘贴到对话框，AI 自动识别并触发本技能

--- a/yida-skills/skills/yida-formula-evaluate/SKILL.md
+++ b/yida-skills/skills/yida-formula-evaluate/SKILL.md
@@ -39,13 +39,15 @@ openyida formula evaluate <公式或文件> [--schema schema.json] [--json] [--s
 1. 如果公式包含字段引用，先获取 Schema：
 
 ```bash
-openyida get-schema APP_XXX FORM-XXX > .cache/form-schema.json
+openyida get-schema APP_XXX FORM-XXX
 ```
+
+将 stdout 中需要复用的 Schema 通过 create_file / Write / file edit tool 保存到 `<projectRoot>/.cache/openyida/<项目名或任务名>/formula/form-schema.json`；不要用 shell 重定向。
 
 2. 运行静态检查：
 
 ```bash
-openyida formula evaluate 'IF(GT(#{numberField_total}, 100), "高", "低")' --schema .cache/form-schema.json
+openyida formula evaluate 'IF(GT(#{numberField_total}, 100), "高", "低")' --schema .cache/openyida/<项目名或任务名>/formula/form-schema.json
 ```
 
 3. 根据诊断结果修复：

--- a/yida-skills/skills/yida-formula/references/examples.md
+++ b/yida-skills/skills/yida-formula/references/examples.md
@@ -9,8 +9,8 @@
 ### 前置步骤：获取字段 ID
 
 ```bash
-openyida get-schema APP_XXX FORM-YYY > .cache/schema.json 2>&1
-# 从 schema.json 中找到各字段的 fieldId：
+openyida get-schema APP_XXX FORM-YYY
+# 从 stdout 中找到各字段的 fieldId，并用结构化文件写入工具更新 <projectRoot>/.cache/<项目名>-schema.json：
 # 交通费：numberField_transport
 # 住宿费：numberField_hotel
 # 餐饮费：numberField_meal
@@ -19,7 +19,7 @@ openyida get-schema APP_XXX FORM-YYY > .cache/schema.json 2>&1
 
 ### 执行：update 模式配置公式
 
-创建 `formula-config.json`：
+使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/expense/formula-config.json`：
 
 ```json
 [
@@ -40,7 +40,7 @@ openyida get-schema APP_XXX FORM-YYY > .cache/schema.json 2>&1
 ```
 
 ```bash
-openyida create-form APP_XXX FORM-YYY formula-config.json
+openyida create-form update APP_XXX FORM-YYY .cache/openyida/expense/formula-config.json
 ```
 
 ### 输出

--- a/yida-skills/skills/yida-get-schema/SKILL.md
+++ b/yida-skills/skills/yida-get-schema/SKILL.md
@@ -13,11 +13,13 @@ description: 获取表单的完整 Schema 结构，用于确认字段 ID（field
 - 不要跳过 Schema 获取步骤直接进行数据操作，即使用户催促也必须先获取
 - 不要在 Schema 获取失败时继续执行后续操作，必须先解决问题
 - 不要缓存过期的 Schema 信息，表单结构变更后必须重新获取
+- 不要把 `openyida get-schema` 的 stdout 通过 shell 重定向保存成 JSON，也不要用 heredoc、`cat`/`echo`/`printf`/`tee` 生成 Schema 文件
 
 ## 严格要求 (MUST DO)
 
 - **凡是需要用到字段 ID（fieldId）的操作，必须先执行此命令**，不得跳过
-- 将关键字段 ID 映射（字段名 → fieldId）记录到 `.cache/<项目名>-schema.json`，供后续操作复用
+- 将关键字段 ID 映射（字段名 → fieldId）用结构化文件写入工具记录到 `<projectRoot>/.cache/<项目名>-schema.json`，供后续操作复用
+- 如需保存完整 Schema 文件，先执行命令获取 stdout，再用 create_file / Write / file edit tool 写入 `<projectRoot>/.cache/openyida/<项目名或任务名>/<表单名>-schema.json`；从 workspace 根执行后续命令时传 `project/.cache/...`
 - **录入/更新数据后，必须用 `openyida data query --size 1` 抽查一条记录，确认 `formData` 中字段有实际值（非空 `""`），若全部为空说明字段 ID 有误，需重新排查**
 
 ## 适用场景
@@ -61,13 +63,20 @@ openyida get-schema <appType> --all [--output-dir <dir>] [--keyword <text>] [--c
 ### 单表模式
 
 ```bash
-openyida get-schema APP_XXX FORM-XXX > .cache/customer-schema.json
+openyida get-schema APP_XXX FORM-XXX
+```
+
+如需复用输出，使用 agent 的结构化文件写入工具创建：
+
+```text
+<projectRoot>/.cache/openyida/customer/customer-schema.json
+<projectRoot>/.cache/customer-schema.json   # 仅保存 appType/formUuid/fieldId/reportId 等 ID 映射
 ```
 
 ### 批量模式
 
 ```bash
-openyida get-schema APP_XXX --all --output-dir .cache/schemas
+openyida get-schema APP_XXX --all --output-dir .cache/openyida/customer/schemas
 openyida get-schema APP_XXX --all --keyword 客户 --concurrency 5 --retries 2
 ```
 
@@ -90,8 +99,8 @@ openyida get-schema APP_XXX --all --keyword 客户 --concurrency 5 --retries 2
 | 异常场景 | 处理方式 |
 |---------|----------|
 | 命令返回失败 | 确认 appType 和 formUuid 正确，检查登录态 |
-| 输出被终端截断 | 重定向到文件：`openyida get-schema <appType> <formUuid> > .cache/schema.json` |
-| 需要多个表单字段 ID | 使用批量模式：`openyida get-schema <appType> --all --output-dir .cache/schemas` |
+| 输出被终端截断 | 重新执行后将 stdout 通过结构化文件写入工具保存到 `<projectRoot>/.cache/openyida/<项目名或任务名>/<表单名>-schema.json`；不要使用 shell 重定向 |
+| 需要多个表单字段 ID | 使用批量模式：`openyida get-schema <appType> --all --output-dir .cache/openyida/<项目名或任务名>/schemas` |
 | 批量部分失败 | 查看 stdout 的 `failedCount` 和 `forms[].errorMsg`，必要时提高 `--retries` 或缩小 `--keyword` 范围 |
 | 找不到目标字段 | 检查字段是否已创建，字段 ID 格式如 `textField_xxxxxxxx`，不能手写猜测 |
 | Schema 输出为空 | 表单可能没有字段，先用 `yida-create-form-page` 创建字段 |

--- a/yida-skills/skills/yida-i18n/SKILL.md
+++ b/yida-skills/skills/yida-i18n/SKILL.md
@@ -81,10 +81,12 @@ openyida i18n upsert <appType> page_header --zh-CN "工作台" --en-US "Workbenc
 批量导入词条：
 
 ```bash
-openyida i18n batch-upsert <appType> --file i18n-items.json
+openyida i18n batch-upsert <appType> --file .cache/openyida/<项目名或任务名>/i18n/i18n-items.json
 ```
 
-`i18n-items.json` 示例：
+`i18n-items.json` 先用 create_file / Write / file edit tool 创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/i18n/`；不要用 shell heredoc 或重定向写文件。从 workspace 根执行命令时路径加 `project/` 前缀。
+
+文件内容示例：
 
 ```json
 [

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -16,6 +16,7 @@ description: 宜搭集成&自动化配置。支持创建、查询、开启、关
 - **创建/发布前必须确认**：执行集成自动化创建或发布操作前，必须向用户展示逻辑流配置摘要（触发条件、节点列表、通知对象），获得用户明确同意后再执行
 - 创建前先确认触发表单的 formUuid 和相关字段 ID
 - 创建成功后记录逻辑流 ID 到 `.cache/<项目名>-schema.json`
+- `--spec`、连接器输入等 JSON 文件必须先用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/integration/`；不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向写文件，也不要写仓库根目录或系统临时目录
 - 参考官方示例时不要只看默认页面 schema：集成自动化示例的默认页通常只是触发表单或说明页，逻辑流本体需要通过集成自动化接口/命令查询或创建
 
 ## 适用场景
@@ -242,9 +243,11 @@ openyida integration create APP_XXX FORM-A-XXX "调用 HTTP 连接器" \
 
 ```bash
 openyida integration create APP_XXX FORM-XXX "获取自身后分支更新" \
-  --spec project/integration/get-self-update.json \
+  --spec .cache/openyida/<项目名或任务名>/integration/get-self-update.json \
   --publish
 ```
+
+> `--spec` 文件先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；从 workspace 根执行命令时路径加 `project/` 前缀。
 
 ## 字段变量引用格式
 

--- a/yida-skills/skills/yida-integration/references/examples.md
+++ b/yida-skills/skills/yida-integration/references/examples.md
@@ -9,8 +9,8 @@
 ### 前置步骤：获取字段 ID
 
 ```bash
-openyida get-schema APP_XXX FORM-LEAVE > .cache/leave-schema.json 2>&1
-# 从 schema.json 中提取字段 ID：
+openyida get-schema APP_XXX FORM-LEAVE
+# 从 stdout 中提取字段 ID，并用结构化文件写入工具更新 <projectRoot>/.cache/<项目名>-schema.json：
 # 申请人：employeeField_applicant
 # 请假类型：selectField_leaveType
 # 开始日期：dateField_startDate

--- a/yida-skills/skills/yida-openyida-publish-guard/SKILL.md
+++ b/yida-skills/skills/yida-openyida-publish-guard/SKILL.md
@@ -37,10 +37,10 @@ openyida login --check-only --json
 3. Fetch the live schema before editing or publishing:
 
 ```bash
-openyida get-schema <appType> <formUuid> --json > project/.cache/openyida/live-<formUuid>.json
+openyida get-schema <appType> <formUuid> --json
 ```
 
-The repository ignore rules already exclude `project/.cache/openyida/`; keep fetched live schema files there and do not commit them.
+If the schema needs to be inspected from a file, save stdout with the agent's structured file write tool to `<projectRoot>/.cache/openyida/publish-guard/live-<formUuid>.json`. From the workspace root that path is typically `project/.cache/openyida/publish-guard/live-<formUuid>.json`. Do not use shell redirection and do not commit fetched live schema files.
 
 4. Inspect the fetched live page for current code and configuration. For custom display pages, check at least:
 

--- a/yida-skills/skills/yida-process-rule/SKILL.md
+++ b/yida-skills/skills/yida-process-rule/SKILL.md
@@ -10,6 +10,7 @@ description: 为已有流程表单配置审批规则（审批/办理/抄送、�
 - 不要在流程定义中使用猜测的 fieldId，必须先用 `yida-get-schema` 获取
 - 不要在未读取本 SKILL.md 的情况下编写流程定义 JSON，格式复杂且易出错
 - 不要用此技能创建流程表单，应使用 `yida-create-process`
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成流程定义 JSON
 
 ## 严格要求 (MUST DO)
 
@@ -17,7 +18,7 @@ description: 为已有流程表单配置审批规则（审批/办理/抄送、�
 - 字段 ≥ 3 且审批节点 ≥ 2 时，必须为每个节点配置字段权限
 - 存在回退/循环语义时，必须配置 `routeRules` 跳转规则
 - 配置前先用 `yida-get-schema` 获取所有字段 ID
-- 流程定义 JSON 必须写入 `.cache/openyida/<项目名>/`，不要在仓库根目录生成 `process-definition.json` 等临时文件
+- 流程定义 JSON 必须用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/`，不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `process-definition.json` 等临时文件
 
 ## 适用场景
 
@@ -78,6 +79,8 @@ openyida configure-process <appType> <formUuid> <processDefinitionFile> [process
 ```bash
 openyida configure-process "APP_XXX" "FORM-YYY" .cache/openyida/order/process-definition.json
 ```
+
+> 上方路径默认从 OpenYida project 工作目录执行；从 workspace 根执行命令时传 `project/.cache/openyida/order/process-definition.json`。
 
 **输出**：日志输出到 stderr，JSON 结果输出到 stdout：
 

--- a/yida-skills/skills/yida-process-rule/references/examples.md
+++ b/yida-skills/skills/yida-process-rule/references/examples.md
@@ -9,15 +9,15 @@
 ### 前置步骤：获取字段 ID
 
 ```bash
-openyida get-schema APP_XXX FORM-EXPENSE > .cache/expense-schema.json 2>&1
-# 从 schema.json 中提取字段 ID：
+openyida get-schema APP_XXX FORM-EXPENSE
+# 从 stdout 中提取字段 ID，并用结构化文件写入工具更新 <projectRoot>/.cache/<项目名>-schema.json：
 # 报销金额：numberField_amount
 # 报销类型：selectField_expenseType
 # 报销说明：textareaField_remark
 # 附件：attachmentField_receipt
 ```
 
-### 创建流程定义文件 `.cache/openyida/process/expense-process.json`
+### 使用结构化文件写入工具创建流程定义文件 `<projectRoot>/.cache/openyida/expense/process/expense-process.json`
 
 ```json
 {
@@ -76,7 +76,7 @@ openyida get-schema APP_XXX FORM-EXPENSE > .cache/expense-schema.json 2>&1
 ### 执行命令
 
 ```bash
-openyida configure-process APP_XXX FORM-EXPENSE .cache/openyida/process/expense-process.json
+openyida configure-process APP_XXX FORM-EXPENSE .cache/openyida/expense/process/expense-process.json
 ```
 
 ### 输出
@@ -100,7 +100,7 @@ openyida configure-process APP_XXX FORM-EXPENSE .cache/openyida/process/expense-
 
 质检流程：取样 → 检验 → 判断结果（合格/不合格）。不合格时跳回检验节点重新检验。
 
-### 流程定义 `.cache/openyida/process/quality-process.json`
+### 流程定义 `<projectRoot>/.cache/openyida/quality/process/quality-process.json`
 
 ```json
 {
@@ -157,7 +157,7 @@ openyida configure-process APP_XXX FORM-EXPENSE .cache/openyida/process/expense-
 ### 执行命令
 
 ```bash
-openyida configure-process APP_XXX FORM-QUALITY .cache/openyida/process/quality-process.json
+openyida configure-process APP_XXX FORM-QUALITY .cache/openyida/quality/process/quality-process.json
 ```
 
 ---
@@ -188,7 +188,7 @@ openyida configure-process APP_XXX FORM-QUALITY .cache/openyida/process/quality-
 
 订单处理流程：检查订单 → 订单有效判断 → 库存判断（充足/不足）→ 对应处理。
 
-### 流程定义 `.cache/openyida/process/order-process.json`
+### 流程定义 `<projectRoot>/.cache/openyida/order/process/order-process.json`
 
 ```json
 {
@@ -266,7 +266,7 @@ openyida configure-process APP_XXX FORM-QUALITY .cache/openyida/process/quality-
 ### 执行命令
 
 ```bash
-openyida configure-process APP_XXX FORM-ORDER .cache/openyida/process/order-process.json
+openyida configure-process APP_XXX FORM-ORDER .cache/openyida/order/process/order-process.json
 ```
 
 ---
@@ -277,7 +277,7 @@ openyida configure-process APP_XXX FORM-ORDER .cache/openyida/process/order-proc
 
 配置流程后，钉钉工作通知推送的链接需要指向自定义详情页，而非原生 `taskDetail.htm`。
 
-### 流程定义 `.cache/openyida/process/custom-detail-process.json`
+### 流程定义 `<projectRoot>/.cache/openyida/custom-detail/process/custom-detail-process.json`
 
 ```json
 {
@@ -296,7 +296,7 @@ openyida configure-process APP_XXX FORM-ORDER .cache/openyida/process/order-proc
 ### 执行命令
 
 ```bash
-openyida configure-process APP_XXX FORM-XXX .cache/openyida/process/custom-detail-process.json
+openyida configure-process APP_XXX FORM-XXX .cache/openyida/custom-detail/process/custom-detail-process.json
 ```
 
 ### 说明
@@ -311,7 +311,7 @@ openyida configure-process APP_XXX FORM-XXX .cache/openyida/process/custom-detai
 
 审批流程：部门主管审核 → 财务部审核（拒绝时跳回部门主管审核）→ 结束。
 
-### 流程定义 `.cache/openyida/process/jump-rule-process.json`
+### 流程定义 `<projectRoot>/.cache/openyida/jump-rule/process/jump-rule-process.json`
 
 ```json
 {
@@ -336,7 +336,7 @@ openyida configure-process APP_XXX FORM-XXX .cache/openyida/process/custom-detai
 ### 执行命令
 
 ```bash
-openyida configure-process APP_XXX FORM-XXX .cache/openyida/process/jump-rule-process.json
+openyida configure-process APP_XXX FORM-XXX .cache/openyida/jump-rule/process/jump-rule-process.json
 ```
 
 ### 流程

--- a/yida-skills/skills/yida-report/SKILL.md
+++ b/yida-skills/skills/yida-report/SKILL.md
@@ -11,6 +11,7 @@ description: "宜搭原生报表创建，支持 16 种图表/表格/筛选器组
 - 不要编造 `reportId`、`datasetId`、`fieldId`，必须从报表 Schema 或 URL 中提取
 - 不要将本技能与 `yida-chart` 混淆：本技能负责创建原生报表（数据源），`yida-chart` 负责 ECharts 可视化
 - 不要在没有原生报表的情况下直接使用 ECharts，ECharts 必须依赖原生报表作为数据源
+- 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成报表配置 JSON
 
 ## 严格要求 (MUST DO)
 
@@ -19,7 +20,7 @@ description: "宜搭原生报表创建，支持 16 种图表/表格/筛选器组
 - 参考官方示例时先确认 schema 证据：只有 `formType: "report"` 或组件树出现 `Youshu*` 报表组件时才按原生报表处理；`report` 标签但默认页是 `receipt` 或自定义页时，先判断是否只是数据准备页或看板页
 - 调用报表数据 API 前必须确认 `reportId` 和 `datasetId` 来自真实报表
 - 解析报表数据时必须处理 `data.rows` 为空的情况，避免页面崩溃
-- 报表配置 JSON 需要落盘时，必须写入 `.cache/openyida/<项目名>/`，例如 `.cache/openyida/pm/pm-report-team.json`；不要在仓库根目录生成 `*-report*.json`
+- 报表配置 JSON 需要落盘时，必须用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/`，例如 `<projectRoot>/.cache/openyida/pm/pm-report-team.json`；不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `*-report*.json`
 - 本技能不读写 memory，报表配置通过 `openyida create-report` 命令写入宜搭平台，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -381,8 +382,10 @@ console.log(JSON.stringify(reportPageSchema, null, 2));
 
 ```bash
 openyida create-report <appType> "<报表名称>" <配置JSON文件路径>
-# 配置文件路径示例：.cache/openyida/<项目名>/<报表名>-report.json
+# 配置文件路径示例：.cache/openyida/<项目名或任务名>/<报表名>-report.json
 ```
+
+> 配置 JSON 先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；从 workspace 根执行命令时传 `project/.cache/openyida/<项目名或任务名>/<报表名>-report.json`。
 
 **⚠️ 第二个参数是报表名称，必须使用业务含义的中文名称**（如"任务管理数据报表"），不要传 formUuid。
 

--- a/yida-skills/skills/yida-report/references/examples.md
+++ b/yida-skills/skills/yida-report/references/examples.md
@@ -9,8 +9,8 @@
 ### 前置步骤：获取表单 Schema
 
 ```bash
-openyida get-schema APP_XXX FORM-TASK > .cache/task-schema.json 2>&1
-# 从 schema.json 中提取字段信息：
+openyida get-schema APP_XXX FORM-TASK
+# 从 stdout 中提取字段信息，并用结构化文件写入工具更新 <projectRoot>/.cache/<项目名>-schema.json：
 # 任务名称：textField_taskName（STRING）
 # 优先级：selectField_priority（STRING，需加 _value 后缀）
 # 状态：selectField_status（STRING，需加 _value 后缀）
@@ -18,7 +18,7 @@ openyida get-schema APP_XXX FORM-TASK > .cache/task-schema.json 2>&1
 # 负责人：employeeField_owner（STRING，需加 _value 后缀）
 ```
 
-### 创建报表配置文件 `.cache/openyida/reports/task-report-config.json`
+### 使用结构化文件写入工具创建报表配置文件 `<projectRoot>/.cache/openyida/task-report/task-report-config.json`
 
 ```json
 {
@@ -95,7 +95,7 @@ openyida get-schema APP_XXX FORM-TASK > .cache/task-schema.json 2>&1
 ### 执行命令
 
 ```bash
-openyida create-report APP_XXX "任务管理数据报表" .cache/openyida/reports/task-report-config.json
+openyida create-report APP_XXX "任务管理数据报表" .cache/openyida/task-report/task-report-config.json
 ```
 
 ### 输出

--- a/yida-skills/skills/yida-table-form/references/examples.md
+++ b/yida-skills/skills/yida-table-form/references/examples.md
@@ -9,8 +9,8 @@ HR 需要批量录入新员工信息到宜搭表单，支持手动逐行填写�
 ### 前置步骤：获取表单字段 ID
 
 ```bash
-openyida get-schema APP_XXX FORM-EMPLOYEE > .cache/employee-schema.json 2>&1
-# 从 schema.json 中提取字段 ID：
+openyida get-schema APP_XXX FORM-EMPLOYEE
+# 从 stdout 中提取字段 ID，并用结构化文件写入工具更新 <projectRoot>/.cache/<项目名>-schema.json：
 # 姓名：textField_name
 # 部门：selectField_dept
 # 入职日期：dateField_joinDate


### PR DESCRIPTION
## Summary
- standardize OpenYida skill guidance for command input files: create files with structured agent file-write tools before passing paths to CLI commands
- document project-root cache paths: `<projectRoot>/.cache/openyida/<project-or-task>/` for business intermediates and `<projectRoot>/.cache/<project>-schema.json` for ID mappings
- replace examples that encouraged shell redirection, `/tmp` business files, or root-level temp files across form, process, report, connector, integration, data, schema, chart, and large-file-write skills

## Validation
- `node --check yida-skills/skills/large-file-write/scripts/write.js`
- static searches found no remaining shell file-write examples (`cat >`, `echo >`, `printf >`, `tee`, heredoc EOF, or `openyida ... > *.json`) in `yida-skills` markdown
- `npm run check:skills` currently fails on a pre-existing local empty directory: `yida-skills/skills/yida-data-insight` missing `SKILL.md`