### PR TITLE
fix: align yida-app fast_build contract

### DIFF
--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -37,11 +37,20 @@ function buildAgentCapabilities() {
       workdir: projectRoot,
       cache_dir: path.join(projectRoot, '.cache'),
       openyida_task_cache_dir: path.join(projectRoot, '.cache', 'openyida'),
+      default_full_app_workflow: manifest.summary.core_workflows.full_app_fast_build,
     },
     skills: {
       index_file: 'skills-index.json',
       entry: 'openyida',
       note: 'Use host use_skill/search_skills when available; otherwise load only the current-stage SKILL.md selected by the root routing table.',
+    },
+    commands: {
+      count: manifest.summary.command_count,
+      group_count: manifest.summary.group_count,
+      side_effect_counts: manifest.summary.side_effect_counts,
+      read_only_command_ids: manifest.summary.read_only_command_ids,
+      mutating_command_ids: manifest.summary.mutating_command_ids,
+      core_workflows: manifest.summary.core_workflows,
     },
     sideEffects: {
       read_only_preflight: [
@@ -52,13 +61,14 @@ function buildAgentCapabilities() {
       ],
       retry_policy: 'Do not repeat the same failed command without changing login state, organization, parameters, files, or field IDs.',
       completion_contracts: {
-        full_app: 'Publishing the primary page successfully and returning an access URL completes the default build.',
+        full_app: 'Default fast_build is complete after creating the app, core forms, primary page, publishing it, and returning an access URL.',
       },
     },
     command_manifest: {
       schema_version: manifest.schema_version,
       groups: manifest.groups,
       side_effect_schema: manifest.side_effect_schema,
+      summary: manifest.summary,
       commands: manifest.commands,
     },
   };

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -598,9 +598,77 @@ function localizeCommand(entry, translate) {
   };
 }
 
+function summarizeLocalizedCommands(commands) {
+  const sideEffectCounts = {};
+  const idsBySideEffect = {};
+  const readOnlyCommandIds = [];
+  const mutatingCommandIds = [];
+
+  for (const entry of commands) {
+    const effect = entry.side_effect || {};
+    const kind = effect.kind || 'unknown';
+    sideEffectCounts[kind] = (sideEffectCounts[kind] || 0) + 1;
+    if (!idsBySideEffect[kind]) {
+      idsBySideEffect[kind] = [];
+    }
+    idsBySideEffect[kind].push(entry.id);
+
+    if (effect.mutates_yida === false && effect.mutates_local === false && kind !== 'mixed') {
+      readOnlyCommandIds.push(entry.id);
+    }
+    if (effect.mutates_yida === true || effect.mutates_local === true || kind === 'mixed') {
+      mutatingCommandIds.push(entry.id);
+    }
+  }
+
+  return {
+    command_count: commands.length,
+    group_count: COMMAND_GROUPS.length,
+    side_effect_counts: sideEffectCounts,
+    ids_by_side_effect: idsBySideEffect,
+    read_only_command_ids: readOnlyCommandIds,
+    mutating_command_ids: mutatingCommandIds,
+    core_workflows: {
+      full_app_fast_build: {
+        mode: 'fast_build',
+        trigger_phrases: ['默认方案', '不要追问', '直接创建', '尽快搭建'],
+        default_page_skill_id: 'yida-custom-page',
+        optional_canvas_skill_id: 'yida-canvas-custom-page',
+        canvas_usage: 'Use Code Canvas only when the user explicitly asks for it, the target page is already YidaCodeCanvas, or the current organization/page is confirmed to support Canvas.',
+        required_command_ids: [
+          'agent-capabilities',
+          'create-app',
+          'create-form.create',
+          'create-page',
+          'publish',
+        ],
+        optional_read_command_ids: ['get-schema', 'list-forms'],
+        optional_after_done_command_ids: [
+          'nav-group',
+          'data',
+          'save-share-config',
+          'get-page-config',
+          'create-report',
+          'append-chart',
+        ],
+        do_not_default_skill_ids: [
+          'yida-page-uiux',
+          'yida-canvas-custom-page',
+          'yida-data-source-connectors',
+          'yida-data-management',
+          'yida-nav-group',
+          'yida-dashboard',
+        ],
+        completion_contract: 'Create app, core forms, primary page, publish it, and return an access URL.',
+      },
+    },
+  };
+}
+
 function buildCommandManifest(options = {}) {
   const translate = typeof options.t === 'function' ? options.t : key => key;
   const commands = flattenCommandManifest();
+  const localizedCommands = commands.map(entry => localizeCommand(entry, translate));
 
   return {
     schema_version: 1,
@@ -615,7 +683,8 @@ function buildCommandManifest(options = {}) {
       commands: group.commands.map(entry => entry.id),
     })),
     side_effect_schema: cloneSideEffectSchema(),
-    commands: commands.map(entry => localizeCommand(entry, translate)),
+    summary: summarizeLocalizedCommands(localizedCommands),
+    commands: localizedCommands,
   };
 }
 

--- a/scripts/eval/routing.js
+++ b/scripts/eval/routing.js
@@ -28,7 +28,7 @@ function loadRoutingContext(skillMdPath = DEFAULT_SKILL_MD) {
 
 /**
  * 加载 scenarios 目录下的 *.json golden 用例。
- * @returns {Array<{id, prompt, expectedSkill, expectedStages?, rubric?}>}
+ * @returns {Array<{id, prompt, expectedSkill, expectedMode?, forbiddenDefaultSkills?, expectedStages?, rubric?}>}
  */
 function loadScenarios(dir) {
   if (!dir || !fs.existsSync(dir)) {return [];}
@@ -58,7 +58,7 @@ function normalizeSkill(name) {
 function buildRoutingPrompt({ request, routingContext, skillNames }) {
   return [
     '下面是宜搭 AI 应用开发技能（openyida）的路由说明文档。请严格依据它，',
-    '判断针对用户请求应当选择哪一个**子技能**来处理。',
+    '判断针对用户请求应当选择哪一个**子技能**来处理。如果是完整应用搭建，还要判断 yida-app 的模式。',
     '',
     '=== 路由说明文档开始 ===',
     routingContext,
@@ -69,8 +69,20 @@ function buildRoutingPrompt({ request, routingContext, skillNames }) {
     `用户请求：「${request}」`,
     '',
     '只输出一个 JSON 对象，不要任何其它文字，形如：',
-    '{"skill": "yida-dashboard", "reason": "一句话理由"}',
+    '{"skill": "yida-app", "mode": "fast_build", "defaultLoadSkills": ["yida-app"], "reason": "一句话理由"}',
+    '',
+    '要求：',
+    '- skill 必须是上面可选子技能名之一。',
+    '- 只有完整应用搭建才填写 mode；默认方案 / 不要追问 / 直接创建 必须是 fast_build。',
+    '- defaultLoadSkills 只列默认会加载的技能；optionalAfterDone 不要列入默认加载。',
   ].join('\n');
+}
+
+function normalizeSkillList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(normalizeSkill).filter(Boolean);
 }
 
 /**
@@ -111,13 +123,28 @@ function evaluateScenario(options = {}) {
   }
 
   const actual = res.json && res.json.skill ? res.json.skill : null;
-  const hit = actual !== null
+  const skillHit = actual !== null
     && normalizeSkill(actual) === normalizeSkill(scenario.expectedSkill);
+  const actualMode = res.json && res.json.mode ? String(res.json.mode).trim() : null;
+  const modeHit = scenario.expectedMode
+    ? normalizeSkill(actualMode) === normalizeSkill(scenario.expectedMode)
+    : null;
+  const defaultLoadSkills = normalizeSkillList(res.json && res.json.defaultLoadSkills);
+  const forbiddenDefaultSkillHits = normalizeSkillList(scenario.forbiddenDefaultSkills)
+    .filter(skillName => defaultLoadSkills.includes(skillName));
+  const hit = skillHit
+    && (modeHit !== false)
+    && forbiddenDefaultSkillHits.length === 0;
 
   return {
     id: scenario.id,
     expected: scenario.expectedSkill,
     actual,
+    expectedMode: scenario.expectedMode || null,
+    actualMode,
+    modeHit,
+    defaultLoadSkills,
+    forbiddenDefaultSkillHits,
     reason: res.json ? res.json.reason : null,
     hit,
     status: actual === null ? 'unparsed' : 'ok',

--- a/scripts/eval/scenarios/routing-core.json
+++ b/scripts/eval/scenarios/routing-core.json
@@ -66,6 +66,21 @@
     "note": "从零多步骤全流程 → yida-app 编排"
   },
   {
+    "id": "full-app-visitor-fast-build",
+    "prompt": "帮我搭建一个访客系统，按默认方案搭建，不要追问，直接创建",
+    "expectedSkill": "yida-app",
+    "expectedMode": "fast_build",
+    "forbiddenDefaultSkills": [
+      "yida-page-uiux",
+      "yida-canvas-custom-page",
+      "yida-data-source-connectors",
+      "yida-data-management",
+      "yida-nav-group",
+      "yida-dashboard"
+    ],
+    "note": "默认方案/不要追问/直接创建 → yida-app fast_build；Canvas、UIUX、数据源、示例数据、导航整理均为 optionalAfterDone"
+  },
+  {
     "id": "table-form",
     "prompt": "我要一个像 Excel 那样可以多行批量录入再一次提交的页面",
     "expectedSkill": "yida-table-form",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -251,13 +251,21 @@ openyida login --browser
 openyida copy
 \`\`\`
 
+## 完整应用默认链路
+
+用户说“按默认方案 / 不要追问 / 直接创建 / 尽快搭建”时，加载 \`yida-app\` 并选择 \`fast_build\`。
+
+\`fast_build\` 只做：创建应用 → 核心表单 → 主页面 → 编写主页面源码 → 发布 → 返回访问链接。发布主页面成功并输出 URL 后即完成。
+
+不要默认加载 \`yida-page-uiux\`、\`yida-data-source-connectors\`、\`yida-data-management\`、\`yida-nav-group\`、\`yida-dashboard\`，也不要默认做示例数据、导航整理、截图验收、公开访问、长 PRD 或深读 references；这些只在用户明确要求或 \`full_demo\` / \`deep_design\` 时执行。
+
 ## 子技能索引
 
 根据用户意图选择最匹配的子技能。支持 \`use_skill\` / \`search_skills\` 的宿主中，必须调用 \`use_skill("<技能名>", "<本次目的>")\` 加载子技能；不要用 Read / read_file / cat 读取 SKILL.md 路径。\`skills-index.json\` 仅供 yida-agent 或同构宿主机器发现，不支持该索引的宿主忽略它。完全没有 \`use_skill\` 的本地工具，才允许按根技能路由表选定技能，并按 \`skills/<技能名>/SKILL.md\` 定位当前阶段唯一必要的 SKILL.md，禁止并发批量读取多个 SKILL.md。
 
 | 意图 | 子技能 |
 | --- | --- |
-| 完整应用开发编排 | \`yida-app\` |
+| 完整应用开发编排（默认 \`fast_build\`：创建应用、核心表单、主页面、发布并返回 URL） | \`yida-app\` |
 | 登录态管理 | \`yida-login\` |
 | 退出登录 / 切换账号 | \`yida-logout\` |
 | 创建应用 | \`yida-create-app\` |

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -177,6 +177,32 @@ describe('CLI offline smoke', () => {
         action_dependent: expect.stringContaining('mixed commands'),
       },
     });
+    expect(parsed.summary).toMatchObject({
+      command_count: parsed.commands.length,
+      group_count: parsed.groups.length,
+    });
+    expect(parsed.summary.side_effect_counts.remote_write).toBeGreaterThan(0);
+    expect(parsed.summary.read_only_command_ids).toContain('agent-capabilities');
+    expect(parsed.summary.mutating_command_ids).toContain('create-app');
+    expect(parsed.summary.core_workflows.full_app_fast_build).toMatchObject({
+      mode: 'fast_build',
+      default_page_skill_id: 'yida-custom-page',
+      optional_canvas_skill_id: 'yida-canvas-custom-page',
+      required_command_ids: expect.arrayContaining([
+        'agent-capabilities',
+        'create-app',
+        'create-form.create',
+        'create-page',
+        'publish',
+      ]),
+      do_not_default_skill_ids: expect.arrayContaining([
+        'yida-page-uiux',
+        'yida-canvas-custom-page',
+        'yida-data-source-connectors',
+        'yida-data-management',
+        'yida-nav-group',
+      ]),
+    });
     expect(commands).toContain('env');
     expect(commands).toContain('login');
     expect(commands).toContain('corp-efficiency');
@@ -302,17 +328,46 @@ describe('CLI offline smoke', () => {
         entry: 'openyida',
       },
     });
+    expect(parsed.commands).toMatchObject({
+      count: parsed.command_manifest.commands.length,
+      group_count: parsed.command_manifest.groups.length,
+    });
+    expect(parsed.commands.side_effect_counts.remote_write).toBeGreaterThan(0);
+    expect(parsed.commands.read_only_command_ids).toContain('agent-capabilities');
+    expect(parsed.commands.core_workflows.full_app_fast_build).toMatchObject({
+      mode: 'fast_build',
+      default_page_skill_id: 'yida-custom-page',
+      optional_canvas_skill_id: 'yida-canvas-custom-page',
+      required_command_ids: expect.arrayContaining([
+        'create-app',
+        'create-form.create',
+        'create-page',
+        'publish',
+      ]),
+      do_not_default_skill_ids: expect.arrayContaining([
+        'yida-page-uiux',
+        'yida-canvas-custom-page',
+        'yida-data-source-connectors',
+        'yida-data-management',
+        'yida-nav-group',
+      ]),
+    });
+    expect(parsed.recommended.default_full_app_workflow).toMatchObject({
+      mode: 'fast_build',
+      completion_contract: expect.stringContaining('Create app'),
+    });
     expect(parsed.command_manifest.side_effect_schema).toMatchObject({
       version: 1,
       kinds: {
         mixed: expect.stringContaining('Action-dependent command'),
       },
     });
+    expect(parsed.command_manifest.summary.command_count).toBe(parsed.command_manifest.commands.length);
     expect(parsed.login).toHaveProperty('status');
     expect(parsed.login).not.toHaveProperty('cookies');
     expect(parsed.login).not.toHaveProperty('csrf_token');
     expect(parsed.sideEffects.read_only_preflight).toContain('openyida agent-capabilities --json');
-    expect(parsed.sideEffects.completion_contracts.full_app).toContain('Publishing the primary page');
+    expect(parsed.sideEffects.completion_contracts.full_app).toContain('creating the app');
     const commandIds = parsed.command_manifest.commands.map(entry => entry.id);
     const commandById = Object.fromEntries(parsed.command_manifest.commands.map(entry => [entry.id, entry]));
     expect(commandIds).toContain('agent-capabilities');

--- a/tests/eval-routing.test.js
+++ b/tests/eval-routing.test.js
@@ -65,6 +65,8 @@ describe('eval routing', () => {
     expect(p).toContain('ROUTING-DOC');
     expect(p).toContain('做个看板');
     expect(p).toContain('yida-dashboard');
+    expect(p).toContain('mode');
+    expect(p).toContain('defaultLoadSkills');
   });
 
   test('evaluateScenario 命中判定', () => {
@@ -77,6 +79,75 @@ describe('eval routing', () => {
     });
     expect(r.hit).toBe(true);
     expect(r.status).toBe('ok');
+  });
+
+  test('evaluateScenario 校验默认建访客系统走 yida-app fast_build 且不默认加载可选技能', () => {
+    const scenario = {
+      id: 'visitor-fast-build',
+      prompt: '帮我搭建一个访客系统，按默认方案搭建，不要追问，直接创建',
+      expectedSkill: 'yida-app',
+      expectedMode: 'fast_build',
+      forbiddenDefaultSkills: [
+        'yida-page-uiux',
+        'yida-canvas-custom-page',
+        'yida-data-source-connectors',
+        'yida-data-management',
+        'yida-nav-group',
+      ],
+    };
+    const fakeAgent = () => ({
+      available: true,
+      json: {
+        skill: 'yida-app',
+        mode: 'fast_build',
+        defaultLoadSkills: [
+          'yida-app',
+          'yida-create-app',
+          'yida-create-form-page',
+          'yida-create-page',
+          'yida-custom-page',
+          'yida-publish-page',
+        ],
+        reason: '默认方案直接创建',
+      },
+    });
+    const r = evaluateScenario({
+      scenario,
+      routingContext: 'doc',
+      skillNames: ['yida-app', 'yida-page-uiux', 'yida-data-source-connectors'],
+      runAgent: fakeAgent,
+    });
+
+    expect(r.hit).toBe(true);
+    expect(r.modeHit).toBe(true);
+    expect(r.defaultLoadSkills).toContain('yida-app');
+    expect(r.forbiddenDefaultSkillHits).toEqual([]);
+  });
+
+  test('evaluateScenario 把默认链路加载 UIUX / Canvas / 数据源判为未命中', () => {
+    const fakeAgent = () => ({
+      available: true,
+      json: {
+        skill: 'yida-app',
+        mode: 'fast_build',
+        defaultLoadSkills: ['yida-app', 'yida-page-uiux', 'yida-canvas-custom-page', 'yida-data-source-connectors'],
+      },
+    });
+    const r = evaluateScenario({
+      scenario: {
+        id: 'visitor-fast-build',
+        prompt: '帮我搭建一个访客系统，按默认方案搭建，不要追问，直接创建',
+        expectedSkill: 'yida-app',
+        expectedMode: 'fast_build',
+        forbiddenDefaultSkills: ['yida-page-uiux', 'yida-canvas-custom-page', 'yida-data-source-connectors'],
+      },
+      routingContext: 'doc',
+      skillNames: ['yida-app', 'yida-page-uiux', 'yida-data-source-connectors'],
+      runAgent: fakeAgent,
+    });
+
+    expect(r.hit).toBe(false);
+    expect(r.forbiddenDefaultSkillHits).toEqual(['yida-page-uiux', 'yida-canvas-custom-page', 'yida-data-source-connectors']);
   });
 
   test('evaluateScenario 未命中与 agent 不可用', () => {

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -25,7 +25,7 @@ description: >
 
 > ⚡ **前置门槛**：确认 openyida 已安装、Node/npm 依赖达标、登录态就绪。**未通过只读验证前，禁止创建应用/页面/表单或发布等任何真实资源操作。**
 
-**怎么做**：优先跑一次 `openyida agent-capabilities --json`。该命令一次返回 version、cwd、AI 工具环境、推荐工作目录、登录态摘要、commands 和 sideEffects，避免反复 `which openyida`、`openyida --version`、`openyida --help`、`openyida env`、`login --check-only`。
+**怎么做**：优先跑一次 `openyida agent-capabilities --json`。该命令一次返回 version、cwd、AI 工具环境、推荐工作目录、登录态摘要、commands、command count、sideEffects 和默认 `fast_build` 契约，避免反复 `which openyida`、`openyida --version`、`openyida --help`、`openyida env`、`login --check-only`。
 
 若当前 OpenYida 版本还没有 `agent-capabilities`，退回跑 `openyida env --json` 和 `openyida login --check-only --json`。旧版本地 agent 不需要认识 `skills-index.json`，也不需要支持 `agent-capabilities` 才能继续执行。
 
@@ -36,7 +36,7 @@ description: >
 | `login.status` 不是 `ok` 且 `login.can_auto_use` 不是 true | 未登录 → `openyida login`（指定入口带 URL 或 flag） |
 | `active.projectRootExists` 为 false | 无工作目录 → `openyida copy` 初始化 |
 
-**👉 完整命令解读、悟空降级、Codex handoff 等特殊分支 → [references/setup-and-env.md](references/setup-and-env.md)（必读）。**
+**👉 环境异常、登录失败、悟空降级、Codex handoff 等特殊分支 → [references/setup-and-env.md](references/setup-and-env.md)。正常 `agent-capabilities` 通过时不要默认读取该 reference。**
 
 ---
 
@@ -57,9 +57,13 @@ description: >
 > 加载子技能 `yida-app`，由它负责完整应用 workflow、阶段子技能加载、关键 ID 流转、PRD 与 schema cache 约束。
 > 用户说“按默认方案 / 不要追问 / 直接创建 / 尽快搭建”时，`yida-app` 选择 `fast_build`：创建应用、必要表单、主页面、发布并输出链接。
 
+**默认链路**：`fast_build` 必须只做 `创建应用 → 核心表单 → 主页面 → 编写主页面源码 → 发布 → 返回访问链接`。不要因为应用名里有“看板 / 系统 / 管理”就升级到 `deep_design` 或 `full_demo`。
+
+**fast_build 默认加载边界**：只加载 `yida-app` 和当前阶段必需的子技能：`yida-create-app`、`yida-create-form-page`、`yida-create-page`、`yida-custom-page`、`yida-publish-page`。Code Canvas 尚未全量，只有用户明确要求、已有页面为 `YidaCodeCanvas`，或已确认当前组织/页面支持时才加载 `yida-canvas-custom-page`。不要默认加载 `yida-page-uiux`、`yida-data-source-connectors`、`yida-data-management`、`yida-nav-group`、`yida-dashboard`，也不要默认深读 `references/`。
+
 **doneWhen**：`yida-app` 发布主页面成功并输出可访问 URL。到这里默认完成；不要发布后继续 TaskCreate、重复读技能或继续规划。
 
-**optionalAfterDone**：导航整理、示例数据、公开访问、截图验证、深度视觉方向、报表/大屏，只在用户明确要求或 `yida-app` 模式为 `full_demo` / `deep_design` 时执行。
+**optionalAfterDone**：导航整理、示例数据、公开访问、截图验证、深度视觉方向、数据源/连接器深度接入、报表/大屏，只在用户明确要求或 `yida-app` 模式为 `full_demo` / `deep_design` 时执行。
 
 ---
 
@@ -73,12 +77,12 @@ description: >
 
 > ⚠️ **同类易错先分清**：改字段结构→`create-form-page`｜只读 Schema→`get-schema`｜改数据记录→`data-management`｜详情页美化→`form-detail`；自定义页视觉方向/去AI味→`page-uiux`(定方向)｜token/组件实现→`custom-page`(design-system)；加导航先分清→平台左侧菜单分组/排序→`nav-group`｜页面隐藏应用导航后页面内自绘导航壳→`nav-shell`（必须隐藏原导航，并让导航项 URL 带 `isRenderNav=false` 等参数）；字段实时校验→`formula`｜提交后编排→`integration`｜跨表高级函数→`business-rule`；从零建流程→`create-process`｜改已有流程→`process-rule`；权限按层级：组织→`corp-manager`／应用→`app-permission`／表单→`form-permission`／页面分享→`page-config`；**自定义页面选路见下方专表**。
 
-> 🧭 **自定义页面选路（默认 Code Canvas，按顺序命中即停）**：
-> 1. **默认 → Code Canvas** `yida-canvas-custom-page`：现代 React 交互 / hooks 状态 / 可视化 / AI 生成 / 需崩溃隔离，**以及只需通过开放 API（HTTP）读取宜搭数据的页面**（Canvas 自写 fetch 即可拿数据）；
-> 2. 仅当页面强依赖**原生实例数据桥**——表单内字段双向绑定 `this.$(fieldId)`、`this.utils.yida.*`、`dataSourceMap`、提交流程 / 设计器数据源深度耦合，且用开放 API 重写代价过高 → 回退 **native** `yida-custom-page`；
-> 3. 已有普通 `.oyd.jsx` 要迁到 Canvas → `yida-canvas-upgrade`。
+> 🧭 **自定义页面选路（兼容优先，按顺序命中即停）**：
+> 1. **默认 → native** `yida-custom-page`：平台全量兼容的 `.oyd.jsx` 链路，适合完整应用 `fast_build` 和未确认 Canvas 能力的组织；
+> 2. 仅当用户明确要求 Code Canvas / 代码画布，已有页面 Schema 是 `YidaCodeCanvas`，或已确认当前组织/页面支持 Canvas → `yida-canvas-custom-page`；
+> 3. 已有普通 `.oyd.jsx` 要迁到 Canvas，且目标组织支持 Canvas → `yida-canvas-upgrade`。
 >
-> 依据（源码核实）：Canvas 代码在宿主页真实 `window` 中 `new Function` 执行，但物料只透传 `code/runtimeCode/importedModules/pageType`，**无 `this` 上下文、无 `dataSourceMap`**，`this.utils.yida.*` 不可用；宿主 window 全局（`__yida_plugin_runtime__` 插件系统、`__VcDeepYidaUtils__`）均非表单数据桥，也无 `window.Deep` 字段组件。Canvas 读宜搭数据 = 在 `YidaComp` 内自写 HTTP 调开放 API。只有需要免费 `this` 实例桥的页才留 native。
+> 依据：Code Canvas 组件在宜搭平台侧尚未全量。native `.oyd.jsx` 是默认兼容链路；Canvas 代码在宿主页真实 `window` 中 `new Function` 执行，但物料只透传 `code/runtimeCode/importedModules/pageType`，无 `this` 上下文、无 `dataSourceMap`，`this.utils.yida.*` 不可用。需要实例桥或未确认 Canvas 支持时留 native。
 
 | 分组 | 加载目标 | 何时选择（关键区别已内联） |
 |------|------|--------------------------|
@@ -89,10 +93,10 @@ description: >
 | **页面与表单** | 加载子技能 `yida-create-page` | 创建空白自定义页面拿 formUuid，后续写 JSX |
 | | 加载子技能 `yida-create-form-page` | 创建/更新表单、增删改**字段结构**（普通表单，无审批） |
 | | 加载子技能 `yida-create-process` | 从零建**带审批**流程表单（表单还不存在，一步到位） |
-| | 加载子技能 `yida-page-uiux` | 写自定义页面 UI 前先定视觉方向、去 AI 味（工作台/看板/列表/详情/官网落地页；产出决策块，不写代码；canvas / native 两链路通用） |
-| | 加载子技能 `yida-canvas-custom-page` | **自定义页面默认链路**：现代 React 交互 / hooks / 可视化 / AI 页，含只需开放 API HTTP 读数据的页（Code Canvas，`runtimeCode` + `importedModules`，真 React18 + 崩溃隔离） |
-| | 加载子技能 `yida-custom-page` | 回退项：仅当强依赖原生实例数据桥（`this.$(fieldId)` 双向绑定 / `this.utils.yida.*` / `dataSourceMap` / 提交流程深度耦合）时才用（native `.oyd.jsx` 链路） |
-| | 加载子技能 `yida-canvas-upgrade` | 将已有普通 `.oyd.jsx` / `Jsx` 页面升级迁移到 Code Canvas / `YidaCodeCanvas` 链路 |
+| | 加载子技能 `yida-page-uiux` | 单点页面美化、用户明确要求视觉方向/去 AI 味，或 `yida-app` 进入 `deep_design` 时使用；`fast_build` 不默认加载 |
+| | 加载子技能 `yida-custom-page` | **自定义页面默认兼容链路**：native `.oyd.jsx`，适合完整应用 `fast_build` 和未确认 Canvas 能力的组织 |
+| | 加载子技能 `yida-canvas-custom-page` | Code Canvas 可选链路：用户明确要求代码画布、已有页面为 `YidaCodeCanvas`，或已确认当前组织/页面支持 Canvas 时使用 |
+| | 加载子技能 `yida-canvas-upgrade` | 将已有普通 `.oyd.jsx` / `Jsx` 页面升级迁移到 Code Canvas / `YidaCodeCanvas` 链路；仅在目标组织支持 Canvas 时执行 |
 | | 加载子技能 `yida-nav-shell` | 自定义页**隐藏应用导航**（`isRenderNav=false`，沉浸/门户/大屏/分享）后，页面内用 JSX 自绘侧边/顶部/浮动/标签导航壳；发布后要配置隐藏原导航，跨页导航项要拼完整 URL 并合并 `isRenderNav=false` / `corpid` / 业务参数（**区别** `yida-nav-group` 平台左侧菜单分组：那是真实导航树，本项是页面内自建导航） |
 | | 加载子技能 `yida-publish-page` | JSX 写完后编译并发布 |
 | | 加载子技能 `yida-openyida-publish-guard` | 发布已有自定义页面前检查线上设计器状态，避免本地旧源码覆盖用户在线改动 |
@@ -104,7 +108,7 @@ description: >
 | | 加载子技能 `yida-dashboard` | 完整看板 / 驾驶舱产品化交付 |
 | **连接器** | 加载子技能 `yida-connector` | 创建/管理连接器、配鉴权 |
 | | 加载子技能 `yida-connector-safe-actions` | 连接器已有，从 API 代码生成执行动作 |
-| | 加载子技能 `yida-data-source-connectors` | 自定义页面中通过数据源调用连接器 |
+| | 加载子技能 `yida-data-source-connectors` | 用户明确要求通过设计器数据源/连接器调用外部 API 时使用；完整应用 `fast_build` 不默认加载 |
 | **数据与公式** | 加载子技能 `yida-data-management` | 增删改查**数据记录**，不动字段结构 |
 | | 加载子技能 `yida-get-schema` | **只读**查 Schema / 字段 ID，不改结构 |
 | | 加载子技能 `yida-formula` | 配在**字段属性**上的实时计算/默认值/校验 |
@@ -157,7 +161,7 @@ description: >
 9. **报表美化先问方案**：用户说"优化/美化报表"时先问选原生报表(`yida-report`)还是 ECharts(`yida-chart`)。
 10. **按 schema 证据选技能**：先看 `formType`、组件树、`dataSource.online`；`receipt/process/report` 分别落到表单/流程/报表技能。
 11. **官方示例范式优先**：蒸馏官方示例时先理解脱敏 schema 承载方式，不凭截图/标题/视觉判断。
-12. **默认完成即停止**：完整应用默认以发布成功并输出 URL 为 doneWhen；示例数据、导航、截图、TaskCreate 和深度设计都是 optionalAfterDone。
+12. **默认完成即停止**：完整应用默认以发布成功并输出 URL 为 doneWhen；UIUX、数据源深读、示例数据、导航、截图、TaskCreate 和深度设计都是 optionalAfterDone。
 
 > 📖 每条规则的完整说明、PRD 质量门槛、临时文件路径规范、报表美化话术 → [references/development-rules.md](references/development-rules.md)
 

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -70,7 +70,7 @@
       "name": "yida-canvas-custom-page",
       "path": "skills/yida-canvas-custom-page/SKILL.md",
       "display_name": "Code Canvas 自定义页面",
-      "description": "宜搭 Code Canvas / 代码画布自定义页面开发规范，覆盖现代 React 交互、hooks 状态、可视化、AI 生成和开放 API 数据读取页面。",
+      "description": "宜搭 Code Canvas / 代码画布自定义页面开发规范。Canvas 尚未全量，仅在用户明确要求、已有页面为 YidaCodeCanvas，或已确认组织/页面支持时使用。",
       "category": "yida/page",
       "tags": ["Code Canvas", "React18", "runtimeCode", "自定义页面"],
       "aliases": ["代码画布", "Canvas 页面"]
@@ -169,7 +169,7 @@
       "name": "yida-custom-page",
       "path": "skills/yida-custom-page/SKILL.md",
       "display_name": "Native 自定义页面 JSX 开发",
-      "description": "宜搭自定义页面 React 16 / JSX 开发规范、运行时限制、UI 与数据源调用约束。",
+      "description": "宜搭 native 自定义页面 React 16 / JSX 开发规范，默认兼容链路，适合完整应用 fast_build 和未确认 Code Canvas 能力的组织。",
       "category": "yida/page",
       "tags": ["JSX", "自定义页面", "React 16", "页面代码"],
       "aliases": ["页面开发", "native 页面"]

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -13,6 +13,8 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 
 用户说“按默认方案”“不要追问”“直接创建”“尽快搭建”等，必须选择 `fast_build`，用合理 MVP 假设直接执行，不展开深度 PRD 讨论。
 
+**默认判定**：从零搭建完整应用时，只要用户表达“默认方案 / 不要追问 / 直接创建 / 尽快搭建”等快速交付信号，就必须命中 `fast_build`。默认完成链路固定为 `创建应用 → 核心表单 → 主页面 → 编写主页面源码 → 发布 → 返回访问链接`。
+
 ## 模式
 
 | 模式 | 何时使用 | 目标 |
@@ -21,7 +23,7 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 | `full_demo` | 用户明确要演示完整、示例数据、导航整理、可点验收 | 在 `fast_build` 后补导航、示例数据、公开访问或截图 |
 | `deep_design` | 用户明确要深度产品设计、视觉方向、多角色、多页面、复杂流程 | 先做详细 PRD/视觉决策，再执行多阶段搭建 |
 
-默认不要把 `full_demo` / `deep_design` 的动作塞进 `fast_build`。
+默认不要把 `full_demo` / `deep_design` 的动作塞进 `fast_build`。不要因为用户说“看板”“系统”“管理”就自动加载视觉决策、数据源、示例数据、导航整理或截图验收。
 
 ## 预检
 
@@ -32,14 +34,14 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 | 阶段 | 子技能 | 必做动作 | doneWhen |
 |------|--------|----------|----------|
 | 1. 创建应用 | `yida-create-app` | `openyida create-app`，提取 `appType` | 拿到真实 `appType` |
-| 2. 记录最小需求 | 无 | 写 `prd/<项目名>.md`：MVP、角色、核心表单/页面、完成标准；写 `.cache/<项目名>-schema.json` 初始骨架 | 业务语义和 ID 存储位置明确 |
+| 2. 记录最小需求 | 无 | 写 `prd/<项目名>.md`：只记录 MVP 假设、核心表单/页面、完成标准；写 `.cache/<项目名>-schema.json` 初始骨架；不要写长 PRD | 业务语义和 ID 存储位置明确 |
 | 3. 创建必要表单 | `yida-create-form-page` | 只创建支撑 MVP 的核心表单；字段配置文件写入 `.cache/openyida/<项目名>/` | 拿到表单 `formUuid` 和真实 `fieldId` |
 | 4. 创建主页面 | `yida-create-page` | 创建一个用户主入口页面，通常是工作台/看板/列表入口 | 拿到页面 `formUuid` |
-| 5. 编写页面 | 默认 `yida-canvas-custom-page`；强依赖原生实例桥才用 `yida-custom-page` | 生成主页面源码；只实现 MVP 首屏和核心操作，不加载视觉/密度/报表等额外技能 | 本地源码通过对应页面技能的基础校验 |
-| 6. 发布页面 | `yida-publish-page` | 按页面链路校验后发布：Canvas `.canvas.jsx` 用 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检；native `.oyd.jsx` / `.jsx` 才跑 `check-page` / `compile`；再发布主页面 | 发布成功并获得可访问 URL |
+| 5. 编写页面 | 默认 `yida-custom-page`；用户明确要求或已确认支持 Canvas 时才用 `yida-canvas-custom-page` | 生成主页面源码；只实现 MVP 首屏和核心操作。可用已创建表单链接、轻量统计占位和基础列表/入口布局完成主页面；不要加载视觉/密度/报表/数据源等额外技能 | 本地源码通过对应页面技能的基础校验 |
+| 6. 发布页面 | `yida-publish-page` | 按页面链路校验后发布：默认 native `.oyd.jsx` / `.jsx` 跑 `check-page` / `compile` 后发布；Canvas `.canvas.jsx` 仅在已选择 Canvas 链路时用 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检；再发布主页面 | 发布成功并获得可访问 URL |
 | 7. 输出结果 | 无 | 返回应用链接、主页面链接、已创建资源摘要、后续可选项 | 用户拿到 URL |
 
-`fast_build` 不默认执行：导航重排、示例数据、截图验收、公开访问配置、深度 UI 设计、TaskCreate / 继续规划任务。
+`fast_build` 不默认执行：`yida-page-uiux`、`yida-canvas-custom-page`（除非已确认 Canvas 支持或用户明确要求）、`yida-data-source-connectors`、`yida-data-management`、`yida-nav-group`、`yida-dashboard`、导航重排、示例数据、截图验收、公开访问配置、深度 UI 设计、长 PRD、TaskCreate / 继续规划任务，也不默认读取 `references/app-build-contract.md`。
 
 ## full_demo 可选后置
 
@@ -55,7 +57,7 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 
 ## deep_design 附加要求
 
-进入 `deep_design` 时，可以读取 [详细编排参考](references/app-build-contract.md)，并按需加载 `yida-page-uiux`、`yida-density`、`yida-dashboard` 等设计/看板技能。不要在 `fast_build` 中默认读取这些参考或技能。
+进入 `deep_design` 时，可以读取 [详细编排参考](references/app-build-contract.md)，并按需加载 `yida-page-uiux`、`yida-density`、`yida-dashboard`、`yida-data-source-connectors` 等设计/看板/数据源技能。不要在 `fast_build` 中默认读取这些参考或技能。
 
 ## 完成条件
 
@@ -84,4 +86,4 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 
 ## 参考
 
-- [详细编排参考](references/app-build-contract.md)：PRD 模板、字段文件示例、URL 规则、典型场景、删除应用确认、故障处理。
+- [详细编排参考](references/app-build-contract.md)：仅 `full_demo` / `deep_design` / 排障时读取；包含 PRD 模板、字段文件示例、URL 规则、典型场景、删除应用确认、故障处理。

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yida-canvas-custom-page
-description: 宜搭 Code Canvas / 代码画布自定义页面开发规范，是**自定义页面的默认链路**——现代 React 交互、hooks 状态、可视化、AI 生成或需要崩溃隔离的页面都用它（真 React18 + `runtimeCode` + `importedModules`）。只需通过开放 API（HTTP fetch）读写宜搭数据的页面也用它——Canvas 无 this 数据桥，在 YidaComp 内自写 HTTP 桥即可。也覆盖用户明确提到 code canvas、代码画布、YidaCodeCanvas、runtimeCode、importedModules，或在 Code Canvas 中使用 EmployeeField、SelectField、DepartmentSelectField 等原生组件的场景。仅当页面强依赖原生实例数据桥（this.$(fieldId) 双向绑定、this.utils.yida.*、dataSourceMap、提交流程深度耦合）时才回退 yida-custom-page。
+description: 宜搭 Code Canvas / 代码画布自定义页面开发规范。Code Canvas 尚未在宜搭平台全量，只有用户明确要求代码画布、已有页面为 YidaCodeCanvas，或已确认当前组织/页面支持 Canvas 时使用；默认兼容链路仍是 yida-custom-page。
 ---
 
 # 宜搭 Code Canvas 自定义页面开发
@@ -8,6 +8,8 @@ description: 宜搭 Code Canvas / 代码画布自定义页面开发规范，是*
 ## 核心定位
 
 Code Canvas 是宜搭的**代码画布自定义页面链路**：以 `YidaCodeCanvas` 物料为承载，用户写标准 React18 函数组件源码，编译为 `runtimeCode` + 依赖清单（OpenYida CLI 本地用 Babel 完成），运行时按依赖白名单加载资源并 `new Function` 执行，渲染出真正的 React 组件。相较宜搭原生 `.oyd.jsx` 页面，它提供现代 hooks 写法、组件级崩溃隔离（ErrorBoundary）、Tailwind 运行时样式，适合现代交互 / 可视化 / AI 生成页面。
+
+> **可用性边界**：Code Canvas 组件在宜搭平台侧尚未全量。完整应用 `fast_build` 和未确认 Canvas 能力的组织默认使用 `yida-custom-page` native 链路；本技能只在用户明确要求、已有页面是 `YidaCodeCanvas`，或已确认当前组织/页面支持 Canvas 时使用。
 
 运行链路（源码核实自 `vc-deep-yida` 物料）：
 
@@ -21,12 +23,13 @@ Code Canvas 是宜搭的**代码画布自定义页面链路**：以 `YidaCodeCan
 
 | 证据 | 判断 |
 | --- | --- |
-| 现代 React 交互 / hooks 状态 / 可视化 / AI 生成 / 需崩溃隔离的自定义页 | **默认使用本技能** |
+| 用户明确要求 Code Canvas / 代码画布 / runtimeCode / importedModules | 使用本技能 |
+| 已确认当前组织/页面支持 `YidaCodeCanvas`，且需要现代 React 交互 / hooks 状态 / 可视化 / AI 生成 / 崩溃隔离 | 使用本技能 |
 | 页面 Schema 或组件树里有 `componentName: "YidaCodeCanvas"` | 使用本技能 |
-| 需求明确是“代码画布 / Code Canvas / runtimeCode / importedModules” | 使用本技能 |
 | 需求明确是“从 OpenYida 原链路升级/迁移到 Canvas” | 切到 `yida-canvas-upgrade` |
-| 只需通过开放 API（HTTP）读写宜搭数据的页面 | **仍用本技能**：在 `YidaComp` 内自写 fetch 调开放 API / 连接器代理（Canvas 无 `this` 桥，需自建 HTTP 数据桥） |
-| 强依赖原生实例数据桥：表单内字段双向绑定 `this.$(fieldId)`、`this.utils.yida.*`、`dataSourceMap`、提交流程深度耦合 | 回退 `yida-custom-page`（该实例桥仅 native 免费提供） |
+| 未确认 Canvas 能力，或只是完整应用 `fast_build` 的主入口页 | 使用 `yida-custom-page` |
+| 只需通过开放 API（HTTP）读写宜搭数据，但未确认 Canvas 能力 | 使用 `yida-custom-page`；不要为了 HTTP 数据读取默认切 Canvas |
+| 强依赖原生实例数据桥：表单内字段双向绑定 `this.$(fieldId)`、`this.utils.yida.*`、`dataSourceMap`、提交流程深度耦合 | 使用 `yida-custom-page`（该实例桥仅 native 免费提供） |
 | 需要字段结构、公式、联动、权限、报表、流程 | 切到对应配置型技能，不用 Code Canvas 承载 |
 
 OpenYida CLI 已支持发布 `YidaCodeCanvas` 页面：把 Code Canvas 源码写成 `.canvas.jsx`（推荐 `project/pages/src/<页面名>.canvas.jsx`），执行 `openyida publish <源文件> <appType> <formUuid>` 即自动走 Canvas 链路——`.canvas.jsx` 扩展名会被识别，CLI **本地用 Babel 编译**出 `runtimeCode` + `importedModules`（无需在线编译服务、无需登录态即可完成编译），构造 `YidaCodeCanvas` 组件的 Schema 并保存。扩展名不规范但确为 Canvas 源码时，加 `--canvas` 显式指定。**不要**把 Canvas 源码用普通 `.oyd.jsx`/`.jsx` 走 native 链路发布（会被 Babel 兼容编译器当 `renderJsx` 处理而失败）。
@@ -45,9 +48,9 @@ OpenYida CLI 已支持发布 `YidaCodeCanvas` 页面：把 Code Canvas 源码写
 > 🔌 在 `YidaComp` 内自写 HTTP 桥读写宜搭数据（连接器代理 / 同源 fetch / 可复用 hook）→ [references/data-bridge-guide.md](references/data-bridge-guide.md)
 > 🎨 主色跟随 App 品牌：antd `ConfigProvider.colorPrimary` / Tailwind CSS 变量 / 图表配色的落地写法 → [references/canvas-design-system.md](references/canvas-design-system.md)
 
-## 视觉方向：先定方向，再写代码
+## 视觉方向：按需定方向
 
-写页面前先定视觉方向，避免首次就生成「默认蓝 + 大圆角 + emoji」的 AI 味套版。视觉决策是**栈无关**的，与 native 链路共用决策层技能 `yida-page-uiux`：需要视觉方向时调用 `use_skill("yida-page-uiux", "确定 Code Canvas 页面的视觉方向")`，按页面类型（工作台/仪表盘/列表/详情）做 5 维差异化、走去 AI 味清单、严禁 emoji。
+单点页面美化、用户明确要求好看/去 AI 味，或 `yida-app` 进入 `deep_design` 时，再调用 `use_skill("yida-page-uiux", "确定 Code Canvas 页面的视觉方向")`。`yida-app fast_build` 默认不加载 `yida-page-uiux`：直接使用克制的 MVP 工作台/列表/入口布局，禁 emoji、少装饰、主色跟随 App 品牌即可。
 
 Canvas 这套栈（React18 + antd + Tailwind）怎么把「主色跟随 App 品牌」落地由 [references/canvas-design-system.md](references/canvas-design-system.md) 负责。一句话记忆：**CSS 变量 `var(--color-brand1-*)` 对普通 DOM / Tailwind 直接可用（Canvas 跑在真 window、节点在宿主树内会级联）；antd token 和图表颜色是 JS 消费，需用 `getComputedStyle` 把品牌色解析成真实色值再喂进去。** 语义色（成功/警告/错误）保持固定，不随主题变。
 
@@ -100,7 +103,7 @@ openyida get-schema <appType> <formUuid>
 | 发布 Canvas 页（`.canvas.jsx` → `openyida publish` 自动走 Canvas 链路） | 本技能开发流程 step 4 |
 | 编译并发布 native `.oyd.jsx`/`.jsx` 页面 | `yida-publish-page` |
 | 创建空白自定义页面 | `yida-create-page` |
-| 通过数据源调用连接器 | `yida-data-source-connectors` |
+| 用户明确要求通过设计器数据源调用连接器 | `yida-data-source-connectors`；`fast_build` 不默认加载 |
 | 创建或管理 HTTP 连接器 | `yida-connector` |
 | 配表单字段结构，如真正的 EmployeeField 字段 | `yida-create-form-page` |
 

--- a/yida-skills/skills/yida-create-app/SKILL.md
+++ b/yida-skills/skills/yida-create-app/SKILL.md
@@ -8,7 +8,7 @@ description: 创建宜搭应用，返回 appType。搭建应用的第一步。�
 ## 严格禁止 (NEVER DO)
 - 不要编造 appType，必须从命令返回的 JSON 中提取
 - 不要在未确认 corpId 的情况下创建应用（先运行 `openyida env` 确认登录态）
-- 不要重复创建同名应用，先询问用户是否已有应用
+- 不要在同一轮已成功创建应用后重复创建。若接口明确返回名称冲突，单点任务先询问用户；`yida-app fast_build` 可追加短后缀重试一次，不要为了查重额外探测。
 
 ## 严格要求 (MUST DO)
 
@@ -20,7 +20,7 @@ description: 创建宜搭应用，返回 appType。搭建应用的第一步。�
 
 用户说"创建应用"、"新建系统"、"搭建平台"时使用此技能。
 创建应用后，通常需要继续执行：创建表单（`yida-create-form-page`）→ 创建页面（`yida-create-page`）→ 发布页面（`yida-publish-page`）。
-后续如果需要自定义页面，默认走 OpenYida 页面源码链路：源码写到 `project/pages/src/<页面名>.oyd.jsx`，先 `openyida check-page` / `openyida compile`，再 `openyida publish`。不要回到旧的普通 `.jsx` 直发链路。
+后续如果需要自定义页面，默认走 native 兼容链路：源码写到 `project/pages/src/<页面名>.oyd.jsx`，先 `openyida check-page` / `openyida compile`，再 `openyida publish`。Code Canvas 尚未全量，只有用户明确要求或已确认当前组织/页面支持时才走 `.canvas.jsx` 链路。
 
 ---
 

--- a/yida-skills/skills/yida-create-page/SKILL.md
+++ b/yida-skills/skills/yida-create-page/SKILL.md
@@ -11,9 +11,9 @@ description: 在宜搭应用中创建自定义展示页面（display 类型）�
 
 ## 严格要求 (MUST DO)
 
-- **创建前必须确认**：执行创建命令前，必须向用户确认页面名称和目标应用，获得用户明确同意后再执行
+- **创建前必须确认**：单点创建页面时，执行创建命令前必须向用户确认页面名称和目标应用。由 `yida-app fast_build` 编排且用户已说“默认方案 / 不要追问 / 直接创建”时，合理命名并直接创建，不再二次追问。
 - 创建成功后，将 formUuid 记录到 `.cache/<项目名>-schema.json`
-- 创建页面后，必须继续执行 `yida-custom-page` 编写 JSX 代码，再用 `yida-publish-page` 发布
+- 创建页面后，必须继续执行 `yida-custom-page`（默认兼容链路）或 `yida-canvas-custom-page`（用户明确要求或已确认支持 Canvas 时）编写 JSX 代码，再用 `yida-publish-page` 发布
 - **本技能不读写 memory**：formUuid 等信息输出到 stdout，通过 `.cache/<项目名>-schema.json` 持久化，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -52,7 +52,7 @@ openyida create-page <appType> <pageName> [--mode dashboard]
 {"success":true,"pageId":"FORM-XXX","pageName":"驾驶舱","appType":"APP_XXX","mode":"dashboard","chromeless":true,"url":"{base_url}/APP_XXX/custom/FORM-XXX?isRenderNav=false","workbenchUrl":"{base_url}/APP_XXX/workbench/FORM-XXX"}
 ```
 
-> 创建后使用 `yida-custom-page` 编写 JSX 代码，再用 `openyida publish` 发布。
+> 创建后默认使用 `yida-custom-page` 编写 `.oyd.jsx` 代码，并通过 `openyida check-page` / `openyida compile` / `openyida publish` 发布；Code Canvas 仅在用户明确要求或已确认支持时使用。
 > 如需创建表单页面（带字段的数据收集页），请使用 `yida-create-form-page`。
 
 ## 异常处理

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: yida-custom-page
-description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原生 export function renderJsx 模式、宜搭 JS API、状态管理与编码约束）。是**回退链路**：仅当页面强依赖原生实例数据桥（this.$(fieldId) 表单字段双向绑定、this.utils.yida.*、dataSourceMap、提交流程深度耦合）时才用；纯展示无刷新页也可用。其余自定义页面（含只需开放 API HTTP 读数据的页）默认走 yida-canvas-custom-page。
+description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原生 export function renderJsx 模式、宜搭 JS API、状态管理与编码约束）。这是默认兼容链路，适合完整应用 fast_build、未确认 Code Canvas 能力的组织，以及强依赖 this.$(fieldId)、this.utils.yida.*、dataSourceMap 的页面。
 ---
 
 # 自定义页面开发
 
-> **先确认链路**：自定义页面**默认走 Code Canvas** `yida-canvas-custom-page`（现代 React 交互 / hooks / 可视化 / AI / 需崩溃隔离，含只需开放 API HTTP 读数据的页）。本 native 技能是**回退链路**，只处理：① 强依赖原生实例数据桥——表单内字段双向绑定 `this.$(fieldId)`、`this.utils.yida.*`、`dataSourceMap`、提交流程深度耦合——的页面（Canvas 无 `this` 桥，重写代价过高时留 native）；② 纯展示、无运行态刷新页。把已有 native 页升级到 Canvas 走 `yida-canvas-upgrade`。
+> **先确认链路**：Code Canvas 在宜搭平台侧尚未全量。自定义页面默认走 native 兼容链路 `yida-custom-page`（`.oyd.jsx` + `check-page` / `compile` / `publish`）。只有用户明确要求 Code Canvas / 代码画布，已有页面 Schema 是 `YidaCodeCanvas`，或已确认当前组织/页面支持 Canvas 时，才切到 `yida-canvas-custom-page`；把已有 native 页升级到 Canvas 走 `yida-canvas-upgrade`。
 
 ## 核心规则
 
@@ -32,7 +32,7 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 
 影响代码质量和用户体验：
 
-0. **写 UI 前先定视觉方向**：面向用户的页面在动手写 JSX 前，调用 `use_skill("yida-page-uiux", "确定自定义页面视觉方向")` 完成「视觉方向决策」（页面类型判定 + 差异化 + 去 AI 味自检），拿到「视觉方向决策块」后再按本技能 `references/design-system.md` 的 token/组件实现；不要直接套用统一灰白底 + 8px 圆角卡片网格的默认模板（那正是 AI 味来源）。
+0. **视觉方向按需加载**：单点页面美化、用户明确要求好看/去 AI 味，或 `yida-app` 进入 `deep_design` 时，调用 `use_skill("yida-page-uiux", "确定自定义页面视觉方向")` 完成「视觉方向决策」。`yida-app fast_build` 默认不加载该技能，直接使用克制的 MVP 工作台/列表/入口布局，禁 emoji、少装饰、主色跟随 App 品牌即可。
 1. **代码生成前确认功能摘要**：详见 [编码指南 编注 0](references/coding-guide.md)
 2. **pageSize 推荐 50，最大 100**：列表/看板默认 `pageSize: 50`；分页接口 `searchFormDatas` 等的 `pageSize` 最大 100
 3. **didUnmount 清理定时器**：在 `didUnmount` 中清理所有 `setInterval`/`setTimeout`，防止内存泄漏
@@ -59,7 +59,7 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 | 层 | 默认内容 | 生成要求 |
 | --- | --- | --- |
 | 状态层 | `loading`、`list/tableData`、`currentPage`、`pageSize`、`totalCount`、`filters/searchFieldJson`、`selectedRowKeys`、`dialogVisible` | 放入 `_customState`，所有失败路径必须恢复 `loading: false` |
-| 数据源层 | 表单查询、保存、更新、删除、流程发起、任务列表、连接器动作 | 优先调用已有 `this.dataSourceMap.<name>.load()`；没有数据源且是宜搭内置数据时用 `this.utils.yida.*`；第三方/连接器必须先走 `yida-data-source-connectors` |
+| 数据源层 | 表单查询、保存、更新、删除、流程发起、任务列表、连接器动作 | 优先调用已有 `this.dataSourceMap.<name>.load()`；没有数据源且是宜搭内置数据时用 `this.utils.yida.*`；第三方/连接器且用户明确要求设计器数据源时才走 `yida-data-source-connectors`，`fast_build` 不默认加载 |
 | 交互层 | 筛选栏、表格/卡片列表、分页、弹窗、Tab/Collapse、操作按钮 | `renderJsx` 只负责展示和事件分发，业务逻辑拆成 `export function` |
 
 默认页面结构按官方高频组件范式转译为 JSX：顶部筛选/操作区、主体表格或卡片列表、分页、详情/编辑弹窗、空态/错误态。不要把数据查询、复杂计算和大段 DOM 混在一个 `renderJsx` 里。
@@ -176,7 +176,7 @@ openyida check-page pages/src/home.oyd.jsx --json      # 输出机器可读的�
 | 文档 | 覆盖范围 | 何时阅读 |
 |------|---------|---------|
 | **本技能文档** | | |
-| `yida-page-uiux` 子技能 | 页面类型 playbook、5 维差异化引擎、去 AI 味黑名单/8 问自检、图标策略 | 实现面向用户的 UI 且要求好看/去 AI 味时，调用 `use_skill("yida-page-uiux", "确定自定义页面视觉方向")` 并产出决策块 |
+| `yida-page-uiux` 子技能 | 页面类型 playbook、5 维差异化引擎、去 AI 味黑名单/8 问自检、图标策略 | 用户明确要求好看/去 AI 味或 `deep_design` 时加载；`fast_build` 不默认加载 |
 | [编码指南](references/coding-guide.md) | 文件结构模板、状态管理、生命周期、19 条编码规范 | 编写任何页面代码前必读 |
 | [运行时护栏](references/runtime-guardrails.md) | pageSize、loading 恢复、ECharts DOM 时序、setState 约束、check-page 规则映射 | 编写列表、看板、图表或接口页面前必读 |
 | [设计规范](references/design-system.md) | 色彩/圆角/字体/间距系统、7 类组件样式模板、8 条反模式 | 实现 UI 样式时必读 |


### PR DESCRIPTION
## Summary
- add machine-readable command summaries and default full-app fast_build workflow to commands/agent-capabilities JSON
- tighten yida-app fast_build so default builds stop at published URL and keep UIUX, Canvas, data sources, sample data, nav, screenshots as optional
- keep custom page fast_build compatible by defaulting to native yida-custom-page; Canvas is opt-in/confirmed-support only
- add routing and smoke assertions for the visitor-system default-build regression

## Validation
- npm run check:skills
- npm run build:skills -- --no-zip
- npm test -- --runInBand tests/eval-routing.test.js
- npm test -- --runInBand tests/cli-smoke.test.js
- npm test -- --runInBand tests/build-skills-package.test.js
- node scripts/validate-command-manifest.js