### PR TITLE
fix: tighten OpenYida fast_build skill contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida create-form add-option <appType> <formUuid> <fieldLabel> <option1> [option2] ...` | Update a form page |
 | `openyida list-forms <appType> [--keyword <text>]` | List forms/pages in an app |
 | `openyida aggregate-table <list\|create-empty\|inspect\|preview\|save\|publish\|status> <appType> ...` | Manage aggregate tables (virtualView) |
-| `openyida get-schema <appType> <formUuid\|--all>` | Get one form Schema or all form Schemas |
+| `openyida get-schema <appType> <formUuid\|--all> [--summary-json\|--field-map-json]` | Get one form Schema or all form Schemas |
 | `openyida er <appType> [--format mermaid\|json] [--output file] [--include-system] [--include-pages]` | Export app entity relationship diagram |
 | `openyida create-page <appType> "<name>" [--mode dashboard] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a custom display page |
 | `openyida generate-page <template>` | Generate page from curated template |

--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -2,8 +2,8 @@
  * get-schema.js - 宜搭表单 Schema 获取命令
  *
  * 用法：
- *   openyida get-schema <appType> <formUuid>
- *   openyida get-schema <appType> --all [--output-dir <dir>] [--concurrency N] [--retries N]
+ *   openyida get-schema <appType> <formUuid> [--summary-json|--field-map-json]
+ *   openyida get-schema <appType> --all [--summary-json] [--output-dir <dir>] [--concurrency N] [--retries N]
  */
 
 'use strict';
@@ -31,7 +31,7 @@ const FIELD_TYPES_NEEDING_VALUE_SUFFIX = new Set([
 /**
  * 从 Schema 中提取字段摘要，列出每个字段的真实 fieldId、组件别名和报表用 reportFieldCode。
  * @param {object} schemaResult - getFormSchema API 返回结果
- * @returns {Array<{label, componentName, fieldId, alias, reportFieldCode}>}
+ * @returns {Array<{label, componentName, fieldId, alias, reportFieldCode, options}>}
  */
 function extractFieldSummary(schemaResult) {
   const fields = [];
@@ -62,12 +62,17 @@ function extractFieldSummary(schemaResult) {
         ? `${fieldId}_value`
         : fieldId;
       if (fieldId) {
+        const options = extractOptionSummary(props);
+        const optionSource = getOptionSource(props) || [];
         fields.push({
           label,
           componentName: node.componentName,
           fieldId,
           alias: aliasMaps.aliasByFieldId[fieldId] || '',
           reportFieldCode,
+          options,
+          optionCount: optionSource.length,
+          optionsTruncated: optionSource.length > options.length,
         });
       }
     }
@@ -85,6 +90,70 @@ function extractFieldSummary(schemaResult) {
   }
 
   return fields;
+}
+
+function normalizeOptionLabel(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'object') {
+    return value.zh_CN || value.zh_HK || value.en_US || value.ja_JP || value.text || value.label || value.value || '';
+  }
+  return String(value);
+}
+
+function firstPresent(values) {
+  return values.find(value => value !== undefined && value !== null);
+}
+
+function normalizeOptionValue(value, fallback) {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  if (typeof value === 'object') {
+    return value.value || value.label || value.text || fallback;
+  }
+  return String(value);
+}
+
+function optionArrayFromDataSource(dataSource) {
+  if (!dataSource) {
+    return null;
+  }
+  if (Array.isArray(dataSource)) {
+    return dataSource;
+  }
+  const candidates = [
+    dataSource.options,
+    dataSource.data,
+    dataSource.list,
+    dataSource.values,
+  ];
+  return candidates.find(Array.isArray) || null;
+}
+
+function getOptionSource(props = {}) {
+  return Array.isArray(props.options)
+    ? props.options
+    : optionArrayFromDataSource(props.dataSource);
+}
+
+function extractOptionSummary(props = {}) {
+  const source = getOptionSource(props);
+  if (!source) {
+    return [];
+  }
+  return source.slice(0, 50).map((item, index) => {
+    if (typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean') {
+      const text = String(item);
+      return { label: text, value: text };
+    }
+    const label = normalizeOptionLabel(firstPresent([item.label, item.text, item.name, item.title, item.value]));
+    return {
+      label,
+      value: normalizeOptionValue(firstPresent([item.value, item.key, item.id]), label || String(index)),
+    };
+  });
 }
 
 function buildComponentAliasMaps(schemaResult) {
@@ -136,6 +205,7 @@ function parseArgs(args) {
     // 仅返回目标字段的 {componentName, fieldId, label, props}
     field: '',
     json: false,
+    summaryJson: false,
   };
 
   for (let index = 1; index < args.length; index++) {
@@ -159,6 +229,8 @@ function parseArgs(args) {
       index++;
     } else if (arg === '--json') {
       parsed.json = true;
+    } else if (arg === '--summary-json' || arg === '--field-map-json') {
+      parsed.summaryJson = true;
     } else if (!arg.startsWith('--') && !parsed.formUuid) {
       parsed.formUuid = arg;
     }
@@ -303,6 +375,18 @@ function printFieldSummary(result) {
   process.stderr.write(`  ${c.dim}注：SelectField/EmployeeField 在报表中需加 _value 后缀${c.reset}\n\n`);
 }
 
+function buildSchemaSummary(appType, formUuid, schemaResult, meta = {}) {
+  const fields = extractFieldSummary(schemaResult);
+  return {
+    success: true,
+    appType,
+    formUuid,
+    ...meta,
+    fieldCount: fields.length,
+    fields,
+  };
+}
+
 function filterForms(forms, keyword) {
   if (!keyword) {
     return forms;
@@ -373,9 +457,19 @@ async function fetchSchemaRecord(appType, form, authRef, retries) {
   };
 }
 
-function writeBatchOutput(outputDir, records) {
+function summarizeRecord(record) {
+  if (!record.success) {
+    return record;
+  }
+  const { schema, ...summary } = record;
+  void schema;
+  return summary;
+}
+
+function writeBatchOutput(outputDir, records, options = {}) {
+  const compact = !!options.compact;
   if (!outputDir) {
-    return records;
+    return compact ? records.map(summarizeRecord) : records;
   }
 
   const resolvedDir = path.resolve(outputDir);
@@ -391,10 +485,8 @@ function writeBatchOutput(outputDir, records) {
     const filePath = path.join(resolvedDir, fileName);
     fs.writeFileSync(filePath, JSON.stringify(record.schema, null, 2), 'utf-8');
 
-    const { schema, ...summary } = record;
-    void schema;
     return {
-      ...summary,
+      ...summarizeRecord(record),
       schemaFile: filePath,
     };
   });
@@ -452,6 +544,11 @@ async function runSingle(parsed, authRef) {
     return;
   }
 
+  if (parsed.summaryJson) {
+    console.log(JSON.stringify(buildSchemaSummary(parsed.appType, parsed.formUuid, result), null, 2));
+    return;
+  }
+
   chalkSuccess(t('get_schema.success'));
   printFieldSummary(result);
   console.log(JSON.stringify(result, null, 2));
@@ -494,7 +591,7 @@ async function runBatch(parsed, authRef) {
     return record;
   });
 
-  const outputRecords = writeBatchOutput(parsed.outputDir, records);
+  const outputRecords = writeBatchOutput(parsed.outputDir, records, { compact: parsed.summaryJson });
   const successCount = records.filter(record => record.success).length;
   const failedCount = records.length - successCount;
 
@@ -509,6 +606,7 @@ async function runBatch(parsed, authRef) {
     total: records.length,
     successCount,
     failedCount,
+    summaryOnly: parsed.summaryJson || undefined,
     outputDir: parsed.outputDir ? path.resolve(parsed.outputDir) : undefined,
     forms: outputRecords,
   }, null, 2));
@@ -527,6 +625,8 @@ async function run(args) {
 
 module.exports = {
   extractFieldSummary,
+  extractOptionSummary,
+  buildSchemaSummary,
   buildComponentAliasMaps,
   parseArgs,
   filterForms,

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -63,6 +63,7 @@ function buildAgentCapabilities() {
       completion_contracts: {
         full_app: 'Default fast_build is complete after creating the app, core forms, primary page, publishing it, and returning an access URL.',
       },
+      fast_build_data_contract: 'Default fast_build page code must not call this.dataSourceMap.* unless the same run created and bound a designer data source; use this.utils.yida.* or an entry-only page by default.',
     },
     command_manifest: {
       schema_version: manifest.schema_version,

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -407,7 +407,7 @@ const COMMAND_GROUPS = [
       command('aggregate-table', ['aggregate-table'], 'aggregate-table <list|create-empty|inspect|preview|save|publish|status> <appType> ...', 'help.cmd_aggregate_table', {
         output: 'json',
       }),
-      command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all>', 'help.cmd_get_schema'),
+      command('get-schema', ['get-schema'], 'get-schema <appType> <formUuid|--all> [--summary-json|--field-map-json]', 'help.cmd_get_schema'),
       command('er', ['er'], 'er <appType> [--format mermaid|json] [--output file] [--include-system] [--include-pages]', 'help.cmd_er', {
         output: 'text|json',
       }),
@@ -643,6 +643,11 @@ function summarizeLocalizedCommands(commands) {
           'publish',
         ],
         optional_read_command_ids: ['get-schema', 'list-forms'],
+        recommended_read_commands: [
+          'openyida get-schema <appType> <formUuid> --summary-json',
+          'openyida get-schema <appType> --all --summary-json --keyword <text> --output-dir .cache/openyida/<task>/schemas',
+        ],
+        default_data_contract: 'Do not use this.dataSourceMap.* in fast_build page code unless a designer data source was created and bound in the same run; use this.utils.yida.* or an entry-only page by default.',
         optional_after_done_command_ids: [
           'nav-group',
           'data',

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -257,11 +257,13 @@ openyida copy
 
 \`fast_build\` 只做：创建应用 → 核心表单 → 主页面 → 编写主页面源码 → 发布 → 返回访问链接。发布主页面成功并输出 URL 后即完成。
 
+fast_build 页面源码默认不得使用 \`this.dataSourceMap.*\`，除非本轮已经明确创建并绑定设计器数据源；默认使用入口型页面或 \`this.utils.yida.*\` 查询已创建表单。
+
 不要默认加载 \`yida-page-uiux\`、\`yida-data-source-connectors\`、\`yida-data-management\`、\`yida-nav-group\`、\`yida-dashboard\`，也不要默认做示例数据、导航整理、截图验收、公开访问、长 PRD 或深读 references；这些只在用户明确要求或 \`full_demo\` / \`deep_design\` 时执行。
 
 ## 子技能索引
 
-根据用户意图选择最匹配的子技能。支持 \`use_skill\` / \`search_skills\` 的宿主中，必须调用 \`use_skill("<技能名>", "<本次目的>")\` 加载子技能；不要用 Read / read_file / cat 读取 SKILL.md 路径。\`skills-index.json\` 仅供 yida-agent 或同构宿主机器发现，不支持该索引的宿主忽略它。完全没有 \`use_skill\` 的本地工具，才允许按根技能路由表选定技能，并按 \`skills/<技能名>/SKILL.md\` 定位当前阶段唯一必要的 SKILL.md，禁止并发批量读取多个 SKILL.md。
+根据用户意图选择最匹配的子技能。支持 \`use_skill\` / \`search_skills\` 的宿主中，必须调用 \`use_skill("<技能名>", "<本次目的>")\` 加载子技能；不要用 Read / read_file / cat 读取 SKILL.md 路径，也不要猜测 .skills、插件缓存或 workspace/project/.skills。\`skills-index.json\` 仅供 yida-agent 或同构宿主机器发现，不支持该索引的宿主忽略它。完全没有 \`use_skill\` 的本地工具，才允许按根技能路由表选定技能，并按 \`skills/<技能名>/SKILL.md\` 定位当前阶段唯一必要的 SKILL.md，禁止并发批量读取多个 SKILL.md。
 
 | 意图 | 子技能 |
 | --- | --- |

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -202,6 +202,10 @@ describe('CLI offline smoke', () => {
         'yida-data-management',
         'yida-nav-group',
       ]),
+      recommended_read_commands: expect.arrayContaining([
+        expect.stringContaining('--summary-json'),
+      ]),
+      default_data_contract: expect.stringContaining('this.dataSourceMap'),
     });
     expect(commands).toContain('env');
     expect(commands).toContain('login');
@@ -351,6 +355,10 @@ describe('CLI offline smoke', () => {
         'yida-data-management',
         'yida-nav-group',
       ]),
+      recommended_read_commands: expect.arrayContaining([
+        expect.stringContaining('--summary-json'),
+      ]),
+      default_data_contract: expect.stringContaining('this.dataSourceMap'),
     });
     expect(parsed.recommended.default_full_app_workflow).toMatchObject({
       mode: 'fast_build',
@@ -368,6 +376,7 @@ describe('CLI offline smoke', () => {
     expect(parsed.login).not.toHaveProperty('csrf_token');
     expect(parsed.sideEffects.read_only_preflight).toContain('openyida agent-capabilities --json');
     expect(parsed.sideEffects.completion_contracts.full_app).toContain('creating the app');
+    expect(parsed.sideEffects.fast_build_data_contract).toContain('this.dataSourceMap');
     const commandIds = parsed.command_manifest.commands.map(entry => entry.id);
     const commandById = Object.fromEntries(parsed.command_manifest.commands.map(entry => [entry.id, entry]));
     expect(commandIds).toContain('agent-capabilities');

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -20,6 +20,8 @@ const utils = require('../lib/core/utils');
 const { fetchFormPageList } = require('../lib/app/form-navigation');
 const {
   extractFieldSummary,
+  extractOptionSummary,
+  buildSchemaSummary,
   buildComponentAliasMaps,
   parseArgs,
   filterForms,
@@ -63,11 +65,22 @@ describe('parseArgs', () => {
       keyword: '客户',
       field: '',
       json: false,
+      summaryJson: false,
     });
   });
 
   test('keeps existing single form mode', () => {
     expect(parseArgs(['APP_XXX', 'FORM-AAA']).formUuid).toBe('FORM-AAA');
+  });
+
+  test('parses compact field-map aliases', () => {
+    expect(parseArgs(['APP_XXX', 'FORM-AAA', '--summary-json'])).toMatchObject({
+      appType: 'APP_XXX',
+      formUuid: 'FORM-AAA',
+      summaryJson: true,
+    });
+    expect(parseArgs(['APP_XXX', 'FORM-AAA', '--field-map-json']).summaryJson).toBe(true);
+    expect(parseArgs(['APP_XXX', 'FORM-AAA', '--field-map']).summaryJson).toBe(false);
   });
 });
 
@@ -95,7 +108,16 @@ describe('extractFieldSummary', () => {
                     children: [
                       {
                         componentName: 'SelectField',
-                        props: { fieldId: 'selectField_status', label: { en_US: 'Status' } },
+                        props: {
+                          fieldId: 'selectField_status',
+                          label: { en_US: 'Status' },
+                          dataSource: {
+                            options: [
+                              { label: { zh_CN: '待访' }, value: 'pending' },
+                              { text: '已离开', value: 'left' },
+                            ],
+                          },
+                        },
                       },
                     ],
                   },
@@ -114,6 +136,9 @@ describe('extractFieldSummary', () => {
         fieldId: 'textField_name',
         alias: 'customerName',
         reportFieldCode: 'textField_name',
+        options: [],
+        optionCount: 0,
+        optionsTruncated: false,
       },
       {
         label: 'Status',
@@ -121,8 +146,52 @@ describe('extractFieldSummary', () => {
         fieldId: 'selectField_status',
         alias: '',
         reportFieldCode: 'selectField_status_value',
+        options: [
+          { label: '待访', value: 'pending' },
+          { label: '已离开', value: 'left' },
+        ],
+        optionCount: 2,
+        optionsTruncated: false,
       },
     ]);
+  });
+
+  test('extracts lightweight options from static props', () => {
+    expect(extractOptionSummary({
+      options: ['待访', { label: '已离开', value: 'left' }, { label: 0, value: 0 }, { label: false, value: false }],
+    })).toEqual([
+      { label: '待访', value: '待访' },
+      { label: '已离开', value: 'left' },
+      { label: '0', value: '0' },
+      { label: 'false', value: 'false' },
+    ]);
+  });
+
+  test('marks option summaries as truncated when option count exceeds compact limit', () => {
+    const options = Array.from({ length: 55 }, (_, index) => ({ label: `选项${index}`, value: index }));
+    const [field] = extractFieldSummary({
+      content: {
+        pages: [
+          {
+            componentsTree: [
+              {
+                componentName: 'FormContainer',
+                children: [
+                  {
+                    componentName: 'SelectField',
+                    props: { fieldId: 'selectField_many', label: '大量选项', options },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(field.options).toHaveLength(50);
+    expect(field.optionCount).toBe(55);
+    expect(field.optionsTruncated).toBe(true);
   });
 
   test('builds alias maps and finds fields by alias', () => {
@@ -157,6 +226,43 @@ describe('extractFieldSummary', () => {
     expect(aliasMaps.aliasByFieldId.textField_name).toBe('customerName');
     expect(aliasMaps.fieldIdByAlias.customerName).toBe('textField_name');
     expect(findFieldNode(nodes, 'customerName', aliasMaps.aliasByFieldId).props.fieldId).toBe('textField_name');
+  });
+});
+
+describe('buildSchemaSummary', () => {
+  test('builds compact field map without full schema pages', () => {
+    const summary = buildSchemaSummary('APP_XXX', 'FORM-A', {
+      content: {
+        pages: [
+          {
+            componentsTree: [
+              {
+                componentName: 'FormContainer',
+                children: [
+                  {
+                    componentName: 'TextField',
+                    props: { fieldId: 'textField_name', label: '姓名' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(summary).toMatchObject({
+      success: true,
+      appType: 'APP_XXX',
+      formUuid: 'FORM-A',
+      fieldCount: 1,
+    });
+    expect(summary.fields[0]).toMatchObject({
+      label: '姓名',
+      fieldId: 'textField_name',
+    });
+    expect(summary).not.toHaveProperty('content');
+    expect(summary).not.toHaveProperty('pages');
   });
 });
 
@@ -218,6 +324,47 @@ describe('run --all', () => {
     const output = JSON.parse(mockLog.mock.calls[mockLog.mock.calls.length - 1][0]);
     expect(output.successCount).toBe(1);
     expect(output.outputDir).toBe(outputDir);
+    mockLog.mockRestore();
+  });
+
+  test('summary-json keeps batch stdout and index compact', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-schemas-compact-'));
+    fetchFormPageList.mockResolvedValue([
+      { formUuid: 'FORM-A', formName: '客户信息', formType: 'form', pathName: 'customer' },
+    ]);
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: {
+        pages: [
+          {
+            componentsTree: [
+              {
+                componentName: 'FormContainer',
+                children: [
+                  {
+                    componentName: 'TextField',
+                    props: { fieldId: 'textField_name', label: '姓名' },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['APP_XXX', '--all', '--summary-json', '--output-dir', outputDir]);
+
+    const index = JSON.parse(fs.readFileSync(path.join(outputDir, 'index.json'), 'utf-8'));
+    expect(index[0]).toHaveProperty('fieldSummary');
+    expect(index[0]).toHaveProperty('schemaFile');
+    expect(index[0]).not.toHaveProperty('schema');
+
+    const output = JSON.parse(mockLog.mock.calls[mockLog.mock.calls.length - 1][0]);
+    expect(output.summaryOnly).toBe(true);
+    expect(output.forms[0]).toHaveProperty('fieldSummary');
+    expect(output.forms[0]).not.toHaveProperty('schema');
     mockLog.mockRestore();
   });
 });

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+function readSkill(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+describe('OpenYida skill contracts', () => {
+  test('yida-app fast_build forbids unbound dataSourceMap by default', () => {
+    const skill = readSkill('yida-skills/skills/yida-app/SKILL.md');
+
+    expect(skill).toContain('默认页面源码不得使用 `this.dataSourceMap.*`');
+    expect(skill).toContain('`this.utils.yida.searchFormDatas`');
+    expect(skill).toContain('发布输出出现 `No custom page data sources to preserve`');
+    expect(skill).toContain('`yida-data-source-connectors`');
+  });
+
+  test('yida-custom-page fast_build uses compact native defaults and reads references on demand', () => {
+    const skill = readSkill('yida-skills/skills/yida-custom-page/SKILL.md');
+
+    expect(skill).toContain('`fast_build` 默认不得生成依赖 dataSourceMap 的代码');
+    expect(skill).toContain('不得在 fast_build 里写 `this.dataSourceMap.<name>.load()`');
+    expect(skill).toContain('## Available Files');
+    expect(skill).toContain('check-page 报错、复杂交互、状态管理问题、`deep_design`');
+    expect(skill).not.toContain('编写页面代码前**必须完整阅读**');
+    expect(skill).not.toContain('编写任何页面代码前必读');
+  });
+
+  test('yida-get-schema documents compact field-map first', () => {
+    const skill = readSkill('yida-skills/skills/yida-get-schema/SKILL.md');
+
+    expect(skill).toContain('openyida get-schema <appType> <formUuid> [--summary-json|--field-map-json]');
+    expect(skill).toContain('页面开发默认使用 compact 输出');
+    expect(skill).toContain('不内联完整 Schema');
+  });
+
+  test('yida-publish-page treats missing preserved data sources as incomplete when code uses dataSourceMap', () => {
+    const skill = readSkill('yida-skills/skills/yida-publish-page/SKILL.md');
+
+    expect(skill).toContain('源码包含 `this.dataSourceMap.`');
+    expect(skill).toContain('`No custom page data sources to preserve`');
+    expect(skill).toContain('本次发布不能视为完成');
+  });
+});

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -16,8 +16,9 @@ description: >
 
 - 如果当前宿主提供 `use_skill` / `search_skills`：必须通过 `use_skill("<技能名>", "<本阶段目的>")` 加载主技能和子技能，禁止用 `Read` / `read_file` / `cat` 读取 `SKILL.md` 路径；`use_skill` 会稳定返回技能内容和可读取的辅助文件列表。
 - `skills-index.json` 仅供 yida-agent 或同构宿主做机器可读发现；不支持该索引的宿主忽略它，不要把它当作运行前置条件。
+- 支持 `use_skill` / `search_skills` 的宿主只能读取该工具返回的辅助文件；禁止猜测 `.skills`、`skills`、`yida-skills`、插件缓存、workspace/project/.skills 等安装路径。
 - 如果当前宿主没有 `use_skill` / `search_skills`：按本文的技能路由表选定技能名，按 `skills/<技能名>/SKILL.md` 定位当前阶段唯一必要的子技能文档；禁止并发批量读取多个 `SKILL.md`；禁止预读未来阶段技能。
-- `references/`、`scripts/`、`assets/` 等辅助文件只能在已加载对应技能后按需读取。
+- `references/`、`scripts/`、`assets/` 等辅助文件只能在已加载对应技能后，读取该技能正文明确列出的相对路径；不要把 yida-agent 的 sandbox 路径当作通用路径。
 
 ---
 

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -34,7 +34,7 @@
       "name": "yida-app",
       "path": "skills/yida-app/SKILL.md",
       "display_name": "宜搭完整应用开发",
-      "description": "从零到一搭建完整宜搭应用的流程编排技能。默认 fast_build 只创建应用、必要表单、主页面、发布并输出链接；导航、示例数据和深度设计按需后置。",
+      "description": "从零到一搭建完整宜搭应用的流程编排技能。默认 fast_build 只创建应用、必要表单、主页面、发布并输出链接；不默认使用未绑定 dataSourceMap，导航、示例数据和深度设计按需后置。",
       "category": "yida/app",
       "tags": ["宜搭", "完整应用", "搭建", "管理系统", "访客系统"],
       "aliases": ["完整应用", "应用搭建", "管理系统搭建"]
@@ -169,9 +169,9 @@
       "name": "yida-custom-page",
       "path": "skills/yida-custom-page/SKILL.md",
       "display_name": "Native 自定义页面 JSX 开发",
-      "description": "宜搭 native 自定义页面 React 16 / JSX 开发规范，默认兼容链路，适合完整应用 fast_build 和未确认 Code Canvas 能力的组织。",
+      "description": "宜搭 native 自定义页面 React 16 / JSX 开发规范，默认兼容链路；fast_build 默认使用 this.utils.yida.* 或入口型页面，只有已绑定设计器数据源时才用 dataSourceMap。",
       "category": "yida/page",
-      "tags": ["JSX", "自定义页面", "React 16", "页面代码"],
+      "tags": ["JSX", "自定义页面", "React 16", "页面代码", "fast_build"],
       "aliases": ["页面开发", "native 页面"]
     },
     {
@@ -277,7 +277,7 @@
       "name": "yida-get-schema",
       "path": "skills/yida-get-schema/SKILL.md",
       "display_name": "获取表单 Schema",
-      "description": "获取表单完整 Schema 结构，用于确认 fieldId 和组件配置。",
+      "description": "获取表单 Schema 或 compact 字段映射；页面开发优先用 --summary-json / --field-map-json 确认 fieldId。",
       "category": "yida/schema",
       "tags": ["Schema", "fieldId", "formUuid", "字段定义"],
       "aliases": ["查字段ID"]
@@ -394,7 +394,7 @@
       "name": "yida-publish-page",
       "path": "skills/yida-publish-page/SKILL.md",
       "display_name": "发布自定义页面",
-      "description": "将自定义页面源码编译为宜搭可运行 Schema，并发布到目标 formUuid。",
+      "description": "将自定义页面源码编译为宜搭可运行 Schema 并发布；源码依赖 dataSourceMap 但发布无数据源时不能视为完成。",
       "category": "yida/page",
       "tags": ["发布", "publish", "compile", "check-page"],
       "aliases": ["页面发布"]

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -43,6 +43,13 @@ description: 宜搭完整应用开发编排技能。从零搭建应用时使用�
 
 `fast_build` 不默认执行：`yida-page-uiux`、`yida-canvas-custom-page`（除非已确认 Canvas 支持或用户明确要求）、`yida-data-source-connectors`、`yida-data-management`、`yida-nav-group`、`yida-dashboard`、导航重排、示例数据、截图验收、公开访问配置、深度 UI 设计、长 PRD、TaskCreate / 继续规划任务，也不默认读取 `references/app-build-contract.md`。
 
+### fast_build 页面数据契约
+
+- 默认页面源码不得使用 `this.dataSourceMap.*`，除非本轮已经明确创建并绑定对应设计器数据源。
+- 默认页面只走两类可闭环方案：入口型页面（表单入口、资源链接、轻量统计占位）或内置数据 API 页面（`this.utils.yida.searchFormDatas` / `saveFormData` 等查询本轮已创建表单）。
+- 如果页面源码确实需要 `this.dataSourceMap.*`，必须先把模式升级为可选数据源链路：加载 `yida-data-source-connectors`，创建/绑定数据源，并在发布后确认页面 Schema 中存在对应数据源；否则 `fast_build` 未完成。
+- 发布输出出现 `No custom page data sources to preserve` 时，只有源码不依赖 `this.dataSourceMap.*` 才能视为正常；若源码依赖 dataSourceMap，必须改源码或补数据源后重新发布。
+
 ## full_demo 可选后置
 
 仅当用户要求，或模式明确为 `full_demo` / `deep_design` 时执行：

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -26,7 +26,7 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 11. **生命周期名称大小写固定**：只允许 `export function didMount()` 与 `export function didUnmount()`；`didmount`、`componentDidMount`、`componentWillUnmount` 会被 `check-page` 阻塞
 12. **按钮必须真的绑定事件**：禁止 `onclick` 小写属性、`onClick={self.save()}`、`onClick={(e) => self.save}`、`<button>静态标签</button>` 等看起来有按钮但不会正确绑定的写法；统一使用 `onClick={(e) => { self.save(e); }}`。如果只是状态标签/截图标记，用 `span`/`div`，不要用 `button`
 13. **业务状态禁止直接 `this.setState`**：业务态只写 `_customState`，通过 `setCustomState()` / `forceUpdate()` 触发重渲染；`this.setState` 只允许写 `timestamp` 等运行时契约字段
-14. **读状态只能用 `getCustomState()`，禁止读 `this.state.<业务字段>`**：`this.state` 里只有 `timestamp`（重渲染标记）和 `urlParams`，业务态在 `_customState`。读 `this.state.agg`、`this.state.loading` 等恒为 `undefined`，页面无报错却渲染成"数据全占位、图表全空"的空壳页，极难排查。`renderJsx`/`renderCharts` 等所有读状态处一律 `this.getCustomState()`（详见 [编码指南 · 状态管理](references/coding-guide.md)）
+14. **读状态只能用 `getCustomState()`，禁止读 `this.state.<业务字段>`**：`this.state` 里只有 `timestamp`（重渲染标记）和 `urlParams`，业务态在 `_customState`。读 `this.state.agg`、`this.state.loading` 等恒为 `undefined`，页面无报错却渲染成"数据全占位、图表全空"的空壳页，极难排查。`renderJsx`/`renderCharts` 等所有读状态处一律 `this.getCustomState()`；遇到状态同步问题时再读 [编码指南 · 状态管理](references/coding-guide.md)
 
 ### 重要规则（IMPORTANT）
 
@@ -48,9 +48,9 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 13. **严禁 emoji**：页面渲染出来的任何位置（标题、按钮、标签、状态、空态文案、图表标题等）**一律禁止出现 emoji**（😀🚀✅⚠️📦📊 等一切彩色符号字符）。需要图标一律用功能性内联 SVG（见 `skills/yida-page-uiux` 图标策略）；需要状态标记用文字 + 语义色标签。emoji 是最明显的 AI 味来源之一，且跨端显示不一致。JS 注释里也不要留装饰性符号。
 14. **发布前必须跑检查链路**：先执行 `openyida check-page <file>` 和 `openyida compile <file>`；若出现 warning/error，按规则修复后再发布
 
-> 每条规则的代码示例、反模式和常见错误见 [编码指南](references/coding-guide.md)（编写代码前强制必读）。
-> 运行时易错点、`check-page` 规则和兼容层自动修复边界见 [运行时护栏](references/runtime-guardrails.md)。
-> 表单类 JSX 控件、筛选栏、表格、成员/附件等组件写法见 [组件指南](references/component-jsx-guide.md)；未验证的平台组件能力不得编造。
+> 每条规则的代码示例、反模式和常见错误见 [编码指南](references/coding-guide.md)；`fast_build` 默认先遵守本技能正文，不预读长 reference，只有 check-page 报错、复杂交互、`deep_design` 或正文覆盖不了的问题时才读取。
+> 运行时易错点、`check-page` 规则和兼容层自动修复边界见 [运行时护栏](references/runtime-guardrails.md)，按需读取。
+> 表单类 JSX 控件、筛选栏、表格、成员/附件等组件写法见 [组件指南](references/component-jsx-guide.md)，涉及这些复杂组件时读取；未验证的平台组件能力不得编造。
 
 ## 官方示例范式内化
 
@@ -59,7 +59,7 @@ description: 宜搭 native 自定义页面 JSX 开发规范（React 16 宜搭原
 | 层 | 默认内容 | 生成要求 |
 | --- | --- | --- |
 | 状态层 | `loading`、`list/tableData`、`currentPage`、`pageSize`、`totalCount`、`filters/searchFieldJson`、`selectedRowKeys`、`dialogVisible` | 放入 `_customState`，所有失败路径必须恢复 `loading: false` |
-| 数据源层 | 表单查询、保存、更新、删除、流程发起、任务列表、连接器动作 | 优先调用已有 `this.dataSourceMap.<name>.load()`；没有数据源且是宜搭内置数据时用 `this.utils.yida.*`；第三方/连接器且用户明确要求设计器数据源时才走 `yida-data-source-connectors`，`fast_build` 不默认加载 |
+| 数据源层 | 表单查询、保存、更新、删除、流程发起、任务列表、连接器动作 | 只有已存在或本轮已创建设计器数据源时，才允许调用 `this.dataSourceMap.<name>.load()`；`fast_build` 默认不得生成依赖 dataSourceMap 的代码。查询本轮新建的宜搭表单数据时默认用 `this.utils.yida.searchFormDatas(params)`；不需要真实列表时用入口卡片 + 统计占位，不编造 dataSourceMap |
 | 交互层 | 筛选栏、表格/卡片列表、分页、弹窗、Tab/Collapse、操作按钮 | `renderJsx` 只负责展示和事件分发，业务逻辑拆成 `export function` |
 
 默认页面结构按官方高频组件范式转译为 JSX：顶部筛选/操作区、主体表格或卡片列表、分页、详情/编辑弹窗、空态/错误态。不要把数据查询、复杂计算和大段 DOM 混在一个 `renderJsx` 里。
@@ -99,19 +99,57 @@ openyida publish project/pages/src/employee-query.oyd.jsx APP_XXX FORM-QUERY001
 
 **关键说明**：
 - **Step 1** 的 get-schema 输出包含所有字段的 fieldId，在代码中必须使用 `FIELDS` 常量映射这些 ID
-- **Step 3** 的页面代码必须遵循 [编码指南](references/coding-guide.md) 和 [运行时护栏](references/runtime-guardrails.md)
+- **Step 3** 的页面代码必须遵循本技能正文；[编码指南](references/coding-guide.md) 和 [运行时护栏](references/runtime-guardrails.md) 在 check-page 报错、复杂交互、`deep_design` 或正文覆盖不了时读取
 - 优先通过 `openyida generate-page ... --compile` 生成高质量骨架；需要完整交互样板时使用 `todo-mvc`
 - 页面生成 spec、接口调试 JSON、一次性验证脚本等临时工件必须用结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/` 下；不要在仓库根目录、系统临时目录或 `.cache/` 顶层生成 `page.json`、`data.json` 或脚本文件
 - `check-page` 支持行级禁用：`// openyida-lint-disable-line <rule>` 或 `// openyida-lint-disable-next-line <rule>`。只在确认该行不会触发宜搭运行时问题时使用。
 
+## fast_build 默认页面模板
+
+完整应用 `fast_build` 生成主页面时，默认选择以下轻量闭环之一：
+
+1. 入口型页面：展示表单入口、核心流程说明、少量统计占位和快捷按钮，不执行真实列表查询。
+2. 内置数据 API 页面：用 `this.utils.yida.searchFormDatas` 查询已创建表单，用 `this.utils.yida.saveFormData` 做快速新增；所有失败路径恢复 `loading: false` 并展示空态。
+
+最小查询形态：
+
+```js
+export function loadVisitorList() {
+  var self = this;
+  var state = self.getCustomState();
+  self.setCustomState({ loading: true });
+  return self.utils.yida.searchFormDatas({
+    formUuid: FORM_UUIDS.visitor,
+    currentPage: state.currentPage || 1,
+    pageSize: state.pageSize || 50,
+    searchFieldJson: JSON.stringify(state.searchFieldJson || []),
+  }).then(function(res) {
+    var data = (res && res.data) || (res && res.content && res.content.data) || [];
+    var total = (res && res.totalCount) || (res && res.content && res.content.totalCount) || 0;
+    self.setCustomState({
+      loading: false,
+      list: Array.isArray(data) ? data : [],
+      totalCount: total,
+    });
+    self.forceUpdate();
+  }).catch(function(error) {
+    self.setCustomState({ loading: false, list: [], totalCount: 0 });
+    self.utils.toast({ title: error && error.message ? error.message : '数据加载失败', type: 'error' });
+    self.forceUpdate();
+  });
+}
+```
+
+不得在 fast_build 里写 `this.dataSourceMap.<name>.load()`，除非本轮已明确创建并绑定该数据源，并且已加载 `yida-data-source-connectors` 完成数据源链路。
+
 ## 开发规范
 
-> 编写页面代码前**必须完整阅读** [编码指南](references/coding-guide.md)，包含文件结构模板、状态管理模式、生命周期钩子、全局变量及全部 19 条编码注意事项。
-> 涉及输入控件、日期、选择、成员/部门、附件、表格或筛选栏时，同时阅读 [组件指南](references/component-jsx-guide.md)。
+> `fast_build` 默认不读取长 reference，直接遵守本技能正文的核心规则和模板。只有 check-page 报错、复杂交互/复杂组件、`deep_design`、或正文覆盖不了的运行时问题，才读取下方 Available Files。
+> 涉及输入控件、日期、选择、成员/部门、附件、表格或筛选栏时，读取 [组件指南](references/component-jsx-guide.md)。
 
 ## 官方示例模板与编码注意事项
 
-原“官方示例模板”的全局变量表已归并到 [编码指南](references/coding-guide.md) 的“全局变量”；原“编码注意事项”的完整规则和示例仍在 [编码指南](references/coding-guide.md)。入口层只保留导航和执行命令，避免与 reference 重复。
+原“官方示例模板”的全局变量表已归并到 [编码指南](references/coding-guide.md) 的“全局变量”；原“编码注意事项”的完整规则和示例仍在 [编码指南](references/coding-guide.md)。fast_build 不默认读取这些长 reference，入口层只保留导航和执行命令，避免与 reference 重复。
 
 代码编写前，先按需获取模板并完整读取生成文件：
 
@@ -125,7 +163,7 @@ openyida generate-page todo-mvc --output pages/src/todo-mvc.oyd.jsx --compile  #
 openyida check-page pages/src/home.oyd.jsx --json      # 输出机器可读的规范检查结果；.oyd.jsx 会先兼容构建
 ```
 
-- 完整文件结构、状态管理、全局变量、19 条编码规则见 [编码指南](references/coding-guide.md)
+- 完整文件结构、状态管理、全局变量、19 条编码规则见 [编码指南](references/coding-guide.md)，按需读取
 - `--spec` 文件先用 create_file / Write / file edit tool 创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/page-specs/`
 - 运行时高风险规则、`check-page` 规则和自动修复边界见 [运行时护栏](references/runtime-guardrails.md)
 - 输入控件、筛选栏、下拉、表格、附件等组件骨架见 [组件指南](references/component-jsx-guide.md)
@@ -169,7 +207,16 @@ openyida check-page pages/src/home.oyd.jsx --json      # 输出机器可读的�
 | `router.push` | 路由跳转 |
 | `loadScript` | 动态加载脚本 |
 
-> **上表为常用 API 速查，完整 API 列表见 [yida-api.md](../../references/yida-api.md)。使用前必须阅读完整参数文档，禁止猜测参数。**
+> **上表为常用 API 速查，完整 API 列表见 [yida-api.md](../../references/yida-api.md)。复杂参数不确定时读取完整参数文档，禁止猜测参数。**
+
+## Available Files
+
+| key | path | when |
+|-----|------|------|
+| `coding-guide` | `references/coding-guide.md` | check-page 报错、复杂交互、状态管理问题、`deep_design` |
+| `runtime-guardrails` | `references/runtime-guardrails.md` | 页面运行时报错、check-page 规则不清、编译兼容边界不清 |
+| `component-jsx-guide` | `references/component-jsx-guide.md` | 输入控件、日期、选择、成员/部门、附件、表格或筛选栏 |
+| `design-system` | `references/design-system.md` | 用户明确要求视觉细化，或已进入 `deep_design` / `yida-page-uiux` 后落地样式 |
 
 ## 参考文档
 
@@ -177,14 +224,14 @@ openyida check-page pages/src/home.oyd.jsx --json      # 输出机器可读的�
 |------|---------|---------|
 | **本技能文档** | | |
 | `yida-page-uiux` 子技能 | 页面类型 playbook、5 维差异化引擎、去 AI 味黑名单/8 问自检、图标策略 | 用户明确要求好看/去 AI 味或 `deep_design` 时加载；`fast_build` 不默认加载 |
-| [编码指南](references/coding-guide.md) | 文件结构模板、状态管理、生命周期、19 条编码规范 | 编写任何页面代码前必读 |
-| [运行时护栏](references/runtime-guardrails.md) | pageSize、loading 恢复、ECharts DOM 时序、setState 约束、check-page 规则映射 | 编写列表、看板、图表或接口页面前必读 |
-| [设计规范](references/design-system.md) | 色彩/圆角/字体/间距系统、7 类组件样式模板、8 条反模式 | 实现 UI 样式时必读 |
+| [编码指南](references/coding-guide.md) | 文件结构模板、状态管理、生命周期、19 条编码规范 | check-page 报错、复杂交互、状态管理问题或 `deep_design` 时阅读 |
+| [运行时护栏](references/runtime-guardrails.md) | pageSize、loading 恢复、ECharts DOM 时序、setState 约束、check-page 规则映射 | 页面运行时报错、check-page 规则不清或编译兼容边界不清时阅读 |
+| [设计规范](references/design-system.md) | 色彩/圆角/字体/间距系统、7 类组件样式模板、8 条反模式 | 用户明确要求视觉细化，或已进入 `deep_design` / `yida-page-uiux` 后阅读 |
 | [素材资源](references/assets-guide.md) | 图片/音乐/Icon 素材库、CDN 安全规范 | 需要引入图片、图标、音效时阅读 |
 | [官方示例中心 Schema 范式](../../references/official-example-schema-patterns.md) | 示例中心 156 个 capacity 模板的 schema 抽取链路、类型分布、数据源/报表/连接器模式 | 用户要求参考官方示例、蒸馏模板能力、或实现列表/模板中心/数据源驱动页面时阅读 |
 | **全局共享文档** | | |
-| [宜搭 API](../../references/yida-api.md) | 表单/流程/工具 API 完整参数文档 | 调用 `this.utils.yida.*` 前必读 |
-| [大模型 API](../../references/model-api.md) | AI 文本生成接口参数 | 调用 `txtFromAI` 前必读 |
+| [宜搭 API](../../references/yida-api.md) | 表单/流程/工具 API 完整参数文档 | 复杂参数不确定、接口返回结构异常或正文速查不够时阅读 |
+| [大模型 API](../../references/model-api.md) | AI 文本生成接口参数 | 调用 `txtFromAI` 且参数不确定时阅读 |
 
 ## 注意事项
 

--- a/yida-skills/skills/yida-get-schema/SKILL.md
+++ b/yida-skills/skills/yida-get-schema/SKILL.md
@@ -46,8 +46,8 @@ description: 获取表单的完整 Schema 结构，用于确认字段 ID（field
 ## 命令
 
 ```bash
-openyida get-schema <appType> <formUuid>
-openyida get-schema <appType> --all [--output-dir <dir>] [--keyword <text>] [--concurrency N] [--retries N]
+openyida get-schema <appType> <formUuid> [--summary-json|--field-map-json]
+openyida get-schema <appType> --all [--summary-json] [--output-dir <dir>] [--keyword <text>] [--concurrency N] [--retries N]
 ```
 
 | 参数 | 必填 | 说明 |
@@ -59,12 +59,15 @@ openyida get-schema <appType> --all [--output-dir <dir>] [--keyword <text>] [--c
 | `--keyword <text>` | 否 | 仅批量导出名称、UUID、类型或路径匹配关键词的表单 |
 | `--concurrency N` | 否 | 批量并发数，默认 3，范围 1-10 |
 | `--retries N` | 否 | 单个 Schema 失败后的重试次数，默认 1，范围 0-5 |
+| `--summary-json` / `--field-map-json` | 否 | 只输出字段摘要 JSON，不把完整 Schema 放入 stdout；`--field-map-json` 是语义别名 |
 
 ### 单表模式
 
 ```bash
-openyida get-schema APP_XXX FORM-XXX
+openyida get-schema APP_XXX FORM-XXX --summary-json
 ```
+
+页面开发默认使用 compact 输出，读取 `fields[].label`、`fields[].fieldId`、`fields[].reportFieldCode` 和 `fields[].options` 即可。只有需要组件完整 props、布局结构、字段数据源配置或排障时，才执行不带 `--summary-json` 的完整 Schema 输出。
 
 如需复用输出，使用 agent 的结构化文件写入工具创建：
 
@@ -76,7 +79,7 @@ openyida get-schema APP_XXX FORM-XXX
 ### 批量模式
 
 ```bash
-openyida get-schema APP_XXX --all --output-dir .cache/openyida/customer/schemas
+openyida get-schema APP_XXX --all --summary-json --output-dir .cache/openyida/customer/schemas
 openyida get-schema APP_XXX --all --keyword 客户 --concurrency 5 --retries 2
 ```
 
@@ -88,9 +91,30 @@ openyida get-schema APP_XXX --all --keyword 客户 --concurrency 5 --retries 2
 
 ## 输出
 
-单表模式将完整的 Schema JSON 输出到 stdout，包含 `pages`、`componentsMap` 等字段结构。
+单表模式默认将完整的 Schema JSON 输出到 stdout，包含 `pages`、`componentsMap` 等字段结构；页面开发优先追加 `--summary-json` 或 `--field-map-json`，只输出字段映射：
 
-批量模式将汇总 JSON 输出到 stdout；指定 `--output-dir` 时，完整 Schema 写入文件，stdout 中的 `forms[].schemaFile` 指向对应文件。
+```json
+{
+  "success": true,
+  "appType": "APP_XXX",
+  "formUuid": "FORM-XXX",
+  "fieldCount": 2,
+  "fields": [
+    {
+      "label": "访客姓名",
+      "componentName": "TextField",
+      "fieldId": "textField_xxx",
+      "alias": "visitorName",
+      "reportFieldCode": "textField_xxx",
+      "options": [],
+      "optionCount": 0,
+      "optionsTruncated": false
+    }
+  ]
+}
+```
+
+批量模式将汇总 JSON 输出到 stdout；指定 `--output-dir` 时，完整 Schema 写入文件，stdout 中的 `forms[].schemaFile` 指向对应文件。加 `--summary-json` 时，stdout 和 `index.json` 都只保留字段摘要与 schemaFile 指针，不内联完整 Schema。
 
 > 编码前可用此命令确认表单中各字段的 `fieldId`。
 
@@ -99,8 +123,8 @@ openyida get-schema APP_XXX --all --keyword 客户 --concurrency 5 --retries 2
 | 异常场景 | 处理方式 |
 |---------|----------|
 | 命令返回失败 | 确认 appType 和 formUuid 正确，检查登录态 |
-| 输出被终端截断 | 重新执行后将 stdout 通过结构化文件写入工具保存到 `<projectRoot>/.cache/openyida/<项目名或任务名>/<表单名>-schema.json`；不要使用 shell 重定向 |
-| 需要多个表单字段 ID | 使用批量模式：`openyida get-schema <appType> --all --output-dir .cache/openyida/<项目名或任务名>/schemas` |
+| 输出被终端截断 | 优先改用 `--summary-json`；确需完整 Schema 时，再将 stdout 通过结构化文件写入工具保存到 `<projectRoot>/.cache/openyida/<项目名或任务名>/<表单名>-schema.json`；不要使用 shell 重定向 |
+| 需要多个表单字段 ID | 使用批量 compact 模式：`openyida get-schema <appType> --all --summary-json --output-dir .cache/openyida/<项目名或任务名>/schemas`，默认只读 `index.json` 字段摘要 |
 | 批量部分失败 | 查看 stdout 的 `failedCount` 和 `forms[].errorMsg`，必要时提高 `--retries` 或缩小 `--keyword` 范围 |
 | 找不到目标字段 | 检查字段是否已创建，字段 ID 格式如 `textField_xxxxxxxx`，不能手写猜测 |
 | Schema 输出为空 | 表单可能没有字段，先用 `yida-create-form-page` 创建字段 |

--- a/yida-skills/skills/yida-publish-page/SKILL.md
+++ b/yida-skills/skills/yida-publish-page/SKILL.md
@@ -21,6 +21,7 @@ description: 将 JSX 源码编译发布到宜搭自定义页面。Babel 转 ES5 
 - 发布前确认 `openyida env` 检测通过，登录态有效
 - corpId 不匹配时，必须询问用户是否切换组织，不得强行发布
 - 重新发布已有自定义页面时，`openyida publish` 会自动读取目标页面现有 Schema 并合并页面级 `dataSource`；不要靠 Agent 口头承诺“保留数据源”，必须使用新版 CLI 的默认保护能力
+- 如果源码包含 `this.dataSourceMap.`，而发布输出包含 `No custom page data sources to preserve`，本次发布不能视为完成；说明源码依赖设计器数据源但目标页没有可保留数据源。必须改为 `this.utils.yida.*` / 入口型页面后重新 check、compile、publish，或先通过 `yida-data-source-connectors` 创建并绑定数据源后重新发布
 - **本技能不读写 memory**：发布操作通过 CLI 命令写入宜搭平台，不依赖跨会话的 memory 状态
 
 ## 适用场景
@@ -74,6 +75,11 @@ openyida list-forms <appType> --keyword <页面名>
 `openyida publish` 默认是非破坏式发布：保存新 JSX Schema 前会调用 `getFormSchema` 读取目标自定义页面已有 Schema，提取 Page 组件上的 `dataSource`，再与发布脚本内置的 `urlParams`、`timestamp` 数据源合并。用户在宜搭设计器里手工创建的 HTTP / VALUE / URI 等页面级数据源会随新源码一起保留。
 
 如果读取旧 Schema 失败，发布会停止，避免在无法确认的情况下把已有数据源清空。遇到用户明确要求“保留原有数据源”时，不需要手写额外合并脚本，直接运行新版 `openyida publish` 即可。
+
+发布后判定：
+
+- 源码不含 `this.dataSourceMap.`，发布输出 `No custom page data sources to preserve` 是正常情况，说明没有设计器数据源需要保留。
+- 源码含 `this.dataSourceMap.`，发布输出 `No custom page data sources to preserve` 不是完成态。不要把 API 发布成功等同于页面可用，必须补数据源或改源码后重新发布。
 
 ## OpenYida 兼容编译
 


### PR DESCRIPTION
## Summary
- tighten yida-app/yida-custom-page fast_build so native pages default to this.utils.yida.* or entry-only pages, not unbound dataSourceMap
- add get-schema --summary-json / --field-map-json compact field map output and expose it through command manifest / agent capabilities
- add skill contract regression tests for fast_build optional boundaries and publish dataSourceMap completion checks

## Validation
- node --check lib/app/get-schema.js lib/core/command-manifest.js lib/core/agent-capabilities.js scripts/postinstall.js
- npm test -- --runInBand tests/get-schema.test.js tests/skill-contracts.test.js
- npm test -- --runInBand tests/cli-smoke.test.js tests/eval-routing.test.js
- node scripts/validate-command-manifest.js
- npm run build:skills -- --no-zip
- npm run check:skills
- npm test -- --runInBand tests/build-skills-package.test.js
- git diff --check