### PR TITLE
fix: add compact agent capabilities summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ If Codex is already installed, OpenYida also imports a local Codex plugin during
 Run this from the AI coding workspace where you want OpenYida to operate:
 
 ```bash
-openyida agent-capabilities --json
+openyida agent-capabilities --summary-json
 ```
 
-OpenYida detects the active agent environment, workspace path, login state, organization context, command manifest, and side-effect hints in one machine-readable snapshot. `openyida commands --json` remains available when an agent only needs the command manifest.
+OpenYida returns a compact machine-readable summary with the version, login state, workspace/cache paths, and command manifest digest. `openyida agent-capabilities --json` is the full diagnostic snapshot, and `openyida commands --json` remains available when an agent only needs the command manifest.
 
 ### 3. Log In
 
@@ -457,7 +457,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | Command | Description |
 |---------|-------------|
 | `openyida commands [--json]` | Output machine-readable command manifest |
-| `openyida agent-capabilities [--json]` | Output one-shot agent capability snapshot |
+| `openyida agent-capabilities [--json] [--summary-json\|--compact]` | Output one-shot agent capability snapshot |
 | `openyida a2a <serve\|agent-card> [options]` | Start local read-only A2A adapter or print Agent Card |
 | `openyida bridge start [--token <pair-token>] [--port 6736] [--origin https://demo.aliwork.com] [--open\|--no-open]` | Start OpenYida local web bridge service |
 | `openyida copy [--force]` | Copy project working directory |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run this from the AI coding workspace where you want OpenYida to operate:
 openyida agent-capabilities --summary-json
 ```
 
-OpenYida returns a compact machine-readable summary with the version, login state, workspace/cache paths, and command manifest digest. `openyida agent-capabilities --json` is the full diagnostic snapshot, and `openyida commands --json` remains available when an agent only needs the command manifest.
+OpenYida returns a compact machine-readable summary with the version, login state, workspace/cache paths, and command manifest digest. `openyida agent-capabilities --json` is the full diagnostic snapshot, where compact `workdir` maps to `active.projectRoot` and `workdir_exists` maps to `active.projectRootExists`. `openyida commands --json` remains available when an agent only needs the command manifest.
 
 ### 3. Log In
 

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -22,6 +22,22 @@ function compactLogin(login) {
   };
 }
 
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.keys(value)
+    .sort()
+    .reduce((result, key) => {
+      result[key] = canonicalize(value[key]);
+      return result;
+    }, {});
+}
+
 function buildCommandManifestDigest(manifest) {
   const digestPayload = {
     schema_version: manifest.schema_version,
@@ -46,13 +62,13 @@ function buildCommandManifestDigest(manifest) {
 
   return crypto
     .createHash('sha256')
-    .update(JSON.stringify(digestPayload))
+    .update(JSON.stringify(canonicalize(digestPayload)))
     .digest('hex');
 }
 
 function buildAgentCapabilitiesSummary() {
   const envSnapshot = buildEnvironmentSnapshot();
-  const loginStatus = redactLogin(checkLoginOnly({ includeSecrets: false }));
+  const loginStatus = checkLoginOnly({ includeSecrets: false });
   const manifest = buildCommandManifest({ t, version });
   const projectRoot = envSnapshot.active.projectRoot;
 

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('crypto');
 const path = require('path');
 const { version } = require('../../package.json');
 const { t } = require('./i18n');
@@ -12,6 +13,63 @@ function redactLogin(login) {
   delete redacted.csrf_token;
   delete redacted.cookies;
   return redacted;
+}
+
+function compactLogin(login) {
+  return {
+    status: login.status,
+    can_auto_use: login.can_auto_use === true,
+  };
+}
+
+function buildCommandManifestDigest(manifest) {
+  const digestPayload = {
+    schema_version: manifest.schema_version,
+    command_prefix: manifest.command_prefix,
+    summary: {
+      command_count: manifest.summary.command_count,
+      group_count: manifest.summary.group_count,
+      side_effect_counts: manifest.summary.side_effect_counts,
+      permission_mode_counts: manifest.summary.permission_mode_counts,
+      core_workflows: manifest.summary.core_workflows,
+    },
+    commands: manifest.commands.map(entry => ({
+      id: entry.id,
+      usage: entry.usage,
+      requires_login: entry.requires_login,
+      output: entry.output,
+      side_effect_kind: entry.side_effect && entry.side_effect.kind,
+      permission_mode: entry.permission && entry.permission.mode,
+      permission_effect: entry.permission && entry.permission.effect,
+    })),
+  };
+
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(digestPayload))
+    .digest('hex');
+}
+
+function buildAgentCapabilitiesSummary() {
+  const envSnapshot = buildEnvironmentSnapshot();
+  const loginStatus = redactLogin(checkLoginOnly({ includeSecrets: false }));
+  const manifest = buildCommandManifest({ t, version });
+  const projectRoot = envSnapshot.active.projectRoot;
+
+  return {
+    schema_version: 1,
+    name: 'openyida-agent-capabilities-summary',
+    version,
+    login: compactLogin(loginStatus),
+    workdir: projectRoot,
+    workdir_exists: !!envSnapshot.active.projectRootExists,
+    cache_dir: path.join(projectRoot, '.cache'),
+    openyida_task_cache_dir: path.join(projectRoot, '.cache', 'openyida'),
+    command_manifest_digest: buildCommandManifestDigest(manifest),
+    command_manifest_digest_algorithm: 'sha256',
+    command_count: manifest.summary.command_count,
+    full_capabilities_command: 'openyida agent-capabilities --json',
+  };
 }
 
 function buildAgentCapabilities() {
@@ -32,7 +90,8 @@ function buildAgentCapabilities() {
     active: envSnapshot.active,
     login: loginStatus,
     recommended: {
-      preflight_command: 'openyida agent-capabilities --json',
+      preflight_command: 'openyida agent-capabilities --summary-json',
+      full_capabilities_command: 'openyida agent-capabilities --json',
       mutation_guard: 'Run mutating commands only when login.status is ok or after a successful openyida login.',
       workdir: projectRoot,
       cache_dir: path.join(projectRoot, '.cache'),
@@ -58,7 +117,7 @@ function buildAgentCapabilities() {
     },
     sideEffects: {
       read_only_preflight: [
-        'openyida agent-capabilities --json',
+        'openyida agent-capabilities --summary-json',
         'openyida env --json',
         'openyida login --check-only --json',
         'openyida commands --json',
@@ -80,11 +139,20 @@ function buildAgentCapabilities() {
   };
 }
 
-async function run() {
-  console.log(JSON.stringify(buildAgentCapabilities(), null, 2));
+function shouldUseSummary(args = []) {
+  return args.includes('--summary-json') || args.includes('--compact');
+}
+
+async function run(args = []) {
+  const payload = shouldUseSummary(args)
+    ? buildAgentCapabilitiesSummary()
+    : buildAgentCapabilities();
+  console.log(JSON.stringify(payload, null, 2));
 }
 
 module.exports = {
   buildAgentCapabilities,
+  buildAgentCapabilitiesSummary,
+  buildCommandManifestDigest,
   run,
 };

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -871,7 +871,7 @@ const COMMAND_GROUPS = [
         requiresLogin: false,
         output: 'json',
       }),
-      command('agent-capabilities', ['agent-capabilities'], 'agent-capabilities [--json]', 'help.cmd_agent_capabilities', {
+      command('agent-capabilities', ['agent-capabilities'], 'agent-capabilities [--json] [--summary-json|--compact]', 'help.cmd_agent_capabilities', {
         requiresLogin: false,
         output: 'json',
       }),

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -213,6 +213,8 @@ openyida agent-capabilities --summary-json
 
 \`openyida agent-capabilities --json\` 是 full capabilities，只用于命令契约排障或深度诊断；不要放进完整应用 \`fast_build\` 默认链路。
 
+字段映射：compact 输出的 \`workdir\` 对应 full capabilities 的 \`active.projectRoot\`；\`workdir_exists\` 对应 \`active.projectRootExists\`。
+
 如果 \`openyida\` 不存在，先提醒用户需要安装，或在用户同意后执行：
 
 \`\`\`bash

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -206,10 +206,12 @@ description: >
 在执行任何会创建、修改或发布真实宜搭资源的操作前，先运行只读检查：
 
 \`\`\`bash
-openyida agent-capabilities --json
+openyida agent-capabilities --summary-json
 \`\`\`
 
-该命令一次返回版本、当前工作目录、AI 工具环境、登录态摘要和命令清单，避免反复探测 \`which\`、\`--version\`、\`--help\`、\`env\` 和 \`login --check-only\`。
+该 compact 命令一次返回版本、登录态摘要、工作目录、缓存目录和命令 manifest digest，避免大 JSON 被宿主 offload，也避免反复探测 \`which\`、\`--version\`、\`--help\`、\`env\` 和 \`login --check-only\`。
+
+\`openyida agent-capabilities --json\` 是 full capabilities，只用于命令契约排障或深度诊断；不要放进完整应用 \`fast_build\` 默认链路。
 
 如果 \`openyida\` 不存在，先提醒用户需要安装，或在用户同意后执行：
 

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const { execFileSync, spawnSync } = require('child_process');
 const { version } = require('../package.json');
+const { buildCommandManifestDigest } = require('../lib/core/agent-capabilities');
 
 const ROOT = path.join(__dirname, '..');
 const BIN = path.join(ROOT, 'bin', 'yida.js');
@@ -591,6 +592,71 @@ describe('CLI offline smoke', () => {
     expect(parsed.login).not.toHaveProperty('diagnostics');
     expect(parsed.login).not.toHaveProperty('cookies');
     expect(parsed.login).not.toHaveProperty('csrf_token');
+  });
+
+  test('agent-capabilities command manifest digest canonicalizes object keys', () => {
+    const manifest = {
+      schema_version: 1,
+      command_prefix: 'openyida',
+      summary: {
+        command_count: 1,
+        group_count: 1,
+        side_effect_counts: {
+          remote_write: 0,
+          local_read: 1,
+        },
+        permission_mode_counts: {
+          ask: 0,
+          allow: 1,
+        },
+        core_workflows: {
+          full_app_fast_build: {
+            required_command_ids: ['agent-capabilities'],
+            mode: 'fast_build',
+          },
+        },
+      },
+      commands: [{
+        id: 'agent-capabilities',
+        usage: 'openyida agent-capabilities [--json] [--summary-json|--compact]',
+        requires_login: false,
+        output: 'json',
+        side_effect: { kind: 'local_read' },
+        permission: { mode: 'allow', effect: 'read' },
+      }],
+    };
+    const reorderedManifest = {
+      command_prefix: 'openyida',
+      schema_version: 1,
+      commands: [{
+        permission: { effect: 'read', mode: 'allow' },
+        side_effect: { kind: 'local_read' },
+        output: 'json',
+        requires_login: false,
+        usage: 'openyida agent-capabilities [--json] [--summary-json|--compact]',
+        id: 'agent-capabilities',
+      }],
+      summary: {
+        core_workflows: {
+          full_app_fast_build: {
+            mode: 'fast_build',
+            required_command_ids: ['agent-capabilities'],
+          },
+        },
+        permission_mode_counts: {
+          allow: 1,
+          ask: 0,
+        },
+        side_effect_counts: {
+          local_read: 1,
+          remote_write: 0,
+        },
+        group_count: 1,
+        command_count: 1,
+      },
+    };
+
+    expect(buildCommandManifestDigest(reorderedManifest)).toBe(buildCommandManifestDigest(manifest));
   });
 
   test('agent-capabilities --json renders one-shot agent snapshot', () => {

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -347,7 +347,7 @@ describe('CLI offline smoke', () => {
       requires_login: false,
     });
     expect(parsed.commands.find(entry => entry.id === 'agent-capabilities')).toMatchObject({
-      usage: 'openyida agent-capabilities [--json]',
+      usage: 'openyida agent-capabilities [--json] [--summary-json|--compact]',
       output: 'json',
       requires_login: false,
     });
@@ -557,6 +557,42 @@ describe('CLI offline smoke', () => {
     });
   });
 
+  test('agent-capabilities --summary-json renders compact preflight snapshot', () => {
+    const output = runOk(['agent-capabilities', '--summary-json']);
+    const parsed = JSON.parse(output);
+    const compactAlias = JSON.parse(runOk(['agent-capabilities', '--json', '--compact']));
+    const manifest = JSON.parse(runOk(['commands', '--json']));
+
+    expect(compactAlias).toEqual(parsed);
+    expect(parsed).toMatchObject({
+      schema_version: 1,
+      name: 'openyida-agent-capabilities-summary',
+      version,
+      login: {
+        status: expect.any(String),
+        can_auto_use: expect.any(Boolean),
+      },
+      workdir: expect.any(String),
+      workdir_exists: expect.any(Boolean),
+      cache_dir: expect.any(String),
+      openyida_task_cache_dir: expect.any(String),
+      command_manifest_digest_algorithm: 'sha256',
+      command_count: manifest.summary.command_count,
+      full_capabilities_command: 'openyida agent-capabilities --json',
+    });
+    expect(parsed.command_manifest_digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(parsed.cache_dir).toBe(path.join(parsed.workdir, '.cache'));
+    expect(parsed.openyida_task_cache_dir).toBe(path.join(parsed.workdir, '.cache', 'openyida'));
+    expect(parsed).not.toHaveProperty('system');
+    expect(parsed).not.toHaveProperty('active');
+    expect(parsed).not.toHaveProperty('recommended');
+    expect(parsed).not.toHaveProperty('commands');
+    expect(parsed).not.toHaveProperty('command_manifest');
+    expect(parsed.login).not.toHaveProperty('diagnostics');
+    expect(parsed.login).not.toHaveProperty('cookies');
+    expect(parsed.login).not.toHaveProperty('csrf_token');
+  });
+
   test('agent-capabilities --json renders one-shot agent snapshot', () => {
     const output = runOk(['agent-capabilities', '--json']);
     const parsed = JSON.parse(output);
@@ -613,6 +649,8 @@ describe('CLI offline smoke', () => {
       mode: 'fast_build',
       completion_contract: expect.stringContaining('Create app'),
     });
+    expect(parsed.recommended.preflight_command).toBe('openyida agent-capabilities --summary-json');
+    expect(parsed.recommended.full_capabilities_command).toBe('openyida agent-capabilities --json');
     expect(parsed.command_manifest.side_effect_schema).toMatchObject({
       version: 1,
       kinds: {
@@ -630,7 +668,8 @@ describe('CLI offline smoke', () => {
     expect(parsed.login).toHaveProperty('status');
     expect(parsed.login).not.toHaveProperty('cookies');
     expect(parsed.login).not.toHaveProperty('csrf_token');
-    expect(parsed.sideEffects.read_only_preflight).toContain('openyida agent-capabilities --json');
+    expect(parsed.sideEffects.read_only_preflight).toContain('openyida agent-capabilities --summary-json');
+    expect(parsed.sideEffects.read_only_preflight).not.toContain('openyida agent-capabilities --json');
     expect(parsed.sideEffects.completion_contracts.full_app).toContain('creating the app');
     expect(parsed.sideEffects.fast_build_data_contract).toContain('this.dataSourceMap');
     const commandIds = parsed.command_manifest.commands.map(entry => entry.id);

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -16,6 +16,7 @@ describe('OpenYida skill contracts', () => {
     expect(skill).toContain('openyida agent-capabilities --summary-json');
     expect(skill).toContain('`openyida agent-capabilities --json` 是 full capabilities');
     expect(skill).toContain('不要把 full capabilities 放进 `fast_build` 默认链路');
+    expect(skill).toContain('`workdir` 对应 full capabilities 的 `active.projectRoot`');
     expect(skill).not.toContain('优先跑一次 `openyida agent-capabilities --json`');
   });
 

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -10,6 +10,15 @@ function readSkill(relativePath) {
 }
 
 describe('OpenYida skill contracts', () => {
+  test('root skill uses compact agent-capabilities for default preflight', () => {
+    const skill = readSkill('yida-skills/SKILL.md');
+
+    expect(skill).toContain('openyida agent-capabilities --summary-json');
+    expect(skill).toContain('`openyida agent-capabilities --json` 是 full capabilities');
+    expect(skill).toContain('不要把 full capabilities 放进 `fast_build` 默认链路');
+    expect(skill).not.toContain('优先跑一次 `openyida agent-capabilities --json`');
+  });
+
   test('yida-app fast_build forbids unbound dataSourceMap by default', () => {
     const skill = readSkill('yida-skills/skills/yida-app/SKILL.md');
 

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -30,6 +30,8 @@ description: >
 
 `openyida agent-capabilities --json` 是 full capabilities，只在命令契约排障、manifest 差异诊断或深度调试时使用；不要把 full capabilities 放进 `fast_build` 默认链路。
 
+字段映射：compact 输出的 `workdir` 对应 full capabilities 的 `active.projectRoot`；`workdir_exists` 对应 `active.projectRootExists`。
+
 若当前 OpenYida 版本还没有 `agent-capabilities`，退回跑 `openyida env --json` 和 `openyida login --check-only --json`。旧版本地 agent 不需要认识 `skills-index.json`，也不需要支持 `agent-capabilities` 才能继续执行。
 
 | 检测结果 | 处理 |

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -26,7 +26,9 @@ description: >
 
 > ⚡ **前置门槛**：确认 openyida 已安装、Node/npm 依赖达标、登录态就绪。**未通过只读验证前，禁止创建应用/页面/表单或发布等任何真实资源操作。**
 
-**怎么做**：优先跑一次 `openyida agent-capabilities --json`。该命令一次返回 version、cwd、AI 工具环境、推荐工作目录、登录态摘要、commands、command count、sideEffects 和默认 `fast_build` 契约，避免反复 `which openyida`、`openyida --version`、`openyida --help`、`openyida env`、`login --check-only`。
+**怎么做**：优先跑一次 `openyida agent-capabilities --summary-json`。该 compact 命令只返回 version、`login.status`、`login.can_auto_use`、`workdir`、`workdir_exists`、`cache_dir`、`openyida_task_cache_dir`、`command_count` 和 `command_manifest_digest` 等 agent 必需字段，避免 stdout 过大导致宿主 offload 或误判未读到结果，也避免反复 `which openyida`、`openyida --version`、`openyida --help`、`openyida env`、`login --check-only`。
+
+`openyida agent-capabilities --json` 是 full capabilities，只在命令契约排障、manifest 差异诊断或深度调试时使用；不要把 full capabilities 放进 `fast_build` 默认链路。
 
 若当前 OpenYida 版本还没有 `agent-capabilities`，退回跑 `openyida env --json` 和 `openyida login --check-only --json`。旧版本地 agent 不需要认识 `skills-index.json`，也不需要支持 `agent-capabilities` 才能继续执行。
 
@@ -35,7 +37,7 @@ description: >
 | 命令跑不了（`command not found`） | openyida 未安装 → `npm install -g openyida` |
 | Node/npm 版本不达标 | 先升级 Node（≥16）再装/升级 openyida |
 | `login.status` 不是 `ok` 且 `login.can_auto_use` 不是 true | 未登录 → `openyida login`（指定入口带 URL 或 flag） |
-| `active.projectRootExists` 为 false | 无工作目录 → `openyida copy` 初始化 |
+| `workdir_exists` / `active.projectRootExists` 为 false | 无工作目录 → `openyida copy` 初始化 |
 
 **👉 环境异常、登录失败、悟空降级、Codex handoff 等特殊分支 → [references/setup-and-env.md](references/setup-and-env.md)。正常 `agent-capabilities` 通过时不要默认读取该 reference。**
 

--- a/yida-skills/skills/sls-log-workbench/SKILL.md
+++ b/yida-skills/skills/sls-log-workbench/SKILL.md
@@ -32,7 +32,7 @@ metadata:
 ### 使用前置校验
 
 1. 检查用户当前消息是否提供第一个词作为授权口令；同一会话首次通过脚本校验后可复用。
-2. 运行 `openyida env --json` 或 `openyida agent-capabilities --json`，读取当前登录态 corpId。
+2. 运行 `openyida env --json` 读取当前登录态 corpId；只需确认登录状态时可用 `openyida agent-capabilities --summary-json`。
 3. corpId 必须精确匹配 `ding328fe145009a4328f2c783f7214b6d69`。
 4. 任一校验失败，立即终止，不打开页面、不调用 API、不展示部分查询信息。
 


### PR DESCRIPTION
## Summary
- add compact `openyida agent-capabilities --summary-json` output and support `--json --compact`
- keep full `agent-capabilities --json` for diagnostics while pointing default preflight to compact output
- update OpenYida skill/postinstall/README contracts and tests so fast_build does not default to full capabilities

## Validation
- `node ./node_modules/jest/bin/jest.js --runInBand tests/cli-smoke.test.js tests/skill-contracts.test.js`
- `node scripts/validate-skills.js`
- `node scripts/build-skills-package.js --no-zip`
- `node scripts/validate-command-manifest.js`
- `node scripts/generate-command-docs.js --check`
- `node scripts/check-syntax.js`
- `node scripts/validate-structure.js`
- `git diff --check`