### PR TITLE
fix: restore OAuth token CI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 
 | Command | Description |
 |---------|-------------|
-| `openyida login [target-url] [--env <name>\|--intl\|--overseas\|--global\|--yidaapps\|--alibaba] [--client-id <clientId>] [--endpoint <url>]` | Login (OAuth token mode) |
-| `openyida logout` | Logout / switch account |
-| `openyida auth <status\|login\|refresh\|logout>` | Login state management |
+| `openyida login [target-url] [--env <name>\|--intl\|--overseas\|--global\|--yidaapps\|--alibaba] [--client-id <clientId>] [--endpoint <url>]` | Login with OAuth token mode |
+| `openyida logout` | Logout / clear token |
+| `openyida auth <status\|login\|refresh\|logout>` | Token login state management |
 | `openyida org <list\|switch> [--json] [--corp-id <corpId>]` | Organization management (list / switch by OAuth re-login) |
-| `openyida env [--json\|setup\|list\|show\|switch\|add\|remove] [options]` | Detect AI tool environment & login state |
+| `openyida env [--json\|setup\|list\|show\|switch\|add\|remove] [options]` | Detect AI tool environment & token login state |
 
 ### App Management
 

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -986,7 +986,7 @@ async function main(argv) {
   label('Source:', sourcePath);
   label('Compiled:', compiledPath);
   step(3, t('publish.step_publish'));
-  let response = await requestWithAutoLogin((ref) => sendSaveRequest(
+  const response = await requestWithAutoLogin((ref) => sendSaveRequest(
     ref.csrfToken,
     schemaContent,
     ref.baseUrl,
@@ -1014,7 +1014,7 @@ async function main(argv) {
 
   step(4, t('publish.step_config'));
   info(t('publish.sending_config'));
-  let configResponse = await requestWithAutoLogin((ref) => sendUpdateConfigRequest(
+  const configResponse = await requestWithAutoLogin((ref) => sendUpdateConfigRequest(
     ref.csrfToken,
     ref.baseUrl,
     appType,

--- a/lib/app/update-form-config.js
+++ b/lib/app/update-form-config.js
@@ -107,7 +107,7 @@ async function main() {
 
   step(2, t('update_form_config.step_update'));
   info(t('update_form_config.sending_request'));
-  let apiResult = await requestWithAutoLogin((ref) => sendPostRequest(
+  const apiResult = await requestWithAutoLogin((ref) => sendPostRequest(
     ref.baseUrl,
     `/dingtalk/web/${appType}/query/formdesign/updateFormSchemaInfo.json`,
     buildPostData(ref.csrfToken, formUuid, isRenderNav, title)

--- a/lib/auth/oauth-loopback.js
+++ b/lib/auth/oauth-loopback.js
@@ -68,7 +68,6 @@ function runDingtalkLoopback(options = {}) {
     const state = options.state || randomToken();
     const timeoutMs = Number(options.timeoutMs || process.env.OPENYIDA_OAUTH_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
     let settled = false;
-    let server;
     let timer;
 
     const finish = (err, value) => {
@@ -87,7 +86,7 @@ function runDingtalkLoopback(options = {}) {
       }
     };
 
-    server = http.createServer((req, res) => {
+    const server = http.createServer((req, res) => {
       const requestUrl = new URL(req.url || '/', 'http://127.0.0.1');
       if (requestUrl.pathname !== CALLBACK_PATH) {
         res.statusCode = 404;

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -68,7 +68,7 @@ function buildCommandManifestDigest(manifest) {
 
 function buildAgentCapabilitiesSummary() {
   const envSnapshot = buildEnvironmentSnapshot();
-  const loginStatus = checkLoginOnly({ includeSecrets: false });
+  const loginStatus = tokenStatus({ includeSecrets: false });
   const manifest = buildCommandManifest({ t, version });
   const projectRoot = envSnapshot.active.projectRoot;
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -544,7 +544,7 @@ async function httpPost(baseUrl, requestPath, postData, optionsOverride = {}) {
   const tokenAuth = auth.tokenAuth;
   const effectiveRequestPath = tokenAuth ? stripCsrfFromPath(requestPath) : requestPath;
   const effectivePostData = tokenAuth ? stripCsrfFromFormData(postData) : postData;
-  const bodyData = effectivePostData == null ? '' : String(effectivePostData);
+  const bodyData = effectivePostData === null || effectivePostData === undefined ? '' : String(effectivePostData);
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
@@ -775,7 +775,7 @@ async function httpGet(baseUrl, requestPath, queryParams, optionsOverride = {}) 
  * @returns {Promise<object>}
  */
 async function requestWithAutoLogin(requestFn, authRef) {
-  let result = await requestFn(authRef);
+  const result = await requestFn(authRef);
 
   if (result && result.__csrfExpired) {
     return {

--- a/scripts/check-syntax.js
+++ b/scripts/check-syntax.js
@@ -8,9 +8,15 @@ const { spawnSync } = require('child_process');
 
 const ROOT = path.resolve(__dirname, '..');
 const TARGET_DIRS = ['bin', 'lib', 'scripts', 'tests'];
+const SKIP_DIRS = new Set([
+  path.join(ROOT, 'lib', 'samples'),
+]);
 
 function collectJsFiles(dir, files) {
   if (!fs.existsSync(dir)) {
+    return;
+  }
+  if (SKIP_DIRS.has(dir)) {
     return;
   }
 

--- a/tests/agent-center.test.js
+++ b/tests/agent-center.test.js
@@ -27,7 +27,6 @@ const {
 } = require('../lib/agent-center/agent-center');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/aggregate-table.test.js
+++ b/tests/aggregate-table.test.js
@@ -31,7 +31,6 @@ const {
 } = require('../lib/aggregate-table/aggregate-table');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/ai-form-setting.test.js
+++ b/tests/ai-form-setting.test.js
@@ -27,7 +27,6 @@ const {
 } = require('../lib/process/ai-form-setting');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/app-permission.test.js
+++ b/tests/app-permission.test.js
@@ -21,7 +21,6 @@ const {
 } = require('../lib/app-permission/app-permission');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/basic-info.test.js
+++ b/tests/basic-info.test.js
@@ -13,7 +13,6 @@ const utils = require('../lib/core/utils');
 const basicInfo = require('../lib/basic-info/basic-info');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/batch.test.js
+++ b/tests/batch.test.js
@@ -10,12 +10,10 @@ jest.mock('../lib/core/utils', () => {
   return {
     ...real,
     loadAuthData: jest.fn(() => ({
-  csrf_token: 'openyida_cli_bearer',
-  base_url: 'https://www.aliwork.com',
-  auth_mode: 'token',
-  auth_source: 'token',
-  corp_id: 'corp-1',
-  user_id: 'user-1',
+      auth_mode: 'token',
+      auth_source: 'token',
+      corp_id: 'corp-1',
+      user_id: 'user-1',
       csrf_token: 'fake-csrf',
       base_url: 'https://www.aliwork.com',
     })),

--- a/tests/corp-manager.test.js
+++ b/tests/corp-manager.test.js
@@ -22,7 +22,6 @@ const {
 } = require('../lib/corp-manager/api');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/export-app.test.js
+++ b/tests/export-app.test.js
@@ -21,7 +21,6 @@ const { fetchFormPageList } = require('../lib/app/form-navigation');
 const { run, fetchFormSchema } = require('../lib/app/export-app');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -32,7 +32,6 @@ const {
 } = require('../lib/app/get-schema');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/i18n-management.test.js
+++ b/tests/i18n-management.test.js
@@ -24,7 +24,6 @@ const {
 } = require('../lib/i18n-management/i18n-management');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/integration-create.test.js
+++ b/tests/integration-create.test.js
@@ -2,12 +2,10 @@
 
 jest.mock('../lib/core/utils', () => ({
   loadAuthData: jest.fn(() => ({
-  csrf_token: 'openyida_cli_bearer',
-  base_url: 'https://www.aliwork.com',
-  auth_mode: 'token',
-  auth_source: 'token',
-  corp_id: 'corp-1',
-  user_id: 'user-1',
+    auth_mode: 'token',
+    auth_source: 'token',
+    corp_id: 'corp-1',
+    user_id: 'user-1',
     csrf_token: 'csrf-token',
     base_url: 'https://example.com',
   })),

--- a/tests/integration-list.test.js
+++ b/tests/integration-list.test.js
@@ -12,12 +12,10 @@ jest.mock('../lib/core/utils', () => {
   return {
     ...real,
     loadAuthData: jest.fn(() => ({
-  csrf_token: 'openyida_cli_bearer',
-  base_url: 'https://www.aliwork.com',
-  auth_mode: 'token',
-  auth_source: 'token',
-  corp_id: 'corp-1',
-  user_id: 'user-1',
+      auth_mode: 'token',
+      auth_source: 'token',
+      corp_id: 'corp-1',
+      user_id: 'user-1',
       csrf_token: 'fake-csrf',
       base_url: 'https://www.aliwork.com',
     })),

--- a/tests/list-forms.test.js
+++ b/tests/list-forms.test.js
@@ -12,7 +12,6 @@ const utils = require('../lib/core/utils');
 const { filterForms, parseArgs, run } = require('../lib/app/list-forms');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/page-config.test.js
+++ b/tests/page-config.test.js
@@ -17,7 +17,6 @@ const saveShareConfig = require('../lib/page-config/save-share-config');
 const verifyShortUrl = require('../lib/page-config/verify-short-url');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/permission.test.js
+++ b/tests/permission.test.js
@@ -16,7 +16,6 @@ const utils = require('../lib/core/utils');
 const { run } = require('../lib/permission/get-permission');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/process-small.test.js
+++ b/tests/process-small.test.js
@@ -34,11 +34,8 @@ const createProcess = require('../lib/process/create-process');
 const previewProcess = require('../lib/process/preview-process');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
-  base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',
-  corp_id: 'corp-1',
   user_id: 'user-1',
   csrf_token: 'csrf-token',
   base_url: 'https://www.aliwork.com',

--- a/tests/save-permission.test.js
+++ b/tests/save-permission.test.js
@@ -19,7 +19,6 @@ const utils = require('../lib/core/utils');
 const { run } = require('../lib/permission/save-permission');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',

--- a/tests/task-center.test.js
+++ b/tests/task-center.test.js
@@ -12,7 +12,6 @@ const utils = require('../lib/core/utils');
 const { run } = require('../lib/core/task-center');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',


### PR DESCRIPTION
## Summary

- Regenerate README command docs after OAuth token login changes.
- Exclude YiDA page sample sources from Node CommonJS syntax checks.
- Fix token-mode lint regressions in agent capabilities, OAuth loopback, utils, and test fixtures.

## Tests

- `npm run check:ci`
