### PR TITLE
Release 2026.7.17-3: token refresh base URL fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - `openyida login`、`openyida auth` 默认进入 token 登录态管理，不再要求 CLI 感知或保存 `ai_app_user_auth_token`、`tianshu_csrf_token` 等 Web Cookie。
 - 所有宜搭 HTTP API 调用统一从本地 token session 读取 `base_url` 和 access token，并由请求层自动封装 Bearer 鉴权头。
+- 业务请求遇到 access token 失效时，自动使用本地 refresh token 刷新 access token 并重试原请求；仅 refresh token 也失效时才提示重新 OAuth 登录。
 - `openyida org list` 改为通过 token 请求 `/query/userservice/listCorpInfos.json` 获取可访问组织；`openyida org switch --corp-id <corpId>` 通过 OAuth 重新登录并校验目标组织。
 - MCP Server、批处理、环境诊断、技能文档和命令清单同步使用 token 登录态语义。
 
 ### Removed
 - 移除旧 Cookie 登录、二维码登录、Codex 浏览器登录和相关 Cookie 缓存链路，降低本地明文 Cookie 持久化风险。
+- 移除 CLI 业务请求中显式拼接 `_csrf_token` 的逻辑，运行态只向宜搭服务端传递 `Authorization: Bearer <access_token>`。
 
 ### Tests
 - 更新 CLI、请求层、登录态、MCP、环境诊断和各业务命令的离线测试，覆盖 token session 读取、刷新、登出、组织列表和 Bearer 请求封装。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [2026.7.17] - 2026-07-17
+## [2026.7.17-2] - 2026-07-17
 
 ### Fixed
 - 业务请求遇到 access token 失效时，自动使用本地 refresh token 刷新 access token 并重试原请求；仅 refresh token 也失效时才提示重新 OAuth 登录。
+- refresh token 换取新 access token 时使用当前环境的认证 endpoint，并保留服务端返回的业务 `base_url` 写入本地 token session。
 - 移除 CLI 业务请求中显式拼接 `_csrf_token` 的逻辑，运行态只向宜搭服务端传递 `Authorization: Bearer <access_token>`。
 
 ## [2026.7.14-2] - 2026-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.17-3] - 2026-07-17
+
+### Fixed
+- refresh token 换取新 access token 时，如果服务端未返回业务 `base_url`，继续保留本地 token session 中已有的业务域名，避免刷新后业务请求错误落到认证 endpoint。
+
 ## [2026.7.17-2] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.7.17] - 2026-07-17
+
+### Fixed
+- 业务请求遇到 access token 失效时，自动使用本地 refresh token 刷新 access token 并重试原请求；仅 refresh token 也失效时才提示重新 OAuth 登录。
+- 移除 CLI 业务请求中显式拼接 `_csrf_token` 的逻辑，运行态只向宜搭服务端传递 `Authorization: Bearer <access_token>`。
+
 ## [2026.7.14-2] - 2026-07-14
 
 ### Highlights
@@ -17,13 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - `openyida login`、`openyida auth` 默认进入 token 登录态管理，不再要求 CLI 感知或保存 `ai_app_user_auth_token`、`tianshu_csrf_token` 等 Web Cookie。
 - 所有宜搭 HTTP API 调用统一从本地 token session 读取 `base_url` 和 access token，并由请求层自动封装 Bearer 鉴权头。
-- 业务请求遇到 access token 失效时，自动使用本地 refresh token 刷新 access token 并重试原请求；仅 refresh token 也失效时才提示重新 OAuth 登录。
 - `openyida org list` 改为通过 token 请求 `/query/userservice/listCorpInfos.json` 获取可访问组织；`openyida org switch --corp-id <corpId>` 通过 OAuth 重新登录并校验目标组织。
 - MCP Server、批处理、环境诊断、技能文档和命令清单同步使用 token 登录态语义。
 
 ### Removed
 - 移除旧 Cookie 登录、二维码登录、Codex 浏览器登录和相关 Cookie 缓存链路，降低本地明文 Cookie 持久化风险。
-- 移除 CLI 业务请求中显式拼接 `_csrf_token` 的逻辑，运行态只向宜搭服务端传递 `Authorization: Bearer <access_token>`。
 
 ### Tests
 - 更新 CLI、请求层、登录态、MCP、环境诊断和各业务命令的离线测试，覆盖 token session 读取、刷新、登出、组织列表和 Bearer 请求封装。

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -216,12 +216,6 @@ const TOKEN_OUTPUT_SECRET_KEYS = new Set([
   'accessToken',
   'refresh_token',
   'refreshToken',
-  'ai_app_user_auth_token',
-  'aiAppUserAuthToken',
-  'tianshu_csrf_token',
-  'tianshuCsrfToken',
-  'csrf_token',
-  'csrfToken',
 ]);
 
 function maskSensitiveAuthOutput(value) {
@@ -448,12 +442,6 @@ function applyQuietFlag() {
 function throwCliUsage(...lines) {
   throw new CliError(lines.filter(Boolean).join('\n'), {
     code: 'INVALID_ARGUMENTS',
-  });
-}
-
-function throwNeedLogin(message) {
-  throw new CliError(message, {
-    code: 'NEED_LOGIN',
   });
 }
 

--- a/lib/agent-center/api.js
+++ b/lib/agent-center/api.js
@@ -71,7 +71,7 @@ const AGENT_RANGE_ALIASES = {
 function getAuthRef() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    throw new Error('无法获取有效登录态或 CSRF Token');
+    throw new Error('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -128,7 +128,6 @@ function normalizeYesNo(value, defaultValue = 'n') {
 function buildCommonParams(authRef, apiName, params = {}) {
   const base = {
     _mock: 'false',
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     _stamp: String(Date.now()),
   };
@@ -150,7 +149,7 @@ async function agentPost(path, apiName, params = {}, authRef = getAuthRef()) {
 }
 
 function assertSuccess(result, action) {
-  if (result && result.success !== false && !result.__needLogin && !result.__csrfExpired) {
+  if (result && result.success !== false && !result.__needLogin) {
     return result;
   }
   const message = result && (result.errorMsg || result.message || result.errorCode);

--- a/lib/aggregate-table/aggregate-table.js
+++ b/lib/aggregate-table/aggregate-table.js
@@ -86,7 +86,7 @@ function unwrapContent(result) {
 }
 
 function assertSuccess(result, action) {
-  if (!result || result.success === false || result.__needLogin || result.__csrfExpired) {
+  if (!result || result.success === false || result.__needLogin) {
     const message = result
       ? result.errorMsg || result.error || result.message || t('common.unknown_error')
       : t('common.request_failed');
@@ -103,9 +103,8 @@ async function createAuthRef() {
   return authRef;
 }
 
-function buildCreateEmptyPostData(csrfToken, title) {
+function buildCreateEmptyPostData(title) {
   return querystring.stringify({
-    _csrf_token: csrfToken,
     formType: 'receipt',
     isVirtualView: 'y',
     title: JSON.stringify(buildYidaTitleI18n(title, {
@@ -115,9 +114,8 @@ function buildCreateEmptyPostData(csrfToken, title) {
   });
 }
 
-function buildDesignPostData(csrfToken, formUuid, designInfo, gmtModified) {
+function buildDesignPostData(formUuid, designInfo, gmtModified) {
   const payload = {
-    _csrf_token: csrfToken,
     formUuid,
     designInfo: JSON.stringify(designInfo),
   };
@@ -130,14 +128,14 @@ function buildDesignPostData(csrfToken, formUuid, designInfo, gmtModified) {
 async function checkVirtualViewFeature(authRef, appType) {
   return createYidaClient({ authRef }).postForm(
     `/dingtalk/web/${appType}/query/virtualview/show.json`,
-    auth => ({ _csrf_token: auth.csrfToken })
+    {}
   );
 }
 
 async function createEmptyVirtualView(authRef, appType, title) {
   return createYidaClient({ authRef }).postForm(
     `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
-    auth => buildCreateEmptyPostData(auth.csrfToken, title)
+    buildCreateEmptyPostData(title)
   );
 }
 
@@ -161,7 +159,7 @@ async function postVirtualViewDesign(authRef, appType, formUuid, designInfo, act
 
   return createYidaClient({ authRef }).postForm(
     `/alibaba/web/${appType}/query/virtualview/${endpoint}`,
-    auth => buildDesignPostData(auth.csrfToken, formUuid, designInfo, gmtModified)
+    buildDesignPostData(formUuid, designInfo, gmtModified)
   );
 }
 

--- a/lib/ai/ai.js
+++ b/lib/ai/ai.js
@@ -188,12 +188,11 @@ function getSuccessContent(response, fallbackMessage, code = 'AI_REQUEST_FAILED'
 async function callTextFromAI(prompt, options, authRef) {
   const response = await createYidaClient({ authRef }).postForm(
     '/query/intelligent/txtFromAI.json',
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       prompt,
       maxTokens: String(options.maxTokens || DEFAULT_MAX_TOKENS),
       skill: 'ToText',
-    })
+    }
   );
 
   const content = getSuccessContent(response, 'AI 接口调用失败', 'AI_TEXT_REQUEST_FAILED');
@@ -226,11 +225,10 @@ async function getOssSign(filePath, appType, authRef) {
 
   return createYidaClient({ authRef }).get(
     '/ossSign',
-    auth => ({
+    {
       scene: 'ImageField',
       _api: 'nattyFetch',
       _mock: 'false',
-      _csrf_token: auth.csrfToken,
       appType,
       fileName,
       fileSize: String(stat.size),
@@ -242,7 +240,7 @@ async function getOssSign(filePath, appType, authRef) {
       businessType: '',
       accelerate: 'y',
       _stamp: String(Date.now()),
-    })
+    }
   );
 }
 
@@ -283,10 +281,9 @@ async function postToOss(filePath, signContent) {
 async function convertToPublicImageUrl(downloadUrl, authRef) {
   const response = await createYidaClient({ authRef }).get(
     '/aliyun/sdk/upload2Oss.json',
-    auth => ({
+    {
       imageUrl: downloadUrl,
-      _csrf_token: auth.csrfToken,
-    })
+    }
   );
 
   if (!response || !response.success) {
@@ -306,8 +303,7 @@ async function uploadCallback(filePath, appType, formUuid, signContent, ossResul
   const stat = fs.statSync(filePath);
   return createYidaClient({ authRef }).postForm(
     '/query/attach/uploadCallBack.json',
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       appType,
       fileName: path.basename(filePath),
       fileSize: String(stat.size),
@@ -316,7 +312,7 @@ async function uploadCallback(filePath, appType, formUuid, signContent, ossResul
       procInstId: '',
       ossRequestId: ossResult.requestId || '',
       businessType: 'inst',
-    })
+    }
   );
 }
 
@@ -388,11 +384,10 @@ async function invokeImageRecognition(imageUrl, options, authRef) {
 
   const response = await createYidaClient({ authRef }).postForm(
     '/query/publicService/invokeService.json',
-    auth => ({
+    {
       inputs: JSON.stringify(inputs),
       serviceInfo: JSON.stringify(serviceInfo),
-      _csrf_token: auth.csrfToken,
-    })
+    }
   );
 
   if (!response || !response.success) {

--- a/lib/app-permission/app-permission.js
+++ b/lib/app-permission/app-permission.js
@@ -82,7 +82,7 @@ function printJson(payload) {
 function getAuthRef() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    throw new Error('无法获取有效登录态或 CSRF Token');
+    throw new Error('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -173,7 +173,6 @@ function parseCliOptions(tokens) {
 
 function buildCommonParams(authRef, params = {}) {
   return {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     _stamp: String(Date.now()),
     ...params,

--- a/lib/app/app-list.js
+++ b/lib/app/app-list.js
@@ -25,7 +25,6 @@ function fetchAppListPage(auth, pageIndex, pageSize) {
     pageIndex,
     pageSize,
     creator: ref.userId,
-    _csrf_token: ref.csrfToken,
     _stamp: Date.now(),
   }));
 }
@@ -36,9 +35,8 @@ function fetchAppListPage(auth, pageIndex, pageSize) {
 async function fetchAllApps(auth, pageSize) {
   const firstResult = await fetchAppListPage(auth, 1, pageSize);
 
-  // 如果首次请求就提示需要登录或 CSRF 过期，直接返回原始结果
-  // 让外层 requestWithAutoLogin 处理自动重试
-  if (firstResult.__needLogin || firstResult.__csrfExpired) {
+  // 如果首次请求就提示需要登录，直接返回原始结果让外层自动刷新 token 后重试。
+  if (firstResult.__needLogin) {
     return firstResult;
   }
 
@@ -59,7 +57,7 @@ async function fetchAllApps(auth, pageSize) {
   const remainingResults = await Promise.all(remainingFetches);
   for (const result of remainingResults) {
     // 如果后续翻页也出现登录态问题，同样返回标记对象
-    if (result.__needLogin || result.__csrfExpired) {
+    if (result.__needLogin) {
       return result;
     }
     if (result.success && result.content && result.content.data) {
@@ -122,7 +120,7 @@ async function run(args) {
   }
 
   // 如果重试后仍然返回登录失效标记，说明登录态确实不可用
-  if (apps && (apps.__needLogin || apps.__csrfExpired)) {
+  if (apps && apps.__needLogin) {
     console.error('登录态已失效，请重新登录');
     process.exit(1);
   }

--- a/lib/app/create-app.js
+++ b/lib/app/create-app.js
@@ -246,7 +246,7 @@ async function run(args) {
   try {
     const corpConfig = await httpPost(
       authRef.baseUrl,
-      `/query/exclusive/queryCorpAppConfig.json?_api=Global.queryCorpAppConfig&_mock=false&_csrf_token=${authRef.csrfToken}&_locale_time_zone_offset=28800000&_stamp=${Date.now()}`,
+      `/query/exclusive/queryCorpAppConfig.json?_api=Global.queryCorpAppConfig&_mock=false&_locale_time_zone_offset=28800000&_stamp=${Date.now()}`,
       ''
     );
     if (corpConfig && corpConfig.content) {
@@ -260,7 +260,6 @@ async function run(args) {
   const iconValue = `${icon}%%${iconColor}`;
   const response = await requestWithAutoLogin((auth) => {
     const postData = querystring.stringify({
-      _csrf_token: auth.csrfToken,
       appName: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
       description: JSON.stringify(buildYidaI18n(description, { en_US: description, ja_JP: description })),
       icon: iconValue,

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -4325,10 +4325,8 @@ function applyChangesToSchema(schema, changes) {
 
 // ── 发送 POST 请求（支持 302 自动重登录） ────────────
 
-function sendPostRequest(baseUrl, csrfToken, requestPath, extraParams, formUuid) {
-  const postData = querystring.stringify(
-    Object.assign({ _csrf_token: csrfToken }, extraParams)
-  );
+function sendPostRequest(baseUrl, requestPath, extraParams, formUuid) {
+  const postData = querystring.stringify(extraParams);
   const referer = formUuid
     ? `${baseUrl}/alibaba/web/${extraParams.appType || ''}/design/pageDesigner?formUuid=${formUuid}`
     : baseUrl + '/';
@@ -4337,9 +4335,8 @@ function sendPostRequest(baseUrl, csrfToken, requestPath, extraParams, formUuid)
 
 // ── 发送 updateFormConfig 请求 ───────────────────────
 
-function sendUpdateConfigRequest(baseUrl, csrfToken, appType, formUuid, version, value) {
+function sendUpdateConfigRequest(baseUrl, appType, formUuid, version, value) {
   const postData = querystring.stringify({
-    _csrf_token: csrfToken,
     formUuid: formUuid,
     version: version,
     configType: 'MINI_RESOURCE',
@@ -4378,7 +4375,7 @@ async function saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, ver
 
   const saveResult = await requestWithAutoLogin(function (auth) {
     return sendPostRequest(
-      auth.baseUrl, auth.csrfToken,
+      auth.baseUrl,
       buildApiPath(appType, 'saveFormSchema', { prefix: '_view' }),
       { appType: appType, formUuid: formUuid, content: JSON.stringify(schema), schemaVersion: 'V5', prefix: '_view' },
       formUuid
@@ -4408,7 +4405,7 @@ async function saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, ver
   info(t('create_form.sending_config'));
 
   const configResult = await requestWithAutoLogin(function (auth) {
-    return sendUpdateConfigRequest(auth.baseUrl, auth.csrfToken, appType, formUuid, version || 1, 0);
+    return sendUpdateConfigRequest(auth.baseUrl, appType, formUuid, version || 1, 0);
   }, authRef);
 
   return { saveResult: saveResult, configResult: configResult };
@@ -4436,7 +4433,7 @@ async function mainCreate(parsedArgs, authRef) {
   info(t('create_form.sending_create'));
   const createResult = await requestWithAutoLogin(function (auth) {
     return sendPostRequest(
-      auth.baseUrl, auth.csrfToken,
+      auth.baseUrl,
       buildApiPath(appType, 'saveFormSchemaInfo'),
       { formType: 'receipt', title: JSON.stringify(i18n(formTitle)) }
     );
@@ -5410,7 +5407,6 @@ async function run(args) {
   }
   const baseUrl = resolveBaseUrl(authData);
   const authRef = {
-    csrfToken: authData.csrf_token,
     baseUrl,
     authData,
     authMode: authData.auth_mode || '',

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -48,7 +48,7 @@ function parseArgs(args) {
   };
 }
 
-function buildPageInfoPostData(csrfToken, formUuid, pageName, isRenderNav) {
+function buildPageInfoPostData(formUuid, pageName, isRenderNav) {
   const titleJson = JSON.stringify(buildYidaTitleI18n(pageName, {
     en_US: pageName,
     ja_JP: pageName,
@@ -56,7 +56,6 @@ function buildPageInfoPostData(csrfToken, formUuid, pageName, isRenderNav) {
 
   return querystring.stringify({
     _api: 'Form.updateFormSchemaInfo',
-    _csrf_token: csrfToken,
     _locale_time_zone_offset: '28800000',
     formUuid,
     serialSwitch: 'n',
@@ -90,7 +89,7 @@ async function configureDashboardMode(authRef, appType, pageId, pageName) {
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/updateFormSchemaInfo.json`,
-      buildPageInfoPostData(auth.csrfToken, pageId, pageName, false)
+      buildPageInfoPostData(pageId, pageName, false)
     );
   }, authRef);
 }
@@ -138,7 +137,6 @@ async function run(args) {
 
   const response = await requestWithAutoLogin((auth) => {
     const postData = querystring.stringify({
-      _csrf_token: auth.csrfToken,
       formType: 'display',
       title: JSON.stringify(buildYidaI18n(pageName, { en_US: pageName, ja_JP: pageName })),
     });

--- a/lib/app/er.js
+++ b/lib/app/er.js
@@ -588,7 +588,6 @@ function createAuthRef() {
   }
 
   const authRef = {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',

--- a/lib/app/externalize-form.js
+++ b/lib/app/externalize-form.js
@@ -534,7 +534,6 @@ function createAuthRef() {
     authData = triggerLogin();
   }
   return {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',
@@ -555,7 +554,7 @@ async function fetchSchema(appType, formUuid, authRef) {
 }
 
 function ensureSuccessfulSchema(result) {
-  if (!result || result.success === false || result.__needLogin || result.__csrfExpired) {
+  if (!result || result.success === false || result.__needLogin) {
     const message = result && (result.errorMsg || result.message)
       ? result.errorMsg || result.message
       : 'Failed to fetch form schema';

--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -329,7 +329,6 @@ function createAuthRef() {
   }
 
   const authRef = {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',
@@ -352,7 +351,7 @@ async function fetchSchema(appType, formUuid, authRef) {
 }
 
 function isSuccessfulSchemaResult(result) {
-  return !!(result && result.success !== false && !result.__needLogin && !result.__csrfExpired);
+  return !!(result && result.success !== false && !result.__needLogin);
 }
 
 function printFieldSummary(result) {

--- a/lib/app/import-app.js
+++ b/lib/app/import-app.js
@@ -25,7 +25,6 @@ const { banner, step, label, success, fail, warn, info, error, result, usage, hi
 async function createApp(appName, authRef) {
   const contentLocale = resolveContentLocale({ baseUrl: authRef.baseUrl });
   const postData = querystring.stringify({
-    _csrf_token: authRef.csrfToken,
     appName: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
     description: JSON.stringify(buildYidaI18n(appName, { en_US: appName, ja_JP: appName })),
     icon: 'xian-yingyong%%#0089FF',
@@ -58,9 +57,8 @@ function normalizeImportFormType(formType) {
   return normalized;
 }
 
-function buildCreateFormPostData(csrfToken, formTitle, formType = 'receipt') {
+function buildCreateFormPostData(formTitle, formType = 'receipt') {
   return querystring.stringify({
-    _csrf_token: csrfToken,
     formType: normalizeImportFormType(formType),
     title: JSON.stringify(buildYidaI18n(formTitle, { en_US: formTitle, ja_JP: formTitle })),
   });
@@ -69,7 +67,7 @@ function buildCreateFormPostData(csrfToken, formTitle, formType = 'receipt') {
 // ── 创建空白表单/页面/报表 ──────────────────────────────
 
 async function createBlankForm(appType, formTitle, authRef, formType = 'receipt') {
-  const postData = buildCreateFormPostData(authRef.csrfToken, formTitle, formType);
+  const postData = buildCreateFormPostData(formTitle, formType);
   const result = await requestWithAutoLogin((auth) => {
     return httpPost(
       auth.baseUrl,
@@ -90,7 +88,6 @@ async function createBlankForm(appType, formTitle, authRef, formType = 'receipt'
 
 async function saveFormSchema(appType, formUuid, schema, authRef, formType = 'receipt') {
   const payload = {
-    _csrf_token: authRef.csrfToken,
     appType,
     formUuid,
     content: JSON.stringify(schema),
@@ -116,7 +113,6 @@ async function saveFormSchema(appType, formUuid, schema, authRef, formType = 're
 
 async function updateFormConfig(appType, formUuid, authRef) {
   const postData = querystring.stringify({
-    _csrf_token: authRef.csrfToken,
     appType,
     formUuid,
     setting: JSON.stringify({ MINI_RESOURCE: 0 }),

--- a/lib/app/list-forms.js
+++ b/lib/app/list-forms.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createAuthRef } = require('../core/yida-client');
+const { createAuthRef, isAuthRefReady } = require('../core/yida-client');
 const { t } = require('../core/i18n');
 const { fetchFormPageList } = require('./form-navigation');
 
@@ -57,7 +57,7 @@ async function run(args) {
 
   console.error(t('common.step_login', 1));
   const authRef = createAuthRef();
-  if (!authRef || !authRef.csrfToken) {
+  if (!isAuthRefReady(authRef)) {
     console.error(t('list_forms.no_login'));
     process.exit(1);
   }

--- a/lib/app/nav-group.js
+++ b/lib/app/nav-group.js
@@ -6,7 +6,7 @@ const {
   httpPost,
   requestWithAutoLogin,
 } = require('../core/utils');
-const { createAuthRef } = require('../core/yida-client');
+const { createAuthRef, isAuthRefReady } = require('../core/yida-client');
 
 const ROOT_NAV_UUID = 'NAV-SYSTEM-PARENT-UUID';
 const FORM_UUID_FALLBACK = 'NAV-SYSTEM-FROM-ME-UUID';
@@ -364,7 +364,7 @@ function countChildren(list, navUuid) {
 
 function loadAuthRef() {
   const authRef = createAuthRef();
-  if (!authRef || !authRef.csrfToken) {
+  if (!isAuthRefReady(authRef)) {
     throw new Error('No valid Yida login cache found. Run openyida login first.');
   }
   return authRef;
@@ -378,7 +378,6 @@ async function fetchNavigationList(appType, authRef) {
       {
         _api: 'Nav.queryList',
         _mock: false,
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: 28800000,
         _stamp: Date.now(),
       }
@@ -415,7 +414,7 @@ async function postNavAction(appType, action, payload, authRef) {
   const result = await requestWithAutoLogin((auth) => {
     const path = `/dingtalk/web/${appType}/query/formnav/${endpoint}` +
       `?_api=${encodeURIComponent(apiNames[action])}` +
-      `&_mock=false&_csrf_token=${encodeURIComponent(auth.csrfToken)}` +
+      '&_mock=false' +
       `&_stamp=${Date.now()}`;
     return httpPost(auth.baseUrl, path, querystring.stringify(payload));
   }, authRef);

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -322,7 +322,7 @@ async function fetchExistingSchemaContent(appType, formUuid, authRef) {
     );
   }, authRef);
 
-  if (!result || result.success === false || result.__needLogin || result.__csrfExpired) {
+  if (!result || result.success === false || result.__needLogin) {
     const errorMsg = result ? result.errorMsg || t('common.unknown_error') : t('common.request_failed');
     throw new Error(errorMsg);
   }
@@ -655,10 +655,9 @@ function buildCanvasSchemaContent(sourceCode, runtimeCode, importedModules, form
 
 // ── 4. 发送 saveFormSchema 请求 ──────────────────────
 
-function sendSaveRequest(csrfToken, schemaContent, baseUrl, appType, formUuid) {
+function sendSaveRequest(schemaContent, baseUrl, appType, formUuid) {
   const saveSchemaPath = `/alibaba/web/${appType}/${PREFIX}/query/formdesign/saveFormSchema.json?_stamp=${Date.now()}`;
   const postData = querystring.stringify({
-    _csrf_token: csrfToken,
     prefix: PREFIX,
     content: schemaContent,
     formUuid: formUuid,
@@ -671,10 +670,9 @@ function sendSaveRequest(csrfToken, schemaContent, baseUrl, appType, formUuid) {
 
 // ── 5. 发送 updateFormConfig 请求 ────────────────────
 
-function sendUpdateConfigRequest(csrfToken, baseUrl, appType, formUuid, version, value) {
+function sendUpdateConfigRequest(baseUrl, appType, formUuid, version, value) {
   const updateConfigPath = `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`;
   const postData = querystring.stringify({
-    _csrf_token: csrfToken,
     formUuid: formUuid,
     version: version,
     configType: 'MINI_RESOURCE',
@@ -942,14 +940,12 @@ async function main(argv) {
 
   step(2, t('common.step_login', 2));
   let authData = loadAuthData();
-  if (!authData || !authData.csrf_token) {
+  if (!authData) {
     warn(t('common.login_no_cache'));
     authData = triggerLogin();
   }
-  let csrfToken = authData.csrf_token;
   let baseUrl = resolveBaseUrl(authData);
   const authRef = {
-    csrfToken,
     baseUrl,
     authData,
     authMode: authData.auth_mode || '',
@@ -958,7 +954,6 @@ async function main(argv) {
     userId: authData.user_id || '',
   };
   await ensurePublishTargetOrExit(appType, formUuid, authRef, { force });
-  csrfToken = authRef.csrfToken;
   baseUrl = authRef.baseUrl;
 
   let schemaContent;
@@ -973,7 +968,6 @@ async function main(argv) {
       fail(t('publish.data_source_fetch_failed', dataSourceError.message));
       process.exit(1);
     }
-    csrfToken = authRef.csrfToken;
     baseUrl = authRef.baseUrl;
     schemaContent = buildSchemaContent(sourceCode, compiledCode, formUuid, { existingDataSource });
   }
@@ -987,19 +981,17 @@ async function main(argv) {
   label('Compiled:', compiledPath);
   step(3, t('publish.step_publish'));
   const response = await requestWithAutoLogin((ref) => sendSaveRequest(
-    ref.csrfToken,
     schemaContent,
     ref.baseUrl,
     appType,
     formUuid
   ), authRef);
-  csrfToken = authRef.csrfToken;
   baseUrl = authRef.baseUrl;
 
   if (!response || !response.success) {
     const errorMsg = response ? response.errorMsg || t('common.unknown_error') : t('common.request_failed');
     fail(t('publish.publish_failed', errorMsg));
-    if (response && !response.__needLogin && !response.__csrfExpired) {
+    if (response && !response.__needLogin) {
       hint(t('common.response_detail', JSON.stringify(response, null, 2)));
     }
     process.exit(1);
@@ -1015,14 +1007,12 @@ async function main(argv) {
   step(4, t('publish.step_config'));
   info(t('publish.sending_config'));
   const configResponse = await requestWithAutoLogin((ref) => sendUpdateConfigRequest(
-    ref.csrfToken,
     ref.baseUrl,
     appType,
     savedFormUuid,
     version,
     8
   ), authRef);
-  csrfToken = authRef.csrfToken;
   baseUrl = authRef.baseUrl;
 
   const pageUrl = `${baseUrl}/${appType}/workbench/${savedFormUuid}`;

--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -144,7 +144,6 @@ async function run(args) {
 
   // 构建请求参数
   const postDataObj = {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     appType: params.appType,
   };

--- a/lib/app/update-form-config.js
+++ b/lib/app/update-form-config.js
@@ -35,7 +35,7 @@ function parseArgs() {
   };
 }
 
-function buildPostData(csrfToken, formUuid, isRenderNav, title) {
+function buildPostData(formUuid, isRenderNav, title) {
   const titleJson = JSON.stringify(buildYidaTitleI18n(title, {
     en_US: title,
     ja_JP: title,
@@ -43,7 +43,6 @@ function buildPostData(csrfToken, formUuid, isRenderNav, title) {
 
   return querystring.stringify({
     _api: 'Form.updateFormSchemaInfo',
-    _csrf_token: csrfToken,
     _locale_time_zone_offset: '28800000',
     formUuid: formUuid,
     serialSwitch: 'n',
@@ -93,7 +92,6 @@ async function main() {
     authData = triggerLogin();
   }
   const authRef = {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',
@@ -110,10 +108,10 @@ async function main() {
   const apiResult = await requestWithAutoLogin((ref) => sendPostRequest(
     ref.baseUrl,
     `/dingtalk/web/${appType}/query/formdesign/updateFormSchemaInfo.json`,
-    buildPostData(ref.csrfToken, formUuid, isRenderNav, title)
+    buildPostData(formUuid, isRenderNav, title)
   ), authRef);
 
-  if (apiResult && !apiResult.__needLogin && !apiResult.__csrfExpired) {
+  if (apiResult && !apiResult.__needLogin) {
     if (apiResult.success) {
       result(true, t('update_form_config.update_ok'), [
         ['Render Nav', isRenderNav === 'true' ? t('update_form_config.nav_shown') : t('update_form_config.nav_hidden')],

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -363,13 +363,14 @@ async function tokenRefresh(options = {}) {
   });
   requireOkResponse(response);
   const data = getTokenPayload(response);
+  const businessBaseUrl = session.base_url || authBaseUrlValue;
   const normalized = normalizeTokenResponse({
     ...data,
     corp_id: data.corp_id || data.corpId || session.corp_id,
     user_id: data.user_id || data.userId || session.user_id,
     user_name: data.user_name || data.userName || session.user_name,
     refresh_token: data.refresh_token || data.refreshToken || session.refresh_token,
-  }, authBaseUrlValue, clientId);
+  }, businessBaseUrl, clientId);
   if (!normalized.access_token) {
     return {
       ...normalized,

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -13,13 +13,17 @@ const {
 const { runDingtalkLoopback } = require('./oauth-loopback');
 const {
   clearTokenSession,
-  isAccessTokenUsable,
   loadTokenSession,
   maskToken,
   saveTokenSession,
 } = require('./token-store');
 
 const DEFAULT_AUTH_PATH_PREFIX = '/openapi/cli/v1/auth';
+const REFRESH_AUTH_REQUIRED_STATUSES = new Set([
+  'missing_refresh_token',
+  'invalid_refresh_token',
+  'token_not_issued',
+]);
 
 function stripTrailingSlash(value) {
   return String(value || '').replace(/\/+$/, '');
@@ -130,12 +134,6 @@ function sanitizeRawTokenResponse(response) {
     return response;
   }
   const clone = Array.isArray(response) ? [...response] : { ...response };
-  delete clone.ai_app_user_auth_token;
-  delete clone.aiAppUserAuthToken;
-  delete clone.tianshu_csrf_token;
-  delete clone.tianshuCsrfToken;
-  delete clone.csrf_token;
-  delete clone.csrfToken;
   delete clone.access_token;
   delete clone.accessToken;
   delete clone.refresh_token;
@@ -197,6 +195,67 @@ function requireOkResponse(response) {
   }
 }
 
+function createTokenAuthRequiredError(reason, sourceError) {
+  const { CliError } = require('../core/cli-error');
+  return new CliError(
+    'not_logged_in: token auth is unavailable. Run openyida login first.',
+    {
+      code: 'TOKEN_AUTH_REQUIRED',
+      details: {
+        authMode: 'token',
+        reason,
+        sourceStatusCode: sourceError && sourceError.statusCode,
+        sourceMessage: sourceError && sourceError.message,
+      },
+    }
+  );
+}
+
+function createTokenRefreshFailedError(reason, sourceError) {
+  const { CliError } = require('../core/cli-error');
+  return new CliError(
+    'token_refresh_failed: failed to refresh access token. Please retry later.',
+    {
+      code: 'TOKEN_REFRESH_FAILED',
+      details: {
+        authMode: 'token',
+        reason,
+        sourceStatusCode: sourceError && sourceError.statusCode,
+        sourceMessage: sourceError && sourceError.message,
+      },
+    }
+  );
+}
+
+function getRefreshFailureStatus(value) {
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+  const payload = value.payload && typeof value.payload === 'object'
+    ? value.payload
+    : value;
+  const data = getTokenPayload(payload);
+  return String(
+    data.status ||
+    data.code ||
+    payload.status ||
+    payload.code ||
+    ''
+  ).toLowerCase();
+}
+
+function isRefreshAuthRequired(value) {
+  if (!value) {
+    return false;
+  }
+  if (value.ok === false && !value.access_token) {
+    const status = getRefreshFailureStatus(value);
+    return REFRESH_AUTH_REQUIRED_STATUSES.has(status);
+  }
+  const status = getRefreshFailureStatus(value);
+  return REFRESH_AUTH_REQUIRED_STATUSES.has(status);
+}
+
 async function tokenLogin(options = {}) {
   const baseUrl = resolveTokenBaseUrl(options);
   const authBaseUrl = appendPath(baseUrl, DEFAULT_AUTH_PATH_PREFIX);
@@ -235,7 +294,7 @@ async function tokenLogin(options = {}) {
 
 function tokenStatus(options = {}) {
   const session = loadTokenSession(options);
-  if (!session || !session.access_token) {
+  if (!session || (!session.access_token && !session.refresh_token)) {
     return {
       ok: false,
       auth_mode: 'token',
@@ -244,12 +303,25 @@ function tokenStatus(options = {}) {
       token_file: require('./token-store').getTokenFilePath(options),
     };
   }
-  const usable = isAccessTokenUsable(session);
+  if (!session.access_token && session.refresh_token) {
+    return {
+      ok: true,
+      auth_mode: 'token',
+      status: 'refresh_required',
+      can_auto_use: true,
+      refresh_token: maskToken(session.refresh_token),
+      base_url: session.base_url,
+      corp_id: session.corp_id,
+      user_id: session.user_id,
+    };
+  }
   return {
-    ok: usable,
+    // Local expiry metadata is advisory. Let the business endpoint decide
+    // whether this access token must be refreshed.
+    ok: true,
     auth_mode: 'token',
-    status: usable ? 'ok' : 'expired',
-    can_auto_use: usable,
+    status: 'ok',
+    can_auto_use: true,
     token_type: session.token_type,
     access_token: maskToken(session.access_token),
     refresh_token: maskToken(session.refresh_token),
@@ -303,6 +375,14 @@ async function tokenRefresh(options = {}) {
 
 async function tokenLogout(options = {}) {
   const session = loadTokenSession(options);
+  if (session && session.auth_source === 'env') {
+    return {
+      ok: true,
+      auth_mode: 'token',
+      status: 'logged_out',
+      can_auto_use: false,
+    };
+  }
   if (session && session.refresh_token && session.base_url) {
     try {
       await requestJson('POST', appendPath(appendPath(session.base_url, DEFAULT_AUTH_PATH_PREFIX), '/logout'), {
@@ -325,14 +405,37 @@ async function tokenLogout(options = {}) {
 
 async function getAccessToken(options = {}) {
   let session = loadTokenSession(options);
-  if (isAccessTokenUsable(session, options.skewMs)) {
+  // Do not reject a token from local expiry metadata. The business endpoint is
+  // the authority: requestWithAutoLogin refreshes only after it rejects the
+  // access token, then retries with the newly persisted local session.
+  if (session && session.access_token) {
     return session.access_token;
   }
   if (session && session.refresh_token) {
-    session = await tokenRefresh(options);
+    try {
+      session = await tokenRefresh(options);
+    } catch (error) {
+      if (isRefreshAuthRequired(error)) {
+        throw createTokenAuthRequiredError(
+          getRefreshFailureStatus(error) || 'refresh_token_invalid',
+          error
+        );
+      }
+      throw createTokenRefreshFailedError('refresh_request_failed', error);
+    }
+    if (!session || session.ok === false || !session.access_token) {
+      if (isRefreshAuthRequired(session)) {
+        throw createTokenAuthRequiredError(
+          getRefreshFailureStatus(session) || 'refresh_token_invalid'
+        );
+      }
+      throw createTokenRefreshFailedError(
+        getRefreshFailureStatus(session) || 'refresh_response_invalid'
+      );
+    }
     return session.access_token;
   }
-  throw new Error('not_logged_in');
+  throw createTokenAuthRequiredError('not_logged_in');
 }
 
 module.exports = {
@@ -343,4 +446,6 @@ module.exports = {
   getAccessToken,
   requestJson,
   resolveTokenBaseUrl,
+  isRefreshAuthRequired,
+  createTokenRefreshFailedError,
 };

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -156,6 +156,10 @@ function getTokenPayload(response) {
 
 function normalizeTokenResponse(response, baseUrl, clientId) {
   const data = getTokenPayload(response);
+  const resolvedBaseUrl = normalizeBaseUrl(
+    data.base_url || data.baseUrl || baseUrl,
+    baseUrl
+  );
   return {
     auth_mode: 'token',
     status: data.status || 'ok',
@@ -166,7 +170,7 @@ function normalizeTokenResponse(response, baseUrl, clientId) {
     refresh_token: data.refresh_token || data.refreshToken,
     expires_in: data.expires_in || data.expiresIn,
     expires_at: data.expires_at || data.expiresAt,
-    base_url: baseUrl,
+    base_url: resolvedBaseUrl,
     client_id: data.client_id || data.clientId || clientId,
     corp_id: data.corp_id || data.corpId,
     user_id: data.user_id || data.userId,
@@ -344,9 +348,14 @@ async function tokenRefresh(options = {}) {
     };
   }
 
-  const baseUrl = normalizeBaseUrl(options.endpoint || options.baseUrl || session.base_url, null) ||
-    resolveTokenBaseUrl(options);
-  const authBaseUrl = appendPath(baseUrl, DEFAULT_AUTH_PATH_PREFIX);
+  // Token exchange follows the active environment endpoint, just like the
+  // legacy login bootstrap. The response may return a different corp base_url
+  // for business requests and generated application links.
+  const authBaseUrlValue = resolveTokenBaseUrl({
+    projectRoot: options.projectRoot,
+    endpoint: options.endpoint,
+  });
+  const authBaseUrl = appendPath(authBaseUrlValue, DEFAULT_AUTH_PATH_PREFIX);
   const clientId = options.clientId || session.client_id || DINGTALK_OAUTH_CLIENT_ID;
   const response = await requestJson('POST', appendPath(authBaseUrl, '/refresh'), {
     refreshToken: session.refresh_token,
@@ -360,7 +369,7 @@ async function tokenRefresh(options = {}) {
     user_id: data.user_id || data.userId || session.user_id,
     user_name: data.user_name || data.userName || session.user_name,
     refresh_token: data.refresh_token || data.refreshToken || session.refresh_token,
-  }, baseUrl, clientId);
+  }, authBaseUrlValue, clientId);
   if (!normalized.access_token) {
     return {
       ...normalized,

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -94,6 +94,7 @@ function normalizeTokenSession(session = {}) {
     user_name: session.user_name || session.userName,
     open_user_id: session.open_user_id || session.openUserId,
     scope: session.scope,
+    auth_source: session.auth_source || session.authSource,
     raw: session.raw,
   };
 
@@ -118,7 +119,22 @@ function saveTokenSession(session, options = {}) {
   return normalized;
 }
 
-function loadTokenSession(options = {}) {
+function loadEnvTokenSession(env = process.env) {
+  const refreshToken = String(env.OPENYIDA_REFRESH_TOKEN || '').trim();
+  if (!refreshToken) {
+    return null;
+  }
+  return normalizeTokenSession({
+    refresh_token: refreshToken,
+    base_url: env.OPENYIDA_ENDPOINT,
+    client_id: env.OPENYIDA_TOKEN_CLIENT_ID,
+    corp_id: env.OPENYIDA_TOKEN_CORP_ID,
+    user_id: env.OPENYIDA_TOKEN_USER_ID,
+    auth_source: 'env',
+  });
+}
+
+function loadLocalTokenSession(options = {}) {
   const tokenFile = getTokenFilePath(options);
   if (!fs.existsSync(tokenFile)) {
     return null;
@@ -128,6 +144,30 @@ function loadTokenSession(options = {}) {
   } catch {
     return null;
   }
+}
+
+function loadTokenSession(options = {}) {
+  const localSession = loadLocalTokenSession(options);
+  const envSession = loadEnvTokenSession(options.env || process.env);
+  if (!localSession && !envSession) {
+    return null;
+  }
+
+  const localAccessToken = localSession && localSession.access_token;
+  const localRefreshToken = localSession && localSession.refresh_token;
+  const envRefreshToken = envSession && envSession.refresh_token;
+  const usesLocal = Boolean(localAccessToken || localRefreshToken);
+  const usesEnv = Boolean(
+    !localRefreshToken && envRefreshToken
+  );
+
+  return normalizeTokenSession({
+    ...(envSession || {}),
+    ...(localSession || {}),
+    access_token: localAccessToken,
+    refresh_token: localRefreshToken || envRefreshToken,
+    auth_source: usesLocal && usesEnv ? 'mixed' : (usesLocal ? 'local' : 'env'),
+  });
 }
 
 function clearTokenSession(options = {}) {
@@ -168,6 +208,8 @@ module.exports = {
   saveTokenSession,
   clearTokenSession,
   normalizeTokenSession,
+  loadEnvTokenSession,
+  loadLocalTokenSession,
   isAccessTokenUsable,
   maskToken,
   resolveEnvName,

--- a/lib/basic-info/basic-info.js
+++ b/lib/basic-info/basic-info.js
@@ -93,7 +93,6 @@ function buildCommonParams(auth, extra = {}) {
   return {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: auth.csrfToken,
     _locale_time_zone_offset: String(-new Date().getTimezoneOffset() * 60 * 1000),
     _stamp: Date.now(),
     ...extra,
@@ -101,7 +100,7 @@ function buildCommonParams(auth, extra = {}) {
 }
 
 function unwrapResponse(response, actionName) {
-  if (response && (response.__needLogin || response.__csrfExpired)) {
+  if (response && response.__needLogin) {
     throw new Error('Login state is invalid. Please run openyida login again.');
   }
   if (!response || response.success === false) {
@@ -132,14 +131,8 @@ async function loadAuth() {
     authData = await triggerLogin();
   }
 
-  const csrfToken = authData.csrf_token;
-  if (!csrfToken) {
-    throw new Error('Missing csrf token. Please run openyida login again.');
-  }
-
   return {
     authData,
-    csrfToken,
     corpId: authData.corp_id || '',
     userId: authData.user_id || '',
     baseUrl: resolveBaseUrl(authData),

--- a/lib/bridge/bridge.js
+++ b/lib/bridge/bridge.js
@@ -754,7 +754,7 @@ async function handleLoginStart(req, res, state) {
   const body = await readJsonBody(req);
   const checkLogin = getHandler(state, 'checkLogin', defaultCheckLogin);
   const current = await checkLogin();
-  if (current && (current.status === 'ok' || current.csrf_token || current.can_auto_use)) {
+  if (current && (current.status === 'ok' || current.can_auto_use)) {
     respondJson(req, res, state, 200, {
       ok: true,
       alreadyLoggedIn: true,

--- a/lib/connector/api.js
+++ b/lib/connector/api.js
@@ -13,7 +13,7 @@ const { createAuthRef, createYidaClient } = require('../core/yida-client');
 
 /**
  * 获取当前登录态，未登录则触发登录
- * @returns {{ csrfToken: string, baseUrl: string, authData: object }}
+ * @returns {{ baseUrl: string, authData: object }}
  */
 function getAuthRef() {
   return createAuthRef();
@@ -228,7 +228,6 @@ async function getConnectorDetail(connectorName, authRef) {
 async function saveConnector(params, authRef) {
   // 注意：operations 必须放在 displayName 之前，否则宜搭服务端可能忽略该字段
   const bodyParams = {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     operations: params.operations,
     displayName: params.displayName,
@@ -291,7 +290,6 @@ async function listConnections(connectorName, authRef) {
  */
 async function createConnection(params, authRef) {
   const bodyParams = {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     connectionName: params.connectionName,
     securityValue: params.securityValue,
@@ -323,7 +321,6 @@ async function createConnection(params, authRef) {
  */
 async function testConnector(params, authRef) {
   const bodyParams = {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     connectorId: params.connectorId,
     operationId: params.operationId,

--- a/lib/core/check-data.js
+++ b/lib/core/check-data.js
@@ -79,7 +79,7 @@ function parseError(message) {
 function ensureSession() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    fail('无法获取有效登录态或 CSRF Token');
+    fail('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -365,7 +365,6 @@ async function fetchAllProcessInstances(session, appType, formUuid, pageSize, ma
       result = await createYidaClient({ authRef: session }).get(requestPath, auth => ({
         _api: 'nattyFetch',
         _mock: 'false',
-        _csrf_token: auth.csrfToken,
         _stamp: `${Date.now()}`,
         formUuid,
         currentPage: String(currentPage),

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -106,7 +106,6 @@ function detectLoginStatus(projectRoot) {
   return {
     loggedIn,
     canAutoUse: !!status.can_auto_use,
-    csrfToken: null,
     corpId: status.corp_id || null,
     userId: status.user_id || null,
     baseUrl: status.base_url || null,
@@ -253,7 +252,6 @@ function run(args = []) {
     label('Base URL', loginStatus.baseUrl, { stderr: false });
     label('Corp ID', loginStatus.corpId || t('env.unknown'), { stderr: false });
     label('User ID', loginStatus.userId || t('env.unknown'), { stderr: false });
-    label('CSRF', `${loginStatus.csrfToken ? loginStatus.csrfToken.slice(0, 16) : 'N/A'}…`, { stderr: false });
   } else {
     warn(t('env.not_logged_in'), false);
   }

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -57,7 +57,7 @@ function parseError(message) {
 function ensureSession() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    fail('无法获取有效登录态或 CSRF Token');
+    fail('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -181,7 +181,6 @@ function buildRequestParams(session, params) {
   return {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: session.csrfToken,
     _stamp: `${Date.now()}`,
     ...params,
   };
@@ -242,7 +241,7 @@ async function fetchFormAliasContext(session, appType, formUuid) {
     `/alibaba/web/${appType}/_view/query/formdesign/getFormSchema.json`,
     { formUuid, schemaVersion: 'V5' }
   );
-  if (!result || result.success === false || result.__needLogin || result.__csrfExpired) {
+  if (!result || result.success === false || result.__needLogin) {
     fail(`组件别名解析失败：${result ? result.errorMsg || '无法获取表单 Schema' : '无法获取表单 Schema'}`);
   }
   return {

--- a/lib/core/task-center.js
+++ b/lib/core/task-center.js
@@ -62,7 +62,7 @@ function fail(message) {
 async function ensureSession() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    fail('无法获取有效登录态或 CSRF Token');
+    fail('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -118,13 +118,13 @@ function clampPageSize(options, defaultSize = 20) {
  * 打印 API 响应结果。
  */
 function printResult(result) {
-  if (result && (result.__needLogin || result.__csrfExpired)) {
+  if (result && result.__needLogin) {
     const payload = {
       success: false,
-      errorMsg: result.__needLogin ? '登录态已失效，请重新登录' : 'CSRF Token 已过期，请重新登录',
+      errorMsg: '登录态已失效，请重新登录',
     };
     throw new CliError(payload.errorMsg, {
-      code: result.__needLogin ? 'NEED_LOGIN' : 'CSRF_EXPIRED',
+      code: 'NEED_LOGIN',
       details: payload,
     });
   }
@@ -173,7 +173,6 @@ async function sendTaskCenterRequest(session, endpoint, options, taskType) {
     _api: 'nattyFetch',
     _mock: 'false',
     query: JSON.stringify(queryParam),
-    _csrf_token: auth.csrfToken,
     _stamp: `${Date.now()}`,
   }));
 }

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -5,10 +5,8 @@
  *   findProjectRoot()         - 查找项目根目录（兼容悟空环境）
  *   loadAuthData()            - 读取 token 登录态缓存
  *   triggerLogin()            - 触发登录
- *   refreshCsrfToken()        - 刷新 csrf_token
  *   resolveBaseUrl()          - 从 authData 中解析 base_url
  *   isLoginExpired()          - 检测响应体是否表示登录过期
- *   isCsrfTokenExpired()      - 检测响应体是否表示 csrf_token 过期
  */
 
 'use strict';
@@ -258,15 +256,15 @@ function getNodeExecutable() {
   return 'node';
 }
 
-function isInjectedAuthMode(env = process.env) {
+function isInjectedAuthMode() {
   return false;
 }
 
-function isEnvAuthMode(env = process.env) {
+function isEnvAuthMode() {
   return false;
 }
 
-function isTokenAuthMode(env = process.env) {
+function isTokenAuthMode() {
   return true;
 }
 
@@ -337,11 +335,10 @@ function loadTokenAuthData(projectRoot, defaultBaseUrl) {
   try {
     const { loadTokenSession } = require('../auth/token-store');
     const session = loadTokenSession({ projectRoot });
-    if (!session || !session.access_token) {
+    if (!session || (!session.access_token && !session.refresh_token)) {
       return null;
     }
     return {
-      csrf_token: 'openyida_cli_bearer',
       corp_id: session.corp_id,
       user_id: session.user_id,
       base_url: resolveTokenBaseUrl(projectRoot, defaultBaseUrl, session),
@@ -365,41 +362,6 @@ async function resolveBearerAuthHeaders(options = {}) {
       Authorization: `Bearer ${accessToken}`,
     },
   };
-}
-
-function stripCsrfFromPath(requestPath) {
-  if (!requestPath || !requestPath.includes('_csrf_token') && !requestPath.includes('_tb_token_')) {
-    return requestPath;
-  }
-  const [pathname, query = ''] = String(requestPath).split('?');
-  if (!query) {
-    return requestPath;
-  }
-  const params = new URLSearchParams(query);
-  params.delete('_csrf_token');
-  params.delete('_tb_token_');
-  const nextQuery = params.toString();
-  return nextQuery ? `${pathname}?${nextQuery}` : pathname;
-}
-
-function stripCsrfFromFormData(postData) {
-  if (typeof postData !== 'string' || (!postData.includes('_csrf_token') && !postData.includes('_tb_token_'))) {
-    return postData;
-  }
-  const params = new URLSearchParams(postData);
-  params.delete('_csrf_token');
-  params.delete('_tb_token_');
-  return params.toString();
-}
-
-function stripCsrfFromPayload(payload) {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return payload;
-  }
-  const next = { ...payload };
-  delete next._csrf_token;
-  delete next._tb_token_;
-  return next;
 }
 
 // ── 登录态缓存读取 ────────────────────────────────────
@@ -441,14 +403,6 @@ function triggerLogin(options = {}) {
   );
 }
 
-/**
- * 历史兼容占位：token 模式不在客户端刷新 csrf_token。
- * @returns {object} loginResult
- */
-function refreshCsrfToken() {
-  return null;
-}
-
 // ── 响应检测 ──────────────────────────────────────────
 
 /**
@@ -458,28 +412,37 @@ function refreshCsrfToken() {
  */
 function isLoginExpired(responseJson) {
   if (!responseJson) {return false;}
-  const status = String(responseJson.status || '').toLowerCase();
-  const errorCode = String(responseJson.errorCode || responseJson.code || '').toLowerCase();
-  const errorMsg = String(responseJson.errorMsg || responseJson.message || '').toLowerCase();
-  if (status === 'not_logged_in' || errorCode === 'not_logged_in' || errorMsg.includes('not_logged_in')) {
+  const content = responseJson && typeof responseJson.content === 'object' && !Array.isArray(responseJson.content)
+    ? responseJson.content
+    : {};
+  const status = String(responseJson.status || content.status || '').toLowerCase();
+  const errorCode = String(
+    responseJson.errorCode || responseJson.code || content.errorCode || content.code || ''
+  ).toLowerCase();
+  const errorMsg = String(
+    responseJson.errorMsg || responseJson.message || content.errorMsg || content.message || ''
+  ).toLowerCase();
+  const loginExpiredCodes = new Set([
+    'not_logged_in',
+    'invalid_access_token',
+    'expired_access_token',
+    'access_token_expired',
+    'missing_access_token',
+  ]);
+  if (
+    loginExpiredCodes.has(status) ||
+    loginExpiredCodes.has(errorCode) ||
+    errorMsg.includes('not_logged_in') ||
+    errorMsg.includes('invalid_access_token') ||
+    errorMsg.includes('expired_access_token') ||
+    errorMsg.includes('access_token_expired') ||
+    errorMsg.includes('access token is invalid or expired')
+  ) {
     return true;
   }
   return (
     responseJson.success === false &&
     ['307', '302', '401', '403'].includes(errorCode)
-  );
-}
-
-/**
- * 检测响应体是否表示 csrf_token 过期。
- * @param {object} responseJson
- * @returns {boolean}
- */
-function isCsrfTokenExpired(responseJson) {
-  return (
-    responseJson &&
-    responseJson.success === false &&
-    responseJson.errorCode === 'TIANSHU_000030'
   );
 }
 
@@ -541,10 +504,7 @@ async function httpPost(baseUrl, requestPath, postData, optionsOverride = {}) {
   const http = require('http');
 
   const auth = await resolveBearerAuthHeaders(optionsOverride);
-  const tokenAuth = auth.tokenAuth;
-  const effectiveRequestPath = tokenAuth ? stripCsrfFromPath(requestPath) : requestPath;
-  const effectivePostData = tokenAuth ? stripCsrfFromFormData(postData) : postData;
-  const bodyData = effectivePostData === null || effectivePostData === undefined ? '' : String(effectivePostData);
+  const bodyData = postData === null || postData === undefined ? '' : String(postData);
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
@@ -554,7 +514,7 @@ async function httpPost(baseUrl, requestPath, postData, optionsOverride = {}) {
     const options = {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port || (isHttps ? 443 : 80),
-      path: effectiveRequestPath,
+      path: requestPath,
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -587,10 +547,6 @@ async function httpPost(baseUrl, requestPath, postData, optionsOverride = {}) {
             resolve({ __needLogin: true });
             return;
           }
-          if (isCsrfTokenExpired(parsed)) {
-            resolve({ __csrfExpired: true });
-            return;
-          }
           resolve(parsed);
         } catch {
           warn(t('common.http_response', data.substring(0, 500)));
@@ -617,20 +573,17 @@ async function httpPostJson(baseUrl, requestPath, payload, optionsOverride = {})
   const http = require('http');
 
   const auth = await resolveBearerAuthHeaders(optionsOverride);
-  const tokenAuth = auth.tokenAuth;
-  const effectiveRequestPath = tokenAuth ? stripCsrfFromPath(requestPath) : requestPath;
-  const effectivePayload = tokenAuth ? stripCsrfFromPayload(payload) : payload;
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
     const isHttps = parsedUrl.protocol === 'https:';
     const requestModule = isHttps ? https : http;
-    const body = JSON.stringify(effectivePayload === undefined ? {} : effectivePayload);
+    const body = JSON.stringify(payload === undefined ? {} : payload);
 
     const options = {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port || (isHttps ? 443 : 80),
-      path: effectiveRequestPath,
+      path: requestPath,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -661,10 +614,6 @@ async function httpPostJson(baseUrl, requestPath, payload, optionsOverride = {})
           const parsed = JSON.parse(data);
           if (isLoginExpired(parsed)) {
             resolve({ __needLogin: true });
-            return;
-          }
-          if (isCsrfTokenExpired(parsed)) {
-            resolve({ __csrfExpired: true });
             return;
           }
           resolve(parsed);
@@ -701,14 +650,12 @@ async function httpGet(baseUrl, requestPath, queryParams, optionsOverride = {}) 
   const querystring = require('querystring');
 
   const auth = await resolveBearerAuthHeaders(optionsOverride);
-  const tokenAuth = auth.tokenAuth;
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
     const isHttps = parsedUrl.protocol === 'https:';
     const requestModule = isHttps ? https : http;
-    const rawPath = queryParams ? `${requestPath}?${querystring.stringify(queryParams)}` : requestPath;
-    const fullPath = tokenAuth ? stripCsrfFromPath(rawPath) : rawPath;
+    const fullPath = queryParams ? `${requestPath}?${querystring.stringify(queryParams)}` : requestPath;
 
     const options = {
       hostname: parsedUrl.hostname,
@@ -744,10 +691,6 @@ async function httpGet(baseUrl, requestPath, queryParams, optionsOverride = {}) 
             resolve({ __needLogin: true });
             return;
           }
-          if (isCsrfTokenExpired(parsed)) {
-            resolve({ __csrfExpired: true });
-            return;
-          }
           resolve(parsed);
         } catch {
           warn(t('common.http_response', data.substring(0, 500)));
@@ -771,30 +714,50 @@ async function httpGet(baseUrl, requestPath, queryParams, optionsOverride = {}) 
 /**
  * 带自动重登录的请求封装。
  * @param {Function} requestFn - 接受 authRef 返回 Promise 的工厂函数
- * @param {object} authRef - { csrfToken, baseUrl, authData }
+ * @param {object} authRef - { baseUrl, authData }
  * @returns {Promise<object>}
  */
+function tokenAuthRequiredResult() {
+  return {
+    success: false,
+    __needLogin: true,
+    errorCode: 'TOKEN_AUTH_REQUIRED',
+    errorMsg: 'not_logged_in: token auth is unavailable. Run openyida login first.',
+  };
+}
+
+function tokenRefreshFailedResult(error) {
+  return {
+    success: false,
+    errorCode: 'TOKEN_REFRESH_FAILED',
+    errorMsg: error && error.message
+      ? error.message
+      : 'token_refresh_failed: failed to refresh access token. Please retry later.',
+  };
+}
+
 async function requestWithAutoLogin(requestFn, authRef) {
   const result = await requestFn(authRef);
 
-  if (result && result.__csrfExpired) {
-    return {
-      success: false,
-      __needLogin: true,
-      errorCode: 'TOKEN_AUTH_REQUIRED',
-      errorMsg: 'token_auth_failed: Bearer authenticated requests should not require client csrf_token.',
-    };
-  }
-
   if (result && result.__needLogin) {
+    const { tokenRefresh, isRefreshAuthRequired } = require('../auth/token-auth');
     try {
-      const { tokenRefresh } = require('../auth/token-auth');
-      await tokenRefresh();
       const currentAuthData = authRef && authRef.authData;
-      const refreshedTokenData = loadTokenAuthData(undefined, resolveBaseUrl(currentAuthData));
+      const currentBaseUrl = authRef && authRef.baseUrl ? authRef.baseUrl : resolveBaseUrl(currentAuthData);
+      const refreshResult = await tokenRefresh({
+        projectRoot: authRef && authRef.projectRoot,
+        baseUrl: currentBaseUrl,
+        clientId: currentAuthData && (currentAuthData.client_id || currentAuthData.clientId),
+      });
+      if (!refreshResult || refreshResult.ok === false || !refreshResult.access_token) {
+        if (isRefreshAuthRequired(refreshResult)) {
+          return tokenAuthRequiredResult();
+        }
+        return tokenRefreshFailedResult(new Error('token_refresh_failed'));
+      }
+      const refreshedTokenData = loadTokenAuthData(authRef && authRef.projectRoot, currentBaseUrl);
       if (refreshedTokenData) {
         authRef.authData = refreshedTokenData;
-        authRef.csrfToken = refreshedTokenData.csrf_token;
         authRef.baseUrl = resolveBaseUrl(refreshedTokenData);
         authRef.authMode = refreshedTokenData.auth_mode || refreshedTokenData.authMode || '';
         authRef.authSource = refreshedTokenData.auth_source || refreshedTokenData.authSource || '';
@@ -802,15 +765,13 @@ async function requestWithAutoLogin(requestFn, authRef) {
         authRef.userId = refreshedTokenData.user_id || authRef.userId || '';
         return requestFn(authRef);
       }
-    } catch {
-      // Fall through to token auth error below.
+      return tokenRefreshFailedResult(new Error('token_refresh_failed'));
+    } catch (error) {
+      if (isRefreshAuthRequired(error)) {
+        return tokenAuthRequiredResult();
+      }
+      return tokenRefreshFailedResult(error);
     }
-    return {
-      success: false,
-      __needLogin: true,
-      errorCode: 'TOKEN_AUTH_REQUIRED',
-      errorMsg: 'not_logged_in: token auth is unavailable. Run openyida login first.',
-    };
   }
 
   return result;
@@ -822,10 +783,8 @@ module.exports = {
   findProjectRoot,
   loadAuthData,
   triggerLogin,
-  refreshCsrfToken,
   resolveBaseUrl,
   isLoginExpired,
-  isCsrfTokenExpired,
   httpPost,
   httpPostJson,
   httpGet,

--- a/lib/core/yida-client.js
+++ b/lib/core/yida-client.js
@@ -18,7 +18,7 @@ function isUsableAuthData(authData) {
   if (authData.auth_mode === 'token' || authData.authMode === 'token') {
     return true;
   }
-  return !!authData.csrf_token;
+  return false;
 }
 
 function createAuthRef(authData) {
@@ -29,7 +29,6 @@ function createAuthRef(authData) {
   const safeAuthData = loadedAuthData || {};
 
   return {
-    csrfToken: safeAuthData.csrf_token || '',
     baseUrl: resolveBaseUrl(safeAuthData),
     authData: safeAuthData,
     authMode: safeAuthData.auth_mode || safeAuthData.authMode || '',
@@ -57,7 +56,7 @@ function isTokenAuthRef(authRef) {
 }
 
 function isAuthRefReady(authRef) {
-  if (!authRef || !authRef.csrfToken) {
+  if (!authRef) {
     return false;
   }
   if (isTokenAuthRef(authRef)) {
@@ -126,12 +125,11 @@ class YidaClient {
         const resolvedOptions = typeof options === 'function'
           ? options(ref)
           : options;
-        const requestOptions = Object.assign({ csrfToken: ref.csrfToken }, resolvedOptions || {});
         return httpPostJson(
           ref.baseUrl,
           resolvedRequestPath,
           resolvedBodyParams || {},
-          requestOptions
+          resolvedOptions || {}
         );
       },
       this.authRef

--- a/lib/corp-efficiency/corp-efficiency.js
+++ b/lib/corp-efficiency/corp-efficiency.js
@@ -72,7 +72,6 @@ function buildCommonParams(auth, extra = {}) {
   return {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: auth.csrfToken,
     _locale_time_zone_offset: String(-new Date().getTimezoneOffset() * 60 * 1000),
     _stamp: Date.now(),
     ...extra,
@@ -82,13 +81,13 @@ function buildCommonParams(auth, extra = {}) {
 async function createAuthRef() {
   const authRef = createCoreAuthRef();
   if (!isAuthRefReady(authRef)) {
-    throw new Error('无法获取有效登录态或 CSRF Token');
+    throw new Error('无法获取有效 token 登录态');
   }
   return authRef;
 }
 
 function assertSuccess(result, action) {
-  if (result && (result.__needLogin || result.__csrfExpired)) {
+  if (result && result.__needLogin) {
     throw new Error('登录态已失效，请重新登录');
   }
   if (!result || result.success === false) {

--- a/lib/corp-manager/api.js
+++ b/lib/corp-manager/api.js
@@ -29,7 +29,7 @@ const SCENE_LABELS = {
 function getAuthRef() {
   const authRef = createAuthRef();
   if (!isAuthRefReady(authRef)) {
-    throw new Error('无法获取有效登录态或 CSRF Token');
+    throw new Error('无法获取有效 token 登录态');
   }
   return authRef;
 }
@@ -57,7 +57,6 @@ function normalizeText(value) {
 
 function buildCommonParams(authRef, params = {}) {
   return {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: '28800000',
     _stamp: String(Date.now()),
     ...params,

--- a/lib/db/db-seq-fix.js
+++ b/lib/db/db-seq-fix.js
@@ -111,14 +111,13 @@ function generateFixSeqSql(sequenceName, startValue) {
 /**
  * 执行 SQL 查询
  * @param {string} baseUrl - 基础 URL
- * @param {string} csrfToken - CSRF token
  * @param {string} sql - SQL 语句
  * @returns {Promise<object>}
  */
-async function executeSqlQuery(baseUrl, csrfToken, sql) {
+async function executeSqlQuery(baseUrl, sql) {
   const requestPath = '/query/exclusive/executeSql.json';
 
-  const postData = `_csrf_token=${csrfToken}&_locale_time_zone_offset=28800000&sql=${encodeURIComponent(sql)}`;
+  const postData = `_locale_time_zone_offset=28800000&sql=${encodeURIComponent(sql)}`;
 
   return httpPost(baseUrl, requestPath, postData);
 }
@@ -126,15 +125,13 @@ async function executeSqlQuery(baseUrl, csrfToken, sql) {
 /**
  * 查询专属数据库配置
  * @param {string} baseUrl - 基础 URL
- * @param {string} csrfToken - CSRF token
  * @returns {Promise<object>}
  */
-async function queryExclusiveDbConfig(baseUrl, csrfToken) {
+async function queryExclusiveDbConfig(baseUrl) {
   const requestPath = '/query/exclusive/queryExclusiveDbConfig.json';
   const queryParams = {
     _api: 'Exclusive.queryExclusiveDbConfig',
     _mock: 'false',
-    _csrf_token: csrfToken,
     _locale_time_zone_offset: '28800000',
     _stamp: Date.now().toString(),
   };
@@ -149,15 +146,14 @@ async function queryExclusiveDbConfig(baseUrl, csrfToken) {
  * @param {string} tableName - 表名
  * @param {object} seqInfo - Sequence 信息 { sequence, pkField }
  * @param {string} baseUrl - 基础 URL
- * @param {string} csrfToken - CSRF token
  * @returns {Promise<object>}
  */
-async function checkTableSequence(tableName, seqInfo, baseUrl, csrfToken) {
+async function checkTableSequence(tableName, seqInfo, baseUrl) {
   const { sequence, pkField } = seqInfo;
 
   // 查询表最大 ID
   const maxIdSql = generateMaxIdSql(tableName, pkField);
-  const maxIdResult = await executeSqlQuery(baseUrl, csrfToken, maxIdSql);
+  const maxIdResult = await executeSqlQuery(baseUrl, maxIdSql);
 
   let maxId = 0;
   if (maxIdResult && maxIdResult.content && maxIdResult.content.rows) {
@@ -166,7 +162,7 @@ async function checkTableSequence(tableName, seqInfo, baseUrl, csrfToken) {
 
   // 查询 Sequence 当前值
   const seqValueSql = generateSeqValueSql(sequence);
-  const seqResult = await executeSqlQuery(baseUrl, csrfToken, seqValueSql);
+  const seqResult = await executeSqlQuery(baseUrl, seqValueSql);
 
   let seqValue = 0;
   if (seqResult && seqResult.content && seqResult.content.rows) {
@@ -191,15 +187,14 @@ async function checkTableSequence(tableName, seqInfo, baseUrl, csrfToken) {
 /**
  * 检查所有表的 Sequence 状态
  * @param {string} baseUrl - 基础 URL
- * @param {string} csrfToken - CSRF token
  * @returns {Promise<Array>}
  */
-async function checkAllSequences(baseUrl, csrfToken) {
+async function checkAllSequences(baseUrl) {
   const results = [];
 
   for (const [tableName, seqInfo] of Object.entries(TABLE_SEQUENCE_MAP)) {
     try {
-      const result = await checkTableSequence(tableName, seqInfo, baseUrl, csrfToken);
+      const result = await checkTableSequence(tableName, seqInfo, baseUrl);
       results.push(result);
     } catch (error) {
       results.push({
@@ -219,12 +214,11 @@ async function checkAllSequences(baseUrl, csrfToken) {
  * @param {string} sequenceName - Sequence 名称
  * @param {number} startValue - 起始值
  * @param {string} baseUrl - 基础 URL
- * @param {string} csrfToken - CSRF token
  * @returns {Promise<object>}
  */
-async function fixSequence(sequenceName, startValue, baseUrl, csrfToken) {
+async function fixSequence(sequenceName, startValue, baseUrl) {
   const fixSql = generateFixSeqSql(sequenceName, startValue);
-  return executeSqlQuery(baseUrl, csrfToken, fixSql);
+  return executeSqlQuery(baseUrl, fixSql);
 }
 
 // ── 报告生成 ────────────────────────────────────────────
@@ -330,20 +324,19 @@ async function run(args) {
 
   // 检查登录态
   const authData = loadAuthData();
-  if (!authData || !authData.csrf_token) {
+  if (!authData) {
     warn(t('common.login_no_cache'));
     process.exit(1);
   }
 
   const baseUrl = resolveBaseUrl(authData);
-  const csrfToken = authData.csrf_token;
 
   warn(t('db_seq_fix.checking_login', baseUrl));
 
   try {
     // 查询专属数据库配置
     warn(t('db_seq_fix.querying_db_config'));
-    const dbConfig = await queryExclusiveDbConfig(baseUrl, csrfToken);
+    const dbConfig = await queryExclusiveDbConfig(baseUrl);
 
     if (!dbConfig || !dbConfig.content) {
       warn(t('db_seq_fix.no_db_config'));
@@ -352,7 +345,7 @@ async function run(args) {
 
     // 检查所有 Sequence
     warn(t('db_seq_fix.checking_sequences'));
-    const results = await checkAllSequences(baseUrl, csrfToken);
+    const results = await checkAllSequences(baseUrl);
 
     // 如果是 dry-run，显示修复 SQL
     if (dryRun) {
@@ -373,13 +366,13 @@ async function run(args) {
 
       for (const item of needFix) {
         warn(`  ${t('db_seq_fix.fixing')} ${item.tableName}...`);
-        await fixSequence(item.sequence, item.suggestedValue, baseUrl, csrfToken);
+        await fixSequence(item.sequence, item.suggestedValue, baseUrl);
       }
 
       warn(t('db_seq_fix.fix_done'));
 
       // 重新检查
-      const newResults = await checkAllSequences(baseUrl, csrfToken);
+      const newResults = await checkAllSequences(baseUrl);
       generateReport(newResults, false);
     } else {
       // 仅检查

--- a/lib/flash-note/flash-to-prd.js
+++ b/lib/flash-note/flash-to-prd.js
@@ -86,12 +86,11 @@ async function readFlashNoteContent(filePath) {
 async function callAI(prompt, maxTokens, authRef) {
   const response = await createYidaClient({ authRef }).postForm(
     '/query/intelligent/txtFromAI.json',
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       prompt,
       maxTokens: String(maxTokens),
       skill: 'ToText',
-    })
+    }
   );
 
   if (!response || !response.success) {

--- a/lib/i18n-management/i18n-management.js
+++ b/lib/i18n-management/i18n-management.js
@@ -239,14 +239,13 @@ function normalizeI18nItem(input = {}) {
 function getAuthRef() {
   const authRef = createCoreAuthRef();
   if (!isAuthRefReady(authRef)) {
-    throw new Error('无法获取有效登录态或 CSRF Token');
+    throw new Error('无法获取有效 token 登录态');
   }
   return authRef;
 }
 
 function buildCommonParams(authRef, params = {}) {
   return {
-    _csrf_token: authRef.csrfToken,
     _locale_time_zone_offset: String(-new Date().getTimezoneOffset() * 60 * 1000),
     _stamp: String(Date.now()),
     ...params,

--- a/lib/integration/integration-api.js
+++ b/lib/integration/integration-api.js
@@ -91,8 +91,7 @@ async function saveProcess(authRef, params) {
   const { appType, formUuid, processCode, processJson, viewJson, isOnline } = params;
   return createYidaClient({ authRef }).postForm(
     `/alibaba/web/${appType}/query/simpleProcess/saveProcess.json`,
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       formUuid,
       isLogic: 'true',
       isOnline: String(isOnline),
@@ -100,7 +99,7 @@ async function saveProcess(authRef, params) {
       needReportLine: 'y',
       processCode,
       viewJson: JSON.stringify(viewJson),
-    })
+    }
   );
 }
 
@@ -112,13 +111,12 @@ async function createLogicflow(authRef, params) {
   const { appType, formUuid, flowName } = params;
   const response = await createYidaClient({ authRef }).postForm(
     `/alibaba/web/${appType}/query/formLogicflowBinding/createLogicflow.json`,
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       _locale_time_zone_offset: '28800000',
       name: flowName,
       type: '1',
       formUuid,
-    })
+    }
   );
 
   if (!response || !response.success) {
@@ -150,12 +148,11 @@ async function listLogicflows(authRef, params) {
 
   const response = await createYidaClient({ authRef }).get(
     `/alibaba/web/${appType}/query/appLogicflowBinding/listflow.json`,
-    (auth) => {
+    () => {
       const stamp = Date.now();
       return {
         _api: 'Connector.getListflow',
         _mock: 'false',
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: '28800000',
         type,
         key,
@@ -203,12 +200,11 @@ async function listFormLogicflows(authRef, params) {
 
   const response = await createYidaClient({ authRef }).get(
     `/alibaba/web/${appType}/query/formLogicflowBinding/listflow.json`,
-    (auth) => {
+    () => {
       const stamp = Date.now();
       return {
         _api: 'Connector.getTriggerList',
         _mock: 'false',
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: '28800000',
         type,
         key,
@@ -270,12 +266,11 @@ async function listLogicflowLogs(authRef, params) {
 
   const response = await createYidaClient({ authRef }).get(
     `/alibaba/web/${appType}/query/formLogicflowBinding/listLog.json`,
-    (auth) => {
+    () => {
       const stamp = Date.now();
       const queryParams = {
         _api: 'Connector.listLog',
         _mock: 'false',
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: '28800000',
         dateType,
         processCode,
@@ -330,14 +325,13 @@ async function switchLogicflow(authRef, params) {
       const stamp = Date.now();
       return `/alibaba/web/${appType}/query/formLogicflowBinding/switchflow.json?_api=Connector.switchFlow&_mock=false&_stamp=${stamp}`;
     }()),
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       _locale_time_zone_offset: '28800000',
       enable: enable ? 'y' : 'n',
       processCode,
       formUuid,
       type: '1',
-    })
+    }
   );
 
   if (!response || !response.success) {

--- a/lib/integration/integration-check.js
+++ b/lib/integration/integration-check.js
@@ -410,7 +410,6 @@ function normalizeLogStatus(value) {
 function buildAuthRef() {
   const authData = loadAuthData();
   return Promise.resolve(authData || triggerLogin()).then((resolvedAuthData) => ({
-    csrfToken: resolvedAuthData.csrf_token,
     baseUrl: resolveBaseUrl(resolvedAuthData),
     authData: resolvedAuthData,
     authMode: resolvedAuthData.auth_mode || '',

--- a/lib/integration/integration-create.js
+++ b/lib/integration/integration-create.js
@@ -444,7 +444,6 @@ async function run(args) {
   }
 
   const authRef = {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',

--- a/lib/integration/integration-list.js
+++ b/lib/integration/integration-list.js
@@ -41,7 +41,6 @@ async function createAuthRef() {
     authData = await triggerLogin();
   }
   return {
-    csrfToken: authData.csrf_token,
     baseUrl: resolveBaseUrl(authData),
     authData,
     authMode: authData.auth_mode || '',

--- a/lib/mcp/server.js
+++ b/lib/mcp/server.js
@@ -89,7 +89,6 @@ function sanitizeLoginResult(result) {
     corp_id: result.corp_id,
     user_id: result.user_id,
     selected_corp: result.selected_corp || null,
-    csrf_token: result.csrf_token ? `${String(result.csrf_token).slice(0, 16)}...` : undefined,
   };
 }
 

--- a/lib/page-config/get-page-config.js
+++ b/lib/page-config/get-page-config.js
@@ -35,7 +35,7 @@ function ensureSession() {
 }
 
 function assertRequestSucceeded(result) {
-  if (result && !result.__needLogin && !result.__csrfExpired && result.success !== false) {
+  if (result && !result.__needLogin && result.success !== false) {
     return;
   }
 
@@ -62,12 +62,11 @@ async function run(args) {
 
   const shareConfig = await createYidaClient({ authRef }).postForm(
     `/dingtalk/web/${appType}/query/formdesign/getShareConfig.json`,
-    auth => ({
+    {
       _api: 'Share.getShareConfig',
-      _csrf_token: auth.csrfToken,
       _locale_time_zone_offset: '28800000',
       formUuid,
-    })
+    }
   );
 
   assertRequestSucceeded(shareConfig);

--- a/lib/page-config/save-share-config.js
+++ b/lib/page-config/save-share-config.js
@@ -68,14 +68,13 @@ function ensureSession() {
   return authRef;
 }
 
-function buildSaveParams(params, csrfToken) {
+function buildSaveParams(params) {
   const authConfig = JSON.stringify({
     openAuth: params.openAuth,
     authSources: [],
   });
   const payload = {
     _api: 'Share.saveShareConfig',
-    _csrf_token: csrfToken,
     _locale_time_zone_offset: '28800000',
     formUuid: params.formUuid,
   };
@@ -92,7 +91,7 @@ function buildSaveParams(params, csrfToken) {
 }
 
 function assertRequestFinished(result) {
-  if (result && !result.__needLogin && !result.__csrfExpired) {
+  if (result && !result.__needLogin) {
     return;
   }
   throw new CliError(t('common.request_failed_label'), {
@@ -131,7 +130,7 @@ async function run(args) {
 
   const result = await createYidaClient({ authRef }).postForm(
     `/dingtalk/web/${appType}/query/formdesign/saveShareConfig.json`,
-    auth => buildSaveParams(params, auth.csrfToken)
+    buildSaveParams(params)
   );
 
   assertRequestFinished(result);

--- a/lib/page-config/verify-short-url.js
+++ b/lib/page-config/verify-short-url.js
@@ -72,7 +72,7 @@ function ensureSession() {
 }
 
 function assertRequestFinished(result) {
-  if (result && !result.__needLogin && !result.__csrfExpired) {
+  if (result && !result.__needLogin) {
     return;
   }
   throw new CliError(t('verify_short_url.verify_failed'), {
@@ -109,11 +109,10 @@ async function run(args) {
 
   const result = await createYidaClient({ authRef }).get(
     `/dingtalk/web/${appType}/query/formdesign/verifyShortUrl.json`,
-    auth => {
+    () => {
       const requestParams = {
         _api: 'App.verifyShortUrlForm',
         formUuid,
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: '28800000',
         _stamp: Date.now().toString(),
       };

--- a/lib/permission/get-permission.js
+++ b/lib/permission/get-permission.js
@@ -20,10 +20,9 @@ const SEP = '='.repeat(50);
 function fetchPermitPackages(appType, formUuid, authRef) {
   return createYidaClient({ authRef }).get(
     `/${appType}/permission/manage/listPermitPackages.json`,
-    auth => ({
+    {
       _api: 'Permission.getPermitGroupList',
       _mock: 'false',
-      _csrf_token: auth.csrfToken,
       _locale_time_zone_offset: '28800000',
       formUuid,
       packageName: '',
@@ -32,7 +31,7 @@ function fetchPermitPackages(appType, formUuid, authRef) {
       pageSize: '20',
       appType,
       _stamp: String(Date.now()),
-    })
+    }
   );
 }
 

--- a/lib/permission/save-permission.js
+++ b/lib/permission/save-permission.js
@@ -177,10 +177,9 @@ function normalizeFieldPermission(fieldPermission) {
 function fetchPermitPackages(appType, formUuid, authRef) {
   return createYidaClient({ authRef }).get(
     `/${appType}/permission/manage/listPermitPackages.json`,
-    auth => ({
+    {
       _api: 'Permission.getPermitGroupList',
       _mock: 'false',
-      _csrf_token: auth.csrfToken,
       _locale_time_zone_offset: '28800000',
       formUuid,
       packageName: '',
@@ -189,7 +188,7 @@ function fetchPermitPackages(appType, formUuid, authRef) {
       pageSize: '20',
       appType,
       _stamp: String(Date.now()),
-    })
+    }
   );
 }
 
@@ -237,7 +236,7 @@ function buildRoleData(permitPackage, overrideMembers) {
 function savePermitPackage(appType, formUuid, permitPackage, overrideMembers, authRef) {
   return createYidaClient({ authRef }).postForm(
     `/${appType}/permission/manage/saveOrUpdatePermit.json?_api=Permission.saveOrUpdatePermitGroup&_mock=false&_stamp=${Date.now()}`,
-    auth => {
+    () => {
       // 新增模式：permitPackage.roleData 已经是构建好的字符串，直接使用
       // 更新模式：通过 buildRoleData 处理 overrideMembers
       const roleDataStr = permitPackage.roleData && !overrideMembers
@@ -245,7 +244,6 @@ function savePermitPackage(appType, formUuid, permitPackage, overrideMembers, au
         : JSON.stringify(buildRoleData(permitPackage, overrideMembers));
 
       const postParams = {
-        _csrf_token: auth.csrfToken,
         _locale_time_zone_offset: '28800000',
         formUuid,
         packageType: permitPackage.packageType || 'FORM_PACKAGE_VIEW',

--- a/lib/process/ai-form-setting.js
+++ b/lib/process/ai-form-setting.js
@@ -115,11 +115,10 @@ function buildSettingsUrl(baseUrl, appType, formUuid) {
   return `${baseUrl}/${appType}/admin/${formUuid}/settings/aiFormSetting`;
 }
 
-function buildCommonParams(csrfToken, extra = {}) {
+function buildCommonParams(extra = {}) {
   return {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: csrfToken,
     _locale_time_zone_offset: '28800000',
     _stamp: Date.now(),
     ...extra,
@@ -391,7 +390,7 @@ function normalizeFormComponents(response) {
 }
 
 function assertSuccess(response, action) {
-  if (!response || response.success === false || response.__needLogin || response.__csrfExpired) {
+  if (!response || response.success === false || response.__needLogin) {
     const message = response
       ? response.errorMsg || response.error || response.message || t('common.unknown_error')
       : t('common.request_failed');
@@ -416,28 +415,28 @@ async function createAuthRef() {
 function getAIApproveConfig(authRef, appType, formUuid) {
   return createYidaClient({ authRef }).get(
     `/${appType}/query/aiApprove/getAIApproveConfig.json`,
-    auth => buildCommonParams(auth.csrfToken, { formUuid })
+    buildCommonParams({ formUuid })
   );
 }
 
 function listModels(authRef, appType, itemType) {
   return createYidaClient({ authRef }).get(
     `/${appType}/query/aiApprove/listModels.json`,
-    auth => buildCommonParams(auth.csrfToken, itemType ? { itemType } : {})
+    buildCommonParams(itemType ? { itemType } : {})
   );
 }
 
 function getFormComponent(authRef, appType, formUuid, itemType) {
   return createYidaClient({ authRef }).postForm(
     `/${appType}/query/aiApprove/getFormComponent.json`,
-    auth => buildCommonParams(auth.csrfToken, { formUuid, itemType })
+    buildCommonParams({ formUuid, itemType })
   );
 }
 
 function updateAIApproveStatus(authRef, appType, formUuid, status) {
   return createYidaClient({ authRef }).postForm(
     `/${appType}/query/aiApprove/updateAIApproveStatus.json`,
-    auth => buildCommonParams(auth.csrfToken, { formUuid, status })
+    buildCommonParams({ formUuid, status })
   );
 }
 
@@ -448,7 +447,7 @@ function saveAIApproveConfig(authRef, appType, formUuid, payload) {
     checkItem: payload.checkItem,
   };
   return createYidaClient({ authRef }).postJson(
-    auth => `/${appType}/query/aiApprove/saveOrUpdateAIApproveConfig.json?_csrf_token=${encodeURIComponent(auth.csrfToken)}`,
+    `/${appType}/query/aiApprove/saveOrUpdateAIApproveConfig.json`,
     requestBody,
     auth => ({
       referer: buildSettingsUrl(auth.baseUrl, appType, formUuid),

--- a/lib/process/configure-process.js
+++ b/lib/process/configure-process.js
@@ -1889,10 +1889,9 @@ function buildProcessAndViewJson(definition, processCode, formUuid, baseUrl, app
 
 function queryProcessVersions(authRef, appType, processCode, status) {
   const requestPath = '/alibaba/web/' + appType + '/query/process/pageProcessVersion.json';
-  return createYidaClient({ authRef }).get(requestPath, auth => ({
+  return createYidaClient({ authRef }).get(requestPath, {
     _api: 'Process.getProcessVersionInfo',
     _mock: 'false',
-    _csrf_token: auth.csrfToken,
     _locale_time_zone_offset: '28800000',
     processCode: processCode,
     appType: appType,
@@ -1901,31 +1900,29 @@ function queryProcessVersions(authRef, appType, processCode, status) {
     pageSize: 10,
     orderByModifyTime: 'desc',
     _stamp: Date.now(),
-  }));
+  });
 }
 
 function switchFormType(authRef, appType, formUuid) {
   const requestPath = '/' + appType + '/query/formdesign/switchFormType.json'
     + '?_api=Nav.transformForm&_mock=false&_stamp=' + Date.now();
-  return createYidaClient({ authRef }).postForm(requestPath, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(requestPath, {
     _locale_time_zone_offset: '28800000',
     toFormType: 'process',
     formUuid: formUuid,
-  }));
+  });
 }
 
 function getProcessCodeFromAppParam(authRef, appType, formUuid) {
   const requestPath = '/' + appType + '/query/app/getAppPlatFormParam.json';
-  return createYidaClient({ authRef }).get(requestPath, auth => ({
+  return createYidaClient({ authRef }).get(requestPath, {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: auth.csrfToken,
     _locale_time_zone_offset: '28800000',
     pageIndex: 1,
     pageSize: 50,
     _stamp: Date.now(),
-  })).then(function (result) {
+  }).then(function (result) {
     if (result.success && result.content && result.content.formNavigationList) {
       const navList = result.content.formNavigationList;
       for (let i = 0; i < navList.length; i++) {
@@ -1962,9 +1959,8 @@ function getProcessCodeFromSchema(authRef, appType, formUuid) {
 
 function newDraftProcess(authRef, appType, processCode, formUuid, processId, processVersion) {
   const requestPath = '/' + appType + '/query/simpleProcess/newDraftProcess.json';
-  return createYidaClient({ authRef }).postForm(requestPath, auth => {
+  return createYidaClient({ authRef }).postForm(requestPath, () => {
     const postObj = {
-      _csrf_token: auth.csrfToken,
       _locale_time_zone_offset: '28800000',
       formUuid: formUuid,
       processCode: processCode,
@@ -1977,8 +1973,7 @@ function newDraftProcess(authRef, appType, processCode, formUuid, processId, pro
 
 function saveProcessById(authRef, appType, formUuid, processCode, processId, processVersion, processJsonStr, viewJsonStr) {
   const requestPath = '/alibaba/web/' + appType + '/query/simpleProcess/saveProcessById.json';
-  return createYidaClient({ authRef }).postForm(requestPath, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(requestPath, {
     formUuid: formUuid,
     isOnline: 'true',
     json: processJsonStr,
@@ -1987,18 +1982,17 @@ function saveProcessById(authRef, appType, formUuid, processCode, processId, pro
     processId: String(processId),
     processVersion: String(processVersion),
     viewJson: viewJsonStr,
-  }));
+  });
 }
 
 function publishProcessById(authRef, appType, formUuid, processCode, processId, processVersion) {
   const requestPath = '/alibaba/web/' + appType + '/query/simpleProcess/publishProcessById.json';
-  return createYidaClient({ authRef }).postForm(requestPath, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(requestPath, {
     formUuid: formUuid,
     processCode: processCode,
     processId: String(processId),
     processVersion: String(processVersion),
-  }));
+  });
 }
 
 function parseArgs(args) {

--- a/lib/process/create-process.js
+++ b/lib/process/create-process.js
@@ -75,25 +75,23 @@ function parseArgs(args) {
 function switchFormType(authRef, appType, formUuid) {
   const requestPath = '/' + appType + '/query/formdesign/switchFormType.json'
     + '?_api=Nav.transformForm&_mock=false&_stamp=' + Date.now();
-  return createYidaClient({ authRef }).postForm(requestPath, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(requestPath, {
     _locale_time_zone_offset: '28800000',
     toFormType: 'process',
     formUuid: formUuid,
-  }));
+  });
 }
 
 function getProcessCodeFromAppParam(authRef, appType, formUuid) {
   const requestPath = '/' + appType + '/query/app/getAppPlatFormParam.json';
-  return createYidaClient({ authRef }).get(requestPath, auth => ({
+  return createYidaClient({ authRef }).get(requestPath, {
     _api: 'nattyFetch',
     _mock: 'false',
-    _csrf_token: auth.csrfToken,
     _locale_time_zone_offset: '28800000',
     pageIndex: 1,
     pageSize: 50,
     _stamp: Date.now(),
-  })).then(function (result) {
+  }).then(function (result) {
     if (result.success && result.content && result.content.formNavigationList) {
       const navList = result.content.formNavigationList;
       for (let i = 0; i < navList.length; i++) {

--- a/lib/report/append.js
+++ b/lib/report/append.js
@@ -49,13 +49,12 @@ async function getReportSchema(authRef, appType, reportId) {
 async function saveSchema(authRef, appType, reportId, schema) {
   return createYidaClient({ authRef }).postForm(
     `/dingtalk/web/${appType}/_view/query/formdesign/saveFormSchema.json`,
-    auth => ({
-      _csrf_token: auth.csrfToken,
+    {
       formUuid: reportId,
       content: JSON.stringify(schema),
       schemaVersion: 'V5',
       importSchema: 'true',
-    })
+    }
   );
 }
 

--- a/lib/report/http.js
+++ b/lib/report/http.js
@@ -7,24 +7,22 @@ const { buildYidaI18n } = require('../core/yida-i18n');
  * 调用 saveFormSchemaInfo 创建空白报表
  */
 async function createBlankReport(authRef, appType, reportTitle) {
-  return createYidaClient({ authRef }).postForm(`/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(`/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`, {
     formType: 'report',
     title: JSON.stringify(buildYidaI18n(reportTitle, { en_US: reportTitle, ja_JP: reportTitle })),
-  }));
+  });
 }
 
 /**
  * 调用 saveFormSchema 保存报表 Schema
  */
 async function saveReportSchema(authRef, appType, reportId, schema) {
-  return createYidaClient({ authRef }).postForm(`/dingtalk/web/${appType}/_view/query/formdesign/saveFormSchema.json`, auth => ({
-    _csrf_token: auth.csrfToken,
+  return createYidaClient({ authRef }).postForm(`/dingtalk/web/${appType}/_view/query/formdesign/saveFormSchema.json`, {
     formUuid: reportId,
     content: JSON.stringify(schema),
     schemaVersion: 'V5',
     importSchema: 'true',
-  }));
+  });
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.14-2",
+  "version": "2026.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.14-2",
+      "version": "2026.7.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.17",
+  "version": "2026.7.17-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.17",
+      "version": "2026.7.17-2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.17-2",
+  "version": "2026.7.17-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.17-2",
+      "version": "2026.7.17-3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.14-2",
+  "version": "2026.7.17",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.17-2",
+  "version": "2026.7.17-3",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.17",
+  "version": "2026.7.17-2",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/tests/agent-center.test.js
+++ b/tests/agent-center.test.js
@@ -32,7 +32,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 beforeEach(() => {

--- a/tests/aggregate-table.test.js
+++ b/tests/aggregate-table.test.js
@@ -36,7 +36,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf-token',
 };
 
 beforeEach(() => {
@@ -51,11 +50,10 @@ afterEach(() => {
 
 describe('aggregate-table helpers', () => {
   test('buildCreateEmptyPostData creates a virtualView placeholder payload', () => {
-    const parsed = querystring.parse(buildCreateEmptyPostData('csrf-1', '客户聚合表'));
+    const parsed = querystring.parse(buildCreateEmptyPostData('客户聚合表'));
     const title = JSON.parse(parsed.title);
 
     expect(parsed).toMatchObject({
-      _csrf_token: 'csrf-1',
       formType: 'receipt',
       isVirtualView: 'y',
     });
@@ -100,7 +98,7 @@ describe('aggregate-table helpers', () => {
   });
 
   test('buildDesignPostData preserves blank gmtModified for first draft save', () => {
-    const parsed = querystring.parse(buildDesignPostData('csrf-1', 'FORM-VIEW', {
+    const parsed = querystring.parse(buildDesignPostData('FORM-VIEW', {
       formUuid: 'FORM-VIEW',
       relationForms: [],
       relationships: [],
@@ -111,7 +109,6 @@ describe('aggregate-table helpers', () => {
     }, null));
 
     expect(parsed).toMatchObject({
-      _csrf_token: 'csrf-1',
       formUuid: 'FORM-VIEW',
       gmtModified: '',
     });
@@ -130,7 +127,6 @@ describe('aggregate-table run', () => {
     await run(['list', 'APP_XXX', '--json']);
 
     expect(fetchFormPageList).toHaveBeenCalledWith('APP_XXX', expect.objectContaining({
-      csrfToken: 'csrf-token',
       baseUrl: 'https://www.aliwork.com',
     }));
     expect(mockLog).toHaveBeenCalledWith(JSON.stringify([
@@ -158,7 +154,7 @@ describe('aggregate-table run', () => {
       1,
       'https://www.aliwork.com',
       '/dingtalk/web/APP_XXX/query/virtualview/show.json',
-      expect.stringContaining('_csrf_token=csrf-token')
+      ''
     );
     const createPostData = utils.httpPost.mock.calls[1][2];
     expect(querystring.parse(createPostData)).toMatchObject({

--- a/tests/ai-form-setting.test.js
+++ b/tests/ai-form-setting.test.js
@@ -14,7 +14,6 @@ jest.mock('../lib/core/utils', () => ({
   httpPostJson: jest.fn(),
   requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
   isLoginExpired: jest.fn(() => false),
-  isCsrfTokenExpired: jest.fn(() => false),
 }));
 
 const utils = require('../lib/core/utils');
@@ -32,7 +31,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf-token',
 };
 
 beforeEach(() => {
@@ -219,10 +217,9 @@ describe('ai-form-setting run', () => {
 
       expect(utils.httpPostJson).toHaveBeenCalledWith(
         'https://www.aliwork.com',
-        '/APP_XXX/query/aiApprove/saveOrUpdateAIApproveConfig.json?_csrf_token=csrf-token',
+        '/APP_XXX/query/aiApprove/saveOrUpdateAIApproveConfig.json',
         expect.objectContaining({ formUuid: 'FORM_XXX' }),
         {
-          csrfToken: 'csrf-token',
           referer: 'https://www.aliwork.com/APP_XXX/admin/FORM_XXX/settings/aiFormSetting',
         }
       );

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -31,7 +31,6 @@ const {
 } = require('../lib/ai/ai');
 
 const authRef = {
-  csrfToken: 'csrf-token',
   baseUrl: 'https://demo.aliwork.com',
   authMode: 'token',
   authSource: 'token',
@@ -49,7 +48,6 @@ describe('openyida ai command helpers', () => {
     jest.clearAllMocks();
     utils.findProjectRoot.mockReturnValue(tmpDir);
     utils.loadAuthData.mockReturnValue({
-      csrf_token: authRef.csrfToken,
       base_url: authRef.baseUrl,
       auth_mode: 'token',
       auth_source: 'token',
@@ -111,7 +109,6 @@ describe('openyida ai command helpers', () => {
     expect(baseUrl).toBe('https://demo.aliwork.com');
     expect(requestPath).toBe('/query/intelligent/txtFromAI.json');
     expect(querystring.parse(postData)).toMatchObject({
-      _csrf_token: 'csrf-token',
       prompt: '检查文本',
       maxTokens: '3000',
       skill: 'ToText',
@@ -247,7 +244,6 @@ describe('openyida ai command helpers', () => {
     const result = getAuthRef({ baseUrl: 'https://custom.example.com' });
 
     expect(result).toMatchObject({
-      csrfToken: 'csrf-token',
       baseUrl: 'https://custom.example.com',
       authMode: 'token',
       authSource: 'token',

--- a/tests/app-list.test.js
+++ b/tests/app-list.test.js
@@ -19,7 +19,6 @@ jest.mock('../lib/core/i18n', () => ({
 const utils = require('../lib/core/utils');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',
@@ -36,7 +35,6 @@ const makeApp = (overrides = {}) => ({
 
 const mockAuth = {
   baseUrl: 'https://www.aliwork.com',
-  csrfToken: 'tok123',
   userId: 'user001',
 };
 

--- a/tests/app-permission.test.js
+++ b/tests/app-permission.test.js
@@ -26,7 +26,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 beforeEach(() => {
@@ -55,7 +54,7 @@ describe('app-permission api', () => {
     expect(utils.httpGet).toHaveBeenCalledWith(
       'https://www.aliwork.com',
       '/APP_1/query/app/getAppIncludingAecpInfo.json',
-      expect.objectContaining({ appKey: 'APP_1', _csrf_token: 'csrf' }),
+      expect.objectContaining({ appKey: 'APP_1' }),
     );
     expect(result).toMatchObject({
       success: true,

--- a/tests/basic-info.test.js
+++ b/tests/basic-info.test.js
@@ -18,7 +18,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'cookie-csrf',
 };
 
 function mockSuccess(content) {

--- a/tests/batch.test.js
+++ b/tests/batch.test.js
@@ -14,7 +14,6 @@ jest.mock('../lib/core/utils', () => {
       auth_source: 'token',
       corp_id: 'corp-1',
       user_id: 'user-1',
-      csrf_token: 'fake-csrf',
       base_url: 'https://www.aliwork.com',
     })),
     triggerLogin: jest.fn(),

--- a/tests/bridge.test.js
+++ b/tests/bridge.test.js
@@ -312,7 +312,7 @@ describe('bridge HTTP protocol', () => {
           appName: '售后工单',
           appType: 'APP_AFTER_SALES',
           systemLink: 'https://www.aliwork.com/APP_AFTER_SALES/workbench',
-          csrfToken: 'secret-token',
+          access_token: 'secret-token',
         },
         {
           name: '异常链接',

--- a/tests/configure-process.test.js
+++ b/tests/configure-process.test.js
@@ -409,7 +409,6 @@ describe('configure-process command runner', () => {
     fs.writeFileSync(definitionFile, JSON.stringify({ nodes: [] }));
 
     const mockAuthRef = {
-      csrfToken: 'csrf-test',
       baseUrl: 'https://www.aliwork.com',
     };
     const mockGet = jest.fn().mockResolvedValueOnce({

--- a/tests/corp-efficiency.test.js
+++ b/tests/corp-efficiency.test.js
@@ -29,7 +29,6 @@ const {
 const utils = require('../lib/core/utils');
 
 const mockAuthData = {
-  csrf_token: 'openyida_cli_bearer',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',
@@ -39,7 +38,6 @@ const mockAuthData = {
 
 const mockAuth = {
   baseUrl: 'https://www.aliwork.com',
-  csrfToken: 'openyida_cli_bearer',
   authMode: 'token',
   authSource: 'token',
   corpId: 'ding-corp',

--- a/tests/corp-manager.test.js
+++ b/tests/corp-manager.test.js
@@ -27,7 +27,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 beforeEach(() => {

--- a/tests/create-page.test.js
+++ b/tests/create-page.test.js
@@ -14,7 +14,7 @@ describe('create-page locale handling', () => {
   });
 
   test('buildPageInfoPostData fills Japanese title instead of null', () => {
-    const parsed = querystring.parse(buildPageInfoPostData('csrf', 'FORM_X', '経営ダッシュボード', false));
+    const parsed = querystring.parse(buildPageInfoPostData('FORM_X', '経営ダッシュボード', false));
     const title = JSON.parse(parsed.title);
 
     expect(title).toMatchObject({

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -46,7 +46,6 @@ describe('detectLoginStatus', () => {
     expect(result).toMatchObject({
       loggedIn: false,
       canAutoUse: false,
-      csrfToken: null,
       corpId: null,
       userId: null,
       baseUrl: null,
@@ -74,7 +73,6 @@ describe('detectLoginStatus', () => {
     expect(result).toMatchObject({
       loggedIn: true,
       canAutoUse: true,
-      csrfToken: null,
       corpId: 'corpABC',
       userId: 'user456',
       baseUrl: 'https://www.aliwork.com',

--- a/tests/export-app.test.js
+++ b/tests/export-app.test.js
@@ -26,7 +26,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'tok123',
 };
 
 let logSpy;
@@ -62,7 +61,6 @@ describe('export-app', () => {
       const exported = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
 
       expect(fetchFormPageList).toHaveBeenCalledWith('APP_XXX', expect.objectContaining({
-        csrfToken: 'tok123',
         baseUrl: 'https://www.aliwork.com',
       }));
       expect(utils.httpGet).toHaveBeenCalledTimes(2);
@@ -98,7 +96,6 @@ describe('export-app', () => {
     });
 
     const result = await fetchFormSchema('APP_XXX', 'FORM_MISSING', {
-      csrfToken: 'tok123',
       baseUrl: 'https://www.aliwork.com',
     });
 

--- a/tests/flash-note.test.js
+++ b/tests/flash-note.test.js
@@ -139,7 +139,6 @@ describe('flash-to-prd CLI command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     utils.loadAuthData.mockReturnValue({
-      csrf_token: 'tok123',
       base_url: 'https://www.aliwork.com',
       auth_mode: 'token',
       auth_source: 'token',
@@ -175,7 +174,6 @@ describe('flash-to-prd CLI command', () => {
 
   test('callAI posts through yida-client and returns generated text', async () => {
     const result = await callAI('生成 PRD', 2048, {
-      csrfToken: 'tok123',
       baseUrl: 'https://www.aliwork.com',
       authMode: 'token',
       authSource: 'token',
@@ -185,7 +183,6 @@ describe('flash-to-prd CLI command', () => {
     expect(utils.httpPost).toHaveBeenCalledTimes(1);
     expect(utils.httpPost.mock.calls[0][1]).toBe('/query/intelligent/txtFromAI.json');
     expect(querystring.parse(utils.httpPost.mock.calls[0][2])).toMatchObject({
-      _csrf_token: 'tok123',
       prompt: '生成 PRD',
       maxTokens: '2048',
       skill: 'ToText',
@@ -199,7 +196,6 @@ describe('flash-to-prd CLI command', () => {
     });
 
     await expect(callAI('生成 PRD', 2048, {
-      csrfToken: 'tok123',
       baseUrl: 'https://www.aliwork.com',
       authMode: 'token',
       authSource: 'token',

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -37,7 +37,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'tok123',
 };
 
 beforeEach(() => {
@@ -295,7 +294,7 @@ describe('fetchSchemaRecord', () => {
     const record = await fetchSchemaRecord(
       'APP_XXX',
       { formUuid: 'FORM-A', formName: '客户信息' },
-      { csrfToken: 'tok123', authMode: 'token', authSource: 'token' },
+      { authMode: 'token', authSource: 'token' },
       1
     );
 

--- a/tests/i18n-management.test.js
+++ b/tests/i18n-management.test.js
@@ -29,7 +29,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 beforeEach(() => {

--- a/tests/import-app.test.js
+++ b/tests/import-app.test.js
@@ -12,15 +12,15 @@ describe('import-app helpers', () => {
     expect(__test__.normalizeImportFormType('')).toBe('receipt');
 
     const displayPayload = querystring.parse(
-      __test__.buildCreateFormPostData('csrf-1', 'Imported Page', 'display')
+      __test__.buildCreateFormPostData('Imported Page', 'display')
     );
     const reportPayload = querystring.parse(
-      __test__.buildCreateFormPostData('csrf-1', 'Imported Report', 'report')
+      __test__.buildCreateFormPostData('Imported Report', 'report')
     );
 
     expect(displayPayload.formType).toBe('display');
     expect(reportPayload.formType).toBe('report');
-    expect(displayPayload._csrf_token).toBe('csrf-1');
+    expect(displayPayload).not.toHaveProperty('_csrf_token');
     expect(JSON.parse(displayPayload.title).zh_CN).toBe('Imported Page');
   });
 

--- a/tests/integration-api.test.js
+++ b/tests/integration-api.test.js
@@ -22,7 +22,6 @@ describe('integration api', () => {
       get: jest.fn(async (path, query, options) => {
         const auth = {
           baseUrl: 'https://example.com',
-          csrfToken: 'csrf-token',
         };
         const resolvedQuery = typeof query === 'function' ? query(auth) : query;
         return httpGet(auth.baseUrl, path, resolvedQuery, options);
@@ -42,7 +41,6 @@ describe('integration api', () => {
 
     const result = await listLogicflowLogs({
       baseUrl: 'https://example.com',
-      csrfToken: 'csrf-token',
     }, {
       appType: 'APP_TEST',
       processCode: 'LPROC-TEST',
@@ -76,7 +74,6 @@ describe('integration api', () => {
 
     await listFormLogicflows({
       baseUrl: 'https://example.com',
-      csrfToken: 'csrf-token',
     }, {
       appType: 'APP_TEST',
       formUuid: 'FORM_TEST',
@@ -133,7 +130,6 @@ describe('integration api', () => {
 
     const fields = await getFormSchema({
       baseUrl: 'https://example.com',
-      csrfToken: 'csrf-token',
     }, {
       appType: 'APP_TEST',
       formUuid: 'FORM_TARGET',

--- a/tests/integration-create.test.js
+++ b/tests/integration-create.test.js
@@ -6,7 +6,6 @@ jest.mock('../lib/core/utils', () => ({
     auth_source: 'token',
     corp_id: 'corp-1',
     user_id: 'user-1',
-    csrf_token: 'csrf-token',
     base_url: 'https://example.com',
   })),
   triggerLogin: jest.fn(),

--- a/tests/integration-list.test.js
+++ b/tests/integration-list.test.js
@@ -16,7 +16,6 @@ jest.mock('../lib/core/utils', () => {
       auth_source: 'token',
       corp_id: 'corp-1',
       user_id: 'user-1',
-      csrf_token: 'fake-csrf',
       base_url: 'https://www.aliwork.com',
     })),
     triggerLogin: jest.fn(),

--- a/tests/list-forms.test.js
+++ b/tests/list-forms.test.js
@@ -17,7 +17,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'tok123',
 };
 
 beforeEach(() => {

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -79,7 +79,6 @@ describe('OpenYida MCP server helpers', () => {
       selected_corp: null,
     });
     expect(result.cookies).toBeUndefined();
-    expect(result.csrf_token).toBeUndefined();
   });
 });
 

--- a/tests/page-config.test.js
+++ b/tests/page-config.test.js
@@ -22,7 +22,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'tok123',
 };
 
 let logSpy;
@@ -71,7 +70,6 @@ describe('get-page-config', () => {
     expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/query/formdesign/getShareConfig.json');
     expect(querystring.parse(utils.httpPost.mock.calls[0][2])).toMatchObject({
       _api: 'Share.getShareConfig',
-      _csrf_token: 'tok123',
       formUuid: 'FORM_XXX',
     });
     expect(result).toEqual({
@@ -103,7 +101,6 @@ describe('verify-short-url', () => {
     expect(utils.httpGet.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/query/formdesign/verifyShortUrl.json');
     expect(utils.httpGet.mock.calls[0][2]).toMatchObject({
       _api: 'App.verifyShortUrlForm',
-      _csrf_token: 'tok123',
       formUuid: 'FORM_XXX',
       openUrl: '/o/new-page',
     });
@@ -162,7 +159,6 @@ describe('save-share-config', () => {
     const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
     expect(body).toMatchObject({
       _api: 'Share.saveShareConfig',
-      _csrf_token: 'tok123',
       formUuid: 'FORM_XXX',
       openUrl: '/o/public-page',
       isOpen: 'y',

--- a/tests/permission.test.js
+++ b/tests/permission.test.js
@@ -21,7 +21,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 describe('get-permission command regression', () => {
@@ -71,7 +70,6 @@ describe('get-permission command regression', () => {
       '/APP-1/permission/manage/listPermitPackages.json',
       expect.objectContaining({
         _api: 'Permission.getPermitGroupList',
-        _csrf_token: 'csrf',
         formUuid: 'FORM-1',
         appType: 'APP-1',
       })

--- a/tests/process-small.test.js
+++ b/tests/process-small.test.js
@@ -37,7 +37,6 @@ const mockAuthData = {
   auth_mode: 'token',
   auth_source: 'token',
   user_id: 'user-1',
-  csrf_token: 'csrf-token',
   base_url: 'https://www.aliwork.com',
   corp_id: 'corp-1',
 };
@@ -84,7 +83,6 @@ describe('small process commands', () => {
     });
     expect(utils.httpPost.mock.calls[0][1]).toContain('/APP_XXX/query/formdesign/switchFormType.json');
     expect(querystring.parse(utils.httpPost.mock.calls[0][2])).toMatchObject({
-      _csrf_token: 'csrf-token',
       toFormType: 'process',
       formUuid: 'FORM_1',
     });

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -19,7 +19,6 @@ jest.mock('../lib/core/utils', () => ({
 const utils = require('../lib/core/utils');
 
 const mockAuthData = {
-  csrf_token: 'tok123',
   base_url: 'https://www.aliwork.com',
   auth_mode: 'token',
   auth_source: 'token',
@@ -116,14 +115,14 @@ describe('run() 未登录场景', () => {
     utils.loadAuthData.mockReturnValue(null);
     utils.triggerLogin.mockReturnValue(null);
 
-    await expectCliError(run(['query', 'form', 'APP_XXX', 'FORM-XXX']), '无法获取有效登录态');
+    await expectCliError(run(['query', 'form', 'APP_XXX', 'FORM-XXX']), '无法获取有效 token 登录态');
   });
 
   test('loadAuthData 返回不可用对象时尝试 triggerLogin，仍失败则退出', async () => {
     utils.loadAuthData.mockReturnValue({});
     utils.triggerLogin.mockReturnValue(null);
 
-    await expectCliError(run(['query', 'form', 'APP_XXX', 'FORM-XXX']), '无法获取有效登录态');
+    await expectCliError(run(['query', 'form', 'APP_XXX', 'FORM-XXX']), '无法获取有效 token 登录态');
   });
 });
 

--- a/tests/report-command.test.js
+++ b/tests/report-command.test.js
@@ -22,14 +22,12 @@ const createReport = require('../lib/report/index');
 const appendReport = require('../lib/report/append');
 
 const authRef = {
-  csrfToken: 'csrf-token',
   baseUrl: 'https://demo.aliwork.com',
   authMode: 'token',
   authSource: 'token',
   corpId: 'corp-1',
   userId: 'user-1',
   authData: {
-    csrf_token: 'csrf-token',
     base_url: 'https://demo.aliwork.com',
     auth_mode: 'token',
     auth_source: 'token',
@@ -67,7 +65,6 @@ describe('report command helpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     utils.loadAuthData.mockReturnValue({
-      csrf_token: authRef.csrfToken,
       base_url: authRef.baseUrl,
       auth_mode: 'token',
       auth_source: 'token',
@@ -92,12 +89,10 @@ describe('report command helpers', () => {
 
     expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/query/formdesign/saveFormSchemaInfo.json');
     expect(querystring.parse(utils.httpPost.mock.calls[0][2])).toMatchObject({
-      _csrf_token: 'csrf-token',
       formType: 'report',
     });
     expect(utils.httpPost.mock.calls[1][1]).toBe('/dingtalk/web/APP_XXX/_view/query/formdesign/saveFormSchema.json');
     expect(querystring.parse(utils.httpPost.mock.calls[1][2])).toMatchObject({
-      _csrf_token: 'csrf-token',
       formUuid: 'REPORT_1',
       schemaVersion: 'V5',
       importSchema: 'true',

--- a/tests/save-permission.test.js
+++ b/tests/save-permission.test.js
@@ -24,7 +24,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'csrf',
 };
 
 describe('save-permission command', () => {
@@ -77,7 +76,6 @@ describe('save-permission command', () => {
     expect(utils.httpPost).toHaveBeenCalledTimes(1);
     const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
     expect(body).toMatchObject({
-      _csrf_token: 'csrf',
       formUuid: 'FORM-1',
       packageUuid: 'pkg-1',
       fieldPermit: '{"fieldRange":"CUSTOM","fields":{"textField_a":"READONLY"}}',
@@ -112,7 +110,6 @@ describe('save-permission command', () => {
     const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
     expect(body.packageUuid).toBeUndefined();
     expect(body).toMatchObject({
-      _csrf_token: 'csrf',
       formUuid: 'FORM-1',
       fieldPermit: '{"fieldRange":"CUSTOM","fields":{"textField_a":"READONLY"}}',
     });

--- a/tests/task-center.test.js
+++ b/tests/task-center.test.js
@@ -17,7 +17,6 @@ const mockAuthData = {
   auth_source: 'token',
   corp_id: 'corp-1',
   user_id: 'user-1',
-  csrf_token: 'tok123',
 };
 
 beforeEach(() => {

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -62,6 +62,7 @@ describe('token-auth', () => {
             accessToken: 'new-local-access-token',
             refreshToken: 'new-local-refresh-token',
             expiresIn: 1800,
+            baseUrl: 'https://corp.example.com',
           },
         }));
       });
@@ -80,6 +81,7 @@ describe('token-auth', () => {
 
       const refreshed = await tokenRefresh({
         projectRoot: tmpDir,
+        endpoint: `http://127.0.0.1:${port}`,
         env: {
           OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
         },
@@ -90,6 +92,7 @@ describe('token-auth', () => {
       const saved = JSON.parse(fs.readFileSync(getTokenFilePath({ projectRoot: tmpDir }), 'utf8'));
       expect(saved.access_token).toBe('new-local-access-token');
       expect(saved.refresh_token).toBe('new-local-refresh-token');
+      expect(saved.base_url).toBe('https://corp.example.com');
       expect(saved.corp_id).toBe('corp-local');
       expect(saved.user_id).toBe('user-local');
     } finally {
@@ -106,13 +109,17 @@ describe('token-auth', () => {
       userId: process.env.OPENYIDA_TOKEN_USER_ID,
     };
     const seenAccessTokens = [];
-    let refreshTokenUsed;
+    const refreshTokensUsed = [];
+    let refreshRequestCount = 0;
     const server = http.createServer((req, res) => {
       if (req.url === '/openapi/cli/v1/auth/refresh') {
+        refreshRequestCount += 1;
         const chunks = [];
         req.on('data', (chunk) => chunks.push(chunk));
         req.on('end', () => {
-          refreshTokenUsed = JSON.parse(Buffer.concat(chunks).toString('utf8')).refreshToken;
+          refreshTokensUsed.push(
+            JSON.parse(Buffer.concat(chunks).toString('utf8')).refreshToken
+          );
           res.setHeader('content-type', 'application/json');
           res.end(JSON.stringify({
             success: true,
@@ -121,6 +128,7 @@ describe('token-auth', () => {
               accessToken: 'refreshed-access-token',
               refreshToken: 'refreshed-refresh-token',
               expiresIn: 1800,
+              base_url: 'https://corp.example.com',
             },
           }));
         });
@@ -142,16 +150,22 @@ describe('token-auth', () => {
       seenAccessTokens.push(firstToken);
       const secondToken = await getAccessToken({ projectRoot: tmpDir });
       seenAccessTokens.push(secondToken);
+      await tokenRefresh({ projectRoot: tmpDir });
 
       expect(seenAccessTokens).toEqual([
         'refreshed-access-token',
         'refreshed-access-token',
       ]);
-      expect(refreshTokenUsed).toBe('sandbox-refresh-token');
+      expect(refreshTokensUsed).toEqual([
+        'sandbox-refresh-token',
+        'refreshed-refresh-token',
+      ]);
+      expect(refreshRequestCount).toBe(2);
 
       const saved = JSON.parse(fs.readFileSync(getTokenFilePath({ projectRoot: tmpDir }), 'utf8'));
       expect(saved.access_token).toBe('refreshed-access-token');
       expect(saved.refresh_token).toBe('refreshed-refresh-token');
+      expect(saved.base_url).toBe('https://corp.example.com');
       expect(saved.corp_id).toBe('corp-env');
       expect(saved.user_id).toBe('user-env');
     } finally {

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const { getAccessToken, tokenRefresh, tokenStatus } = require('../lib/auth/token-auth');
+const { getTokenFilePath, saveTokenSession } = require('../lib/auth/token-store');
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+describe('token-auth', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-auth-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('本地 access token 即使过期也优先返回，等待业务接口判定', async () => {
+    saveTokenSession({
+      access_token: 'expired-local-access-token',
+      expires_at: Date.now() - 1000,
+      base_url: 'https://www.aliwork.com',
+    }, { projectRoot: tmpDir });
+
+    await expect(getAccessToken({
+      projectRoot: tmpDir,
+      env: {
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_ACCESS_TOKEN_EXPIRES_IN: '1800',
+      },
+    })).resolves.toBe('expired-local-access-token');
+    expect(tokenStatus({ projectRoot: tmpDir })).toMatchObject({
+      ok: true,
+      status: 'ok',
+      can_auto_use: true,
+    });
+  });
+
+  test('本地缺少 refresh token 时使用环境变量刷新并把新 session 落盘', async () => {
+    let refreshBody;
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (chunk) => chunks.push(chunk));
+      req.on('end', () => {
+        refreshBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({
+          success: true,
+          content: {
+            status: 'ok',
+            accessToken: 'new-local-access-token',
+            refreshToken: 'new-local-refresh-token',
+            expiresIn: 1800,
+          },
+        }));
+      });
+    });
+    const port = await listen(server);
+
+    try {
+      saveTokenSession({
+        access_token: 'expired-access-token',
+        expires_at: Date.now() - 1000,
+        base_url: `http://127.0.0.1:${port}`,
+        client_id: 'suite9xvlxxerybljwheo',
+        corp_id: 'corp-local',
+        user_id: 'user-local',
+      }, { projectRoot: tmpDir });
+
+      const refreshed = await tokenRefresh({
+        projectRoot: tmpDir,
+        env: {
+          OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        },
+      });
+      expect(refreshBody.refreshToken).toBe('env-refresh-token');
+      expect(refreshed.access_token).toBe('new-local-access-token');
+
+      const saved = JSON.parse(fs.readFileSync(getTokenFilePath({ projectRoot: tmpDir }), 'utf8'));
+      expect(saved.access_token).toBe('new-local-access-token');
+      expect(saved.refresh_token).toBe('new-local-refresh-token');
+      expect(saved.corp_id).toBe('corp-local');
+      expect(saved.user_id).toBe('user-local');
+    } finally {
+      server.close();
+    }
+  });
+
+  test('只有环境 refresh token 时首次获取 access token 会刷新落盘', async () => {
+    const previousEnv = {
+      access: process.env.OPENYIDA_ACCESS_TOKEN,
+      refresh: process.env.OPENYIDA_REFRESH_TOKEN,
+      endpoint: process.env.OPENYIDA_ENDPOINT,
+      corpId: process.env.OPENYIDA_TOKEN_CORP_ID,
+      userId: process.env.OPENYIDA_TOKEN_USER_ID,
+    };
+    const seenAccessTokens = [];
+    let refreshTokenUsed;
+    const server = http.createServer((req, res) => {
+      if (req.url === '/openapi/cli/v1/auth/refresh') {
+        const chunks = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => {
+          refreshTokenUsed = JSON.parse(Buffer.concat(chunks).toString('utf8')).refreshToken;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({
+            success: true,
+            content: {
+              status: 'ok',
+              accessToken: 'refreshed-access-token',
+              refreshToken: 'refreshed-refresh-token',
+              expiresIn: 1800,
+            },
+          }));
+        });
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+    const port = await listen(server);
+
+    try {
+      delete process.env.OPENYIDA_ACCESS_TOKEN;
+      process.env.OPENYIDA_REFRESH_TOKEN = 'sandbox-refresh-token';
+      process.env.OPENYIDA_ENDPOINT = `http://127.0.0.1:${port}`;
+      process.env.OPENYIDA_TOKEN_CORP_ID = 'corp-env';
+      process.env.OPENYIDA_TOKEN_USER_ID = 'user-env';
+
+      const firstToken = await getAccessToken({ projectRoot: tmpDir });
+      seenAccessTokens.push(firstToken);
+      const secondToken = await getAccessToken({ projectRoot: tmpDir });
+      seenAccessTokens.push(secondToken);
+
+      expect(seenAccessTokens).toEqual([
+        'refreshed-access-token',
+        'refreshed-access-token',
+      ]);
+      expect(refreshTokenUsed).toBe('sandbox-refresh-token');
+
+      const saved = JSON.parse(fs.readFileSync(getTokenFilePath({ projectRoot: tmpDir }), 'utf8'));
+      expect(saved.access_token).toBe('refreshed-access-token');
+      expect(saved.refresh_token).toBe('refreshed-refresh-token');
+      expect(saved.corp_id).toBe('corp-env');
+      expect(saved.user_id).toBe('user-env');
+    } finally {
+      server.close();
+      const restore = (name, value) => {
+        if (value === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = value;
+        }
+      };
+      restore('OPENYIDA_ACCESS_TOKEN', previousEnv.access);
+      restore('OPENYIDA_REFRESH_TOKEN', previousEnv.refresh);
+      restore('OPENYIDA_ENDPOINT', previousEnv.endpoint);
+      restore('OPENYIDA_TOKEN_CORP_ID', previousEnv.corpId);
+      restore('OPENYIDA_TOKEN_USER_ID', previousEnv.userId);
+    }
+  });
+});

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -62,7 +62,6 @@ describe('token-auth', () => {
             accessToken: 'new-local-access-token',
             refreshToken: 'new-local-refresh-token',
             expiresIn: 1800,
-            baseUrl: 'https://corp.example.com',
           },
         }));
       });
@@ -73,7 +72,7 @@ describe('token-auth', () => {
       saveTokenSession({
         access_token: 'expired-access-token',
         expires_at: Date.now() - 1000,
-        base_url: `http://127.0.0.1:${port}`,
+        base_url: 'https://legacy-corp.example.com',
         client_id: 'suite9xvlxxerybljwheo',
         corp_id: 'corp-local',
         user_id: 'user-local',
@@ -92,7 +91,7 @@ describe('token-auth', () => {
       const saved = JSON.parse(fs.readFileSync(getTokenFilePath({ projectRoot: tmpDir }), 'utf8'));
       expect(saved.access_token).toBe('new-local-access-token');
       expect(saved.refresh_token).toBe('new-local-refresh-token');
-      expect(saved.base_url).toBe('https://corp.example.com');
+      expect(saved.base_url).toBe('https://legacy-corp.example.com');
       expect(saved.corp_id).toBe('corp-local');
       expect(saved.user_id).toBe('user-local');
     } finally {

--- a/tests/token-store.test.js
+++ b/tests/token-store.test.js
@@ -58,6 +58,106 @@ describe('token-store', () => {
     expect(loadTokenSession(options)).toBe(null);
   });
 
+  test('uses the injected env refresh token when the local token file is absent', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_ENDPOINT: 'https://www.aliwork.com',
+        OPENYIDA_TOKEN_CLIENT_ID: 'openyida-cli',
+        OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+        OPENYIDA_TOKEN_USER_ID: 'user-env',
+      },
+    };
+
+    const loaded = loadTokenSession(options);
+
+    expect(loaded.access_token).toBeUndefined();
+    expect(loaded.refresh_token).toBe('env-refresh-token');
+    expect(loaded.auth_source).toBe('env');
+    expect(loaded.corp_id).toBe('corp-env');
+    expect(loaded.user_id).toBe('user-env');
+  });
+
+  test('does not fall back to env when a valid local token file exists', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      },
+    };
+    saveTokenSession({
+      access_token: 'local-access-token',
+      refresh_token: 'local-refresh-token',
+      expires_in: 1800,
+    }, options);
+
+    const loaded = loadTokenSession(options);
+
+    expect(loaded.access_token).toBe('local-access-token');
+    expect(loaded.refresh_token).toBe('local-refresh-token');
+    expect(loaded.auth_source).toBe('local');
+  });
+
+  test('fills a missing local refresh token from env without replacing local access token', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      },
+    };
+    saveTokenSession({
+      access_token: 'local-access-token',
+      expires_at: Date.now() - 1000,
+    }, options);
+
+    const loaded = loadTokenSession(options);
+    expect(loaded.access_token).toBe('local-access-token');
+    expect(loaded.refresh_token).toBe('env-refresh-token');
+    expect(loaded.auth_source).toBe('mixed');
+  });
+
+  test('never fills a missing local access token from env', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      },
+    };
+    saveTokenSession({ refresh_token: 'local-refresh-token' }, options);
+
+    const loaded = loadTokenSession(options);
+    expect(loaded.access_token).toBeUndefined();
+    expect(loaded.refresh_token).toBe('local-refresh-token');
+    expect(loaded.auth_source).toBe('local');
+  });
+
+  test('falls back to env fields when the local token file cannot be parsed', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      },
+    };
+    const tokenFile = getTokenFilePath(options);
+    fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
+    fs.writeFileSync(tokenFile, '{not-json', 'utf8');
+
+    const loaded = loadTokenSession(options);
+    expect(loaded.access_token).toBeUndefined();
+    expect(loaded.refresh_token).toBe('env-refresh-token');
+    expect(loaded.auth_source).toBe('env');
+  });
+
   test('masks token values', () => {
     expect(maskToken('1234567890abcdefg')).toBe('12345678...bcdefg');
     expect(maskToken('short')).toBe('shor...');

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -9,7 +9,6 @@ const http = require('http');
 const {
   resolveBaseUrl,
   isLoginExpired,
-  isCsrfTokenExpired,
   loadAuthData,
   detectActiveTool,
   hasDesktopEnvironment,
@@ -17,7 +16,6 @@ const {
   httpPost,
   httpPostJson,
   httpGet,
-  requestWithAutoLogin,
 } = require('../lib/core/utils');
 
 jest.mock('../lib/auth/token-auth', () => ({
@@ -121,6 +119,17 @@ describe('isLoginExpired', () => {
     expect(isLoginExpired({ success: false, errorCode: 'not_logged_in' })).toBe(true);
   });
 
+  test('invalid_access_token 状态会被识别为 access token 失效', () => {
+    expect(isLoginExpired({ status: 'invalid_access_token' })).toBe(true);
+    expect(isLoginExpired({
+      success: true,
+      content: {
+        status: 'invalid_access_token',
+        message: 'Authorization Bearer token is invalid or expired',
+      },
+    })).toBe(true);
+  });
+
   test('success 为 true 时返回 false', () => {
     expect(isLoginExpired({ success: true, errorCode: '307' })).toBe(false);
   });
@@ -135,26 +144,6 @@ describe('isLoginExpired', () => {
 
   test('空对象时返回 false', () => {
     expect(isLoginExpired({})).toBe(false);
-  });
-});
-
-// ── isCsrfTokenExpired ────────────────────────────────────────────────
-
-describe('isCsrfTokenExpired', () => {
-  test('errorCode TIANSHU_000030 时返回 true', () => {
-    expect(isCsrfTokenExpired({ success: false, errorCode: 'TIANSHU_000030' })).toBe(true);
-  });
-
-  test('success 为 true 时返回 false', () => {
-    expect(isCsrfTokenExpired({ success: true, errorCode: 'TIANSHU_000030' })).toBe(false);
-  });
-
-  test('errorCode 不匹配时返回 false', () => {
-    expect(isCsrfTokenExpired({ success: false, errorCode: 'OTHER_CODE' })).toBe(false);
-  });
-
-  test('null 时返回 falsy', () => {
-    expect(isCsrfTokenExpired(null)).toBeFalsy();
   });
 });
 
@@ -251,35 +240,46 @@ describe('http redirect login detection', () => {
 // ── requestWithAutoLogin ──────────────────────────────────────────────
 
 describe('requestWithAutoLogin', () => {
-  test('csrf 失败在 token-only 模式下直接返回明确错误', async () => {
-    const requestFn = jest.fn().mockResolvedValueOnce({ __csrfExpired: true });
+  test('登录失效且 refresh 请求失败时不回退到登录引导', async () => {
+    jest.resetModules();
+    const tokenRefresh = jest.fn(() => {
+      throw new Error('refresh failed');
+    });
+    const isRefreshAuthRequired = jest.fn(() => false);
+    jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh, isRefreshAuthRequired }));
+    const utils = require('../lib/core/utils');
+    const requestFn = jest.fn().mockResolvedValueOnce({ __needLogin: true });
 
-    const result = await requestWithAutoLogin(requestFn, {
-      csrfToken: 'openyida_cli_bearer',
+    const result = await utils.requestWithAutoLogin(requestFn, {
       baseUrl: 'https://www.aliwork.com',
       authMode: 'token',
       authSource: 'token',
     });
 
+    expect(tokenRefresh).toHaveBeenCalledTimes(1);
     expect(requestFn).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
       success: false,
-      __needLogin: true,
-      errorCode: 'TOKEN_AUTH_REQUIRED',
+      errorCode: 'TOKEN_REFRESH_FAILED',
     });
+    jest.dontMock('../lib/auth/token-auth');
+    jest.resetModules();
   });
 
-  test('登录失效且 refresh 失败时不回退到 cookie 登录', async () => {
+  test('登录失效且 refresh token 无效时才提示重新登录', async () => {
     jest.resetModules();
-    const tokenRefresh = jest.fn(() => {
-      throw new Error('refresh failed');
+    const tokenRefresh = jest.fn().mockResolvedValue({
+      ok: false,
+      auth_mode: 'token',
+      status: 'invalid_refresh_token',
+      can_auto_use: false,
     });
-    jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh }));
+    const isRefreshAuthRequired = jest.fn((value) => value && value.status === 'invalid_refresh_token');
+    jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh, isRefreshAuthRequired }));
     const utils = require('../lib/core/utils');
     const requestFn = jest.fn().mockResolvedValueOnce({ __needLogin: true });
 
     const result = await utils.requestWithAutoLogin(requestFn, {
-      csrfToken: 'openyida_cli_bearer',
       baseUrl: 'https://www.aliwork.com',
       authMode: 'token',
       authSource: 'token',
@@ -293,6 +293,58 @@ describe('requestWithAutoLogin', () => {
       errorCode: 'TOKEN_AUTH_REQUIRED',
     });
     jest.dontMock('../lib/auth/token-auth');
+    jest.resetModules();
+  });
+
+  test('登录失效且 refresh 成功时刷新 token 并重试原请求', async () => {
+    jest.resetModules();
+    const tokenRefresh = jest.fn().mockResolvedValue({
+      access_token: 'new-access-token',
+      refresh_token: 'refresh-token',
+      base_url: 'https://www.aliwork.com',
+    });
+    const loadTokenSession = jest.fn().mockReturnValue({
+      access_token: 'new-access-token',
+      refresh_token: 'refresh-token',
+      base_url: 'https://www.aliwork.com',
+      corp_id: 'ding-corp',
+      user_id: 'user-1',
+    });
+    const isRefreshAuthRequired = jest.fn(() => false);
+    jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh, isRefreshAuthRequired }));
+    jest.doMock('../lib/auth/token-store', () => ({ loadTokenSession }));
+    const utils = require('../lib/core/utils');
+    const requestFn = jest.fn()
+      .mockResolvedValueOnce({ __needLogin: true })
+      .mockResolvedValueOnce({ success: true, content: { ok: true } });
+    const authRef = {
+      baseUrl: 'https://www.aliwork.com',
+      authData: {
+        auth_mode: 'token',
+        auth_source: 'token',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'suite9xvlxxerybljwheo',
+      },
+      authMode: 'token',
+      authSource: 'token',
+    };
+
+    const result = await utils.requestWithAutoLogin(requestFn, authRef);
+
+    expect(tokenRefresh).toHaveBeenCalledWith(expect.objectContaining({
+      baseUrl: 'https://www.aliwork.com',
+      clientId: 'suite9xvlxxerybljwheo',
+    }));
+    expect(requestFn).toHaveBeenCalledTimes(2);
+    expect(authRef.authData).toMatchObject({
+      auth_mode: 'token',
+      base_url: 'https://www.aliwork.com',
+      corp_id: 'ding-corp',
+      user_id: 'user-1',
+    });
+    expect(result).toEqual({ success: true, content: { ok: true } });
+    jest.dontMock('../lib/auth/token-auth');
+    jest.dontMock('../lib/auth/token-store');
     jest.resetModules();
   });
 });
@@ -323,7 +375,6 @@ describe('loadAuthData', () => {
 
     const result = loadAuthData(tmpDir);
     expect(result).toMatchObject({
-      csrf_token: 'openyida_cli_bearer',
       corp_id: 'corpA',
       user_id: 'user1',
       base_url: 'https://www.aliwork.com',
@@ -336,7 +387,7 @@ describe('loadAuthData', () => {
     const cacheDir = path.join(tmpDir, '.cache');
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, 'cookies.json'), JSON.stringify([
-      { name: 'tianshu_csrf_token', value: 'unsafe-cookie-token' },
+      { name: 'ai_app_user_auth_token', value: 'unsafe-cookie-token' },
     ]), 'utf-8');
 
     expect(loadAuthData(tmpDir)).toBeNull();

--- a/tests/yida-client.test.js
+++ b/tests/yida-client.test.js
@@ -17,7 +17,6 @@ describe('yida-client', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     utils.loadAuthData.mockReturnValue({
-      csrf_token: 'csrf123',
       base_url: 'https://example.yida.test',
       auth_mode: 'token',
       auth_source: 'token',
@@ -33,7 +32,6 @@ describe('yida-client', () => {
     const authRef = createAuthRef();
 
     expect(authRef).toMatchObject({
-      csrfToken: 'csrf123',
       baseUrl: 'https://example.yida.test',
       authMode: 'token',
       authSource: 'token',
@@ -48,14 +46,13 @@ describe('yida-client', () => {
   test('falls back to login when cache is missing', () => {
     utils.loadAuthData.mockReturnValue(null);
     utils.triggerLogin.mockReturnValue({
-      csrf_token: 'fresh',
       auth_mode: 'token',
       auth_source: 'token',
     });
 
     const authRef = createAuthRef();
 
-    expect(authRef.csrfToken).toBe('fresh');
+    expect(authRef.authMode).toBe('token');
     expect(utils.triggerLogin).toHaveBeenCalledTimes(1);
   });
 
@@ -86,15 +83,15 @@ describe('yida-client', () => {
 
   test('can build request params from the current auth ref', async () => {
     const client = createYidaClient();
-    await client.postForm('/save/path.json', auth => ({ _csrf_token: auth.csrfToken, name: 'Ada' }));
+    await client.postForm('/save/path.json', auth => ({ userId: auth.userId, name: 'Ada' }));
 
-    expect(utils.httpPost.mock.calls[0][2]).toBe('_csrf_token=csrf123&name=Ada');
+    expect(utils.httpPost.mock.calls[0][2]).toBe('userId=user-1&name=Ada');
   });
 
   test('posts JSON bodies with auth-aware paths and referers', async () => {
     const client = createYidaClient();
     const result = await client.postJson(
-      auth => `/save/path.json?_csrf_token=${auth.csrfToken}`,
+      auth => `/save/path.json?userId=${auth.userId}`,
       { name: 'Ada Lovelace' },
       auth => ({ referer: `${auth.baseUrl}/settings` })
     );
@@ -102,9 +99,9 @@ describe('yida-client', () => {
     expect(result).toEqual({ success: true, method: 'post-json' });
     expect(utils.httpPostJson).toHaveBeenCalledWith(
       'https://example.yida.test',
-      '/save/path.json?_csrf_token=csrf123',
+      '/save/path.json?userId=user-1',
       { name: 'Ada Lovelace' },
-      { csrfToken: 'csrf123', referer: 'https://example.yida.test/settings' }
+      { referer: 'https://example.yida.test/settings' }
     );
   });
 });


### PR DESCRIPTION
## Summary
- bump openyida to 2026.7.17-3
- keep the existing business base_url in token session when refresh response omits base_url
- keep token refresh exchange using the active auth endpoint while subsequent business calls continue using the preserved business endpoint

## Validation
- npm test -- tests/token-auth.test.js tests/token-store.test.js tests/utils.test.js tests/yida-client.test.js --runInBand
- npm run check:ci

## Notes
- docs/ local markdown changes are intentionally not included in this release commit