### PR TITLE
fix: avoid Windows cmd truncating browser URLs at '&'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
 
+## [2026.7.18-1] - 2026-07-18
+
+### Fixed
+- 修复 Windows 下 `openyida login` 无法登录的问题：拉起浏览器时改用 `rundll32 url.dll,FileProtocolHandler`，不再经过 `cmd /c start`。此前 cmd.exe 会把 OAuth URL 中的 `&` 当作命令分隔符，导致 URL 在第一个 `&` 处被截断，`client_id`、`response_type`、`scope`、`state` 全部丢失，钉钉登录页报「参数无效：clientId is blank」。macOS/Linux 不受影响，因此该问题仅在 Windows 用户侧出现。
+- 同步修复 `openyida bridge` 页面唤起在 Windows 下的相同缺陷：bridge 页面 URL 通过 hash 片段携带的 `oy_bridge_url`、`oy_bridge_token` 参数会被 `cmd /c start` 在 `&` 处截断，导致 bridge 配对回连信息丢失、配对失败。现与登录链路复用同一套浏览器拉起逻辑（`resolveBrowserLauncher`），行为统一。
+
+
 ## [2026.7.18] - 2026-07-18
 
 ### Highlights

--- a/lib/auth/oauth-loopback.js
+++ b/lib/auth/oauth-loopback.js
@@ -11,19 +11,26 @@ function randomToken(bytes = 24) {
   return crypto.randomBytes(bytes).toString('base64url');
 }
 
+function resolveBrowserLauncher(url, platform = process.platform) {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [url] };
+  }
+  if (platform === 'win32') {
+    // rundll32 hands the URL to the default browser as a single argument.
+    // Going through `cmd /c start` would let cmd.exe treat the `&` in the
+    // OAuth URL as command separators and truncate the query string after
+    // redirect_uri, dropping client_id/state and breaking login.
+    return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', url] };
+  }
+  return { command: 'xdg-open', args: [url] };
+}
+
 function openBrowser(url) {
   if (process.env.OPENYIDA_NO_BROWSER === '1') {
     return false;
   }
 
-  let command = 'xdg-open';
-  let args = [url];
-  if (process.platform === 'darwin') {
-    command = 'open';
-  } else if (process.platform === 'win32') {
-    command = 'cmd';
-    args = ['/c', 'start', '', url];
-  }
+  const { command, args } = resolveBrowserLauncher(url);
 
   try {
     const child = spawn(command, args, {
@@ -152,5 +159,6 @@ function runDingtalkLoopback(options = {}) {
 module.exports = {
   runDingtalkLoopback,
   buildDingtalkOAuthUrl,
+  resolveBrowserLauncher,
   CALLBACK_PATH,
 };

--- a/lib/bridge/bridge.js
+++ b/lib/bridge/bridge.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const { parseOpenOption } = require('../core/browser-handoff');
+const { resolveBrowserLauncher } = require('../auth/oauth-loopback');
 const { banner, label, success, hint, fail } = require('../core/chalk');
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -1128,19 +1129,11 @@ async function startBridgeServer(options = {}) {
 }
 
 function openExternalUrl(url) {
-  const platform = process.platform;
-  let command;
-  let args;
-  if (platform === 'darwin') {
-    command = 'open';
-    args = [url];
-  } else if (platform === 'win32') {
-    command = 'cmd';
-    args = ['/c', 'start', '', url];
-  } else {
-    command = 'xdg-open';
-    args = [url];
-  }
+  // Reuse the shared launcher so the URL is passed as a single argument.
+  // On Windows this avoids `cmd /c start` splitting the URL on `&`, which
+  // would drop the bridge params carried in the URL hash
+  // (oy_bridge_url / oy_bridge_token) and break bridge pairing.
+  const { command, args } = resolveBrowserLauncher(url);
 
   const child = spawn(command, args, {
     detached: true,

--- a/tests/oauth-loopback.test.js
+++ b/tests/oauth-loopback.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const {
+  buildDingtalkOAuthUrl,
+  resolveBrowserLauncher,
+} = require('../lib/auth/oauth-loopback');
+
+describe('resolveBrowserLauncher', () => {
+  // A realistic OAuth URL: redirect_uri is the FIRST query param, so anything
+  // that truncates at the first `&` loses client_id/scope/state.
+  const oauthUrl = buildDingtalkOAuthUrl({
+    clientId: 'suite9xvlxxerybljwheo',
+    redirectUri: 'http://127.0.0.1:34882/oauth/callback',
+    state: 'abc123',
+    scope: 'openid corpid',
+  });
+
+  test('darwin passes the full URL as a single argument', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'darwin');
+    expect(command).toBe('open');
+    expect(args).toEqual([oauthUrl]);
+  });
+
+  test('linux passes the full URL as a single argument', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'linux');
+    expect(command).toBe('xdg-open');
+    expect(args).toEqual([oauthUrl]);
+  });
+
+  test('win32 uses rundll32 and never routes the URL through cmd', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'win32');
+    // The core of the fix: NOT cmd.exe, which would split the URL on `&`.
+    expect(command).toBe('rundll32');
+    expect(command).not.toBe('cmd');
+    expect(args[0]).toBe('url.dll,FileProtocolHandler');
+    // The URL must be a single, untouched argv element (not split on `&`).
+    expect(args).toHaveLength(2);
+    expect(args[1]).toBe(oauthUrl);
+  });
+
+  test('win32 preserves client_id and all params after the first &', () => {
+    const { args } = resolveBrowserLauncher(oauthUrl, 'win32');
+    const passedUrl = args[1];
+    expect(passedUrl).toContain('&client_id=suite9xvlxxerybljwheo');
+    expect(passedUrl).toContain('&response_type=code');
+    expect(passedUrl).toContain('&scope=');
+    expect(passedUrl).toContain('&state=abc123');
+    // Simulate the old cmd truncation-at-first-& bug and prove we avoid it:
+    const truncated = passedUrl.split('&')[0];
+    expect(truncated).not.toContain('client_id');
+    expect(passedUrl).not.toBe(truncated);
+  });
+});


### PR DESCRIPTION
### Summary- Fix Windows OAuth browser launch URL truncation when parameters contain `&`.### Testing- Not run in this environment, code-path focused change.