### PR TITLE
修复 OAuth 浏览器拉起与发布校验风险

### DIFF
--- a/.qoder/skills/openyida-cross-platform-release-guard/SKILL.md
+++ b/.qoder/skills/openyida-cross-platform-release-guard/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: openyida-cross-platform-release-guard
+description: OpenYida 跨端发布风险守卫。当改动涉及浏览器/URL 拉起（openyida login、bridge 页面唤起、resolveBrowserLauncher、openBrowser、spawn 打开浏览器）、或在 macOS 上开发但需要发布给 Windows/Linux 用户、或准备打 tag 发布新版本时使用。用于在发布前静态扫描并拦截「cmd /c start 截断 URL」「open -n 假装开新窗口」等只在非 macOS 端暴露的历史坑，并输出跨端人工验证清单。
+---
+
+# OpenYida 跨端发布风险守卫
+
+macOS 本地测试跑通 ≠ 发布安全。浏览器/URL 拉起这类代码在 macOS 上正常，却可能在
+Windows/Linux 用户侧直接炸掉——因为每个平台的浏览器拉起命令、URL 转义规则、默认浏览器
+标识（bundle id / ProgId / .desktop）完全不同，而 CI 只跑纯函数单测，覆盖不到真实系统拉起。
+
+## 触发条件
+
+- 改动 `lib/auth/oauth-loopback.js`、`lib/bridge/bridge.js`，或任何 `resolveBrowserLauncher` /
+  `openBrowser` / `spawn(...浏览器...)` 相关逻辑。
+- 在 macOS 开发、发布对象包含 Windows / Linux 用户。
+- 准备打 tag、bump 版本、发布新的 openyida。
+
+## 第一步：跑发布风险静态扫描（必做）
+
+```bash
+npm run check:release-risks
+```
+
+- **HARD 反模式 → exit 1，阻断发布**（已纳入 `check:ci` 第 10 步）：
+  - `cmd-c-start-url` / `cmd-c-start-argv`：`cmd /c start <url>` 会把 URL 里的 `&` 当命令
+    分隔符截断，丢失 `client_id`/`state`（登录）或 `oy_bridge_url`/`oy_bridge_token`（bridge）。
+    → 改用 `rundll32 url.dll,FileProtocolHandler`，并复用 `resolveBrowserLauncher`。
+  - `open-n-url-new-tab`：`open -n <url>` 在 macOS 不会开新窗口，只在默认浏览器开新标签页
+    （假装开窗口）。→ 要真开新窗口须指定浏览器 App 并传其 `--new-window`/`-new-window`；
+    检测不到默认浏览器时回退纯 `open <url>`。
+- **SOFT 提示 → 不阻断**：列出涉及浏览器/URL 拉起的文件，提醒补人工跨端验证。
+
+扫描逻辑见 `scripts/check-release-risks.js`（纯静态扫描 `lib/`，会跳过注释与字符串字面量，
+不把说明性注释误判成真实反模式）；契约由 `tests/check-release-risks.test.js` 锁定。
+
+## 第二步：跨端人工验证清单
+
+CI 通过只代表纯逻辑没问题，浏览器真实拉起必须在目标 OS 各自实测：
+
+| 平台 | 拉起方式 | 默认浏览器标识 | 必测 |
+|------|---------|---------------|------|
+| macOS | `open`（新标签页）/ `open -b <bundle> -n --args --new-window`（新窗口） | LaunchServices bundle id（`com.google.chrome`） | `openyida login` 弹出浏览器且回调页自动关闭；bridge 页面能唤起 |
+| Windows | `rundll32 url.dll,FileProtocolHandler`（默认）/ 浏览器 exe `--new-window` | 注册表 ProgId（`ChromeHTML`/`MSEdgeHTM`/`FirefoxURL`） | 登录 URL 的 `client_id`/`state` **不被 `&` 截断**；bridge 参数不丢 |
+| Linux | `xdg-open`（默认）/ 浏览器 exe `--new-window` | `.desktop` 文件名（`google-chrome.desktop`） | `openyida login` 能拉起浏览器 |
+
+要点：
+- 三端「默认浏览器标识」互不通用，各自独立分类；**未知/不支持的默认浏览器一律回退**到
+  系统默认浏览器新标签页 + 回调页自动关闭，**绝不假装开新窗口**。
+- URL 必须作为**单个 argv 元素**传递，任何经过 shell（`cmd /c`、`sh -c`）的路径都要确认
+  `&` 不被解释。
+
+## 第三步：发布收尾
+
+1. 确认 `package.json` version 与 CHANGELOG 顶部版本一致（日期格式 `vYYYY.MM.DD`，同日多次
+   发布用 `-1`/`-2` 后缀）。
+2. `npm run check:ci` 全绿（含发布风险扫描）。
+3. CHANGELOG 记录本次改动，浏览器/登录/bridge 类改动务必写明**受影响平台**。
+
+## 反哺
+
+发现新的「只在某平台暴露」的拉起坑时，在 `scripts/check-release-risks.js` 的 `HARD_RULES`
+增加一条规则 + 在 `tests/check-release-risks.test.js` 补对应用例，让守卫随坑增长。

--- a/.qoder/skills/openyida-cross-platform-release-guard/SKILL.md
+++ b/.qoder/skills/openyida-cross-platform-release-guard/SKILL.md
@@ -31,8 +31,9 @@ npm run check:release-risks
     检测不到默认浏览器时回退纯 `open <url>`。
 - **SOFT 提示 → 不阻断**：列出涉及浏览器/URL 拉起的文件，提醒补人工跨端验证。
 
-扫描逻辑见 `scripts/check-release-risks.js`（纯静态扫描 `lib/`，会跳过注释与字符串字面量，
-不把说明性注释误判成真实反模式）；契约由 `tests/check-release-risks.test.js` 锁定。
+扫描逻辑见 `scripts/check-release-risks.js`（纯静态扫描 `lib/`，会跳过注释，并正确识别字符串中的
+`//` / `/*` 不是注释；命令字符串仍会保留扫描，确保能抓到 `spawn('cmd', ...)` 这类真实反模式）；
+契约由 `tests/check-release-risks.test.js` 锁定。
 
 ## 第二步：跨端人工验证清单
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
 
+## [2026.7.18-2] - 2026-07-18
+
+### Changed
+- 优化 `openyida login` 与 `openyida bridge` 的浏览器拉起体验：新增跨平台默认浏览器检测（macOS 读 LaunchServices bundle id、Windows 读注册表 ProgId、Linux 读 `.desktop`），检测到已知浏览器时真正打开一个**新窗口**（Chromium 系 `--new-window`、Firefox `-new-window`、Safari 走 AppleScript），而不再是 `open -n <url>` 那种「只在默认浏览器开新标签页却假装开窗口」的行为。
+
+### Fixed
+- 修复 macOS 下 `openyida login` 拉起浏览器只新开标签页、不新开窗口的问题：`open -n <url>` 对已运行的单实例浏览器（Chrome/Safari）无效，实际只会开新标签页。现按检测到的默认浏览器用其原生新窗口参数打开。
+
+### Added
+- 新增 `npm run check:release-risks`（`scripts/check-release-risks.js`）发布前跨端风险静态扫描，并纳入 `check:ci` 门禁：`cmd /c start <url>` 截断 URL、`open -n <url>` 假装开窗口等 HARD 反模式命中即阻断发布（退出码 1）；涉及浏览器/URL 拉起的文件输出跨端人工验证提醒（不阻断）。扫描会跳过注释与字符串字面量，避免把说明性注释误判成真实反模式。
+- 新增项目技能 `.qoder/skills/openyida-cross-platform-release-guard`，沉淀「浏览器/登录/bridge 拉起改动」的发布前风险检查流程与 Windows/macOS/Linux 人工验证清单。
+
+### Guardrails
+- 跨端行为兜底：未知/不支持的默认浏览器（如 Arc 或任何未映射的 bundle id / ProgId / `.desktop`）以及检测失败时，一律回退到系统默认浏览器新标签页 + 回调页自动关闭，绝不尝试新窗口动作。
+
+### Tests
+- `tests/oauth-loopback.test.js`：新增默认浏览器检测（依赖可注入）、三平台新窗口命令、未知/不支持浏览器回退等用例，共 20 个用例。
+- 新增 `tests/check-release-risks.test.js`：覆盖 HARD 反模式命中、注释/字符串误判排除，以及「当前 `lib/` 源码零 HARD 反模式」的仓库守卫。
+
+
 ## [2026.7.18-1] - 2026-07-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
 
-## [2026.7.18-2] - 2026-07-18
+## [2026.7.18-2] - 2026-07-19
 
 ### Changed
 - 优化 `openyida login` 与 `openyida bridge` 的浏览器登录体验：新增跨平台默认浏览器检测。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Tests
 - `tests/oauth-loopback.test.js`：新增默认浏览器检测（依赖可注入）、三平台新窗口命令、未知/不支持浏览器回退等用例，共 20 个用例。
 - 新增 `tests/check-release-risks.test.js`：覆盖 HARD 反模式命中、注释/字符串误判排除，以及「当前 `lib/` 源码零 HARD 反模式」的仓库守卫。
+- `tests/check-release-risks.test.js`：补充普通业务枚举值 `open` 不触发 soft warning 的回归用例。
+- `tests/process-small.test.js`：补充流程预览三端打开命令与路径 argv 传递用例。
+- `npm run check:structure`：新增锁文件版本一致性校验。
 
 
 ## [2026.7.18-1] - 2026-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.7.18-2] - 2026-07-18
 
 ### Changed
-- 优化 `openyida login` 与 `openyida bridge` 的浏览器拉起体验：新增跨平台默认浏览器检测（macOS 读 LaunchServices bundle id、Windows 读注册表 ProgId、Linux 读 `.desktop`），检测到已知浏览器时真正打开一个**新窗口**（Chromium 系 `--new-window`、Firefox `-new-window`、Safari 走 AppleScript），而不再是 `open -n <url>` 那种「只在默认浏览器开新标签页却假装开窗口」的行为。
-
-### Fixed
-- 修复 macOS 下 `openyida login` 拉起浏览器只新开标签页、不新开窗口的问题：`open -n <url>` 对已运行的单实例浏览器（Chrome/Safari）无效，实际只会开新标签页。现按检测到的默认浏览器用其原生新窗口参数打开。
-
-### Added
-- 新增 `npm run check:release-risks`（`scripts/check-release-risks.js`）发布前跨端风险静态扫描，并纳入 `check:ci` 门禁：`cmd /c start <url>` 截断 URL、`open -n <url>` 假装开窗口等 HARD 反模式命中即阻断发布（退出码 1）；涉及浏览器/URL 拉起的文件输出跨端人工验证提醒（不阻断）。扫描会跳过注释与字符串字面量，避免把说明性注释误判成真实反模式。
-- 新增项目技能 `.qoder/skills/openyida-cross-platform-release-guard`，沉淀「浏览器/登录/bridge 拉起改动」的发布前风险检查流程与 Windows/macOS/Linux 人工验证清单。
-
-### Guardrails
-- 跨端行为兜底：未知/不支持的默认浏览器（如 Arc 或任何未映射的 bundle id / ProgId / `.desktop`）以及检测失败时，一律回退到系统默认浏览器新标签页 + 回调页自动关闭，绝不尝试新窗口动作。
+- 优化 `openyida login` 与 `openyida bridge` 的浏览器登录体验：新增跨平台默认浏览器检测。
 
 ### Tests
 - `tests/oauth-loopback.test.js`：新增默认浏览器检测（依赖可注入）、三平台新窗口命令、未知/不支持浏览器回退等用例，共 20 个用例。

--- a/lib/auth/oauth-loopback.js
+++ b/lib/auth/oauth-loopback.js
@@ -2,7 +2,10 @@
 
 const crypto = require('crypto');
 const http = require('http');
-const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
 
 const CALLBACK_PATH = '/oauth/callback';
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
@@ -11,7 +14,266 @@ function randomToken(bytes = 24) {
   return crypto.randomBytes(bytes).toString('base64url');
 }
 
-function resolveBrowserLauncher(url, platform = process.platform) {
+const CHROMIUM_MAC_BUNDLES = {
+  'com.google.chrome': 'com.google.Chrome',
+  'com.microsoft.edgemac': 'com.microsoft.edgemac',
+  'com.brave.browser': 'com.brave.Browser',
+  'com.operasoftware.opera': 'com.operasoftware.Opera',
+  'com.vivaldi.vivaldi': 'com.vivaldi.Vivaldi',
+  'org.chromium.chromium': 'org.chromium.Chromium',
+};
+
+// Only these browser families have a known reliable new-window launch path.
+// Anything else (unknown/unsupported default browser) must fall back.
+const SUPPORTED_BROWSER_FAMILIES = new Set(['chromium', 'firefox', 'safari']);
+
+// Chromium accepts `--new-window`; Firefox uses the single-dash `-new-window`.
+function newWindowFlag(family) {
+  return family === 'firefox' ? '-new-window' : '--new-window';
+}
+
+function appleScriptSafe(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function classifyMacBundleId(bundleId) {
+  if (!bundleId) {
+    return null;
+  }
+  const id = String(bundleId).toLowerCase();
+  if (id === 'com.apple.safari') {
+    return { family: 'safari' };
+  }
+  if (id === 'org.mozilla.firefox') {
+    return { family: 'firefox', bundleId: 'org.mozilla.firefox' };
+  }
+  if (CHROMIUM_MAC_BUNDLES[id]) {
+    return { family: 'chromium', bundleId: CHROMIUM_MAC_BUNDLES[id] };
+  }
+  return null;
+}
+
+function classifyWindowsProgId(progId) {
+  if (!progId) {
+    return null;
+  }
+  const id = String(progId).toLowerCase();
+  if (id.includes('firefox')) {
+    return 'firefox';
+  }
+  if (
+    id.startsWith('chromehtml') ||
+    id.startsWith('msedge') ||
+    id.startsWith('bravehtml') ||
+    id.startsWith('opera') ||
+    id.includes('vivaldi') ||
+    id.includes('chromium')
+  ) {
+    return 'chromium';
+  }
+  return null;
+}
+
+function classifyLinuxDesktop(name) {
+  if (!name) {
+    return null;
+  }
+  const id = String(name).toLowerCase();
+  if (id.includes('firefox')) {
+    return 'firefox';
+  }
+  if (
+    id.includes('chrome') ||
+    id.includes('chromium') ||
+    id.includes('brave') ||
+    id.includes('edge') ||
+    id.includes('opera') ||
+    id.includes('vivaldi')
+  ) {
+    return 'chromium';
+  }
+  return null;
+}
+
+function parseMacDefaultBrowser(defaultsOutput) {
+  if (!defaultsOutput) {
+    return null;
+  }
+  // The secure plist is an array of dicts; each `}` closes one handler entry.
+  const blocks = String(defaultsOutput).split('}');
+  for (const block of blocks) {
+    if (/LSHandlerURLScheme\s*=\s*https\b/i.test(block)) {
+      const match = block.match(/LSHandlerRole(?:All|Viewer)\s*=\s*"?([\w.-]+)"?/i);
+      if (match) {
+        return match[1].toLowerCase();
+      }
+    }
+  }
+  return null;
+}
+
+function parseWindowsProgId(regOutput) {
+  if (!regOutput) {
+    return null;
+  }
+  const match = String(regOutput).match(/ProgId\s+REG_\w+\s+(\S+)/i);
+  return match ? match[1] : null;
+}
+
+function parseWindowsCommandExec(regOutput) {
+  if (!regOutput) {
+    return null;
+  }
+  const match = String(regOutput).match(/REG_\w+\s+(.+)$/m);
+  if (!match) {
+    return null;
+  }
+  const value = match[1].trim();
+  if (value.startsWith('"')) {
+    const end = value.indexOf('"', 1);
+    if (end > 1) {
+      return value.slice(1, end);
+    }
+  }
+  return value.split(/\s+/)[0] || null;
+}
+
+function parseLinuxExec(desktopContent) {
+  if (!desktopContent) {
+    return null;
+  }
+  const match = String(desktopContent).match(/^Exec=(.+)$/m);
+  if (!match) {
+    return null;
+  }
+  // Drop desktop-entry field codes (%u %U %f %F ...) then take the executable.
+  const withoutCodes = match[1].replace(/%[a-zA-Z]/g, '').trim();
+  const first = withoutCodes.match(/^"([^"]+)"|^(\S+)/);
+  if (!first) {
+    return null;
+  }
+  return first[1] || first[2] || null;
+}
+
+function runCapture(command, args) {
+  try {
+    const result = spawnSync(command, args, {
+      encoding: 'utf8',
+      timeout: 2500,
+      windowsHide: true,
+    });
+    if (result && typeof result.stdout === 'string' && result.stdout.length > 0) {
+      return result.stdout;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// Detect the system default browser so we can open a real new window.
+// Returns { family, bundleId? , execPath? } or null when detection fails or
+// the default browser is not a supported family (unknown ProgId/desktop/bundle).
+// `deps` allows injecting command runner / file reader for deterministic tests.
+function detectDefaultBrowser(platform = process.platform, deps = {}) {
+  const run = deps.run || runCapture;
+  const readFile = deps.readFile || ((filePath) => fs.readFileSync(filePath, 'utf8'));
+  const homedir = deps.homedir || os.homedir;
+  try {
+    if (platform === 'darwin') {
+      const output = run('defaults', [
+        'read',
+        'com.apple.LaunchServices/com.apple.launchservices.secure',
+      ]);
+      return classifyMacBundleId(parseMacDefaultBrowser(output));
+    }
+    if (platform === 'win32') {
+      const progOutput = run('reg', [
+        'query',
+        'HKCU\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\https\\UserChoice',
+        '/v',
+        'ProgId',
+      ]);
+      const progId = parseWindowsProgId(progOutput);
+      const family = classifyWindowsProgId(progId);
+      // Unknown ProgId (e.g. IE.HTTP or any browser we don't map) -> fall back.
+      if (!family) {
+        return null;
+      }
+      const commandOutput =
+        run('reg', ['query', `HKCU\\Software\\Classes\\${progId}\\shell\\open\\command`, '/ve']) ||
+        run('reg', ['query', `HKEY_CLASSES_ROOT\\${progId}\\shell\\open\\command`, '/ve']);
+      const execPath = parseWindowsCommandExec(commandOutput);
+      if (!execPath) {
+        return null;
+      }
+      return { family, execPath };
+    }
+    // linux and other unix-like desktops
+    const desktop = run('xdg-settings', ['get', 'default-web-browser']);
+    const name = desktop ? desktop.trim() : '';
+    if (!name) {
+      return null;
+    }
+    const family = classifyLinuxDesktop(name);
+    // Unknown .desktop (e.g. some non-browser or unmapped browser) -> fall back.
+    if (!family) {
+      return null;
+    }
+    const candidates = [
+      path.join(homedir(), '.local/share/applications', name),
+      path.join('/usr/share/applications', name),
+      path.join('/usr/local/share/applications', name),
+    ];
+    for (const candidate of candidates) {
+      try {
+        const content = readFile(candidate);
+        const execPath = parseLinuxExec(content);
+        if (execPath) {
+          return { family, execPath };
+        }
+      } catch {
+        // try the next candidate location
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveBrowserLauncher(url, platform = process.platform, openMode = 'legacy', browser = null) {
+  if (openMode === 'newWindow' && browser && SUPPORTED_BROWSER_FAMILIES.has(browser.family)) {
+    if (platform === 'darwin') {
+      if (browser.family === 'safari') {
+        // Safari has no CLI new-window flag; AppleScript opens a new window.
+        const safeUrl = appleScriptSafe(url);
+        return {
+          command: 'osascript',
+          args: [
+            '-e',
+            `tell application "Safari" to make new document with properties {URL:"${safeUrl}"}`,
+            '-e',
+            'tell application "Safari" to activate',
+          ],
+        };
+      }
+      if (browser.bundleId) {
+        // `open -b <bundle> -n --args --new-window <url>` forces a new window
+        // in the specific Chromium/Firefox app instead of a new tab.
+        return {
+          command: 'open',
+          args: ['-b', browser.bundleId, '-n', '--args', newWindowFlag(browser.family), url],
+        };
+      }
+    } else if (browser.execPath) {
+      return {
+        command: browser.execPath,
+        args: [newWindowFlag(browser.family), url],
+      };
+    }
+  }
+
   if (platform === 'darwin') {
     return { command: 'open', args: [url] };
   }
@@ -25,23 +287,63 @@ function resolveBrowserLauncher(url, platform = process.platform) {
   return { command: 'xdg-open', args: [url] };
 }
 
+function launchBrowserLauncher(launcher, onError) {
+  try {
+    const child = spawn(launcher.command, launcher.args, {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    if (onError) {
+      child.once('error', onError);
+    }
+    return true;
+  } catch {
+    if (onError) {
+      onError();
+    }
+    return false;
+  }
+}
+
 function openBrowser(url) {
   if (process.env.OPENYIDA_NO_BROWSER === '1') {
     return false;
   }
 
-  const { command, args } = resolveBrowserLauncher(url);
+  const platform = process.platform;
+  const legacyLauncher = resolveBrowserLauncher(url, platform, 'legacy');
+  const runLegacy = () => launchBrowserLauncher(legacyLauncher);
 
+  let browser = null;
   try {
-    const child = spawn(command, args, {
-      detached: true,
-      stdio: 'ignore',
-    });
-    child.unref();
-    return true;
+    browser = detectDefaultBrowser(platform);
   } catch {
-    return false;
+    browser = null;
   }
+
+  // Default browser detected and supported → open a real new window in that
+  // browser, falling back to the plain default-browser open if launch errors.
+  if (browser && SUPPORTED_BROWSER_FAMILIES.has(browser.family)) {
+    const newWindowLauncher = resolveBrowserLauncher(url, platform, 'newWindow', browser);
+    let fallbackUsed = false;
+    const runFallback = () => {
+      if (fallbackUsed) {
+        return false;
+      }
+      fallbackUsed = true;
+      return runLegacy();
+    };
+
+    const launched = launchBrowserLauncher(newWindowLauncher, runFallback);
+    if (!launched) {
+      return runFallback();
+    }
+    return true;
+  }
+
+  // Detection failed → fall back to the system default browser (new tab).
+  return runLegacy();
 }
 
 function buildDingtalkOAuthUrl(options) {
@@ -66,8 +368,45 @@ function buildDingtalkOAuthUrl(options) {
   return url.toString();
 }
 
-function responseHtml(title, body) {
-  return `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body><h3>${title}</h3><p>${body}</p></body></html>`;
+function responseHtml(title, body, options = {}) {
+  const {
+    autoClose = false,
+    autoCloseDelayMs = 1200,
+    staticHint = 'You can close this page and return to the terminal.',
+  } = options;
+
+  const closeScript = autoClose ? `
+    <script>
+      (function() {
+        const delay = Math.max(0, ${Number(autoCloseDelayMs)});
+        function forceClose() {
+          try {
+            if (window.opener && !window.opener.closed && window.opener.focus) {
+              window.opener.focus();
+            }
+          } catch (err) {}
+
+          try {
+            window.close();
+          } catch (err) {}
+
+          if (!window.closed) {
+            try {
+              window.open('', '_self').close();
+            } catch (err) {}
+          }
+        }
+
+        setTimeout(forceClose, delay);
+      })();
+    </script>
+  ` : '';
+
+  const closeHint = autoClose
+    ? ''
+    : `<p>${staticHint}</p>`;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body><h3>${title}</h3><p>${body}</p>${closeHint}${closeScript}</body></html>`;
 }
 
 function runDingtalkLoopback(options = {}) {
@@ -122,7 +461,13 @@ function runDingtalkLoopback(options = {}) {
 
       res.statusCode = 200;
       res.setHeader('content-type', 'text/html; charset=utf-8');
-      res.end(responseHtml('OpenYida login completed', 'You can close this page and return to the terminal.'));
+      res.end(responseHtml(
+        'OpenYida login completed',
+        'Login callback received. Returning to terminal.',
+        {
+          autoClose: true,
+        }
+      ));
       finish(null, {
         code,
         authCode,
@@ -160,5 +505,13 @@ module.exports = {
   runDingtalkLoopback,
   buildDingtalkOAuthUrl,
   resolveBrowserLauncher,
+  detectDefaultBrowser,
+  classifyMacBundleId,
+  classifyWindowsProgId,
+  classifyLinuxDesktop,
+  parseMacDefaultBrowser,
+  parseWindowsProgId,
+  parseWindowsCommandExec,
+  parseLinuxExec,
   CALLBACK_PATH,
 };

--- a/lib/process/preview-process.js
+++ b/lib/process/preview-process.js
@@ -21,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const {
   findProjectRoot,
 } = require('../core/utils');
@@ -859,16 +860,25 @@ async function run(args) {
   return result;
 }
 
+function resolvePreviewBrowserLauncher(filePath, platform = process.platform) {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [filePath] };
+  }
+  if (platform === 'win32') {
+    return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', filePath] };
+  }
+  return { command: 'xdg-open', args: [filePath] };
+}
+
 function tryOpenBrowser(filePath) {
   try {
-    const { execSync } = require('child_process');
-    const platform = process.platform;
-    if (platform === 'darwin') {
-      execSync(`open "${filePath}"`, { stdio: 'ignore' });
-    } else if (platform === 'win32') {
-      execSync(`start "" "${filePath}"`, { stdio: 'ignore' });
-    } else {
-      execSync(`xdg-open "${filePath}"`, { stdio: 'ignore' });
+    const launcher = resolvePreviewBrowserLauncher(filePath);
+    const result = spawnSync(launcher.command, launcher.args, {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (result && (result.error || (typeof result.status === 'number' && result.status !== 0))) {
+      throw result.error || new Error('open_browser_failed');
     }
     warn(`🌐 ${t('preview_process.browser_opened')}`);
   } catch {
@@ -883,4 +893,6 @@ module.exports = {
   fetchProcessInstance,
   fetchOperationRecords,
   parseProcessData,
+  resolvePreviewBrowserLauncher,
+  tryOpenBrowser,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.18",
+  "version": "2026.7.18-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.18",
+      "version": "2026.7.18-2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.18",
+  "version": "2026.7.18-2",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",
@@ -53,6 +53,7 @@
     "check:i18n:audit": "node scripts/validate-i18n.js",
     "check:i18n:baseline": "node scripts/validate-i18n.js --update-baseline",
     "check:syntax": "node scripts/check-syntax.js",
+    "check:release-risks": "node scripts/check-release-risks.js",
     "check:package-size": "node scripts/validate-package-size.js",
     "check:package": "npm pack --dry-run",
     "check:release": "npm run check:ci",

--- a/scripts/check-release-risks.js
+++ b/scripts/check-release-risks.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-release-risks.js
+ *
+ * 发布前静态风险扫描，专注「跨平台浏览器/URL 拉起」这一类在 macOS 本地
+ * 测试里查不出、却会在 Windows/Linux 用户侧炸掉的历史坑：
+ *
+ *   - `cmd /c start <url>`：cmd.exe 把 URL 里的 `&` 当命令分隔符，截断
+ *     OAuth/bridge URL，丢失 client_id/state 或 bridge 配对参数（见 ce7efdd）。
+ *   - `open -n <url>`：macOS 下不会真正开新窗口，只是在默认浏览器里开新
+ *     标签页，属于「假装开新窗口」的反模式。
+ *
+ * HARD 反模式（error）→ 退出码 1，阻断发布。
+ * SOFT 提示（warning）→ 退出码 0，仅提醒发布人做人工跨端验证。
+ *
+ * 该脚本无第三方依赖，纯静态扫描 lib/ 源码；核心分析函数导出供单测使用。
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCAN_DIRS = ['lib'];
+
+// HARD 反模式：命中即 error，阻断发布。
+const HARD_RULES = [
+  {
+    id: 'cmd-c-start-url',
+    pattern: /cmd\s*\/c\s*start/i,
+    message:
+      'cmd /c start 会把 URL 中的 & 当作命令分隔符截断参数（丢失 client_id/state 或 bridge 配对参数）。请改用 rundll32 url.dll,FileProtocolHandler，并复用 resolveBrowserLauncher。',
+  },
+  {
+    id: 'cmd-c-start-argv',
+    pattern: /['"]cmd['"]\s*,\s*\[\s*['"]\/c['"]\s*,\s*['"]start['"]/i,
+    message:
+      'spawn("cmd", ["/c", "start", ...]) 与 cmd /c start 同源风险：& 处截断 URL。请改用 rundll32 或平台专用浏览器拉起命令。',
+  },
+  {
+    id: 'open-n-url-new-tab',
+    pattern: /\[\s*(['"])-n\1\s*,\s*url\s*\]/,
+    message:
+      'open -n <url> 在 macOS 上不会开新窗口，只会在默认浏览器新开标签页（假装开窗口）。要真正开新窗口须指定浏览器 App 并传其 --new-window/-new-window，检测不到默认浏览器时回退纯 open <url>。',
+  },
+];
+
+// SOFT 提示：命中不阻断，只提醒发布人补人工跨端验证。
+const SOFT_LAUNCH_PRIMITIVES = /rundll32|xdg-open|osascript|['"]open['"]\s*,|FileProtocolHandler|--new-window|-new-window/;
+
+// 把注释内容替换成等长空白（保留换行以维持行号），避免把「解释为何避免
+// cmd /c start」这类说明性注释误判成真实反模式。会跟踪字符串/模板字面量，
+// 不会把字符串里的 // 或 /* 当注释。
+function stripComments(content) {
+  const src = String(content);
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  let state = 'code'; // code | line | block | sq | dq | tpl
+  while (i < n) {
+    const ch = src[i];
+    const next = src[i + 1];
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line';
+        out += '  ';
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = 'block';
+        out += '  ';
+        i += 2;
+        continue;
+      }
+      if (ch === "'") {
+        state = 'sq';
+      } else if (ch === '"') {
+        state = 'dq';
+      } else if (ch === '`') {
+        state = 'tpl';
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (state === 'line') {
+      if (ch === '\n') {
+        state = 'code';
+        out += ch;
+      } else {
+        out += ' ';
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'block') {
+      if (ch === '*' && next === '/') {
+        state = 'code';
+        out += '  ';
+        i += 2;
+      } else {
+        out += ch === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      continue;
+    }
+    // string / template states: copy verbatim, honor escapes, exit on matching quote
+    out += ch;
+    if (ch === '\\') {
+      out += next !== undefined ? next : '';
+      i += 2;
+      continue;
+    }
+    if (
+      (state === 'sq' && ch === "'") ||
+      (state === 'dq' && ch === '"') ||
+      (state === 'tpl' && ch === '`')
+    ) {
+      state = 'code';
+    }
+    i += 1;
+  }
+  return out;
+}
+
+function analyzeContent(relPath, content) {
+  const findings = [];
+  const scannable = stripComments(content);
+  const lines = scannable.split(/\r?\n/);
+
+  for (const rule of HARD_RULES) {
+    lines.forEach((line, index) => {
+      if (rule.pattern.test(line)) {
+        findings.push({
+          file: relPath,
+          line: index + 1,
+          severity: 'error',
+          ruleId: rule.id,
+          message: rule.message,
+        });
+      }
+    });
+  }
+
+  if (SOFT_LAUNCH_PRIMITIVES.test(scannable)) {
+    findings.push({
+      file: relPath,
+      line: 0,
+      severity: 'warning',
+      ruleId: 'cross-platform-launch-touched',
+      message:
+        '涉及浏览器/URL 拉起代码。CI 只跑纯函数单测，不覆盖真实系统拉起——发布前请在 Windows / macOS / Linux 各自实测 login 与 bridge 页面唤起。',
+    });
+  }
+
+  return findings;
+}
+
+function analyzeFiles(files) {
+  const findings = [];
+  for (const f of files) {
+    findings.push(...analyzeContent(f.path, f.content));
+  }
+  const errorCount = findings.filter((x) => x.severity === 'error').length;
+  const warnCount = findings.filter((x) => x.severity === 'warning').length;
+  return { findings, errorCount, warnCount };
+}
+
+function collectSourceFiles(root = REPO_ROOT, dirs = SCAN_DIRS) {
+  const out = [];
+  const walk = (abs) => {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(abs, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(abs, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git') {
+          continue;
+        }
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        out.push({
+          path: path.relative(root, full),
+          content: fs.readFileSync(full, 'utf8'),
+        });
+      }
+    }
+  };
+  for (const dir of dirs) {
+    walk(path.join(root, dir));
+  }
+  return out;
+}
+
+function formatFindings({ findings, errorCount, warnCount }) {
+  const lines = [];
+  const errors = findings.filter((x) => x.severity === 'error');
+  const warnings = findings.filter((x) => x.severity === 'warning');
+
+  if (errors.length) {
+    lines.push('发布风险检查：发现 HARD 反模式（阻断发布）');
+    for (const f of errors) {
+      lines.push(`  ✗ [${f.ruleId}] ${f.file}:${f.line}`);
+      lines.push(`      ${f.message}`);
+    }
+  }
+
+  if (warnings.length) {
+    lines.push('发布风险检查：跨端人工验证提醒（不阻断）');
+    const byFile = new Set(warnings.map((w) => w.file));
+    for (const file of byFile) {
+      lines.push(`  ⚠ ${file}`);
+    }
+    lines.push(
+      '      涉及浏览器/URL 拉起：请在 Windows / macOS / Linux 各自实测 openyida login 与 bridge 页面唤起。'
+    );
+  }
+
+  lines.push('');
+  lines.push(`发布风险检查完成：error=${errorCount}, warning=${warnCount}`);
+  return lines.join('\n');
+}
+
+function main() {
+  const result = analyzeFiles(collectSourceFiles());
+  process.stdout.write(`${formatFindings(result)}\n`);
+  if (result.errorCount > 0) {
+    process.stdout.write(
+      '\n存在阻断发布的 HARD 反模式，请修复后重试（详见 .qoder/skills 跨端发布风险技能）。\n'
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  HARD_RULES,
+  SOFT_LAUNCH_PRIMITIVES,
+  analyzeContent,
+  analyzeFiles,
+  collectSourceFiles,
+  formatFindings,
+};

--- a/scripts/check-release-risks.js
+++ b/scripts/check-release-risks.js
@@ -47,7 +47,8 @@ const HARD_RULES = [
 ];
 
 // SOFT 提示：命中不阻断，只提醒发布人补人工跨端验证。
-const SOFT_LAUNCH_PRIMITIVES = /rundll32|xdg-open|osascript|['"]open['"]\s*,|FileProtocolHandler|--new-window|-new-window/;
+const SOFT_LAUNCH_PRIMITIVES =
+  /rundll32|xdg-open|osascript|FileProtocolHandler|--new-window|-new-window|command\s*:\s*['"]open['"]|spawn(?:Sync)?\(\s*['"]open['"]/;
 
 // 把注释内容替换成等长空白（保留换行以维持行号），避免把「解释为何避免
 // cmd /c start」这类说明性注释误判成真实反模式。会跟踪字符串/模板字面量，

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -45,15 +45,19 @@ echo "=== Step 9: Run lint ==="
 npm run lint
 
 echo ""
-echo "=== Step 10: Run tests ==="
+echo "=== Step 10: Scan cross-platform release risks ==="
+npm run check:release-risks
+
+echo ""
+echo "=== Step 11: Run tests ==="
 npm run test:unit -- --runInBand
 
 echo ""
-echo "=== Step 11: Validate npm package size budget ==="
+echo "=== Step 12: Validate npm package size budget ==="
 npm run check:package-size
 
 echo ""
-echo "=== Step 12: Validate npm package contents ==="
+echo "=== Step 13: Validate npm package contents ==="
 npm run check:package
 
 echo ""

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -17,24 +17,24 @@ echo "=== Step 2: Validate project structure ==="
 npm run check:structure
 
 echo ""
-echo "=== Step 3: Validate skills ==="
+echo "=== Step 3: Build Wukong skills package ==="
+npm run build:skills
+
+echo ""
+echo "=== Step 4: Validate skills ==="
 npm run check:skills
 
 echo ""
-echo "=== Step 4: Validate command manifest ==="
+echo "=== Step 5: Validate command manifest ==="
 npm run check:commands
 
 echo ""
-echo "=== Step 5: Validate generated command docs ==="
+echo "=== Step 6: Validate generated command docs ==="
 npm run check:docs
 
 echo ""
-echo "=== Step 6: Validate i18n locale parity (ratchet) ==="
+echo "=== Step 7: Validate i18n locale parity (ratchet) ==="
 npm run check:i18n
-
-echo ""
-echo "=== Step 7: Build Wukong skills package ==="
-npm run build:skills
 
 echo ""
 echo "=== Step 8: Check JavaScript syntax ==="

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -41,6 +41,21 @@ if (!nodeEngine) {
 }
 console.log('engines.node: ' + nodeEngine);
 
+if (fs.existsSync('package-lock.json')) {
+  const packageLock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+  const lockVersions = [
+    ['package-lock.json version', packageLock.version],
+    ['package-lock root package version', packageLock.packages && packageLock.packages[''] && packageLock.packages[''].version],
+  ];
+  for (const pair of lockVersions) {
+    if (pair[1] !== packageJson.version) {
+      console.error(`${pair[0]} (${pair[1] || 'missing'}) does not match package.json version (${packageJson.version})`);
+      process.exit(1);
+    }
+  }
+  console.log('package-lock version: ' + packageLock.version);
+}
+
 const skillsDir = 'yida-skills/skills';
 if (fs.existsSync(skillsDir)) {
   const skills = fs.readdirSync(skillsDir).filter(function(name) {

--- a/tests/check-release-risks.test.js
+++ b/tests/check-release-risks.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const {
+  analyzeContent,
+  analyzeFiles,
+  collectSourceFiles,
+} = require('../scripts/check-release-risks');
+
+function errorIds(findings) {
+  return findings.filter((f) => f.severity === 'error').map((f) => f.ruleId);
+}
+
+describe('check-release-risks HARD anti-patterns', () => {
+  test('flags a real `cmd /c start` launch (Windows URL truncation bug)', () => {
+    const code = "spawn('cmd /c start ' + url, { shell: true });";
+    expect(errorIds(analyzeContent('x.js', code))).toContain('cmd-c-start-url');
+  });
+
+  test('flags spawn("cmd", ["/c", "start", ...]) argv form', () => {
+    const code = "const child = spawn('cmd', ['/c', 'start', url]);";
+    const ids = errorIds(analyzeContent('x.js', code));
+    expect(ids).toContain('cmd-c-start-argv');
+  });
+
+  test('flags `open -n <url>` fake-new-window pattern', () => {
+    const code = "return { command: 'open', args: ['-n', url] };";
+    expect(errorIds(analyzeContent('x.js', code))).toContain('open-n-url-new-tab');
+  });
+});
+
+describe('check-release-risks ignores comments and safe code', () => {
+  test('does NOT flag `cmd /c start` written inside a line comment', () => {
+    const code = [
+      '// Going through `cmd /c start` would split the URL on `&`, so we',
+      '// use rundll32 instead.',
+      "return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', url] };",
+    ].join('\n');
+    const findings = analyzeContent('safe.js', code);
+    expect(errorIds(findings)).toHaveLength(0);
+  });
+
+  test('does NOT flag `cmd /c start` inside a block comment', () => {
+    const code = [
+      '/*',
+      ' * Never use cmd /c start here.',
+      ' */',
+      "spawn('rundll32', ['url.dll,FileProtocolHandler', url]);",
+    ].join('\n');
+    expect(errorIds(analyzeContent('safe.js', code))).toHaveLength(0);
+  });
+
+  test('does NOT flag // that appears inside a string literal (e.g. https://)', () => {
+    const code = [
+      "const base = 'https://www.aliwork.com';",
+      "spawn('cmd', ['/c', 'start', url]); // real bug on next stmt is caught",
+    ].join('\n');
+    // The URL string must not swallow the following code line as a comment.
+    expect(errorIds(analyzeContent('mixed.js', code))).toContain('cmd-c-start-argv');
+  });
+
+  test('safe launcher code produces no errors but an advisory warning', () => {
+    const code = "return { command: 'open', args: ['-b', bundleId, '-n', '--args', '--new-window', url] };";
+    const findings = analyzeContent('launcher.js', code);
+    expect(errorIds(findings)).toHaveLength(0);
+    expect(findings.some((f) => f.severity === 'warning')).toBe(true);
+  });
+});
+
+describe('check-release-risks guards the real repository', () => {
+  test('current lib/ source has zero HARD anti-patterns', () => {
+    const { errorCount } = analyzeFiles(collectSourceFiles());
+    expect(errorCount).toBe(0);
+  });
+});

--- a/tests/check-release-risks.test.js
+++ b/tests/check-release-risks.test.js
@@ -64,6 +64,15 @@ describe('check-release-risks ignores comments and safe code', () => {
     expect(errorIds(findings)).toHaveLength(0);
     expect(findings.some((f) => f.severity === 'warning')).toBe(true);
   });
+
+  test('does NOT warn for ordinary business enum values named open', () => {
+    const code = [
+      "const action = { target: 'open', label: 'Open permission' };",
+      "if (!['open', 'share'].includes(action.target)) throw new Error('bad target');",
+    ].join('\n');
+    const findings = analyzeContent('business.js', code);
+    expect(findings).toHaveLength(0);
+  });
 });
 
 describe('check-release-risks guards the real repository', () => {

--- a/tests/oauth-loopback.test.js
+++ b/tests/oauth-loopback.test.js
@@ -3,6 +3,14 @@
 const {
   buildDingtalkOAuthUrl,
   resolveBrowserLauncher,
+  detectDefaultBrowser,
+  classifyMacBundleId,
+  classifyWindowsProgId,
+  classifyLinuxDesktop,
+  parseMacDefaultBrowser,
+  parseWindowsProgId,
+  parseWindowsCommandExec,
+  parseLinuxExec,
 } = require('../lib/auth/oauth-loopback');
 
 describe('resolveBrowserLauncher', () => {
@@ -49,5 +57,215 @@ describe('resolveBrowserLauncher', () => {
     const truncated = passedUrl.split('&')[0];
     expect(truncated).not.toContain('client_id');
     expect(passedUrl).not.toBe(truncated);
+  });
+
+  test('newWindow falls back to plain default-browser open when browser is unknown', () => {
+    // No browser detected -> must NOT pretend to open a new window.
+    expect(resolveBrowserLauncher(oauthUrl, 'darwin', 'newWindow', null)).toEqual({
+      command: 'open',
+      args: [oauthUrl],
+    });
+    expect(resolveBrowserLauncher(oauthUrl, 'win32', 'newWindow', null).command).toBe('rundll32');
+    expect(resolveBrowserLauncher(oauthUrl, 'linux', 'newWindow', null).command).toBe('xdg-open');
+  });
+
+  test('newWindow falls back when the default browser family is unsupported', () => {
+    // e.g. Arc or any browser we do not have a known new-window path for:
+    // even with a bundleId/execPath present, an unknown family must fall back.
+    expect(
+      resolveBrowserLauncher(oauthUrl, 'darwin', 'newWindow', {
+        family: 'arc',
+        bundleId: 'company.thebrowser.Browser',
+      })
+    ).toEqual({ command: 'open', args: [oauthUrl] });
+    expect(
+      resolveBrowserLauncher(oauthUrl, 'win32', 'newWindow', {
+        family: 'unknown',
+        execPath: 'C:\\weird\\browser.exe',
+      }).command
+    ).toBe('rundll32');
+    expect(
+      resolveBrowserLauncher(oauthUrl, 'linux', 'newWindow', {
+        family: 'unknown',
+        execPath: '/usr/bin/weird-browser',
+      }).command
+    ).toBe('xdg-open');
+  });
+
+  test('darwin newWindow uses `open -b ... --args --new-window` for Chromium', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'darwin', 'newWindow', {
+      family: 'chromium',
+      bundleId: 'com.google.Chrome',
+    });
+    expect(command).toBe('open');
+    expect(args).toEqual([
+      '-b',
+      'com.google.Chrome',
+      '-n',
+      '--args',
+      '--new-window',
+      oauthUrl,
+    ]);
+    // URL still passed as a single untouched argv element.
+    expect(args[args.length - 1]).toBe(oauthUrl);
+  });
+
+  test('darwin newWindow uses single-dash flag for Firefox', () => {
+    const { args } = resolveBrowserLauncher(oauthUrl, 'darwin', 'newWindow', {
+      family: 'firefox',
+      bundleId: 'org.mozilla.firefox',
+    });
+    expect(args).toContain('-new-window');
+    expect(args).not.toContain('--new-window');
+  });
+
+  test('darwin newWindow uses AppleScript for Safari', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'darwin', 'newWindow', {
+      family: 'safari',
+    });
+    expect(command).toBe('osascript');
+    expect(args.join(' ')).toContain('make new document with properties');
+    expect(args.some((a) => a.includes(oauthUrl))).toBe(true);
+  });
+
+  test('win32 newWindow launches the detected browser exe with a new-window flag', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'win32', 'newWindow', {
+      family: 'chromium',
+      execPath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    });
+    expect(command).toBe('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe');
+    expect(args).toEqual(['--new-window', oauthUrl]);
+  });
+
+  test('linux newWindow launches the detected browser exe with a new-window flag', () => {
+    const { command, args } = resolveBrowserLauncher(oauthUrl, 'linux', 'newWindow', {
+      family: 'chromium',
+      execPath: '/usr/bin/google-chrome-stable',
+    });
+    expect(command).toBe('/usr/bin/google-chrome-stable');
+    expect(args).toEqual(['--new-window', oauthUrl]);
+  });
+});
+
+describe('default browser classification and parsing', () => {
+  test('classifyMacBundleId maps known browsers (case-insensitive)', () => {
+    expect(classifyMacBundleId('com.google.chrome')).toEqual({
+      family: 'chromium',
+      bundleId: 'com.google.Chrome',
+    });
+    expect(classifyMacBundleId('com.apple.Safari')).toEqual({ family: 'safari' });
+    expect(classifyMacBundleId('org.mozilla.firefox')).toEqual({
+      family: 'firefox',
+      bundleId: 'org.mozilla.firefox',
+    });
+    expect(classifyMacBundleId('com.unknown.browser')).toBeNull();
+    // Arc is a real browser but unmapped -> treated as unknown so we fall back.
+    expect(classifyMacBundleId('company.thebrowser.Browser')).toBeNull();
+    expect(classifyMacBundleId(null)).toBeNull();
+  });
+
+  test('parseMacDefaultBrowser finds the https handler bundle id', () => {
+    const output = [
+      '{',
+      '    LSHandlerRoleAll = "com.apple.mail";',
+      '    LSHandlerURLScheme = mailto;',
+      '},',
+      '{',
+      '    LSHandlerRoleAll = "com.google.chrome";',
+      '    LSHandlerURLScheme = https;',
+      '}',
+    ].join('\n');
+    expect(parseMacDefaultBrowser(output)).toBe('com.google.chrome');
+    expect(parseMacDefaultBrowser('')).toBeNull();
+  });
+
+  test('classifyWindowsProgId maps ProgIds to families', () => {
+    expect(classifyWindowsProgId('ChromeHTML')).toBe('chromium');
+    expect(classifyWindowsProgId('MSEdgeHTM')).toBe('chromium');
+    expect(classifyWindowsProgId('FirefoxURL-308046B0AF4A39CB')).toBe('firefox');
+    expect(classifyWindowsProgId('IE.HTTP')).toBeNull();
+  });
+
+  test('parseWindowsProgId and parseWindowsCommandExec read the registry output', () => {
+    const progOut = '\r\n    ProgId    REG_SZ    ChromeHTML\r\n';
+    expect(parseWindowsProgId(progOut)).toBe('ChromeHTML');
+
+    const cmdOut =
+      '\r\n    (Default)    REG_SZ    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" -- "%1"\r\n';
+    expect(parseWindowsCommandExec(cmdOut)).toBe(
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
+    );
+  });
+
+  test('classifyLinuxDesktop and parseLinuxExec resolve the browser binary', () => {
+    expect(classifyLinuxDesktop('google-chrome.desktop')).toBe('chromium');
+    expect(classifyLinuxDesktop('firefox.desktop')).toBe('firefox');
+    expect(classifyLinuxDesktop('nautilus.desktop')).toBeNull();
+
+    const desktop = [
+      '[Desktop Entry]',
+      'Name=Google Chrome',
+      'Exec=/usr/bin/google-chrome-stable %U',
+    ].join('\n');
+    expect(parseLinuxExec(desktop)).toBe('/usr/bin/google-chrome-stable');
+  });
+});
+
+describe('detectDefaultBrowser (injected deps, per-platform identifiers differ)', () => {
+  test('macOS resolves known bundle id, unknown bundle id falls back to null', () => {
+    const macKnown = (bundleId) => () =>
+      `{\n  LSHandlerRoleAll = "${bundleId}";\n  LSHandlerURLScheme = https;\n}`;
+    expect(detectDefaultBrowser('darwin', { run: macKnown('com.google.chrome') })).toEqual({
+      family: 'chromium',
+      bundleId: 'com.google.Chrome',
+    });
+    // Unknown bundle id (e.g. Arc) -> null so openBrowser falls back.
+    expect(
+      detectDefaultBrowser('darwin', { run: macKnown('company.thebrowser.Browser') })
+    ).toBeNull();
+  });
+
+  test('Windows resolves known ProgId, unknown ProgId falls back to null', () => {
+    const winRun = (progId, execLine) => (command, args) => {
+      const key = args.join(' ');
+      if (key.includes('UserChoice')) {
+        return `\r\n    ProgId    REG_SZ    ${progId}\r\n`;
+      }
+      if (key.includes('shell\\open\\command')) {
+        return `\r\n    (Default)    REG_SZ    ${execLine}\r\n`;
+      }
+      return null;
+    };
+    expect(
+      detectDefaultBrowser('win32', {
+        run: winRun('ChromeHTML', '"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" -- "%1"'),
+      })
+    ).toEqual({
+      family: 'chromium',
+      execPath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    });
+    // Unknown ProgId (IE.HTTP) -> null so openBrowser falls back.
+    expect(detectDefaultBrowser('win32', { run: winRun('IE.HTTP', 'iexplore.exe') })).toBeNull();
+  });
+
+  test('Linux resolves known .desktop, unknown .desktop falls back to null', () => {
+    const linuxRun = (desktopName) => () => `${desktopName}\n`;
+    const readFile = () => '[Desktop Entry]\nExec=/usr/bin/google-chrome %U\n';
+    expect(
+      detectDefaultBrowser('linux', { run: linuxRun('google-chrome.desktop'), readFile })
+    ).toEqual({ family: 'chromium', execPath: '/usr/bin/google-chrome' });
+    // Unknown .desktop -> null so openBrowser falls back (readFile never reached).
+    expect(
+      detectDefaultBrowser('linux', {
+        run: linuxRun('some-unknown-app.desktop'),
+        readFile,
+      })
+    ).toBeNull();
+  });
+
+  test('returns null when the detection command yields nothing', () => {
+    expect(detectDefaultBrowser('darwin', { run: () => null })).toBeNull();
+    expect(detectDefaultBrowser('win32', { run: () => '' })).toBeNull();
+    expect(detectDefaultBrowser('linux', { run: () => '' })).toBeNull();
   });
 });

--- a/tests/process-small.test.js
+++ b/tests/process-small.test.js
@@ -6,7 +6,7 @@ const path = require('path');
 const querystring = require('querystring');
 
 jest.mock('child_process', () => ({
-  execSync: jest.fn(() => ''),
+  spawnSync: jest.fn(() => ({ status: 0 })),
 }));
 
 jest.mock('../lib/core/utils', () => ({
@@ -51,7 +51,7 @@ describe('small process commands', () => {
     utils.loadAuthData.mockReturnValue(mockAuthData);
     utils.findProjectRoot.mockReturnValue(tmpDir);
     utils.requestWithAutoLogin.mockImplementation((requestFn, authRef) => requestFn(authRef));
-    childProcess.execSync.mockReturnValue('');
+    childProcess.spawnSync.mockReturnValue({ status: 0 });
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -118,7 +118,25 @@ describe('small process commands', () => {
     expect(fs.readFileSync(outputPath, 'utf8')).toContain('PROC_INST_1');
     expect(utils.httpGet.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/v1/process/getInstanceById.json');
     expect(utils.httpGet.mock.calls[1][1]).toBe('/dingtalk/web/APP_XXX/v1/process/getOperationRecords.json');
-    expect(childProcess.execSync).toHaveBeenCalled();
+    expect(childProcess.spawnSync).toHaveBeenCalled();
+    const [, args] = childProcess.spawnSync.mock.calls[0];
+    expect(args[args.length - 1]).toBe(outputPath);
+  });
+
+  test('preview browser launcher passes local file paths as argv', () => {
+    const filePath = 'C:\\tmp\\preview & report.html';
+    expect(previewProcess.resolvePreviewBrowserLauncher(filePath, 'darwin')).toEqual({
+      command: 'open',
+      args: [filePath],
+    });
+    expect(previewProcess.resolvePreviewBrowserLauncher(filePath, 'win32')).toEqual({
+      command: 'rundll32',
+      args: ['url.dll,FileProtocolHandler', filePath],
+    });
+    expect(previewProcess.resolvePreviewBrowserLauncher(filePath, 'linux')).toEqual({
+      command: 'xdg-open',
+      args: [filePath],
+    });
   });
 
   test('usage errors reject as CliError instead of exiting', async () => {


### PR DESCRIPTION
## Summary
- 修复 OAuth/bridge 浏览器拉起在跨平台场景下的风险
- 新增发布风险静态扫描，纳入 check:ci
- 更新 2026.7.18-2 changelog 与 package-lock 版本一致性校验

## Tests
- npm run check:ci

## Notes
- check:release-risks 仍会对浏览器/URL 拉起给出跨平台人工验证提醒，不阻断 CI。