### PR TITLE
fix: prevent Canvas templates from faking business data

### DIFF
--- a/lib/samples/yida-canvas-custom-page/business-list.canvas.jsx
+++ b/lib/samples/yida-canvas-custom-page/business-list.canvas.jsx
@@ -136,7 +136,12 @@ const DEFAULT_INSIGHTS = [
     suggestion: '高频批量动作固定在列表底部，选中记录后右侧展示下一步。',
   },
 ];
-const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed' };
+const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed', seedStrategy: 'sample-only' };
+const EMPTY_METRICS = [
+  { label: '真实记录', value: '0', hint: '未接入表单数据' },
+  { label: '数据来源', value: '未接入', hint: '请在 page-spec.json 配置 dataBinding' },
+  { label: '演示记录', value: '0', hint: '演示记录需先写入真实表单' },
+];
 const BACKGROUND_IMAGES = {
   hero: 'https://images.unsplash.com/photo-1566346654781-14e3ef6ee988?auto=format&fit=crop&w=1400&q=80',
   card: 'https://images.unsplash.com/photo-1759884247160-27b8465544b6?auto=format&fit=crop&w=1200&q=80',
@@ -268,6 +273,11 @@ function isDataBindingEnabled(binding) {
   return Boolean(binding && binding.enabled && binding.mode && binding.mode !== 'seed');
 }
 
+function isSampleSeedPreview(binding) {
+  const mode = binding && binding.mode ? binding.mode : 'seed';
+  return RESEARCH_LEVEL === 'sample' && !isDataBindingEnabled(binding) && mode === 'seed';
+}
+
 function getCsrfToken() {
   try {
     return (window.g_config && (window.g_config._csrf_token || window.g_config.csrfToken)) || '';
@@ -393,7 +403,7 @@ function normalizeBoundRows(rows, binding) {
 }
 
 function useYidaData(binding) {
-  const [state, setState] = React.useState({ loading: false, error: '', rows: [], totalCount: null });
+  const [state, setState] = React.useState(() => ({ loading: isDataBindingEnabled(binding), error: '', rows: [], totalCount: null }));
   React.useEffect(() => {
     if (!isDataBindingEnabled(binding)) { return undefined; }
     const controller = new AbortController();
@@ -446,7 +456,9 @@ function YidaComp() {
     period: index % 2 === 0 ? 'week' : 'month',
   })), []);
   const dataState = useYidaData(DATA_BINDING);
-  const rows = dataState.rows.length ? dataState.rows : seedRows;
+  const usesSeedRows = isSampleSeedPreview(DATA_BINDING);
+  const metricItems = usesSeedRows || isDataBindingEnabled(DATA_BINDING) ? METRICS : EMPTY_METRICS;
+  const rows = dataState.rows.length ? dataState.rows : (usesSeedRows ? seedRows : []);
   const filteredRows = useMemo(() => {
     const kw = (filters.keyword || '').trim().toLowerCase();
     return rows.filter((row) => {
@@ -547,6 +559,11 @@ function YidaComp() {
           .oy-list-insight { padding: 12px 14px; margin: 0 0 16px; border-radius: 14px; border: 1px solid color-mix(in srgb, var(--oy-brand), transparent 70%); background: #EFF6FF; }
           .oy-list-brief { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 10px; }
           .oy-data-status { margin: 0 0 12px; padding: 10px 12px; border-radius: 8px; border: 1px solid var(--oy-line); background: var(--oy-surface-soft); display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+          .oy-list-empty-state { min-height: 278px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; padding: 32px 22px; text-align: center; border: 1px dashed var(--oy-line); border-radius: 14px; background: color-mix(in srgb, var(--oy-brand-soft), #fff 58%); }
+          .oy-list-empty-state h4 { margin: 0; color: var(--oy-text); }
+          .oy-list-empty-state .ant-typography { max-width: 540px; }
+          .oy-list-empty-actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; margin-top: 8px; }
+          .oy-list-empty-detail { min-height: 360px; display: flex; flex-direction: column; justify-content: center; padding: 8px; }
           @media (max-width: 960px) {
             .oy-business-list { padding: 20px; }
             .oy-list-grid, .oy-list-metrics, .oy-list-filter, .oy-list-hero { grid-template-columns: 1fr; }
@@ -573,7 +590,7 @@ function YidaComp() {
             </header>
 
             <section className="oy-list-metrics">
-              {METRICS.slice(0, 3).map((item) => (
+              {metricItems.slice(0, 3).map((item) => (
                 <div className="oy-list-metric" key={item.label}>
                   <Text>{item.label}</Text>
                   <div className="oy-list-number">{item.value}</div>
@@ -594,15 +611,39 @@ function YidaComp() {
                       {dataState.error || (dataState.loading ? '正在读取真实数据' : '真实数据已接入' + (dataState.totalCount === null ? '' : '：' + dataState.totalCount + ' 条'))}
                     </Text>
                   </div>
-                ) : null}
-                <Table
-                  columns={columns}
-                  dataSource={filteredRows}
-                  pagination={false}
-                  size="middle"
-                  rowClassName={(_, index) => index === activeIndex ? 'is-selected-row' : ''}
-                  onRow={(_, index) => ({ onClick: () => setSelected(index || 0) })}
-                />
+                ) : (
+                  <div className="oy-data-status">
+                    <Tag color={usesSeedRows ? 'warning' : 'default'}>{usesSeedRows ? 'Sample seed' : '未接数据'}</Tag>
+                    <Text type="secondary">
+                      {usesSeedRows ? '当前为 sample/seed 预览数据，未接真实表单。' : '未配置真实表单 dataBinding，当前不显示前端 seed 列表。'}
+                    </Text>
+                  </div>
+                )}
+                {filteredRows.length ? (
+                  <Table
+                    columns={columns}
+                    dataSource={filteredRows}
+                    pagination={false}
+                    size="middle"
+                    rowClassName={(_, index) => index === activeIndex ? 'is-selected-row' : ''}
+                    onRow={(_, index) => ({ onClick: () => setSelected(index || 0) })}
+                  />
+                ) : (
+                  <div className="oy-list-empty-state">
+                    <Title level={4}>{dataState.loading ? '正在读取真实表单数据' : isDataBindingEnabled(DATA_BINDING) ? '暂无真实表单记录' : usesSeedRows ? '暂无匹配的 sample 记录' : '未接入真实表单数据'}</Title>
+                    <Paragraph type="secondary">
+                      {isDataBindingEnabled(DATA_BINDING)
+                        ? '当前数据源已接入宜搭表单。若需要演示内容，请先通过表单数据写入链路创建 demo records，再刷新本页读取。'
+                        : usesSeedRows
+                          ? '这是模板原样发布的 sample/seed 数据，仅用于离线预览模板结构。'
+                          : '完整应用交付页不会用前端 seedRows 冒充业务记录。请在 page-spec.json 写入 dataBinding.mode=form，或先登记真实表单记录。'}
+                    </Paragraph>
+                    <div className="oy-list-empty-actions">
+                      <Button type="primary">{PAGE.primaryCta || '登记记录'}</Button>
+                      <Button>刷新数据</Button>
+                    </div>
+                  </div>
+                )}
               </div>
               <BulkActionBar actions={INTERACTION_PROFILE.bulkActions} count={filteredRows.length} />
             </section>
@@ -613,7 +654,15 @@ function YidaComp() {
                   <Text strong>{insight.suggestion}</Text>
                 </div>
               ) : null}
-              <DetailPreview active={active} page={PAGE} roadmap={ROADMAP} />
+              {filteredRows.length ? (
+                <DetailPreview active={active} page={PAGE} roadmap={ROADMAP} />
+              ) : (
+                <div className="oy-list-empty-detail">
+                  <Tag color="default">空态入口</Tag>
+                  <Title level={4} style={{ marginTop: 14 }}>等待真实记录</Title>
+                  <Paragraph type="secondary">接入表单后，选中列表记录将在这里展示摘要、负责人、状态和处理路径。</Paragraph>
+                </div>
+              )}
             </aside>
           </div>
         </div>

--- a/lib/samples/yida-canvas-custom-page/dashboard-overview.canvas.jsx
+++ b/lib/samples/yida-canvas-custom-page/dashboard-overview.canvas.jsx
@@ -91,7 +91,13 @@ const DEFAULT_THEME_PROFILE = { followRuntimeTheme: false, name: 'harbor-command
 const DEFAULT_APP_BLUEPRINT = { shell: 'dashboard' };
 const DEFAULT_INTERACTION_PROFILE = { primaryAction: '查看详情' };
 const DEFAULT_INSIGHTS = [{ conclusion: '本周业务整体稳定，建议优先处理高价值待跟进事项。' }];
-const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed' };
+const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed', seedStrategy: 'sample-only' };
+const EMPTY_METRICS = [
+  { label: '真实记录', value: '0', delta: '未接入表单数据' },
+  { label: '数据来源', value: '未接入', delta: '请配置 dataBinding' },
+  { label: '演示指标', value: '0', delta: '演示记录需先写入表单' },
+  { label: '图表状态', value: '空态', delta: '等待真实数据' },
+];
 const BACKGROUND_IMAGES = {
   hero: 'https://images.unsplash.com/photo-1566346654781-14e3ef6ee988?auto=format&fit=crop&w=1400&q=80',
 };
@@ -215,6 +221,19 @@ function ChartPanel({ title, subtitle, children }) {
   );
 }
 
+function DashboardEmptyState({ title, text }) {
+  return (
+    <div className="oy-dashboard-empty">
+      <Title level={4}>{title}</Title>
+      <Paragraph type="secondary">{text}</Paragraph>
+      <div className="oy-dashboard-empty-actions">
+        <Button type="primary">{PAGE.primaryCta || '登记记录'}</Button>
+        <Button>刷新数据</Button>
+      </div>
+    </div>
+  );
+}
+
 function RankList({ data, color }) {
   return (
     <div className="oy-rank-list">
@@ -246,6 +265,11 @@ function ActionStep({ item }) {
 
 function isDataBindingEnabled(binding) {
   return Boolean(binding && binding.enabled && binding.mode && binding.mode !== 'seed');
+}
+
+function isSampleSeedPreview(binding) {
+  const mode = binding && binding.mode ? binding.mode : 'seed';
+  return RESEARCH_LEVEL === 'sample' && !isDataBindingEnabled(binding) && mode === 'seed';
 }
 
 function getCsrfToken() {
@@ -341,8 +365,46 @@ function getTotalCount(payload) {
   return null;
 }
 
+function pickField(row, fieldId, fallbackKeys) {
+  const data = row.formData || row.data || row;
+  if (fieldId && data[fieldId] !== undefined) {
+    return data[fieldId];
+  }
+  for (let i = 0; i < fallbackKeys.length; i++) {
+    if (data[fallbackKeys[i]] !== undefined) {
+      return data[fallbackKeys[i]];
+    }
+  }
+  return undefined;
+}
+
+function parseNumericMetric(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    return null;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return null;
+  }
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function normalizeDashboardRows(rows, binding) {
+  const fields = binding.fields || {};
+  return rows.map((row, index) => {
+    const rawValue = pickField(row, fields.value || fields.amount || fields.count, ['value', 'amount', 'count']);
+    return {
+      name: pickField(row, fields.name || fields.title || fields.code, ['name', 'title', 'code']) || ('记录 ' + (index + 1)),
+      value: parseNumericMetric(rawValue),
+    };
+  });
+}
+
 function useYidaData(binding) {
-  const [state, setState] = React.useState({ loading: false, error: '', rows: [], totalCount: null });
+  const [state, setState] = React.useState(() => ({ loading: isDataBindingEnabled(binding), error: '', rows: [], totalCount: null }));
   React.useEffect(() => {
     if (!isDataBindingEnabled(binding)) { return undefined; }
     const controller = new AbortController();
@@ -358,7 +420,7 @@ function useYidaData(binding) {
       if (binding.emptyAsError !== false && totalCount > 0 && rows.length === 0) {
         throw new Error('接口返回结构未识别：totalCount=' + totalCount + ' 但 rows=0');
       }
-      setState({ loading: false, error: '', rows, totalCount });
+      setState({ loading: false, error: '', rows: normalizeDashboardRows(rows, binding), totalCount });
     }).catch((err) => {
       if (err.name === 'AbortError') { return; }
       setState({ loading: false, error: err.message || String(err), rows: [], totalCount: null });
@@ -378,7 +440,7 @@ function YidaComp() {
   const brandSoft = getThemeColor(THEME_PROFILE, 'themeColorSoft', readBrandColor(2, '#F3F5FB'));
   const palette = parseColorGroup(THEME_PROFILE.palette || [brand, '#14B8A6', '#F97316', '#22C55E', '#A855F7']);
   const themeVars = buildScopedThemeVars(THEME_SCOPE, THEME_PROFILE);
-  const trendData = useMemo(() => [
+  const seedTrendData = useMemo(() => [
     { name: '周一', value: 42, target: 36 },
     { name: '周二', value: 48, target: 39 },
     { name: '周三', value: 51, target: 44 },
@@ -386,18 +448,73 @@ function YidaComp() {
     { name: '周五', value: 58, target: 49 },
     { name: '周六', value: 63, target: 55 },
   ], []);
-  const rankData = useMemo(() => FEATURES.slice(0, 5).map((item, index) => ({
+  const seedRankData = useMemo(() => FEATURES.slice(0, 5).map((item, index) => ({
     name: item.title,
     value: 88 - index * 11,
   })), []);
-  const mainMetric = METRICS[0] || { value: '-', label: '核心指标' };
   const insight = INSIGHTS[0] || null;
   const primaryAction = INTERACTION_PROFILE.primaryAction || PAGE.primaryCta;
   const shellLabel = APP_BLUEPRINT.shell || 'single_page';
   const dataState = useYidaData(DATA_BINDING);
-  const dataMetric = isDataBindingEnabled(DATA_BINDING) && dataState.totalCount !== null
-    ? { value: String(dataState.totalCount), label: DATA_BINDING.sourceName || '真实记录' }
-    : null;
+  const usesSeedRows = isSampleSeedPreview(DATA_BINDING);
+  const chartRows = isDataBindingEnabled(DATA_BINDING)
+    ? dataState.rows.filter((row) => Number.isFinite(row.value))
+    : [];
+  const hasRowsWithoutChartValue = isDataBindingEnabled(DATA_BINDING)
+    && !dataState.loading
+    && !dataState.error
+    && dataState.rows.length > 0
+    && chartRows.length === 0;
+  const trendData = usesSeedRows
+    ? seedTrendData
+    : chartRows.length
+      ? chartRows.slice(0, 6).map((row, index) => ({ name: row.name || '记录 ' + (index + 1), value: row.value, target: row.value }))
+      : [];
+  const rankData = usesSeedRows
+    ? seedRankData
+    : chartRows.length
+      ? chartRows.slice(0, 5)
+      : [];
+  const metricItems = usesSeedRows
+    ? METRICS
+    : isDataBindingEnabled(DATA_BINDING)
+      ? [
+        { value: dataState.loading ? '--' : String(dataState.totalCount === null ? dataState.rows.length : dataState.totalCount), label: DATA_BINDING.sourceName || '真实记录', delta: dataState.loading ? '正在读取真实表单' : '来自宜搭表单' },
+        { value: dataState.error ? '异常' : '已接入', label: '数据状态', delta: dataState.error || 'DataBridge' },
+        { value: Object.keys(DATA_BINDING.fields || {}).length + ' 项', label: '字段映射', delta: 'page-spec.json' },
+        { value: '0', label: '演示指标', delta: '演示记录需先写入表单' },
+      ]
+      : EMPTY_METRICS;
+  const mainMetric = metricItems[0] || { value: '-', label: '核心指标' };
+  const hasChartData = trendData.length > 0 && rankData.length > 0;
+  const trendEmptyTitle = isDataBindingEnabled(DATA_BINDING)
+    ? dataState.error
+      ? '真实数据读取异常'
+      : dataState.loading
+        ? '正在读取真实表单数据'
+        : hasRowsWithoutChartValue
+          ? '缺少数值字段映射'
+          : '暂无真实趋势数据'
+    : '未接入真实表单数据';
+  const trendEmptyText = isDataBindingEnabled(DATA_BINDING)
+    ? hasRowsWithoutChartValue
+      ? '已读取真实表单记录，但字段映射中没有可解析的数值字段，趋势图暂不绘制。'
+      : '当前数据源已接入宜搭表单。若需要演示内容，请先通过表单数据写入链路创建 demo records，再刷新本页读取。'
+    : '完整应用交付页不会用前端静态趋势冒充业务数据，请在 page-spec.json 写入 dataBinding.mode=form。';
+  const rankEmptyTitle = isDataBindingEnabled(DATA_BINDING)
+    ? dataState.error
+      ? '真实数据读取异常'
+      : dataState.loading
+        ? '正在读取真实排行数据'
+        : hasRowsWithoutChartValue
+          ? '暂无可绘图数据'
+          : '暂无真实排行记录'
+    : '未接入真实排行数据';
+  const rankEmptyText = isDataBindingEnabled(DATA_BINDING)
+    ? hasRowsWithoutChartValue
+      ? 'DataBridge 已读取真实记录，但缺少可用于排行的数值字段映射，页面不会合成前端指标。'
+      : 'DataBridge 已启用，页面不会回退到 sample 排行。'
+    : '请配置真实表单 dataBinding，或先写入 demo records 后再让 Canvas 读取。';
 
   return (
     <ConfigProvider
@@ -478,6 +595,10 @@ function YidaComp() {
           .oy-rank-bar { height: 8px; border-radius: 999px; background: color-mix(in srgb, var(--oy-brand) 12%, #fff); overflow: hidden; }
           .oy-rank-bar span { display: block; height: 100%; border-radius: inherit; }
           .oy-data-status { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: 12px; }
+          .oy-dashboard-empty { min-height: 220px; display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 8px; text-align: center; padding: 28px 18px; border: 1px dashed color-mix(in srgb, var(--oy-brand) 24%, #D7E4EA); border-radius: 14px; background: color-mix(in srgb, var(--oy-brand-soft), #fff 54%); }
+          .oy-dashboard-empty h4 { margin: 0; color: #102A2F; }
+          .oy-dashboard-empty .ant-typography { max-width: 560px; }
+          .oy-dashboard-empty-actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; margin-top: 8px; }
           @media (max-width: 960px) {
             .oy-dashboard-overview { padding: 20px; }
             .oy-dashboard-grid, .oy-dashboard-chart-row, .oy-dashboard-kpi { grid-template-columns: 1fr; }
@@ -511,12 +632,19 @@ function YidaComp() {
                         {dataState.error || (dataState.loading ? '正在读取真实数据' : '真实数据已接入' + (dataState.totalCount === null ? '' : '：' + dataState.totalCount + ' 条'))}
                       </Text>
                     </div>
-                  ) : null}
+                  ) : (
+                    <div className="oy-data-status">
+                      <Tag color={usesSeedRows ? 'warning' : 'default'}>{usesSeedRows ? 'Sample seed' : '未接数据'}</Tag>
+                      <Text type="secondary">
+                        {usesSeedRows ? '当前为 sample/seed 预览指标，未接真实表单。' : '未配置真实表单 dataBinding，当前不显示前端静态业务指标。'}
+                      </Text>
+                    </div>
+                  )}
                 </div>
-                <DataFreshnessBadge researchLevel={RESEARCH_LEVEL} />
+                <DataFreshnessBadge researchLevel={usesSeedRows ? 'sample seed' : isDataBindingEnabled(DATA_BINDING) ? 'DataBridge' : 'empty'} />
               </div>
               <div className="oy-dashboard-kpi">
-                {(dataMetric ? [dataMetric].concat(METRICS) : METRICS).slice(0, 4).map((item, index) => (
+                {metricItems.slice(0, 4).map((item, index) => (
                   <KpiPrimitive item={item} index={index} brandDeep={brandDeep} key={item.label} />
                 ))}
               </div>
@@ -537,29 +665,45 @@ function YidaComp() {
 
           <div className="oy-dashboard-chart-row">
             <ChartPanel title="趋势分析" subtitle={`${mainMetric.label}: ${mainMetric.value}`}>
-              <ResponsiveContainer width="100%" height={220}>
-                <AreaChart data={trendData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="color-mix(in srgb, var(--oy-brand) 12%, #E8F0F8)" />
-                  <XAxis dataKey="name" tickLine={false} axisLine={false} />
-                  <YAxis tickLine={false} axisLine={false} />
-                  <Tooltip />
-                  <Area type="monotone" dataKey="target" name="目标" stroke={palette[2]} fill={palette[2]} fillOpacity={0.12} />
-                  <Area type="monotone" dataKey="value" name="实际" stroke={brand} fill={brand} fillOpacity={0.18} />
-                </AreaChart>
-              </ResponsiveContainer>
+              {hasChartData ? (
+                <ResponsiveContainer width="100%" height={220}>
+                  <AreaChart data={trendData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="color-mix(in srgb, var(--oy-brand) 12%, #E8F0F8)" />
+                    <XAxis dataKey="name" tickLine={false} axisLine={false} />
+                    <YAxis tickLine={false} axisLine={false} />
+                    <Tooltip />
+                    <Area type="monotone" dataKey="target" name="目标" stroke={palette[2]} fill={palette[2]} fillOpacity={0.12} />
+                    <Area type="monotone" dataKey="value" name="实际" stroke={brand} fill={brand} fillOpacity={0.18} />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <DashboardEmptyState
+                  title={trendEmptyTitle}
+                  text={trendEmptyText}
+                />
+              )}
             </ChartPanel>
 
             <ChartPanel title={PAGE.featuresTitle} subtitle={`TOP ${rankData.length}`}>
-              <ResponsiveContainer width="100%" height={220}>
-                <BarChart data={rankData} layout="vertical" margin={{ left: 10, right: 16 }}>
-                  <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="color-mix(in srgb, var(--oy-brand) 12%, #E8F0F8)" />
-                  <XAxis type="number" hide />
-                  <YAxis dataKey="name" type="category" tickLine={false} axisLine={false} width={96} />
-                  <Tooltip />
-                  <Bar dataKey="value" name="贡献度" fill={palette[1] || brand} radius={[0, 6, 6, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-              <RankList data={rankData} color={palette[1] || brand} />
+              {hasChartData ? (
+                <>
+                  <ResponsiveContainer width="100%" height={220}>
+                    <BarChart data={rankData} layout="vertical" margin={{ left: 10, right: 16 }}>
+                      <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="color-mix(in srgb, var(--oy-brand) 12%, #E8F0F8)" />
+                      <XAxis type="number" hide />
+                      <YAxis dataKey="name" type="category" tickLine={false} axisLine={false} width={96} />
+                      <Tooltip />
+                      <Bar dataKey="value" name="贡献度" fill={palette[1] || brand} radius={[0, 6, 6, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                  <RankList data={rankData} color={palette[1] || brand} />
+                </>
+              ) : (
+                <DashboardEmptyState
+                  title={rankEmptyTitle}
+                  text={rankEmptyText}
+                />
+              )}
             </ChartPanel>
           </div>
         </div>

--- a/lib/samples/yida-canvas-custom-page/data-management.canvas.jsx
+++ b/lib/samples/yida-canvas-custom-page/data-management.canvas.jsx
@@ -120,7 +120,13 @@ const DEFAULT_INSIGHTS = [
     suggestion: '首屏保留字段工具条、横向滚动表格、分组行和批量操作，用户能立刻理解这是数据管理场景。',
   },
 ];
-const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed' };
+const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed', seedStrategy: 'sample-only' };
+const EMPTY_METRICS = [
+  { label: '真实记录', value: '0', hint: '未接入表单数据' },
+  { label: '数据来源', value: '未接入', hint: '请在 page-spec.json 配置 dataBinding' },
+  { label: '字段映射', value: '待配置', hint: '写入 appType/formUuid/fields' },
+  { label: '演示记录', value: '0', hint: '演示记录需先写入真实表单' },
+];
 
 const FEATURES = parseTemplateJson('{{FEATURES_JSON}}', DEFAULT_FEATURES);
 const METRICS = parseTemplateJson('{{METRICS_JSON}}', DEFAULT_METRICS);
@@ -219,6 +225,179 @@ function createRowsFromFeatures(features) {
       note: item.text || row.note,
     };
   });
+}
+
+function isDataBindingEnabled(binding) {
+  return Boolean(binding && binding.enabled && binding.mode && binding.mode !== 'seed');
+}
+
+function isSampleSeedPreview(binding) {
+  const mode = binding && binding.mode ? binding.mode : 'seed';
+  return RESEARCH_LEVEL === 'sample' && !isDataBindingEnabled(binding) && mode === 'seed';
+}
+
+function getCsrfToken() {
+  try {
+    return (window.g_config && (window.g_config._csrf_token || window.g_config.csrfToken)) || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function buildDataRequest(binding) {
+  if (binding.mode === 'form' && binding.appType && binding.formUuid) {
+    const qs = new URLSearchParams({
+      formUuid: binding.formUuid,
+      appType: binding.appType,
+      currentPage: String(binding.pageNumber || 1),
+      pageSize: String(binding.pageSize || 50),
+      searchFieldJson: JSON.stringify(binding.query || {}),
+    }).toString();
+    return {
+      url: '/dingtalk/web/' + binding.appType + '/v1/form/searchFormDatas.json?' + qs,
+      method: 'GET',
+      body: {},
+    };
+  }
+  return {
+    url: binding.endpoint,
+    method: binding.method || 'GET',
+    body: binding.body || {},
+  };
+}
+
+function requestJson(req, signal) {
+  const csrfToken = getCsrfToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (csrfToken) {
+    headers.global_csrf_token = csrfToken;
+  }
+  return fetch(req.url, {
+    method: req.method || 'GET',
+    credentials: 'include',
+    headers,
+    body: req.method === 'GET' ? undefined : JSON.stringify(req.body || {}),
+    signal,
+  }).then((resp) => {
+    if (!resp.ok) {
+      throw new Error('HTTP ' + resp.status);
+    }
+    return resp.json();
+  }).then((json) => {
+    if (json && json.success === false) {
+      throw new Error(json.errorMsg || json.message || 'request failed');
+    }
+    return json;
+  });
+}
+
+function unwrapRows(payload) {
+  const queue = [payload];
+  const seen = [];
+  while (queue.length) {
+    const item = queue.shift();
+    if (!item || seen.indexOf(item) >= 0) { continue; }
+    seen.push(item);
+    if (Array.isArray(item)) { return item; }
+    ['data', 'list', 'values', 'records'].forEach((key) => {
+      if (Array.isArray(item[key])) {
+        queue.unshift(item[key]);
+      }
+    });
+    ['result', 'content', 'value'].forEach((key) => {
+      if (item[key] && typeof item[key] === 'object') {
+        queue.push(item[key]);
+      }
+    });
+  }
+  return [];
+}
+
+function getTotalCount(payload) {
+  const queue = [payload];
+  const seen = [];
+  while (queue.length) {
+    const item = queue.shift();
+    if (!item || seen.indexOf(item) >= 0) { continue; }
+    seen.push(item);
+    if (typeof item.totalCount === 'number') { return item.totalCount; }
+    if (typeof item.total === 'number') { return item.total; }
+    if (typeof item.count === 'number') { return item.count; }
+    ['result', 'content', 'data', 'value'].forEach((key) => {
+      if (item[key] && typeof item[key] === 'object') {
+        queue.push(item[key]);
+      }
+    });
+  }
+  return null;
+}
+
+function pickField(row, fieldId, fallbackKeys) {
+  const data = row.formData || row.data || row;
+  if (fieldId && data[fieldId] !== undefined) {
+    return data[fieldId];
+  }
+  for (let i = 0; i < fallbackKeys.length; i++) {
+    if (data[fallbackKeys[i]] !== undefined) {
+      return data[fallbackKeys[i]];
+    }
+  }
+  return '';
+}
+
+function normalizeTags(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).filter(Boolean).slice(0, 4);
+  }
+  if (value === undefined || value === null || value === '') {
+    return ['真实表单'];
+  }
+  return String(value).split(/[,，、\s]+/).filter(Boolean).slice(0, 4);
+}
+
+function normalizeBoundRows(rows, binding) {
+  const fields = binding.fields || {};
+  return rows.map((row, index) => {
+    const status = pickField(row, fields.progress || fields.status, ['progress', 'status', 'state']) || '待确认';
+    return {
+      id: row.formInstanceId || row.instanceId || row.id || index + 1,
+      group: pickField(row, fields.group || fields.owner, ['group', 'owner', 'creator']) || '真实表单记录',
+      task: pickField(row, fields.task || fields.title || fields.code, ['task', 'title', 'name', 'code']) || ('记录 ' + (index + 1)),
+      progress: status,
+      date: pickField(row, fields.date, ['date', 'gmtCreate', 'createTime']) || '-',
+      tags: normalizeTags(pickField(row, fields.tags || fields.tag, ['tags', 'tag', 'category'])),
+      priority: pickField(row, fields.priority, ['priority', 'level']) || '-',
+      note: pickField(row, fields.note || fields.summary, ['note', 'summary', 'description']) || '',
+      rich: pickField(row, fields.rich || fields.content, ['rich', 'content', 'remark']) || '',
+    };
+  });
+}
+
+function useYidaData(binding) {
+  const [state, setState] = React.useState(() => ({ loading: isDataBindingEnabled(binding), error: '', rows: [], totalCount: null }));
+  React.useEffect(() => {
+    if (!isDataBindingEnabled(binding)) { return undefined; }
+    const controller = new AbortController();
+    const req = buildDataRequest(binding);
+    if (!req.url) {
+      setState({ loading: false, error: '数据绑定缺少 endpoint 或 appType/formUuid', rows: [], totalCount: null });
+      return undefined;
+    }
+    setState({ loading: true, error: '', rows: [], totalCount: null });
+    requestJson(req, controller.signal).then((json) => {
+      const rows = unwrapRows(json);
+      const totalCount = getTotalCount(json);
+      if (binding.emptyAsError !== false && totalCount > 0 && rows.length === 0) {
+        throw new Error('接口返回结构未识别：totalCount=' + totalCount + ' 但 rows=0');
+      }
+      setState({ loading: false, error: '', rows: normalizeBoundRows(rows, binding), totalCount });
+    }).catch((err) => {
+      if (err.name === 'AbortError') { return; }
+      setState({ loading: false, error: err.message || String(err), rows: [], totalCount: null });
+    });
+    return () => controller.abort();
+  }, []);
+  return state;
 }
 
 function Icon({ name }) {
@@ -390,7 +569,12 @@ function MetricStrip({ metrics }) {
   );
 }
 
-function Sidebar({ roadmap, insight, dataBinding }) {
+function Sidebar({ roadmap, insight, dataBinding, usesSeedRows }) {
+  const dataText = dataBinding && dataBinding.enabled
+    ? '已配置真实数据源，页面通过 DataBridge 读取宜搭表单。'
+    : usesSeedRows
+      ? '当前为 sample/seed 预览数据，未接真实表单。'
+      : '未接入真实表单 dataBinding，交付态不显示前端 seed 记录。';
   return (
     <aside className="oy-data-sidebar">
       <div className="oy-side-block">
@@ -418,7 +602,7 @@ function Sidebar({ roadmap, insight, dataBinding }) {
       <div className="oy-side-block is-insight">
         <Tag color="cyan">{ARCHETYPE}</Tag>
         <p>{insight.suggestion || PAGE.ctaText}</p>
-        {dataBinding && dataBinding.enabled ? <Text type="secondary">已配置真实数据源</Text> : <Text type="secondary">当前使用演示数据，可通过 dataBinding 接入宜搭表单。</Text>}
+        <Text type="secondary">{dataText}</Text>
       </div>
     </aside>
   );
@@ -430,8 +614,21 @@ const DIMENSION_LABEL = { group: '单选', progress: '状态', date: '日期', p
 function YidaComp() {
   const [activeView, setActiveView] = useState((APP_BLUEPRINT.views && APP_BLUEPRINT.views[0]) || '全部数据');
   const seedRows = useMemo(() => createRowsFromFeatures(FEATURES), []);
-  const [rows, setRows] = useState(seedRows);
-  const [selected, setSelected] = useState([1, 2]);
+  const usesSeedRows = isSampleSeedPreview(DATA_BINDING);
+  const dataState = useYidaData(DATA_BINDING);
+  const [localRows, setLocalRows] = useState(() => usesSeedRows ? seedRows : []);
+  const rows = isDataBindingEnabled(DATA_BINDING) ? dataState.rows : localRows;
+  const metricItems = usesSeedRows
+    ? METRICS
+    : isDataBindingEnabled(DATA_BINDING)
+      ? [
+        { label: DATA_BINDING.sourceName || '真实记录', value: dataState.loading ? '--' : String(dataState.totalCount === null ? rows.length : dataState.totalCount), hint: dataState.loading ? '正在读取真实表单' : '来自宜搭表单' },
+        { label: '数据状态', value: dataState.error ? '异常' : '已接入', hint: dataState.error || 'DataBridge' },
+        { label: '字段映射', value: Object.keys(DATA_BINDING.fields || {}).length + ' 项', hint: 'page-spec.json' },
+        { label: '演示记录', value: '0', hint: '演示记录需先写入表单' },
+      ]
+      : EMPTY_METRICS;
+  const [selected, setSelected] = useState(() => usesSeedRows ? [1, 2] : []);
   const [keyword, setKeyword] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [sortDir, setSortDir] = useState('none');
@@ -509,10 +706,14 @@ function YidaComp() {
     setCollapsed((cur) => cur.indexOf(key) >= 0 ? cur.filter((item) => item !== key) : cur.concat(key));
   }
   function addRecord() {
-    const nextId = rows.reduce((max, row) => Math.max(max, row.id), 0) + 1;
-    const groupName = (rows[0] && rows[0].group) || '20260717-研发治理';
+    if (!usesSeedRows) {
+      notify(isDataBindingEnabled(DATA_BINDING) ? '请通过真实表单登记记录后刷新读取' : '请先在 page-spec.json 接入 dataBinding.mode=form');
+      return;
+    }
+    const nextId = localRows.reduce((max, row) => Math.max(max, Number(row.id) || 0), 0) + 1;
+    const groupName = (localRows[0] && localRows[0].group) || '20260717-研发治理';
     const record = { id: nextId, group: groupName, task: '新任务 ' + nextId, progress: '待确认', date: '2026-07-17', tags: ['新建'], priority: 'P2', note: '待补充', rich: '' };
-    setRows([record].concat(rows));
+    setLocalRows([record].concat(localRows));
     setSelected(selected.concat(nextId));
     if (message && message.success) { message.success('已新增一条记录，已自动选中'); }
   }
@@ -1059,12 +1260,19 @@ function YidaComp() {
                 <Tag color="cyan">{activeView}</Tag>
                 <Tag>{VISUAL_PROFILE.name}</Tag>
                 <Tag>{RESEARCH_LEVEL}</Tag>
-                {DATA_BINDING.enabled ? <Tag color="green">真实数据</Tag> : <Tag>演示数据</Tag>}
+                {isDataBindingEnabled(DATA_BINDING) ? <Tag color={dataState.error ? 'error' : dataState.loading ? 'processing' : 'green'}>DataBridge</Tag> : usesSeedRows ? <Tag color="warning">Sample seed</Tag> : <Tag>未接数据</Tag>}
+                <Text type={dataState.error ? 'danger' : 'secondary'}>
+                  {isDataBindingEnabled(DATA_BINDING)
+                    ? dataState.error || (dataState.loading ? '正在读取真实数据' : '真实数据已接入' + (dataState.totalCount === null ? '' : '：' + dataState.totalCount + ' 条'))
+                    : usesSeedRows
+                      ? '当前为 sample/seed 预览数据，未接真实表单。'
+                      : '未配置真实表单 dataBinding，当前不显示前端 seed 记录。'}
+                </Text>
               </div>
               <Title level={2}>{PAGE.brandName}</Title>
               <p>{PAGE.heroText}</p>
             </div>
-            <MetricStrip metrics={METRICS} />
+            <MetricStrip metrics={metricItems} />
           </section>
 
           <section className={sidebarOpen ? 'oy-data-workspace' : 'oy-data-workspace is-full'}>
@@ -1096,16 +1304,22 @@ function YidaComp() {
                   </React.Fragment>
                 ))}
                 {viewRows.length === 0 ? (
-                  <div className="oy-data-empty">没有符合条件的记录，试试清空搜索或切换筛选</div>
+                  <div className="oy-data-empty">
+                    {isDataBindingEnabled(DATA_BINDING)
+                      ? dataState.loading ? '正在读取真实表单数据' : '暂无真实表单记录。若需要演示内容，请先通过表单数据写入链路创建 demo records，再刷新本页读取。'
+                      : usesSeedRows
+                        ? '没有符合条件的 sample 记录，试试清空搜索或切换筛选'
+                        : '未接入真实表单数据。完整应用交付页不会用前端 seedRows 冒充业务记录，请在 page-spec.json 写入 dataBinding.mode=form。'}
+                  </div>
                 ) : null}
                 <div className="oy-add-row">
-                  <button type="button" onClick={addRecord}>+ 新增一条记录</button>
-                  <Text type="secondary">字段、分组和筛选会保持在当前视图中</Text>
+                  <button type="button" onClick={addRecord}>+ {usesSeedRows ? '新增一条 sample 记录' : '登记真实表单记录'}</button>
+                  <Text type="secondary">{usesSeedRows ? '字段、分组和筛选会保持在当前 sample 视图中' : '请通过表单写入真实记录后刷新读取'}</Text>
                 </div>
               </div>
             </div>
 
-            {sidebarOpen ? <Sidebar roadmap={ROADMAP} insight={insight} dataBinding={DATA_BINDING} /> : null}
+            {sidebarOpen ? <Sidebar roadmap={ROADMAP} insight={insight} dataBinding={DATA_BINDING} usesSeedRows={usesSeedRows} /> : null}
           </section>
         </div>
       </main>

--- a/lib/samples/yida-canvas-custom-page/split-pane-detail.canvas.jsx
+++ b/lib/samples/yida-canvas-custom-page/split-pane-detail.canvas.jsx
@@ -84,7 +84,7 @@ const DEFAULT_ROADMAP = [
   { stage: '03', title: '推进处理', text: '完成分派、备注或状态更新。' },
 ];
 const DEFAULT_THEME_PROFILE = { followRuntimeTheme: false, name: 'amber-client-file', themeColor: '#B7791F', themeColorDeep: '#7C4A03', themeColorSoft: '#FFF8E7', themeColorTint: 'rgba(183, 121, 31, 0.18)', palette: ['#B7791F', '#0F9F8E', '#E11D48', '#2563EB', '#F97316'] };
-const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed' };
+const DEFAULT_DATA_BINDING = { enabled: false, mode: 'seed', seedStrategy: 'sample-only' };
 const DEFAULT_INSIGHTS = [{ conclusion: '双栏详情页适合高频查阅和逐条处理。' }];
 const BACKGROUND_IMAGES = {
   detail: 'https://images.unsplash.com/photo-1771147372627-7fffe86cf00b?auto=format&fit=crop&w=1400&q=80',
@@ -98,6 +98,7 @@ const THEME_PROFILE = parseTemplateJson('{{OPENYIDA_THEME_PROFILE_JSON}}', DEFAU
 const THEME_SCOPE = withFallback('{{OPENYIDA_THEME_SCOPE}}', 'page');
 const DATA_BINDING = parseTemplateJson('{{OPENYIDA_DATA_BINDING_JSON}}', DEFAULT_DATA_BINDING);
 const INSIGHTS = parseTemplateJson('{{OPENYIDA_INSIGHTS_JSON}}', DEFAULT_INSIGHTS);
+const RESEARCH_LEVEL = withFallback('{{OPENYIDA_RESEARCH_LEVEL}}', 'sample');
 
 function getThemeColor(fallback) {
   if (typeof window === 'undefined' || !window.getComputedStyle) {
@@ -152,6 +153,163 @@ function getSeedRows() {
   ];
 }
 
+function isDataBindingEnabled(binding) {
+  return Boolean(binding && binding.enabled && binding.mode && binding.mode !== 'seed');
+}
+
+function isSampleSeedPreview(binding) {
+  const mode = binding && binding.mode ? binding.mode : 'seed';
+  return RESEARCH_LEVEL === 'sample' && !isDataBindingEnabled(binding) && mode === 'seed';
+}
+
+function getCsrfToken() {
+  try {
+    return (window.g_config && (window.g_config._csrf_token || window.g_config.csrfToken)) || '';
+  } catch (err) {
+    return '';
+  }
+}
+
+function buildDataRequest(binding) {
+  if (binding.mode === 'form' && binding.appType && binding.formUuid) {
+    const qs = new URLSearchParams({
+      formUuid: binding.formUuid,
+      appType: binding.appType,
+      currentPage: String(binding.pageNumber || 1),
+      pageSize: String(binding.pageSize || 20),
+      searchFieldJson: JSON.stringify(binding.query || {}),
+    }).toString();
+    return {
+      url: '/dingtalk/web/' + binding.appType + '/v1/form/searchFormDatas.json?' + qs,
+      method: 'GET',
+      body: {},
+    };
+  }
+  return {
+    url: binding.endpoint,
+    method: binding.method || 'GET',
+    body: binding.body || {},
+  };
+}
+
+function requestJson(req, signal) {
+  const csrfToken = getCsrfToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (csrfToken) {
+    headers.global_csrf_token = csrfToken;
+  }
+  return fetch(req.url, {
+    method: req.method || 'GET',
+    credentials: 'include',
+    headers,
+    body: req.method === 'GET' ? undefined : JSON.stringify(req.body || {}),
+    signal,
+  }).then((resp) => {
+    if (!resp.ok) {
+      throw new Error('HTTP ' + resp.status);
+    }
+    return resp.json();
+  }).then((json) => {
+    if (json && json.success === false) {
+      throw new Error(json.errorMsg || json.message || 'request failed');
+    }
+    return json;
+  });
+}
+
+function unwrapRows(payload) {
+  const queue = [payload];
+  const seen = [];
+  while (queue.length) {
+    const item = queue.shift();
+    if (!item || seen.indexOf(item) >= 0) { continue; }
+    seen.push(item);
+    if (Array.isArray(item)) { return item; }
+    ['data', 'list', 'values', 'records'].forEach((key) => {
+      if (Array.isArray(item[key])) {
+        queue.unshift(item[key]);
+      }
+    });
+    ['result', 'content', 'value'].forEach((key) => {
+      if (item[key] && typeof item[key] === 'object') {
+        queue.push(item[key]);
+      }
+    });
+  }
+  return [];
+}
+
+function getTotalCount(payload) {
+  const queue = [payload];
+  const seen = [];
+  while (queue.length) {
+    const item = queue.shift();
+    if (!item || seen.indexOf(item) >= 0) { continue; }
+    seen.push(item);
+    if (typeof item.totalCount === 'number') { return item.totalCount; }
+    if (typeof item.total === 'number') { return item.total; }
+    if (typeof item.count === 'number') { return item.count; }
+    ['result', 'content', 'data', 'value'].forEach((key) => {
+      if (item[key] && typeof item[key] === 'object') {
+        queue.push(item[key]);
+      }
+    });
+  }
+  return null;
+}
+
+function pickField(row, fieldId, fallbackKeys) {
+  const data = row.formData || row.data || row;
+  if (fieldId && data[fieldId] !== undefined) {
+    return data[fieldId];
+  }
+  for (let i = 0; i < fallbackKeys.length; i++) {
+    if (data[fallbackKeys[i]] !== undefined) {
+      return data[fallbackKeys[i]];
+    }
+  }
+  return '';
+}
+
+function normalizeBoundRows(rows, binding) {
+  const fields = binding.fields || {};
+  return rows.map((row, index) => ({
+    id: row.formInstanceId || row.instanceId || row.id || ('ROW-' + (index + 1)),
+    title: pickField(row, fields.title || fields.code, ['title', 'name', 'code']) || ('记录 ' + (index + 1)),
+    desc: pickField(row, fields.desc || fields.summary || fields.description, ['desc', 'summary', 'description', 'content']) || '',
+    status: pickField(row, fields.status, ['status', 'state', 'progress']) || '待处理',
+    owner: pickField(row, fields.owner, ['owner', 'creator', 'dept']) || '未分配',
+    amount: pickField(row, fields.amount || fields.value, ['amount', 'value', 'count']) || '-',
+  }));
+}
+
+function useYidaData(binding) {
+  const [state, setState] = React.useState(() => ({ loading: isDataBindingEnabled(binding), error: '', rows: [], totalCount: null }));
+  React.useEffect(() => {
+    if (!isDataBindingEnabled(binding)) { return undefined; }
+    const controller = new AbortController();
+    const req = buildDataRequest(binding);
+    if (!req.url) {
+      setState({ loading: false, error: '数据绑定缺少 endpoint 或 appType/formUuid', rows: [], totalCount: null });
+      return undefined;
+    }
+    setState({ loading: true, error: '', rows: [], totalCount: null });
+    requestJson(req, controller.signal).then((json) => {
+      const rows = unwrapRows(json);
+      const totalCount = getTotalCount(json);
+      if (binding.emptyAsError !== false && totalCount > 0 && rows.length === 0) {
+        throw new Error('接口返回结构未识别：totalCount=' + totalCount + ' 但 rows=0');
+      }
+      setState({ loading: false, error: '', rows: normalizeBoundRows(rows, binding), totalCount });
+    }).catch((err) => {
+      if (err.name === 'AbortError') { return; }
+      setState({ loading: false, error: err.message || String(err), rows: [], totalCount: null });
+    });
+    return () => controller.abort();
+  }, []);
+  return state;
+}
+
 function getStatusColor(status) {
   if (/高|异常|风险|超时/.test(status)) {
     return 'error';
@@ -164,7 +322,7 @@ function getStatusColor(status) {
 
 const QUEUE_STATUS = { high: '高优先级', pending: '待跟进' };
 
-function SplitQueue({ rows, selectedId, onSelect, filters, onFilterChange }) {
+function SplitQueue({ rows, selectedId, onSelect, filters, onFilterChange, emptyText }) {
   return (
     <aside className="oy-split-queue">
       <div className="oy-filter-bar">
@@ -181,7 +339,7 @@ function SplitQueue({ rows, selectedId, onSelect, filters, onFilterChange }) {
       </div>
       <div className="oy-queue-list">
         {rows.length === 0 ? (
-          <div className="oy-queue-empty"><Text>无匹配工单，试试清空搜索或切换状态</Text></div>
+          <div className="oy-queue-empty"><Text>{emptyText || '无匹配工单，试试清空搜索或切换状态'}</Text></div>
         ) : rows.map((row) => (
           <button
             type="button"
@@ -203,6 +361,28 @@ function SplitQueue({ rows, selectedId, onSelect, filters, onFilterChange }) {
 
 function DetailPane({ item }) {
   const insight = INSIGHTS[0] || { conclusion: PAGE.ctaText, evidence: '', suggestion: '' };
+  if (!item) {
+    return (
+      <section className="oy-detail-pane oy-empty-detail">
+        <div className="oy-detail-hero">
+          <Tag color="default">空态入口</Tag>
+          <Title level={2}>等待真实记录</Title>
+          <Paragraph>未接入真实表单数据时，交付态不会展示前端 seed 详情。请在 page-spec.json 写入 dataBinding.mode=form，或先登记真实表单记录。</Paragraph>
+          <div className="oy-detail-actions">
+            <Button type="primary">{PAGE.primaryCta}</Button>
+            <Button>刷新数据</Button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+  const metricItems = isSampleSeedPreview(DATA_BINDING)
+    ? METRICS
+    : [
+      { label: '当前状态', value: item.status || '-' },
+      { label: '负责人', value: item.owner || '-' },
+      { label: '金额/数值', value: item.amount || '-' },
+    ];
   return (
     <section className="oy-detail-pane">
       <div className="oy-detail-hero">
@@ -215,7 +395,7 @@ function DetailPane({ item }) {
         </div>
       </div>
       <div className="oy-detail-grid">
-        {METRICS.map((metric) => (
+        {metricItems.map((metric) => (
           <div className="oy-metric-card" key={metric.label}>
             <Text>{metric.label}</Text>
             <strong>{metric.value}</strong>
@@ -246,8 +426,11 @@ function DetailPane({ item }) {
 
 function YidaComp() {
   useEffect(() => { updateShellTheme(); }, []);
-  const rows = useMemo(() => getSeedRows(), []);
-  const [selectedId, setSelectedId] = useState(rows[0] && rows[0].id);
+  const seedRows = useMemo(() => getSeedRows(), []);
+  const usesSeedRows = isSampleSeedPreview(DATA_BINDING);
+  const dataState = useYidaData(DATA_BINDING);
+  const rows = dataState.rows.length ? dataState.rows : (usesSeedRows ? seedRows : []);
+  const [selectedId, setSelectedId] = useState(() => usesSeedRows && seedRows[0] ? seedRows[0].id : null);
   const [queueFilters, setQueueFilters] = useState({ keyword: '', status: 'all' });
   const handleQueueFilter = (key, value) => setQueueFilters((prev) => Object.assign({}, prev, { [key]: value }));
   const filteredRows = useMemo(() => {
@@ -262,8 +445,13 @@ function YidaComp() {
     });
   }, [rows, queueFilters]);
   const visibleSelectedId = filteredRows.some((row) => row.id === selectedId) ? selectedId : (filteredRows[0] && filteredRows[0].id);
-  const selected = rows.find((row) => row.id === visibleSelectedId) || rows[0];
+  const selected = rows.find((row) => row.id === visibleSelectedId) || null;
   const themeVars = buildScopedThemeVars();
+  const queueEmptyText = isDataBindingEnabled(DATA_BINDING)
+    ? dataState.loading ? '正在读取真实表单数据' : '暂无真实表单记录。若需要演示内容，请先通过表单数据写入链路创建 demo records。'
+    : usesSeedRows
+      ? '无匹配 sample 记录，试试清空搜索或切换状态'
+      : '未接入真实表单数据。完整应用交付页不会用前端 seedRows 冒充业务队列。';
 
   return (
     <ConfigProvider getPopupContainer={(triggerNode) => (triggerNode && triggerNode.parentElement) || document.body}>
@@ -334,14 +522,22 @@ function YidaComp() {
               <div className="oy-brand-mark">{PAGE.brandInitials}</div>
               <div>
                 <Tag color="warning">{PAGE.tagline}</Tag>
+                {isDataBindingEnabled(DATA_BINDING) ? <Tag color={dataState.error ? 'error' : dataState.loading ? 'processing' : 'green'}>DataBridge</Tag> : usesSeedRows ? <Tag color="warning">Sample seed</Tag> : <Tag>未接数据</Tag>}
                 <h1>{PAGE.brandName}</h1>
                 <p>{PAGE.heroText}</p>
+                <p className="oy-data-status">
+                  {isDataBindingEnabled(DATA_BINDING)
+                    ? dataState.error || (dataState.loading ? '正在读取真实数据' : '真实数据已接入' + (dataState.totalCount === null ? '' : '：' + dataState.totalCount + ' 条'))
+                    : usesSeedRows
+                      ? '当前为 sample/seed 预览数据，未接真实表单。'
+                      : '未配置真实表单 dataBinding，当前不显示前端 seed 队列。'}
+                </p>
               </div>
             </div>
             <Button type="primary">{PAGE.primaryCta}</Button>
           </header>
           <section className="oy-split-layout">
-            <SplitQueue rows={filteredRows} selectedId={visibleSelectedId} onSelect={setSelectedId} filters={queueFilters} onFilterChange={handleQueueFilter} />
+            <SplitQueue rows={filteredRows} selectedId={visibleSelectedId} onSelect={setSelectedId} filters={queueFilters} onFilterChange={handleQueueFilter} emptyText={queueEmptyText} />
             <DetailPane item={selected} />
           </section>
         </div>

--- a/tests/canvas-compile.test.js
+++ b/tests/canvas-compile.test.js
@@ -156,6 +156,103 @@ function collectVisibleStrings(node, result = [], insideStyle = false) {
   return result;
 }
 
+function findNodesByType(node, type, result = []) {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return result;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((item) => findNodesByType(item, type, result));
+    return result;
+  }
+  if (typeof node === 'object') {
+    if (node.type === type) {
+      result.push(node);
+    }
+    findNodesByType(node.children || [], type, result);
+  }
+  return result;
+}
+
+function withCanvasGlobals(stubWindow, fn) {
+  const previousGlobals = {
+    document: global.document,
+    getComputedStyle: global.getComputedStyle,
+    fetch: global.fetch,
+    URLSearchParams: global.URLSearchParams,
+    AbortController: global.AbortController,
+    localStorage: global.localStorage,
+    window: global.window,
+  };
+
+  try {
+    global.document = stubWindow.document;
+    global.getComputedStyle = stubWindow.getComputedStyle;
+    global.fetch = () => Promise.reject(new Error('fetch should not run in canvas render smoke'));
+    global.URLSearchParams = URLSearchParams;
+    global.AbortController = class {
+      constructor() { this.signal = {}; }
+      abort() {}
+    };
+    global.localStorage = stubWindow.localStorage;
+    global.window = stubWindow;
+    return fn();
+  } finally {
+    global.document = previousGlobals.document;
+    global.getComputedStyle = previousGlobals.getComputedStyle;
+    global.fetch = previousGlobals.fetch;
+    global.URLSearchParams = previousGlobals.URLSearchParams;
+    global.AbortController = previousGlobals.AbortController;
+    global.localStorage = previousGlobals.localStorage;
+    global.window = previousGlobals.window;
+  }
+}
+
+function renderCanvasSample(filename, transformSource) {
+  const samplePath = path.join(
+    __dirname,
+    '..',
+    'lib',
+    'samples',
+    'yida-canvas-custom-page',
+    filename
+  );
+  const rawSource = fs.readFileSync(samplePath, 'utf8');
+  const source = transformSource ? transformSource(rawSource) : rawSource;
+  const { runtimeCode } = compileCanvasLocal(source);
+  const stubWindow = stubCanvasSampleWindow();
+  const rendered = withCanvasGlobals(stubWindow, () => renderCanvasRuntime(runtimeCode, stubWindow));
+  return { source, runtimeCode, rendered, visibleText: collectVisibleStrings(rendered).join('\n') };
+}
+
+function renderCanvasSampleWithDataState(filename, transformSource, dataState) {
+  const samplePath = path.join(
+    __dirname,
+    '..',
+    'lib',
+    'samples',
+    'yida-canvas-custom-page',
+    filename
+  );
+  const rawSource = fs.readFileSync(samplePath, 'utf8');
+  const source = transformSource ? transformSource(rawSource) : rawSource;
+  const { runtimeCode } = compileCanvasLocal(source);
+  const stubWindow = stubCanvasSampleWindow();
+  stubWindow.React.useState = (value) => {
+    const initial = typeof value === 'function' ? value() : value;
+    if (
+      initial
+      && typeof initial === 'object'
+      && Object.prototype.hasOwnProperty.call(initial, 'rows')
+      && Object.prototype.hasOwnProperty.call(initial, 'totalCount')
+    ) {
+      return [dataState, () => {}];
+    }
+    return [initial, () => {}];
+  };
+  const rendered = withCanvasGlobals(stubWindow, () => renderCanvasRuntime(runtimeCode, stubWindow));
+  return { source, runtimeCode, rendered, visibleText: collectVisibleStrings(rendered).join('\n') };
+}
+
 describe('extractImportedModules', () => {
   test('collects bare package names, skips relative/absolute, dedups & sorts', () => {
     const code = `
@@ -375,6 +472,305 @@ describe('compileCanvasLocal', () => {
     expect(JSON.parse(importedModules)).toEqual(['antd', 'react']);
     expect(runtimeCode).not.toMatch(/window\.ahooks/);
     expect(runtimeCode).toMatch(/YidaComp\s*=/);
+  });
+
+  test('business-list raw sample renders marked seed rows', () => {
+    const samplePath = path.join(
+      __dirname,
+      '..',
+      'lib',
+      'samples',
+      'yida-canvas-custom-page',
+      'business-list.canvas.jsx'
+    );
+    const source = fs.readFileSync(samplePath, 'utf8');
+    const { runtimeCode } = compileCanvasLocal(source);
+    const stubWindow = stubCanvasSampleWindow();
+
+    const rendered = withCanvasGlobals(stubWindow, () => renderCanvasRuntime(runtimeCode, stubWindow));
+    const table = findNodesByType(rendered, 'Table')[0];
+    const visibleText = collectVisibleStrings(rendered).join('\n');
+
+    expect(table).toBeTruthy();
+    expect(table.props.dataSource.length).toBeGreaterThan(0);
+    expect(visibleText).toContain('Sample seed');
+    expect(visibleText).toContain('当前为 sample/seed 预览数据，未接真实表单。');
+  });
+
+  test('business-list delivery render without dataBinding shows real empty state instead of seed table', () => {
+    const samplePath = path.join(
+      __dirname,
+      '..',
+      'lib',
+      'samples',
+      'yida-canvas-custom-page',
+      'business-list.canvas.jsx'
+    );
+    const source = fs.readFileSync(samplePath, 'utf8')
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none');
+    const { runtimeCode } = compileCanvasLocal(source);
+    const stubWindow = stubCanvasSampleWindow();
+
+    const rendered = withCanvasGlobals(stubWindow, () => renderCanvasRuntime(runtimeCode, stubWindow));
+    const tables = findNodesByType(rendered, 'Table');
+    const visibleText = collectVisibleStrings(rendered).join('\n');
+
+    expect(tables).toHaveLength(0);
+    expect(visibleText).toContain('未接入真实表单数据');
+    expect(visibleText).toContain('完整应用交付页不会用前端 seedRows 冒充业务记录。');
+    expect(visibleText).not.toContain('SO-240716-001');
+  });
+
+  test('business-list form dataBinding keeps DataBridge status and avoids seed fallback', () => {
+    const samplePath = path.join(
+      __dirname,
+      '..',
+      'lib',
+      'samples',
+      'yida-canvas-custom-page',
+      'business-list.canvas.jsx'
+    );
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_TEST',
+      formUuid: 'FORM_TEST',
+      sourceName: '订单表',
+      fields: {
+        code: 'textField_orderNo',
+        summary: 'textareaField_desc',
+        status: 'selectField_status',
+      },
+    });
+    const source = fs.readFileSync(samplePath, 'utf8')
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+      .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding);
+    const { runtimeCode } = compileCanvasLocal(source);
+    const stubWindow = stubCanvasSampleWindow();
+
+    const rendered = withCanvasGlobals(stubWindow, () => renderCanvasRuntime(runtimeCode, stubWindow));
+    const tables = findNodesByType(rendered, 'Table');
+    const visibleText = collectVisibleStrings(rendered).join('\n');
+
+    expect(source).toContain('APP_TEST');
+    expect(source).toContain('FORM_TEST');
+    expect(source).toContain('searchFormDatas.json');
+    expect(tables).toHaveLength(0);
+    expect(visibleText).toContain('DataBridge');
+    expect(visibleText).toContain('正在读取真实数据');
+    expect(visibleText).not.toContain('Sample seed');
+  });
+
+  test('data-management raw sample renders marked seed rows', () => {
+    const { rendered, visibleText } = renderCanvasSample('data-management.canvas.jsx');
+    const rows = findNodesByType(rendered, 'DataRow');
+
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows[0].props.row.task).toBe('openyida skill治理');
+    expect(visibleText).toContain('Sample seed');
+    expect(visibleText).toContain('当前为 sample/seed 预览数据，未接真实表单。');
+  });
+
+  test('data-management delivery render without dataBinding shows empty state instead of seed records', () => {
+    const { rendered, visibleText } = renderCanvasSample('data-management.canvas.jsx', (source) => source
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none'));
+    const dataRows = findNodesByType(rendered, 'DataRow');
+
+    expect(dataRows).toHaveLength(0);
+    expect(visibleText).toContain('未接入真实表单数据');
+    expect(visibleText).toContain('完整应用交付页不会用前端 seedRows 冒充业务记录');
+    expect(visibleText).not.toContain('openyida skill治理');
+  });
+
+  test('data-management form dataBinding keeps DataBridge status and avoids seed fallback', () => {
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_DATA',
+      formUuid: 'FORM_DATA',
+      sourceName: '任务台账',
+      fields: {
+        task: 'textField_task',
+        progress: 'selectField_status',
+        date: 'dateField_due',
+      },
+    });
+    const { source, visibleText } = renderCanvasSample('data-management.canvas.jsx', (raw) => raw
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+      .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding));
+
+    expect(source).toContain('APP_DATA');
+    expect(source).toContain('FORM_DATA');
+    expect(source).toContain('searchFormDatas.json');
+    expect(visibleText).toContain('DataBridge');
+    expect(visibleText).toContain('正在读取真实数据');
+    expect(visibleText).not.toContain('Sample seed');
+    expect(visibleText).not.toContain('openyida skill治理');
+  });
+
+  test('split-pane delivery render without dataBinding shows empty state instead of seed queue', () => {
+    const { rendered, visibleText } = renderCanvasSample('split-pane-detail.canvas.jsx', (source) => source
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none'));
+    const queue = findNodesByType(rendered, 'SplitQueue')[0];
+    const detail = findNodesByType(rendered, 'DetailPane')[0];
+
+    expect(queue.props.rows).toHaveLength(0);
+    expect(queue.props.emptyText).toContain('未接入真实表单数据');
+    expect(detail.props.item).toBeNull();
+    expect(visibleText).toContain('未配置真实表单 dataBinding，当前不显示前端 seed 队列。');
+    expect(visibleText).not.toContain('合同审核');
+  });
+
+  test('split-pane form dataBinding keeps DataBridge status and avoids seed fallback', () => {
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_SPLIT',
+      formUuid: 'FORM_SPLIT',
+      sourceName: '工单池',
+      fields: {
+        title: 'textField_title',
+        summary: 'textareaField_summary',
+        status: 'selectField_status',
+      },
+    });
+    const { source, rendered, visibleText } = renderCanvasSample('split-pane-detail.canvas.jsx', (raw) => raw
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+      .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding));
+    const queue = findNodesByType(rendered, 'SplitQueue')[0];
+
+    expect(source).toContain('APP_SPLIT');
+    expect(source).toContain('FORM_SPLIT');
+    expect(source).toContain('searchFormDatas.json');
+    expect(queue.props.rows).toHaveLength(0);
+    expect(visibleText).toContain('DataBridge');
+    expect(visibleText).toContain('正在读取真实数据');
+    expect(visibleText).not.toContain('合同审核');
+  });
+
+  test('dashboard raw sample renders marked seed charts', () => {
+    const { rendered, visibleText } = renderCanvasSample('dashboard-overview.canvas.jsx');
+
+    expect(findNodesByType(rendered, 'AreaChart')).toHaveLength(1);
+    expect(findNodesByType(rendered, 'BarChart')).toHaveLength(1);
+    expect(findNodesByType(rendered, 'KpiPrimitive')[0].props.item.value).toBe('4,286');
+    expect(visibleText).toContain('Sample seed');
+  });
+
+  test('dashboard delivery render without dataBinding shows empty chart states instead of static metrics', () => {
+    const { rendered, visibleText } = renderCanvasSample('dashboard-overview.canvas.jsx', (source) => source
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none'));
+
+    expect(findNodesByType(rendered, 'AreaChart')).toHaveLength(0);
+    expect(findNodesByType(rendered, 'BarChart')).toHaveLength(0);
+    expect(findNodesByType(rendered, 'DashboardEmptyState')[0].props.title).toBe('未接入真实表单数据');
+    expect(visibleText).toContain('未配置真实表单 dataBinding，当前不显示前端静态业务指标。');
+    expect(findNodesByType(rendered, 'KpiPrimitive')[0].props.item.value).toBe('0');
+    expect(visibleText).not.toContain('增长线索');
+  });
+
+  test('dashboard form dataBinding keeps DataBridge status without static chart fallback', () => {
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_DASH',
+      formUuid: 'FORM_DASH',
+      sourceName: '经营数据',
+      fields: {
+        name: 'textField_store',
+        value: 'numberField_amount',
+      },
+    });
+    const { source, rendered, visibleText } = renderCanvasSample('dashboard-overview.canvas.jsx', (raw) => raw
+      .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+      .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding));
+
+    expect(source).toContain('APP_DASH');
+    expect(source).toContain('FORM_DASH');
+    expect(source).toContain('searchFormDatas.json');
+    expect(source).not.toContain('Math.max(12, 88 - index * 9)');
+    expect(source).toContain('parseNumericMetric(rawValue)');
+    expect(source).toContain("typeof value !== 'number' && typeof value !== 'string'");
+    expect(source).toContain('dataState.rows.filter((row) => Number.isFinite(row.value))');
+    expect(source).toContain('缺少数值字段映射');
+    expect(findNodesByType(rendered, 'AreaChart')).toHaveLength(0);
+    expect(findNodesByType(rendered, 'BarChart')).toHaveLength(0);
+    expect(visibleText).toContain('DataBridge');
+    expect(visibleText).toContain('正在读取真实数据');
+    expect(visibleText).not.toContain('4,286');
+  });
+
+  test('dashboard form dataBinding with records but no numeric value shows chart empty states', () => {
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_DASH',
+      formUuid: 'FORM_DASH',
+      sourceName: '经营数据',
+      fields: {
+        name: 'textField_store',
+      },
+    });
+    const { rendered, visibleText } = renderCanvasSampleWithDataState(
+      'dashboard-overview.canvas.jsx',
+      (raw) => raw
+        .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+        .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding),
+      {
+        loading: false,
+        error: '',
+        rows: [
+          { name: '华东门店', value: null },
+          { name: '华南门店', value: null },
+        ],
+        totalCount: 2,
+      }
+    );
+    const emptyStates = findNodesByType(rendered, 'DashboardEmptyState');
+
+    expect(findNodesByType(rendered, 'AreaChart')).toHaveLength(0);
+    expect(findNodesByType(rendered, 'BarChart')).toHaveLength(0);
+    expect(findNodesByType(rendered, 'KpiPrimitive')[0].props.item.value).toBe('2');
+    expect(emptyStates[0].props.title).toBe('缺少数值字段映射');
+    expect(emptyStates[0].props.text).toContain('没有可解析的数值字段');
+    expect(emptyStates[1].props.title).toBe('暂无可绘图数据');
+    expect(emptyStates[1].props.text).toContain('页面不会合成前端指标');
+    expect(visibleText).not.toContain('4,286');
+  });
+
+  test('dashboard form dataBinding renders charts only with real numeric values', () => {
+    const binding = JSON.stringify({
+      mode: 'form',
+      enabled: true,
+      appType: 'APP_DASH',
+      formUuid: 'FORM_DASH',
+      sourceName: '经营数据',
+      fields: {
+        name: 'textField_store',
+        value: 'numberField_amount',
+      },
+    });
+    const { rendered } = renderCanvasSampleWithDataState(
+      'dashboard-overview.canvas.jsx',
+      (raw) => raw
+        .replace(/{{OPENYIDA_RESEARCH_LEVEL}}/g, 'none')
+        .replace(/{{OPENYIDA_DATA_BINDING_JSON}}/g, binding),
+      {
+        loading: false,
+        error: '',
+        rows: [
+          { name: '华东门店', value: 123 },
+          { name: '华南门店', value: 0 },
+        ],
+        totalCount: 2,
+      }
+    );
+    const areaChart = findNodesByType(rendered, 'AreaChart')[0];
+    const barChart = findNodesByType(rendered, 'BarChart')[0];
+
+    expect(areaChart.props.data.map((item) => item.value)).toEqual([123, 0]);
+    expect(areaChart.props.data.map((item) => item.target)).toEqual([123, 0]);
+    expect(barChart.props.data.map((item) => item.value)).toEqual([123, 0]);
   });
 
   test('all Canvas samples are raw-publish safe', () => {

--- a/tests/generate-page.test.js
+++ b/tests/generate-page.test.js
@@ -422,6 +422,67 @@ describe('generate-page command', () => {
     });
   });
 
+  test('business-list delivery output without dataBinding uses empty state instead of seed list fallback', () => {
+    const specPath = path.join(tmpDir, 'orders-no-binding.json');
+    fs.writeFileSync(specPath, JSON.stringify({
+      template: 'business-list',
+      output: 'pages/src/orders-no-binding.canvas.jsx',
+      requirement: '做订单管理页，支持筛选订单、查看详情和登记新订单。',
+      brandName: '订单管理页',
+      tagline: '订单筛选、处理和详情预览',
+      heroText: '面向运营人员处理订单状态、负责人和下一步动作。',
+      interactionProfile: {
+        primaryAction: '登记订单',
+        detailMode: 'side-pane',
+        bulkActions: ['导出订单', '批量分派'],
+      },
+      visualProfile: {
+        name: 'order-ops-list',
+        density: 'business-compact',
+      },
+      features: [
+        { title: '订单登记', text: '登记客户、金额、状态和负责人。' },
+        { title: '订单筛选', text: '按状态、周期和关键词定位记录。' },
+        { title: '详情处理', text: '在右侧查看摘要并推进下一步。' },
+      ],
+      roadmap: [
+        { stage: '登记', title: '创建订单', text: '从订单表单写入真实记录。' },
+        { stage: '处理', title: '筛选负责人', text: '按状态和负责人分派处理。' },
+        { stage: '复盘', title: '查看结果', text: '从真实表单读取最新记录。' },
+      ],
+    }, null, 2), 'utf8');
+
+    execFileSync(process.execPath, [
+      BIN,
+      'generate-page',
+      '--spec',
+      specPath,
+      '--compile',
+    ], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+
+    const sourcePath = path.join(tmpDir, 'pages', 'src', 'orders-no-binding.canvas.jsx');
+    const compiledPath = path.join(tmpDir, 'pages', 'dist', 'orders-no-binding.canvas.js');
+    const manifestPath = path.join(tmpDir, 'pages', 'src', 'orders-no-binding.canvas.openyida-page.json');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const compiled = fs.readFileSync(compiledPath, 'utf8');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    expect(fs.existsSync(compiledPath)).toBe(true);
+    expect(source).toContain('未接入真实表单数据');
+    expect(source).toContain('usesSeedRows ? seedRows : []');
+    expect(source).not.toContain('dataState.rows.length ? dataState.rows : seedRows');
+    expect(compiled).toContain('完整应用交付页不会用前端 seedRows 冒充业务记录。');
+    expect(manifest.dataBinding).toMatchObject({
+      mode: 'seed',
+      enabled: false,
+    });
+  });
+
   test('workbench canvas sample fills the app surface and avoids demo labels', () => {
     const source = fs.readFileSync(path.join(ROOT, 'lib', 'samples', 'yida-canvas-custom-page', 'workbench-home.canvas.jsx'), 'utf8');
 

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -146,6 +146,8 @@ schema-managed create/update 必须等待用户对当前 `planId` 显式批准�
 
 **fast_build 默认加载边界**：只加载 `yida-app` 和当前阶段必需的子技能。`yida-create-app`、`yida-create-page`、`yida-create-form-page` 只有在目标资源缺失且本次意图允许创建时才加载；已有资源时进入对应 update / publish 分支。页面默认走 Code Canvas；当用户明确要求普通自定义页面 JSX/Jsx 组件链路，或页面强依赖普通自定义页实例桥（`this.$(fieldId)` / `this.utils.yida.*` / `this.dataSourceMap` / 表单提交或字段双向绑定深度耦合）时，选择 `yida-custom-page`。不要默认加载 `yida-page-uiux`、`yida-data-source-connectors`、`yida-data-management`、`yida-nav-group`、`yida-dashboard`，也不要默认深读 `references/`。
 
+**Canvas 数据边界**：完整应用/真实交付页如果展示列表、看板或详情记录，必须优先把本轮真实 `appType/formUuid/fieldId` 写入 `page-spec.json` 的 `dataBinding.mode=form`；需要演示记录时先写入真实表单再读取。未接真实表单且未写入 demo records 时，页面展示空态/入口，不用前端 seedRows 冒充业务数据。
+
 **doneWhen**：`yida-app` 发布主页面成功并输出可访问 URL。到这里默认完成；不要发布后继续 TaskCreate、重复读技能或继续规划。
 
 **optionalAfterDone**：导航整理、示例数据、公开访问、截图验证、深度视觉方向、数据源/连接器深度接入、报表/大屏，只在用户明确要求或 `yida-app` 模式为 `full_demo` / `deep_design` 时执行。

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -78,7 +78,7 @@ description: 宜搭完整应用开发编排技能。对普通 OpenYida 应用做
               ↓
 [Step 6] 编写自定义页面代码 → 默认 use_skill("yida-canvas-custom-page", "生成 Code Canvas 主页面")
               ↓      先写业务化 page-spec.json，再 openyida generate-page <模板> --theme-profile yida-app-theme --theme-scope page --spec <page-spec.json> --compile
-              ↓      需要真实数据时在 spec.dataBinding 写 appType/formUuid/字段映射；深度接入再加载 yida-canvas-data-binding
+              ↓      本轮已创建/解析业务表单且页面需要列表/看板/详情数据时，必须在 spec.dataBinding 写 mode=form + 真实 appType/formUuid/fieldId；深度接入再加载 yida-canvas-data-binding
               ↓      明确要求普通自定义页面 JSX/Jsx 组件链路，或强依赖 this.$ / this.utils.yida.* / this.dataSourceMap 等实例桥时选择 yida-custom-page
               ↓
 [Step 7] 发布页面 → use_skill("yida-publish-page", "发布主页面") → openyida publish <源文件路径> <appType> <formUuid> [--health-check]
@@ -123,7 +123,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 
 - `brandName` / `tagline` / `heroText`：使用当前应用的业务名称、角色和问题域，不沿用模板默认标题。
 - `features`：写真实业务对象、模块入口或处理事项，不写“统一入口 / 状态跟进 / 流程闭环”这类通用模板卖点。
-- `metrics`：写贴合场景的指标口径；没有真实数据时也要使用业务占位口径，并在 `dataBinding.seedStrategy` 标明演示数据。
+- `metrics` / 列表 / 看板 / 详情数据：写贴合场景的指标口径；完整应用或真实交付页不得用前端 seedRows 冒充真实业务记录。本轮已有业务表单时必须写 `dataBinding.mode=form`、真实 `appType/formUuid` 和字段映射；若需要演示数据，先通过表单数据写入链路创建 demo/mock records，再让 Canvas 页面读取这些真实表单记录。没有写入 demo records 且没有真实数据时，页面展示空态、表单入口、刷新/登记按钮，并在 final 明确“未接真实表单数据”。
 - `roadmap` 或 `interactionProfile`：写用户动作、筛选、下钻、批量处理、空/载/错状态。
 - `visualProfile`：写一个区别于 sample 的视觉方向，例如信息密度、构图节奏、强调色来源、图表/列表/队列母题。
 - 官网/品牌页还必须写 `assets` 或明确素材缺口；看板/列表/详情页优先写 `dataBinding`、字段映射或表单链接。
@@ -160,7 +160,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 | 2. 记录最小需求 | 无 | 写 `prd/<项目名>.md`：只记录 MVP 假设、核心表单/页面、完成标准；写/更新 `.cache/<项目名>-schema.json` standalone 映射；不要写长 PRD | 业务语义和 ID 存储位置明确 |
 | 3. resolve forms | `yida-create-form-page` | 已有目标表单时 update/patch/rule/bind-datasource；缺少支撑 MVP 的核心表单且允许创建时才 create；字段配置文件写入 `.cache/openyida/<项目名>/` | 拿到或确认表单 `formUuid` 和真实 `fieldId` |
 | 4. resolve main page | `yida-create-page` 仅在主页面缺失且允许创建时加载 | 已有页面 URL / `formUuid` / bound page 时直接作为主页面；否则创建一个用户主入口 display page | 拿到真实目标页面 `formUuid`，且不会重复创建页面 |
-| 5. 编写/更新页面 | 默认 `yida-canvas-custom-page`；明确要求 JSX/Jsx 组件链路或实例桥强依赖时选择 `yida-custom-page` | 生成或修改主页面源码；只实现 MVP 首屏和核心操作。可用已解析表单链接、轻量统计占位和基础列表/入口布局完成主页面；不要加载视觉/密度/报表/数据源等额外技能 | 本地源码通过对应页面技能的基础校验；未执行 publish 时仍是“源码已修改，尚未发布” |
+| 5. 编写/更新页面 | 默认 `yida-canvas-custom-page`；明确要求 JSX/Jsx 组件链路或实例桥强依赖时选择 `yida-custom-page` | 生成或修改主页面源码；只实现 MVP 首屏和核心操作。可用已解析表单链接、真实空态、表单入口和轻量指标口径完成主页面；若展示业务列表/看板/详情记录，必须接本轮真实表单 `dataBinding.mode=form`，或先写入 demo records 后再读取；不要加载视觉/密度/报表/数据源等额外技能 | 本地源码通过对应页面技能的基础校验；未执行 publish 时仍是“源码已修改，尚未发布” |
 | 6. 发布页面 | `yida-publish-page` | 按页面链路校验后发布到已解析主页面：Canvas `.canvas.jsx` 使用 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检；普通自定义页面 `.oyd.jsx` / `.jsx` 跑 `check-page` / `compile`；再执行 `openyida publish <source> <appType> <displayPageFormUuid>` 发布主页面 | 发布成功并获得可访问 URL |
 | 7. 输出结果 | 无 | 返回应用链接、主页面链接、复用/创建/更新的资源摘要、后续可选项 | 用户拿到 URL |
 
@@ -215,6 +215,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 
 - 默认页面源码不得使用 `this.dataSourceMap.*`，除非本轮已经明确创建并绑定对应设计器数据源。
 - 默认页面只走两类可闭环方案：入口型页面（表单入口、资源链接、轻量统计占位）或内置数据 API 页面（`this.utils.yida.searchFormDatas` / `saveFormData` 等查询本轮已创建表单）。
+- Canvas 列表/看板/详情页的业务记录不得回退到前端 seedRows 冒充真实数据。`openyida sample` 原样发布可以显示 sample/seed 并标注；完整应用交付页必须优先在 `page-spec.json` 中写 `dataBinding.mode=form`，用本轮真实 `appType/formUuid/fieldId` 读取表单。若用户要求可演示数据，先加载数据写入链路把 demo/mock records 写入表单并抽查，再由 Canvas 读取；没写入记录时展示空态和登记入口。
 - 如果页面源码确实需要 `this.dataSourceMap.*`，必须先把模式升级为可选数据源链路：加载 `yida-data-source-connectors`，创建/绑定数据源，并在发布后确认页面 Schema 中存在对应数据源；否则 `fast_build` 未完成。
 - 发布输出出现 `No custom page data sources to preserve` 时，只有源码不依赖 `this.dataSourceMap.*` 才能视为正常；若源码依赖 dataSourceMap，必须改源码或补数据源后重新发布。
 

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -103,6 +103,16 @@ openyida sample yida-canvas-custom-page portal-native-components --output projec
 7. **light 页面禁灰黑主题**：业务列表、协同表、数据管理页、工作台和门户默认不要用 `#111827` 这类近黑色做按钮、描边、选中态或大阴影；主操作、选中态、筛选焦点和批量操作使用品牌色或 sample 自带主题色，边框用浅色品牌混合。只有用户明确要求暗色大屏/夜间模式/高对比风格时才使用深色主视觉。
 8. **门户运行态组件要补必需 props 和局部降级**：`QuickAccessCard` / `RecentlyUsedCard` 必须传 `theme="row-white"` 等必需 props，避免运行态读取 `theme.includes(...)` 报错；所有门户/字段/上传增强组件外层加局部 ErrorBoundary，单个组件不兼容时只降级该块，不让整页进入 Canvas 错误态。
 9. **自定义主题必须页面内注入**：`--theme` 只接受平台预置 key；如果页面设计使用非预置主题（例如活力橙、深玫红、自定义暗黑金），Canvas 页面必须在自身源码中注入 `style#yida-global-theme` 或等价 scoped CSS vars，并在根节点设置 `data-theme-scope="page"`。官方 sample 每个页面都要做，避免宿主应用 `black` 主题把页面染成黑灰。
+10. **真实交付不使用前端 seed 冒充业务数据**：`openyida sample` 原样发布可以保留 sample/seed 数据，但必须在页面上标注为 sample/seed。完整应用或真实交付页只要需要列表、看板、详情记录，并且本轮已经创建/解析业务表单，就必须在 `page-spec.json` 写入 `dataBinding.mode=form`、真实 `appType/formUuid` 和字段映射，让页面从表单读取。若需要演示数据，先通过表单数据写入链路创建 demo/mock records，再由 Canvas 读取这些真实表单记录；未写入 demo records 且没有真实数据时展示空态、表单入口、刷新/登记按钮。
+
+## 数据真实性边界
+
+Canvas 模板有两种允许状态：
+
+- **Sample / 离线预览**：`openyida sample` 或模板原样发布可以显示内置 seedRows，页面必须标注 `sample/seed`，final 也要说明“当前为演示数据/未接真实表单数据”。
+- **完整应用 / 真实交付**：先解析真实 `appType/formUuid/fieldId`，写入 `page-spec.json` 的 `dataBinding.mode=form` 后再 `openyida generate-page ... --spec <page-spec.json>`。需要 demo/mock 记录时，先用数据写入链路把记录写入表单并抽查，再让页面读取；不能把前端 seedRows、静态 DEFAULT_FEATURES 或固定指标说成真实业务数据。
+
+生成后如果 `.openyida-page.json` 的 `dataBinding.enabled !== true`，且页面仍展示列表/看板/详情业务记录，只能标为 sample/draft；完整应用 final 不得说“已接真实数据”。未接数据的交付页应保留真实空态、登记入口、刷新按钮和数据接入提示。
 
 ## 模板占位符防回归
 
@@ -133,7 +143,7 @@ npx jest tests/canvas-compile.test.js tests/generate-page.test.js --runInBand
 - **说清参考转译**：交付 sample 改造时要用 1-2 句话说明参考被转译成了什么，例如“详情页采用对象 hero + sticky 元信息 + 时间线结构”、“数据管理页采用多维表工具栏 + 分组行 + 彩色标签密集表格”。不要只说“已参考 Dribbble”。
 - **每页独立主题**：sample 页默认 `themeScope=page` 或等价固定 CSS 变量；业务列表、详情、门户、工作台、官网、数据管理、大屏要有不同色相和不同信息节奏，不被宿主应用主题统一染色。
 - **非预置主题不走 `--theme`**：`deepBlue/podBlue/.../black` 这些平台 key 才能传给 `--theme`；自己设计的主题色要写到页面 `style#yida-global-theme` / scoped token 中，并确保每个 sample 页面都有这段注入。
-- **数据要像真实业务**：列表、详情、数据管理、工作台、大屏必须模拟足够丰富的数据、状态、筛选、趋势、分组、时间线或指标，不要只放 3 个卡片和空泛文案。
+- **Sample 数据要像真实业务，但不能冒充真实交付数据**：列表、详情、数据管理、工作台、大屏 sample 必须模拟足够丰富的数据、状态、筛选、趋势、分组、时间线或指标，不要只放 3 个卡片和空泛文案；完整应用/真实交付页必须优先接 `dataBinding.mode=form` 或展示真实空态，不把 sample seed 当业务主列表。
 - **工作台不是 demo 壳**：工作台页面要铺满应用内容区，侧栏/导航/主面板形成真实产品首页；禁止用 `max-width + margin: 0 auto + 外层 padding` 做居中展示框，也不要把 `dribbble research`、`sample`、`workbench + operation` 这类设计过程词露给用户。
 - **数据大屏地图要稳定**：大屏中心态势图如果是地图，不能只依赖外部 ECharts CDN / GeoJSON 成功后才显示；优先探测宜搭宿主地图组件（如 `YoushuMap` / `ChinaMap` / `MapChart` 等），并提供内置区域地图组件兜底。禁止把“地图组件暂不可用”作为正常展示态暴露给用户。
 - **截图问题要反哺模板**：用户指出导航未覆盖、地图抽象、颜色不好、内容不丰富、产品首页不像首页等问题时，不只修当前 JSX；如果属于模板共性，补到 sample 模板、测试或本技能规则。

--- a/yida-skills/skills/yida-canvas-custom-page/references/data-bridge-guide.md
+++ b/yida-skills/skills/yida-canvas-custom-page/references/data-bridge-guide.md
@@ -41,7 +41,7 @@ OpenYida `generate-page --spec` 支持把 Canvas 数据契约写成结构化 `da
 
 - `mode=form` 必须来自真实 `appType/formUuid` 和字段 ID，不要猜字段。
 - `mode=connector/url` 必须使用同源代理端点，不把第三方密钥放进 Canvas 源码。
-- `mode=seed` 只能作为演示，不能标注“已接真实数据”。
+- `mode=seed` 只能用于 `openyida sample`、离线预览或明确标注的演示页，不能标注“已接真实数据”；完整应用/真实交付页需要演示记录时，先把 demo/mock records 写入真实表单，再用 `mode=form` 读取。
 - 模板生成的 `DataBridge` 状态要保留，方便线上排查“接口没通 / 结构没识别 / 权限不足”。
 
 ## 可复用读数据 Hook
@@ -194,7 +194,7 @@ function normalizeFormRow(row) {
 
 保护规则：
 
-- 首屏可以用 seed 数据做本地预览兜底，但真实接口返回后必须以接口为准。
+- 首屏只有 sample/离线预览可以用 seed 数据做本地预览兜底；真实交付页未接表单数据时展示空态和登记入口，不用 seedRows 冒充业务记录。真实接口返回后必须以接口为准。
 - 如果 `getTotalCount(json) > 0` 且 `unwrapRows(json).length === 0`，抛出“接口返回结构未识别”，不要展示“暂无数据”。
 - 用 `openyida data query form <appType> <formUuid> --size 20` 或数据管理页核对总数，页面统计必须和真实表单一致。
 
@@ -342,7 +342,7 @@ function fieldOf(row, fieldId) { return (row.formData || row)[fieldId]; }
 1. **把 Code Canvas 当普通自定义页面写**：Canvas 没有 `this.utils.yida.*` / `dataSourceMap`，必须自写 HTTP 桥。
 2. **CSRF 来源取错**：只从 `document.cookie` 找 token 会失败，因为 Cookie 可能是 HttpOnly；应从 `window.g_config` 取页面上下文 token。
 3. **响应结构只解析一层**：表单查询可能返回 `content.result.data` 这类多层包裹，页面只读 `json.data` 就会显示 0 条。
-4. **Demo 数据掩盖真实错误**：seed 数据让页面看起来“有内容”，但没有证明接口数据真的接入；真实数据页必须用 `totalCount` 做保护。
+4. **Demo 数据掩盖真实错误**：seed 数据让页面看起来“有内容”，但没有证明接口数据真的接入；真实数据页必须用 `totalCount` 做保护，接口异常或未接 dataBinding 时展示错误/空态，不回退成漂亮 demo 列表。
 5. **刷新策略不对**：多人状态同步需要 5 秒左右轮询，但轮询只能刷新数值和列表，不能整页 reload，也不能首屏之后反复清空旧数据。
 6. **排序口径混淆**：数据存在但按点赞排行时，0 赞新数据可能排在后面；验收时要同时看总数和列表排序规则。
 

--- a/yida-skills/skills/yida-canvas-custom-page/references/page-generation-guide.md
+++ b/yida-skills/skills/yida-canvas-custom-page/references/page-generation-guide.md
@@ -14,7 +14,13 @@
 - `draft-needs-domain-spec`：用户已有业务要求，但 page spec 仍缺业务对象、指标、交互或视觉方向；继续补 spec 或改源码。
 - `sample-reference`：基本没有业务化输入，结果只能当 sample 参考，不能交付为真实应用页面。
 
-真实业务页的 `page-spec.json` 不能只写 `template/title/output`。至少写清业务名称与定位、业务模块/对象、指标口径、用户动作或下钻方式、视觉方向；看板/列表/详情优先写 `dataBinding` 或字段映射，官网/品牌页优先写 `assets` 或素材缺口。`sample` 是例子，不是框架；如果 `domainFidelity.sampleFallbacks` 里还出现 `features`、`metrics`、`roadmap`、`heroText` 等关键项，必须继续定制。
+真实业务页的 `page-spec.json` 不能只写 `template/title/output`。至少写清业务名称与定位、业务模块/对象、指标口径、用户动作或下钻方式、视觉方向；看板/列表/详情如果本轮已经创建或解析业务表单，必须写 `dataBinding.mode=form`、真实 `appType/formUuid` 和字段映射，官网/品牌页优先写 `assets` 或素材缺口。`sample` 是例子，不是框架；如果 `domainFidelity.sampleFallbacks` 里还出现 `features`、`metrics`、`roadmap`、`heroText` 等关键项，必须继续定制。
+
+数据真实性边界：
+
+- `openyida sample` 或模板原样发布可以展示 sample/seed 数据，但页面必须标注 sample/seed。
+- 完整应用或真实交付页不能用前端 seedRows 冒充业务记录；需要演示数据时，先把 demo/mock records 写入真实宜搭表单，再由 Canvas 读取。
+- 未写入 demo records 且没有真实数据时，页面应展示空态、表单入口、刷新/登记按钮和 dataBinding 接入提示。
 
 | 用户需求 | CLI 模板 | scene | 视觉要点 |
 | --- | --- | --- | --- |

--- a/yida-skills/skills/yida-page-uiux/workflow/output-decision-block.md
+++ b/yida-skills/skills/yida-page-uiux/workflow/output-decision-block.md
@@ -12,7 +12,7 @@
 - **archetype**：<dashboard: overview/analysis/monitor/report/compare/operation；其他场景写 profile/table-management/operation/brand-home 等>
 - **interactionProfile**：<primaryAction、detailMode(drawer/page/iframe/none)、bulkActions、empty/loading/error 状态>
 - **insights**：<看板/报告/工作台写 1-3 条“结论 + 证据 + 建议”；无洞察则空数组>
-- **dataBinding**：<真实数据来源；无真实数据写 mode=seed；有表单写 appType/formUuid/fields；有连接器写同源 endpoint>
+- **dataBinding**：<真实数据来源；有表单写 mode=form + appType/formUuid/fields；有连接器写同源 endpoint；无真实数据的完整交付页写 mode=none/空态策略，只有 sample/离线预览可写 mode=seed 并标注演示数据>
 - **气质关键词**：<2-3 个>
 - **项目特定设计原则**：<3-5 条，具体到业务>
 - **布局骨架**：<来自 scene 文件的骨架，按本页信息调整>


### PR DESCRIPTION
## Summary
- Gate Canvas seed data to sample/preview mode and show real empty states for delivery pages without dataBinding.
- Add DataBridge-aware behavior for business-list, data-management, split-pane-detail, and dashboard-overview.
- Prevent dashboard DataBridge rows from synthesizing chart values; charts render only with real numeric fields.
- Tighten OpenYida skills guidance around real data and demo records.

## Tests
- npx jest tests/canvas-compile.test.js tests/generate-page.test.js --runInBand
- npm run check:skills
- npm run build:skills
- git diff --check