### PR TITLE
fix: accept add-change arrays in create-form fields

### DIFF
--- a/lib/app/create-form/definition-reader.js
+++ b/lib/app/create-form/definition-reader.js
@@ -17,6 +17,26 @@ function readJsonInput(value, options) {
   return fs.readFileSync(resolvedPath, 'utf-8');
 }
 
+function normalizeCreateFields(fields) {
+  if (
+    !Array.isArray(fields)
+    || fields.length === 0
+    || !fields.every((item) => (
+      item
+      && typeof item === 'object'
+      && !Array.isArray(item)
+      && String(item.action || '').toLowerCase() === 'add'
+      && item.field
+      && typeof item.field === 'object'
+      && !Array.isArray(item.field)
+    ))
+  ) {
+    return fields;
+  }
+
+  return fields.map((item) => item.field);
+}
+
 function createDefinitionReaders(dependencies) {
   const {
     fs,
@@ -43,9 +63,9 @@ function createDefinitionReaders(dependencies) {
       let columns = 1;
 
       if (Array.isArray(parsed)) {
-        fields = parsed;
+        fields = normalizeCreateFields(parsed);
       } else if (typeof parsed === 'object' && parsed !== null) {
-        fields = parsed.fields || [];
+        fields = normalizeCreateFields(parsed.fields || []);
         columns = parsed.columns !== undefined ? parsed.columns : 1;
         if (Array.isArray(parsed.validations)) {
           validations = parsed.validations;

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -23,6 +23,7 @@ const createFormSplitSource = [
 ].map((file) => fs.readFileSync(path.join(__dirname, '..', 'lib', 'app', 'create-form', file), 'utf-8')).join('\n');
 const combinedCreateFormSource = sourceCode + '\n' + createFormSplitSource;
 const createForm = require('../lib/app/create-form');
+const { createDefinitionReaders } = require('../lib/app/create-form/definition-reader');
 const formCompiler = require('../lib/app/services/form-compiler');
 const { verifyFieldBindings } = require('../lib/app/services/field-bindings');
 
@@ -637,6 +638,40 @@ describe('create-form module API', () => {
       appType: 'APP_XXX',
       formUuid: 'FORM_XXX',
       validationJsonOrFile: '.cache/openyida/forms/validations.json',
+    });
+  });
+});
+
+describe('create-form definition readers', () => {
+  function createTestReaders() {
+    return createDefinitionReaders({
+      fs,
+      path,
+      safeParseJson: JSON.parse,
+      error(message) {
+        throw new Error(message);
+      },
+      t(key) {
+        return key;
+      },
+    });
+  }
+
+  test('create fields unwrap update-style add changes produced by agents', () => {
+    const { readFieldsDefinition } = createTestReaders();
+
+    const result = readFieldsDefinition(JSON.stringify([
+      { action: 'add', field: { type: 'Divider', title: '访客信息' } },
+      { action: 'add', field: { type: 'TextField', label: '访客姓名', required: true } },
+    ]));
+
+    expect(result).toMatchObject({
+      columns: 1,
+      validations: [],
+      fields: [
+        { type: 'Divider', title: '访客信息' },
+        { type: 'TextField', label: '访客姓名', required: true },
+      ],
     });
   });
 });


### PR DESCRIPTION
## Summary

- Allow create-form field definitions to accept agent-produced update-style add changes
- Unwrap all-add change arrays into plain create field definitions
- Add focused coverage for the compatibility path

## Validation

- git diff --cached --check
- node --check lib/app/create-form/definition-reader.js
- npx jest tests/create-form.test.js --runInBand
- npm run check:syntax
- npm test -- --runInBand

## Notes

This PR only includes the committed create-form compatibility fix. Local unstaged skill/prompt and package metadata changes are intentionally not included.