### PR TITLE
fix: block emoji in generated schemas and page sources

### DIFF
--- a/lib/app/canvas-compile.js
+++ b/lib/app/canvas-compile.js
@@ -29,7 +29,10 @@
  */
 
 const Babel = require('@babel/standalone');
-const { assertNoEmojiInText } = require('../core/no-emoji-guard');
+const {
+  assertNoEmojiInArtifactName,
+  assertNoEmojiInText,
+} = require('../core/no-emoji-guard');
 
 /**
  * 依赖 → window 别名白名单。
@@ -261,6 +264,11 @@ function esmToWindowPlugin({ types: t }, options = {}) {
  * @returns {{ runtimeCode: string, importedModules: string }}
  */
 function compileCanvasLocal(source, options = {}) {
+  if (options.sourcePath) {
+    assertNoEmojiInArtifactName(options.sourcePath, {
+      code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+    });
+  }
   assertNoEmojiInText(source, {
     artifact: options.sourcePath || 'Code Canvas source',
     code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
@@ -310,6 +318,10 @@ function compileCanvasLocal(source, options = {}) {
   });
 
   const runtimeCode = stage2.code || '';
+  assertNoEmojiInText(runtimeCode, {
+    artifact: options.sourcePath ? options.sourcePath + ' runtime' : 'Code Canvas runtime',
+    code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
+  });
   return {
     runtimeCode,
     importedModules: JSON.stringify(importedModules),

--- a/lib/app/canvas-compile.js
+++ b/lib/app/canvas-compile.js
@@ -29,6 +29,7 @@
  */
 
 const Babel = require('@babel/standalone');
+const { assertNoEmojiInText } = require('../core/no-emoji-guard');
 
 /**
  * 依赖 → window 别名白名单。
@@ -260,6 +261,11 @@ function esmToWindowPlugin({ types: t }, options = {}) {
  * @returns {{ runtimeCode: string, importedModules: string }}
  */
 function compileCanvasLocal(source, options = {}) {
+  assertNoEmojiInText(source, {
+    artifact: options.sourcePath || 'Code Canvas source',
+    code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
+  });
+
   const importedModules = extractImportedModules(source);
 
   // 第一步：剥类型 + 转 JSX（classic runtime，产出 React.createElement，

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -64,7 +64,10 @@ const { createAuthRef } = require('../core/yida-client');
 const { CliError } = require('../core/cli-error');
 const { t } = require('../core/i18n');
 const { safeParseJson } = require('../core/safe-json');
-const { assertNoEmojiInValue } = require('../core/no-emoji-guard');
+const {
+  assertNoEmojiInArtifactName,
+  assertNoEmojiInValue,
+} = require('../core/no-emoji-guard');
 const { buildYidaI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { banner, step, label, success, fail, warn, info, error, result, usage, hint, listItem } = require('../core/chalk');
 const { parseOpenOption: parseBrowserOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
@@ -4346,6 +4349,16 @@ function assertNoEmojiInFormDefinition(formTitle, fields, validations, artifact)
   });
 }
 
+function assertNoEmojiInDefinitionFileName(value) {
+  const raw = String(value || '').trim();
+  if (!raw || raw.startsWith('{') || raw.startsWith('[')) {
+    return;
+  }
+  assertNoEmojiInArtifactName(raw, {
+    code: 'OPENYIDA_FORM_DEFINITION_FILENAME_EMOJI_FORBIDDEN',
+  });
+}
+
 // ── 保存 Schema 并更新表单配置（create/update 共用）──
 //
 // 封装了 saveFormSchema + updateFormConfig 两步，以及各自的 302 自动重登录重试。
@@ -4427,6 +4440,7 @@ async function mainCreate(parsedArgs, authRef) {
   label('Fields:', fieldsJsonOrFile);
 
   step(2, t('create_form.step_read_fields', 2));
+  assertNoEmojiInDefinitionFileName(fieldsJsonOrFile);
   const { fields, columns, validations } = readFieldsDefinition(fieldsJsonOrFile);
   assertNoEmojiInFormDefinition(formTitle, fields, validations);
   validateFormFieldDefinitions(fields);
@@ -4576,6 +4590,7 @@ async function createFormForLegacyProcess(context, input) {
   };
 
   const { appType, formTitle, fieldsJsonOrFile, layout, theme, labelAlign } = parsedArgs;
+  assertNoEmojiInDefinitionFileName(fieldsJsonOrFile);
   const { fields, validations } = readFieldsDefinition(fieldsJsonOrFile);
   assertNoEmojiInFormDefinition(formTitle, fields, validations, 'legacy create-form input');
   validateFormFieldDefinitions(fields);

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -64,6 +64,7 @@ const { createAuthRef } = require('../core/yida-client');
 const { CliError } = require('../core/cli-error');
 const { t } = require('../core/i18n');
 const { safeParseJson } = require('../core/safe-json');
+const { assertNoEmojiInValue } = require('../core/no-emoji-guard');
 const { buildYidaI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { banner, step, label, success, fail, warn, info, error, result, usage, hint, listItem } = require('../core/chalk');
 const { parseOpenOption: parseBrowserOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
@@ -4334,6 +4335,17 @@ function emitCreateFormPostCreateFailure(context) {
   }
 }
 
+function assertNoEmojiInFormDefinition(formTitle, fields, validations, artifact) {
+  assertNoEmojiInValue({
+    formTitle,
+    fields,
+    validations,
+  }, {
+    artifact: artifact || 'create-form input',
+    code: 'OPENYIDA_FORM_DEFINITION_EMOJI_FORBIDDEN',
+  });
+}
+
 // ── 保存 Schema 并更新表单配置（create/update 共用）──
 //
 // 封装了 saveFormSchema + updateFormConfig 两步，以及各自的 302 自动重登录重试。
@@ -4348,6 +4360,10 @@ async function saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, ver
     info(t('create_form.formula_prefix_fixed', fixedRefs));
   }
   ensureDividerThemeAction(schema);
+  assertNoEmojiInValue(schema, {
+    artifact: 'Yida form schema ' + formUuid,
+    code: 'OPENYIDA_FORM_SCHEMA_EMOJI_FORBIDDEN',
+  });
   const serverRevision = requireSchemaServerRevision(version, { appType, formUuid });
 
   step(saveStep, t('create_form.step_save_schema', saveStep));
@@ -4412,6 +4428,7 @@ async function mainCreate(parsedArgs, authRef) {
 
   step(2, t('create_form.step_read_fields', 2));
   const { fields, columns, validations } = readFieldsDefinition(fieldsJsonOrFile);
+  assertNoEmojiInFormDefinition(formTitle, fields, validations);
   validateFormFieldDefinitions(fields);
   const fieldCount = countDataFieldDefinitions(fields);
   success(t('create_form.fields_loaded', fieldCount));
@@ -4560,6 +4577,7 @@ async function createFormForLegacyProcess(context, input) {
 
   const { appType, formTitle, fieldsJsonOrFile, layout, theme, labelAlign } = parsedArgs;
   const { fields, validations } = readFieldsDefinition(fieldsJsonOrFile);
+  assertNoEmojiInFormDefinition(formTitle, fields, validations, 'legacy create-form input');
   validateFormFieldDefinitions(fields);
   const fieldCount = countDataFieldDefinitions(fields);
   const createResult = await requestWithAutoLogin(function (auth) {

--- a/lib/app/generate-page.js
+++ b/lib/app/generate-page.js
@@ -6,6 +6,7 @@ const { applyTemplateVariables } = require('../core/sample');
 const { t } = require('../core/i18n');
 const { safeParseJson } = require('../core/safe-json');
 const { error, success, hint, result, warn } = require('../core/chalk');
+const { assertNoEmojiInText } = require('../core/no-emoji-guard');
 const { runLintCheck } = require('./page-linter');
 const { compileSource } = require('./page-compiler');
 const { compileCanvasLocal } = require('./canvas-compile');
@@ -593,6 +594,10 @@ async function run(args) {
 
   const variables = buildTemplateVariablesFromIr(ir);
   const outputSource = applyTemplateVariables(templateSource, variables);
+  assertNoEmojiInText(outputSource, {
+    artifact: outputPath,
+    code: 'OPENYIDA_GENERATED_PAGE_EMOJI_FORBIDDEN',
+  });
 
   ensureOutputDir(outputPath);
   fs.writeFileSync(outputPath, outputSource, 'utf-8');

--- a/lib/app/generate-page.js
+++ b/lib/app/generate-page.js
@@ -6,7 +6,10 @@ const { applyTemplateVariables } = require('../core/sample');
 const { t } = require('../core/i18n');
 const { safeParseJson } = require('../core/safe-json');
 const { error, success, hint, result, warn } = require('../core/chalk');
-const { assertNoEmojiInText } = require('../core/no-emoji-guard');
+const {
+  assertNoEmojiInArtifactName,
+  assertNoEmojiInText,
+} = require('../core/no-emoji-guard');
 const { runLintCheck } = require('./page-linter');
 const { compileSource } = require('./page-compiler');
 const { compileCanvasLocal } = require('./canvas-compile');
@@ -572,6 +575,9 @@ async function run(args) {
     options.output || spec.output || (mode === 'canvas' ? templateConfig.defaultCanvasOutput : templateConfig.defaultNativeOutput)
   );
   const outputPath = outputResolution.outputPath;
+  assertNoEmojiInArtifactName(outputPath, {
+    code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+  });
   const manifestPath = getManifestPath(outputPath);
   const templateSource = fs.readFileSync(templateFile, 'utf-8');
   const ir = normalizePageSpec(spec, {
@@ -613,7 +619,7 @@ async function run(args) {
   reportNavigationConfig(ir);
 
   if (mode === 'canvas') {
-    const canvasResult = compileCanvasLocal(outputSource);
+    const canvasResult = compileCanvasLocal(outputSource, { sourcePath: outputPath });
     const importedModules = JSON.parse(canvasResult.importedModules);
     if (options.compile || spec.compile === true) {
       const distPath = getCanvasDistPath(outputPath);

--- a/lib/app/page-compiler.js
+++ b/lib/app/page-compiler.js
@@ -7,7 +7,10 @@ const { default: babelTransform } = require('../core/babel-transform');
 const { findProjectRoot } = require('../core/utils');
 const { t } = require('../core/i18n');
 const { info, success, error } = require('../core/chalk');
-const { assertNoEmojiInText } = require('../core/no-emoji-guard');
+const {
+  assertNoEmojiInArtifactName,
+  assertNoEmojiInText,
+} = require('../core/no-emoji-guard');
 const { ensureYidaRuntimeContract } = require('./page-compat');
 const { warnLargePageSource } = require('./page-size-guard');
 
@@ -17,6 +20,9 @@ const { warnLargePageSource } = require('./page-size-guard');
  * @returns {{ sourceCode: string, compiledCode: string, compiledPath: string }}
  */
 function compileSource(sourcePath) {
+  assertNoEmojiInArtifactName(sourcePath, {
+    code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+  });
   const sourceFileName = path.basename(sourcePath);
   const parsedPath = path.parse(sourcePath);
   const compiledFileName = `${parsedPath.name}.js`;
@@ -51,6 +57,10 @@ function compileSource(sourcePath) {
   if (uglifyResult.error) {
     error(t('publish.minify_failed', uglifyResult.error.message || String(uglifyResult.error)));
   }
+  assertNoEmojiInText(uglifyResult.code, {
+    artifact: compiledPath,
+    code: 'OPENYIDA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+  });
 
   const outputDir = path.dirname(compiledPath);
   if (!fs.existsSync(outputDir)) {

--- a/lib/app/page-compiler.js
+++ b/lib/app/page-compiler.js
@@ -7,6 +7,7 @@ const { default: babelTransform } = require('../core/babel-transform');
 const { findProjectRoot } = require('../core/utils');
 const { t } = require('../core/i18n');
 const { info, success, error } = require('../core/chalk');
+const { assertNoEmojiInText } = require('../core/no-emoji-guard');
 const { ensureYidaRuntimeContract } = require('./page-compat');
 const { warnLargePageSource } = require('./page-size-guard');
 
@@ -26,6 +27,10 @@ function compileSource(sourcePath) {
   warnLargePageSource(rawSourceCode, sourcePath);
   const runtimeResult = ensureYidaRuntimeContract(rawSourceCode);
   const sourceCode = runtimeResult.code;
+  assertNoEmojiInText(sourceCode, {
+    artifact: sourcePath,
+    code: 'OPENYIDA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+  });
 
   info(t('publish.compiling', sourceFileName));
   const babelResult = babelTransform(sourceCode, {}, false, { RE_VERSION: '7.4.0' });

--- a/lib/app/page-linter.js
+++ b/lib/app/page-linter.js
@@ -2,6 +2,7 @@
 
 const { t } = require('../core/i18n');
 const { warn, fail, hint, success } = require('../core/chalk');
+const { findEmojiInText } = require('../core/no-emoji-guard');
 const Babel = require('@babel/standalone');
 
 const THEN_CALLBACK_LINE_LIMIT = 50;
@@ -662,6 +663,17 @@ function lintYidaSource(sourceCode, filePath) {
   const warnings = [];
   const lines = sourceCode.split('\n');
   const disableMap = buildLineDisableMap(lines);
+
+  findEmojiInText(sourceCode, {
+    artifact: filePath || 'Yida page source',
+    maxIssues: 20,
+  }).forEach((issue) => {
+    errors.push({
+      line: issue.line,
+      rule: 'emoji-forbidden',
+      message: t('publish.lint_emoji_forbidden', issue.emoji),
+    });
+  });
 
   const hasRenderJsx = /export\s+function\s+renderJsx\s*\(/.test(sourceCode);
   if (!hasRenderJsx) {

--- a/lib/app/page-linter.js
+++ b/lib/app/page-linter.js
@@ -2,7 +2,10 @@
 
 const { t } = require('../core/i18n');
 const { warn, fail, hint, success } = require('../core/chalk');
-const { findEmojiInText } = require('../core/no-emoji-guard');
+const {
+  findEmojiInArtifactName,
+  findEmojiInText,
+} = require('../core/no-emoji-guard');
 const Babel = require('@babel/standalone');
 
 const THEN_CALLBACK_LINE_LIMIT = 50;
@@ -663,6 +666,17 @@ function lintYidaSource(sourceCode, filePath) {
   const warnings = [];
   const lines = sourceCode.split('\n');
   const disableMap = buildLineDisableMap(lines);
+
+  findEmojiInArtifactName(filePath, {
+    artifact: filePath || 'Yida page source',
+    maxIssues: 20,
+  }).forEach((issue) => {
+    errors.push({
+      line: 1,
+      rule: 'emoji-forbidden',
+      message: t('publish.lint_emoji_forbidden', issue.emoji),
+    });
+  });
 
   findEmojiInText(sourceCode, {
     artifact: filePath || 'Yida page source',

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -680,7 +680,7 @@ async function main(argv) {
     step(1, t('publish.step_canvas_compile'));
     info(t('publish.canvas_compiling'));
     try {
-      canvasResult = await compileCanvas(initialSourceCode);
+      canvasResult = await compileCanvas(initialSourceCode, { sourcePath });
     } catch (canvasCompileError) {
       fail(t('publish.canvas_compile_failed', canvasCompileError.message));
       process.exit(1);

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -39,6 +39,7 @@ const { buildPageFile, shouldBuildPageSource } = require('./page-compat');
 const { warnLargePageSource } = require('./page-size-guard');
 const { fetchFormPageList } = require('./form-navigation');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
+const { assertNoEmojiInValue } = require('../core/no-emoji-guard');
 const {
   assertLegacyDirectWriteAllowed,
   extractLegacyGuardArgs,
@@ -193,6 +194,14 @@ async function readExistingPageDataSource(appType, formUuid, authRef) {
 
 function buildSchemaContent(sourceCode, compiledCode, formUuid, options = {}) {
   const logInfo = options.silent === true ? () => {} : info;
+  assertNoEmojiInValue({
+    sourceCode,
+    compiledCode,
+    existingDataSource: options.existingDataSource,
+  }, {
+    artifact: 'native page schema ' + formUuid,
+    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+  });
   return buildNativePageSchemaContent(sourceCode, compiledCode, formUuid, {
     ...options,
     onBuildingSchema: () => logInfo(t('publish.building_schema')),
@@ -210,6 +219,14 @@ function buildSchemaContent(sourceCode, compiledCode, formUuid, options = {}) {
 
 function buildCanvasSchemaContent(sourceCode, runtimeCode, importedModules, formUuid) {
   info(t('publish.building_schema'));
+  assertNoEmojiInValue({
+    sourceCode,
+    runtimeCode,
+    importedModules,
+  }, {
+    artifact: 'canvas page schema ' + formUuid,
+    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+  });
   return buildCanvasPageSchemaContent(sourceCode, runtimeCode, importedModules, formUuid);
 }
 

--- a/lib/app/services/canvas-page-compiler.js
+++ b/lib/app/services/canvas-page-compiler.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto');
 const { compileCanvasLocal } = require('../canvas-compile');
+const { assertNoEmojiInText } = require('../../core/no-emoji-guard');
 const { schemaError } = require('../../schema/errors');
 const { isLoadedPageSource } = require('../../schema/page-source-loader');
 
@@ -15,6 +16,17 @@ function compileCanvasPageSource(loadedSource) {
   if (typeof loadedSource.source !== 'string' || loadedSource.source.trim() === '') {
     compilerError('SCHEMA_PAGE_SOURCE_COMPILE_FAILED', 'Canvas page source did not pass local validation.', {
       stage: 'canvas',
+    });
+  }
+  try {
+    assertNoEmojiInText(loadedSource.source, {
+      artifact: loadedSource.relativePath || 'Schema Canvas page source',
+      code: 'SCHEMA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+    });
+  } catch (error) {
+    compilerError('SCHEMA_PAGE_SOURCE_EMOJI_FORBIDDEN', error.message, {
+      stage: 'emoji',
+      issues: error.details && error.details.issues,
     });
   }
 

--- a/lib/app/services/canvas-page-compiler.js
+++ b/lib/app/services/canvas-page-compiler.js
@@ -32,7 +32,9 @@ function compileCanvasPageSource(loadedSource) {
 
   let canvasResult;
   try {
-    canvasResult = compileCanvasLocal(loadedSource.source);
+    canvasResult = compileCanvasLocal(loadedSource.source, {
+      sourcePath: loadedSource.relativePath,
+    });
   } catch (error) {
     compilerError('SCHEMA_PAGE_SOURCE_COMPILE_FAILED', 'Canvas page source could not be compiled.', {
       stage: 'canvas',

--- a/lib/app/services/canvas-page-schema-builder.js
+++ b/lib/app/services/canvas-page-schema-builder.js
@@ -5,7 +5,10 @@ const {
   generateSuffix,
   getGlobalDataSourceFitConfig,
 } = require('./native-page-schema-builder');
-const { assertNoEmojiInValue } = require('../../core/no-emoji-guard');
+const {
+  buildEmojiErrorMessage,
+  findEmojiInValue,
+} = require('../../core/no-emoji-detector');
 
 const CANVAS_ACTIONS_SOURCE = 'export function didMount() {}';
 const CANVAS_ACTIONS_COMPILED = '"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),exports.didMount=didMount;function didMount(){}';
@@ -130,11 +133,23 @@ function buildCanvasPageSchemaObject(sourceCode, runtimeCode, importedModules, f
     },
     config: { connectComponent: [] },
   };
-  assertNoEmojiInValue(schema, {
-    artifact: 'canvas page schema ' + formUuid,
-    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
-  });
+  assertCanvasSchemaHasNoEmoji(schema, formUuid);
   return schema;
+}
+
+function assertCanvasSchemaHasNoEmoji(schema, formUuid) {
+  const artifact = 'canvas page schema ' + formUuid;
+  const issues = findEmojiInValue(schema, {
+    artifact,
+  });
+  if (issues.length === 0) {
+    return;
+  }
+
+  const error = new Error(buildEmojiErrorMessage(issues, { artifact }));
+  error.code = 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN';
+  error.details = { artifact, issues };
+  throw error;
 }
 
 function resolveSchemaBuilderDependency(value, createDefault, property) {

--- a/lib/app/services/canvas-page-schema-builder.js
+++ b/lib/app/services/canvas-page-schema-builder.js
@@ -5,6 +5,7 @@ const {
   generateSuffix,
   getGlobalDataSourceFitConfig,
 } = require('./native-page-schema-builder');
+const { assertNoEmojiInValue } = require('../../core/no-emoji-guard');
 
 const CANVAS_ACTIONS_SOURCE = 'export function didMount() {}';
 const CANVAS_ACTIONS_COMPILED = '"use strict";Object.defineProperty(exports,"__esModule",{value:!0}),exports.didMount=didMount;function didMount(){}';
@@ -32,7 +33,7 @@ function buildCanvasPageSchemaObject(sourceCode, runtimeCode, importedModules, f
   );
   const constructorCode = "function constructor() {\nvar module = { exports: {} };\nvar _this = this;\nthis.__initMethods__(module.exports, module);\nObject.keys(module.exports).forEach(function(item) {\n  if(typeof module.exports[item] === 'function'){\n    _this[item] = module.exports[item];\n  }\n});\n\n}";
 
-  return {
+  const schema = {
     schemaType: 'superform',
     schemaVersion: '5.0',
     pages: [
@@ -129,6 +130,11 @@ function buildCanvasPageSchemaObject(sourceCode, runtimeCode, importedModules, f
     },
     config: { connectComponent: [] },
   };
+  assertNoEmojiInValue(schema, {
+    artifact: 'canvas page schema ' + formUuid,
+    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+  });
+  return schema;
 }
 
 function resolveSchemaBuilderDependency(value, createDefault, property) {

--- a/lib/app/services/form-compiler.js
+++ b/lib/app/services/form-compiler.js
@@ -7,6 +7,7 @@ const {
   deepMerge,
   normalizeFieldValidationRules,
 } = require('./form-validation');
+const { assertNoEmojiInValue } = require('../../core/no-emoji-guard');
 
 const OPTION_FIELD_TYPES = Object.freeze(['RadioField', 'SelectField', 'CheckboxField', 'MultiSelectField']);
 const TABLE_FIELD_TYPE = 'TableField';
@@ -1743,7 +1744,7 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
   };
 
   // 顶层 Schema（与模板结构完全一致）- actions 和 config 与 pages 平级
-  return {
+  const schema = {
     schemaType: 'superform',
     schemaVersion: '5.0',
     pages: [pageSchema],
@@ -1767,6 +1768,11 @@ function buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, t
       connectComponent: [],
     },
   };
+  assertNoEmojiInValue(schema, {
+    artifact: 'compiled form schema ' + formUuid,
+    code: 'OPENYIDA_FORM_SCHEMA_EMOJI_FORBIDDEN',
+  });
+  return schema;
 }
 
 function buildEmptyFormSchema() {

--- a/lib/app/services/native-page-compiler.js
+++ b/lib/app/services/native-page-compiler.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const UglifyJS = require('uglify-js');
 const { default: babelTransform } = require('../../core/babel-transform');
 const { buildPageSource } = require('../page-compat');
+const { assertNoEmojiInText } = require('../../core/no-emoji-guard');
 const { schemaError } = require('../../schema/errors');
 const { isLoadedPageSource } = require('../../schema/page-source-loader');
 
@@ -30,6 +31,17 @@ function compileNativePageSource(loadedSource) {
   if (!buildResult || buildResult.ok !== true || typeof buildResult.code !== 'string' || !buildResult.code) {
     compilerError('SCHEMA_PAGE_SOURCE_COMPILE_FAILED', 'Native page source did not pass local validation.', {
       stage: 'normalize',
+    });
+  }
+  try {
+    assertNoEmojiInText(buildResult.code, {
+      artifact: loadedSource.relativePath || 'Schema native page source',
+      code: 'SCHEMA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+    });
+  } catch (error) {
+    compilerError('SCHEMA_PAGE_SOURCE_EMOJI_FORBIDDEN', error.message, {
+      stage: 'emoji',
+      issues: error.details && error.details.issues,
     });
   }
 

--- a/lib/app/services/native-page-schema-builder.js
+++ b/lib/app/services/native-page-schema-builder.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { stripSubtableFieldPrefix } = require('../../formula/field-refs');
-const { assertNoEmojiInValue } = require('../../core/no-emoji-guard');
 
 function createNodeIdGenerator() {
   let counter = 1;
@@ -393,10 +392,6 @@ function buildNativePageSchemaContent(sourceCode, compiledCode, formUuid, option
     },
   };
 
-  assertNoEmojiInValue(schema, {
-    artifact: 'native page schema ' + formUuid,
-    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
-  });
   return JSON.stringify(schema);
 }
 

--- a/lib/app/services/native-page-schema-builder.js
+++ b/lib/app/services/native-page-schema-builder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { stripSubtableFieldPrefix } = require('../../formula/field-refs');
+const { assertNoEmojiInValue } = require('../../core/no-emoji-guard');
 
 function createNodeIdGenerator() {
   let counter = 1;
@@ -392,6 +393,10 @@ function buildNativePageSchemaContent(sourceCode, compiledCode, formUuid, option
     },
   };
 
+  assertNoEmojiInValue(schema, {
+    artifact: 'native page schema ' + formUuid,
+    code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+  });
   return JSON.stringify(schema);
 }
 

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1116,6 +1116,7 @@ Examples:
     lint_import_require: 'Found import/require. Yida custom pages cannot import modules; load third-party scripts with this.utils.loadScript',
     lint_react_hooks: 'Found React Hooks. Yida runtime uses React 16 class-component style and does not support useState/useEffect hooks',
     lint_export_default: 'Found export default. Yida needs named exports such as export function renderJsx/didMount',
+    lint_emoji_forbidden: 'Found emoji "{0}". OpenYida generated artifacts must not use emoji in UI copy, source comments, filenames, or code constants; use plain text, SVG, or icon components instead.',
     lint_jsx_extension: 'This .js file contains JSX; prefer .jsx for source files. The compiled output is still .js',
     lint_event_direct_method: 'Event binding passes this.xxx directly and will lose this; use (e) => { this.xxx(e); }',
     lint_event_bind_this: 'Event binding uses .bind(this); use (e) => { this.xxx(e); } instead',

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1116,7 +1116,7 @@ Examples:
     lint_import_require: 'Found import/require. Yida custom pages cannot import modules; load third-party scripts with this.utils.loadScript',
     lint_react_hooks: 'Found React Hooks. Yida runtime uses React 16 class-component style and does not support useState/useEffect hooks',
     lint_export_default: 'Found export default. Yida needs named exports such as export function renderJsx/didMount',
-    lint_emoji_forbidden: 'Found emoji "{0}". OpenYida generated artifacts must not use emoji in UI copy, source comments, filenames, or code constants; use plain text, SVG, or icon components instead.',
+    lint_emoji_forbidden: 'Found emoji "{0}". OpenYida generated artifacts must not use emoji in UI copy, source comments, file paths, or code constants; use plain text, SVG, or icon components instead.',
     lint_jsx_extension: 'This .js file contains JSX; prefer .jsx for source files. The compiled output is still .js',
     lint_event_direct_method: 'Event binding passes this.xxx directly and will lose this; use (e) => { this.xxx(e); }',
     lint_event_bind_this: 'Event binding uses .bind(this); use (e) => { this.xxx(e); } instead',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1110,6 +1110,7 @@ openyida - 宜搭命令行工具
     lint_import_require: '检测到 import/require。宜搭自定义页面禁止模块导入，第三方脚本应通过 this.utils.loadScript 加载',
     lint_react_hooks: '检测到 React Hooks。宜搭运行时基于 React 16 类组件模式，不支持 useState/useEffect 等 Hooks',
     lint_export_default: '检测到 export default。宜搭需要 export function renderJsx/didMount 等具名导出',
+    lint_emoji_forbidden: '检测到 emoji「{0}」。OpenYida 生成产物禁止在 UI 文案、源码注释、文件名或代码常量中使用 emoji；请改用普通文字、SVG 或图标组件。',
     lint_jsx_extension: '当前文件是 .js 但包含 JSX，建议改为 .jsx，编译产物仍会输出 .js',
     lint_event_direct_method: '事件绑定直接传入 this.xxx，会导致 this 丢失；请使用 (e) => { this.xxx(e); }',
     lint_event_bind_this: '事件绑定使用了 .bind(this)，请改为 (e) => { this.xxx(e); }',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1110,7 +1110,7 @@ openyida - 宜搭命令行工具
     lint_import_require: '检测到 import/require。宜搭自定义页面禁止模块导入，第三方脚本应通过 this.utils.loadScript 加载',
     lint_react_hooks: '检测到 React Hooks。宜搭运行时基于 React 16 类组件模式，不支持 useState/useEffect 等 Hooks',
     lint_export_default: '检测到 export default。宜搭需要 export function renderJsx/didMount 等具名导出',
-    lint_emoji_forbidden: '检测到 emoji「{0}」。OpenYida 生成产物禁止在 UI 文案、源码注释、文件名或代码常量中使用 emoji；请改用普通文字、SVG 或图标组件。',
+    lint_emoji_forbidden: '检测到 emoji「{0}」。OpenYida 生成产物禁止在 UI 文案、源码注释、文件路径或代码常量中使用 emoji；请改用普通文字、SVG 或图标组件。',
     lint_jsx_extension: '当前文件是 .js 但包含 JSX，建议改为 .jsx，编译产物仍会输出 .js',
     lint_event_direct_method: '事件绑定直接传入 this.xxx，会导致 this 丢失；请使用 (e) => { this.xxx(e); }',
     lint_event_bind_this: '事件绑定使用了 .bind(this)，请改为 (e) => { this.xxx(e); }',

--- a/lib/core/no-emoji-detector.js
+++ b/lib/core/no-emoji-detector.js
@@ -1,0 +1,261 @@
+'use strict';
+
+// Covers common emoji blocks and Dingbats/Misc Symbols such as ✅, ⚠️, 📊, 🚀.
+// Keep this detector scoped to generated artifacts; CLI status output may still
+// use terminal glyphs independently.
+const EMOJI_PATTERN = /(?:[0-9#*]\uFE0F?\u20E3|[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?(?:\u200D[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?)*)/gu;
+const HEX_DIGITS = /^[0-9a-fA-F]+$/;
+
+function normalizeArtifactName(value) {
+  return String(value || 'artifact');
+}
+
+function getLineInfo(text, index) {
+  const before = text.slice(0, index);
+  const line = before.split(/\r\n|\r|\n/).length;
+  const lineStart = Math.max(before.lastIndexOf('\n'), before.lastIndexOf('\r')) + 1;
+  const nextNewline = text.indexOf('\n', index);
+  const lineEnd = nextNewline >= 0 ? nextNewline : text.length;
+  const column = index - lineStart + 1;
+  return {
+    line,
+    column,
+    excerpt: compactExcerpt(text.slice(lineStart, lineEnd), column),
+  };
+}
+
+function compactExcerpt(lineText, column) {
+  const normalized = String(lineText || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  const center = Math.max(0, column - 1);
+  const start = Math.max(0, center - 45);
+  const end = Math.min(normalized.length, start + 110);
+  return (start > 0 ? '...' : '') + normalized.slice(start, end) + (end < normalized.length ? '...' : '');
+}
+
+function createIssue(source, index, emoji, options, extra) {
+  const lineInfo = getLineInfo(source, index);
+  return Object.assign({
+    artifact: normalizeArtifactName(options.artifact),
+    path: options.path || options.valuePath || '',
+    emoji,
+    index,
+    line: lineInfo.line,
+    column: lineInfo.column,
+    excerpt: lineInfo.excerpt,
+  }, extra || {});
+}
+
+function isEmojiCharacter(value) {
+  EMOJI_PATTERN.lastIndex = 0;
+  const matched = EMOJI_PATTERN.test(value);
+  EMOJI_PATTERN.lastIndex = 0;
+  return matched;
+}
+
+function findRawEmojiInText(source, options) {
+  const issues = [];
+  EMOJI_PATTERN.lastIndex = 0;
+
+  let match;
+  while ((match = EMOJI_PATTERN.exec(source)) !== null) {
+    issues.push(createIssue(source, match.index, match[0], options));
+  }
+  return issues;
+}
+
+function readUnicodeEscapeAt(source, index) {
+  if (source[index] !== '\\' || source[index + 1] !== 'u') {
+    return null;
+  }
+
+  if (source[index + 2] === '{') {
+    const closeIndex = source.indexOf('}', index + 3);
+    if (closeIndex < 0) {
+      return null;
+    }
+    const hex = source.slice(index + 3, closeIndex);
+    if (!hex || hex.length > 6 || !HEX_DIGITS.test(hex)) {
+      return null;
+    }
+    const codePoint = Number.parseInt(hex, 16);
+    if (!Number.isFinite(codePoint) || codePoint > 0x10FFFF) {
+      return null;
+    }
+    return {
+      raw: source.slice(index, closeIndex + 1),
+      codePoint,
+      length: closeIndex + 1 - index,
+    };
+  }
+
+  const hex = source.slice(index + 2, index + 6);
+  if (hex.length !== 4 || !HEX_DIGITS.test(hex)) {
+    return null;
+  }
+  return {
+    raw: source.slice(index, index + 6),
+    codePoint: Number.parseInt(hex, 16),
+    length: 6,
+  };
+}
+
+function isHighSurrogate(codePoint) {
+  return codePoint >= 0xD800 && codePoint <= 0xDBFF;
+}
+
+function isLowSurrogate(codePoint) {
+  return codePoint >= 0xDC00 && codePoint <= 0xDFFF;
+}
+
+function combineSurrogatePair(high, low) {
+  return ((high - 0xD800) * 0x400) + (low - 0xDC00) + 0x10000;
+}
+
+function codePointToString(codePoint) {
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return '';
+  }
+}
+
+function findEscapedEmojiInText(source, options) {
+  const issues = [];
+  for (let index = 0; index < source.length; index++) {
+    const first = readUnicodeEscapeAt(source, index);
+    if (!first) {
+      continue;
+    }
+
+    let raw = first.raw;
+    let codePoint = first.codePoint;
+    let length = first.length;
+
+    if (isHighSurrogate(first.codePoint)) {
+      const second = readUnicodeEscapeAt(source, index + first.length);
+      if (second && isLowSurrogate(second.codePoint)) {
+        raw += second.raw;
+        codePoint = combineSurrogatePair(first.codePoint, second.codePoint);
+        length += second.length;
+      }
+    }
+
+    const emoji = codePointToString(codePoint);
+    if (emoji && isEmojiCharacter(emoji)) {
+      issues.push(createIssue(source, index, emoji, options, {
+        escaped: true,
+        escape: raw,
+      }));
+    }
+
+    index += Math.max(length - 1, 0);
+  }
+  return issues;
+}
+
+function findEmojiInText(text, options = {}) {
+  const source = String(text || '');
+  const maxIssues = options.maxIssues || 20;
+  const scanOptions = {
+    artifact: normalizeArtifactName(options.artifact),
+    path: options.path || options.valuePath || '',
+    valuePath: options.valuePath,
+  };
+  return findRawEmojiInText(source, scanOptions)
+    .concat(findEscapedEmojiInText(source, scanOptions))
+    .sort((left, right) => left.index - right.index)
+    .slice(0, maxIssues);
+}
+
+function findEmojiInArtifactName(artifactName, options = {}) {
+  const artifact = normalizeArtifactName(options.artifact || artifactName);
+  return findEmojiInText(String(artifactName || ''), {
+    artifact,
+    path: options.path || 'filePath',
+    maxIssues: options.maxIssues,
+  });
+}
+
+function appendPath(parentPath, key) {
+  if (typeof key === 'number') {
+    return `${parentPath || '$'}[${key}]`;
+  }
+  if (/^[A-Za-z_$][\w$]*$/.test(String(key))) {
+    return parentPath ? `${parentPath}.${key}` : String(key);
+  }
+  return `${parentPath || '$'}[${JSON.stringify(String(key))}]`;
+}
+
+function findEmojiInValue(value, options = {}) {
+  const issues = [];
+  const seen = new WeakSet();
+  const maxIssues = options.maxIssues || 20;
+
+  function visit(current, currentPath) {
+    if (issues.length >= maxIssues) {
+      return;
+    }
+    if (typeof current === 'string') {
+      findEmojiInText(current, {
+        artifact: options.artifact,
+        path: currentPath,
+        maxIssues: maxIssues - issues.length,
+      }).forEach((issue) => issues.push(issue));
+      return;
+    }
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+    if (seen.has(current)) {
+      return;
+    }
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => visit(item, appendPath(currentPath, index)));
+      return;
+    }
+
+    Object.keys(current).forEach((key) => {
+      visit(current[key], appendPath(currentPath, key));
+    });
+  }
+
+  visit(value, options.path || '');
+  return issues;
+}
+
+function formatEmojiIssue(issue) {
+  const location = issue.line
+    ? `${issue.artifact}:${issue.line}:${issue.column}`
+    : issue.artifact;
+  const pathText = issue.path ? ` (${issue.path})` : '';
+  const escapeText = issue.escape ? ` via escape "${issue.escape}"` : '';
+  return `${location}${pathText} contains emoji "${issue.emoji}"${escapeText}`;
+}
+
+function buildEmojiErrorMessage(issues, options = {}) {
+  const artifact = normalizeArtifactName(options.artifact || (issues[0] && issues[0].artifact));
+  const guidance = options.guidance || 'Remove emoji from generated UI copy, Schema strings, comments, file paths, and code constants. Use plain text, SVG, or icon components instead.';
+  const lines = [
+    `${artifact} contains emoji, which is forbidden for OpenYida generated artifacts.`,
+    ...issues.slice(0, 5).map(formatEmojiIssue),
+    guidance,
+  ];
+  if (issues.length > 5) {
+    lines.splice(lines.length - 1, 0, `...and ${issues.length - 5} more emoji occurrence(s).`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  EMOJI_PATTERN,
+  buildEmojiErrorMessage,
+  findEmojiInArtifactName,
+  findEmojiInText,
+  findEmojiInValue,
+  formatEmojiIssue,
+};

--- a/lib/core/no-emoji-guard.js
+++ b/lib/core/no-emoji-guard.js
@@ -1,138 +1,17 @@
 'use strict';
 
 const { CliError } = require('./cli-error');
-
-// Covers common emoji blocks and Dingbats/Misc Symbols such as ✅, ⚠️, 📊, 🚀.
-// Keep this guard scoped to generated artifacts; CLI status output may still use
-// terminal glyphs independently.
-const EMOJI_PATTERN = /(?:[0-9#*]\uFE0F?\u20E3|[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?(?:\u200D[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?)*)/gu;
+const {
+  EMOJI_PATTERN,
+  buildEmojiErrorMessage,
+  findEmojiInArtifactName,
+  findEmojiInText,
+  findEmojiInValue,
+  formatEmojiIssue,
+} = require('./no-emoji-detector');
 
 function normalizeArtifactName(value) {
   return String(value || 'artifact');
-}
-
-function getLineInfo(text, index) {
-  const before = text.slice(0, index);
-  const line = before.split(/\r\n|\r|\n/).length;
-  const lineStart = Math.max(before.lastIndexOf('\n'), before.lastIndexOf('\r')) + 1;
-  const nextNewline = text.indexOf('\n', index);
-  const lineEnd = nextNewline >= 0 ? nextNewline : text.length;
-  const column = index - lineStart + 1;
-  return {
-    line,
-    column,
-    excerpt: compactExcerpt(text.slice(lineStart, lineEnd), column),
-  };
-}
-
-function compactExcerpt(lineText, column) {
-  const normalized = String(lineText || '').replace(/\s+/g, ' ').trim();
-  if (normalized.length <= 120) {
-    return normalized;
-  }
-  const center = Math.max(0, column - 1);
-  const start = Math.max(0, center - 45);
-  const end = Math.min(normalized.length, start + 110);
-  return (start > 0 ? '...' : '') + normalized.slice(start, end) + (end < normalized.length ? '...' : '');
-}
-
-function findEmojiInText(text, options = {}) {
-  const source = String(text || '');
-  const artifact = normalizeArtifactName(options.artifact);
-  const valuePath = options.path || options.valuePath || '';
-  const maxIssues = options.maxIssues || 20;
-  const issues = [];
-  EMOJI_PATTERN.lastIndex = 0;
-
-  let match;
-  while ((match = EMOJI_PATTERN.exec(source)) !== null) {
-    const lineInfo = getLineInfo(source, match.index);
-    issues.push({
-      artifact,
-      path: valuePath,
-      emoji: match[0],
-      index: match.index,
-      line: lineInfo.line,
-      column: lineInfo.column,
-      excerpt: lineInfo.excerpt,
-    });
-    if (issues.length >= maxIssues) {
-      break;
-    }
-  }
-
-  return issues;
-}
-
-function appendPath(parentPath, key) {
-  if (typeof key === 'number') {
-    return `${parentPath || '$'}[${key}]`;
-  }
-  if (/^[A-Za-z_$][\w$]*$/.test(String(key))) {
-    return parentPath ? `${parentPath}.${key}` : String(key);
-  }
-  return `${parentPath || '$'}[${JSON.stringify(String(key))}]`;
-}
-
-function findEmojiInValue(value, options = {}) {
-  const issues = [];
-  const seen = new WeakSet();
-  const maxIssues = options.maxIssues || 20;
-
-  function visit(current, currentPath) {
-    if (issues.length >= maxIssues) {
-      return;
-    }
-    if (typeof current === 'string') {
-      findEmojiInText(current, {
-        artifact: options.artifact,
-        path: currentPath,
-        maxIssues: maxIssues - issues.length,
-      }).forEach((issue) => issues.push(issue));
-      return;
-    }
-    if (!current || typeof current !== 'object') {
-      return;
-    }
-    if (seen.has(current)) {
-      return;
-    }
-    seen.add(current);
-
-    if (Array.isArray(current)) {
-      current.forEach((item, index) => visit(item, appendPath(currentPath, index)));
-      return;
-    }
-
-    Object.keys(current).forEach((key) => {
-      visit(current[key], appendPath(currentPath, key));
-    });
-  }
-
-  visit(value, options.path || '');
-  return issues;
-}
-
-function formatEmojiIssue(issue) {
-  const location = issue.line
-    ? `${issue.artifact}:${issue.line}:${issue.column}`
-    : issue.artifact;
-  const pathText = issue.path ? ` (${issue.path})` : '';
-  return `${location}${pathText} contains emoji "${issue.emoji}"`;
-}
-
-function buildEmojiErrorMessage(issues, options = {}) {
-  const artifact = normalizeArtifactName(options.artifact || (issues[0] && issues[0].artifact));
-  const guidance = options.guidance || 'Remove emoji from generated UI copy, Schema strings, comments, filenames, and code constants. Use plain text, SVG, or icon components instead.';
-  const lines = [
-    `${artifact} contains emoji, which is forbidden for OpenYida generated artifacts.`,
-    ...issues.slice(0, 5).map(formatEmojiIssue),
-    guidance,
-  ];
-  if (issues.length > 5) {
-    lines.splice(lines.length - 1, 0, `...and ${issues.length - 5} more emoji occurrence(s).`);
-  }
-  return lines.join('\n');
 }
 
 function createEmojiError(issues, options = {}) {
@@ -145,26 +24,36 @@ function createEmojiError(issues, options = {}) {
   });
 }
 
-function assertNoEmojiInText(text, options = {}) {
-  const issues = findEmojiInText(text, options);
+function assertIssuesEmpty(issues, options) {
   if (issues.length > 0) {
     throw createEmojiError(issues, options);
   }
 }
 
+function assertNoEmojiInText(text, options = {}) {
+  assertIssuesEmpty(findEmojiInText(text, options), options);
+}
+
 function assertNoEmojiInValue(value, options = {}) {
-  const issues = findEmojiInValue(value, options);
-  if (issues.length > 0) {
-    throw createEmojiError(issues, options);
-  }
+  assertIssuesEmpty(findEmojiInValue(value, options), options);
+}
+
+function assertNoEmojiInArtifactName(artifactName, options = {}) {
+  assertIssuesEmpty(findEmojiInArtifactName(artifactName, options), {
+    ...options,
+    artifact: options.artifact || artifactName,
+  });
 }
 
 module.exports = {
   EMOJI_PATTERN,
+  assertNoEmojiInArtifactName,
   assertNoEmojiInText,
   assertNoEmojiInValue,
   buildEmojiErrorMessage,
   createEmojiError,
+  findEmojiInArtifactName,
   findEmojiInText,
   findEmojiInValue,
+  formatEmojiIssue,
 };

--- a/lib/core/no-emoji-guard.js
+++ b/lib/core/no-emoji-guard.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const { CliError } = require('./cli-error');
+
+// Covers common emoji blocks and Dingbats/Misc Symbols such as ✅, ⚠️, 📊, 🚀.
+// Keep this guard scoped to generated artifacts; CLI status output may still use
+// terminal glyphs independently.
+const EMOJI_PATTERN = /(?:[0-9#*]\uFE0F?\u20E3|[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?(?:\u200D[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}](?:\uFE0F|\uFE0E)?)*)/gu;
+
+function normalizeArtifactName(value) {
+  return String(value || 'artifact');
+}
+
+function getLineInfo(text, index) {
+  const before = text.slice(0, index);
+  const line = before.split(/\r\n|\r|\n/).length;
+  const lineStart = Math.max(before.lastIndexOf('\n'), before.lastIndexOf('\r')) + 1;
+  const nextNewline = text.indexOf('\n', index);
+  const lineEnd = nextNewline >= 0 ? nextNewline : text.length;
+  const column = index - lineStart + 1;
+  return {
+    line,
+    column,
+    excerpt: compactExcerpt(text.slice(lineStart, lineEnd), column),
+  };
+}
+
+function compactExcerpt(lineText, column) {
+  const normalized = String(lineText || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  const center = Math.max(0, column - 1);
+  const start = Math.max(0, center - 45);
+  const end = Math.min(normalized.length, start + 110);
+  return (start > 0 ? '...' : '') + normalized.slice(start, end) + (end < normalized.length ? '...' : '');
+}
+
+function findEmojiInText(text, options = {}) {
+  const source = String(text || '');
+  const artifact = normalizeArtifactName(options.artifact);
+  const valuePath = options.path || options.valuePath || '';
+  const maxIssues = options.maxIssues || 20;
+  const issues = [];
+  EMOJI_PATTERN.lastIndex = 0;
+
+  let match;
+  while ((match = EMOJI_PATTERN.exec(source)) !== null) {
+    const lineInfo = getLineInfo(source, match.index);
+    issues.push({
+      artifact,
+      path: valuePath,
+      emoji: match[0],
+      index: match.index,
+      line: lineInfo.line,
+      column: lineInfo.column,
+      excerpt: lineInfo.excerpt,
+    });
+    if (issues.length >= maxIssues) {
+      break;
+    }
+  }
+
+  return issues;
+}
+
+function appendPath(parentPath, key) {
+  if (typeof key === 'number') {
+    return `${parentPath || '$'}[${key}]`;
+  }
+  if (/^[A-Za-z_$][\w$]*$/.test(String(key))) {
+    return parentPath ? `${parentPath}.${key}` : String(key);
+  }
+  return `${parentPath || '$'}[${JSON.stringify(String(key))}]`;
+}
+
+function findEmojiInValue(value, options = {}) {
+  const issues = [];
+  const seen = new WeakSet();
+  const maxIssues = options.maxIssues || 20;
+
+  function visit(current, currentPath) {
+    if (issues.length >= maxIssues) {
+      return;
+    }
+    if (typeof current === 'string') {
+      findEmojiInText(current, {
+        artifact: options.artifact,
+        path: currentPath,
+        maxIssues: maxIssues - issues.length,
+      }).forEach((issue) => issues.push(issue));
+      return;
+    }
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+    if (seen.has(current)) {
+      return;
+    }
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => visit(item, appendPath(currentPath, index)));
+      return;
+    }
+
+    Object.keys(current).forEach((key) => {
+      visit(current[key], appendPath(currentPath, key));
+    });
+  }
+
+  visit(value, options.path || '');
+  return issues;
+}
+
+function formatEmojiIssue(issue) {
+  const location = issue.line
+    ? `${issue.artifact}:${issue.line}:${issue.column}`
+    : issue.artifact;
+  const pathText = issue.path ? ` (${issue.path})` : '';
+  return `${location}${pathText} contains emoji "${issue.emoji}"`;
+}
+
+function buildEmojiErrorMessage(issues, options = {}) {
+  const artifact = normalizeArtifactName(options.artifact || (issues[0] && issues[0].artifact));
+  const guidance = options.guidance || 'Remove emoji from generated UI copy, Schema strings, comments, filenames, and code constants. Use plain text, SVG, or icon components instead.';
+  const lines = [
+    `${artifact} contains emoji, which is forbidden for OpenYida generated artifacts.`,
+    ...issues.slice(0, 5).map(formatEmojiIssue),
+    guidance,
+  ];
+  if (issues.length > 5) {
+    lines.splice(lines.length - 1, 0, `...and ${issues.length - 5} more emoji occurrence(s).`);
+  }
+  return lines.join('\n');
+}
+
+function createEmojiError(issues, options = {}) {
+  return new CliError(buildEmojiErrorMessage(issues, options), {
+    code: options.code || 'OPENYIDA_ARTIFACT_EMOJI_FORBIDDEN',
+    details: {
+      artifact: normalizeArtifactName(options.artifact || (issues[0] && issues[0].artifact)),
+      issues,
+    },
+  });
+}
+
+function assertNoEmojiInText(text, options = {}) {
+  const issues = findEmojiInText(text, options);
+  if (issues.length > 0) {
+    throw createEmojiError(issues, options);
+  }
+}
+
+function assertNoEmojiInValue(value, options = {}) {
+  const issues = findEmojiInValue(value, options);
+  if (issues.length > 0) {
+    throw createEmojiError(issues, options);
+  }
+}
+
+module.exports = {
+  EMOJI_PATTERN,
+  assertNoEmojiInText,
+  assertNoEmojiInValue,
+  buildEmojiErrorMessage,
+  createEmojiError,
+  findEmojiInText,
+  findEmojiInValue,
+};

--- a/tests/canvas-compile.test.js
+++ b/tests/canvas-compile.test.js
@@ -284,6 +284,48 @@ describe('resolveWindowAlias', () => {
 });
 
 describe('compileCanvasLocal', () => {
+  test('rejects unicode escape sequences that would decode to emoji', () => {
+    expect(() => compileCanvasLocal(`
+      import React from 'react';
+      export default function Page() {
+        return <div>{"\\u2705"}</div>;
+      }
+    `)).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
+    }));
+
+    expect(() => compileCanvasLocal(`
+      import React from 'react';
+      export default function Page() {
+        return <div>{"\\u{1F4CA}"}</div>;
+      }
+    `)).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
+    }));
+
+    expect(() => compileCanvasLocal(`
+      import React from 'react';
+      export default function Page() {
+        return <div>{"\\uD83D\\uDE80"}</div>;
+      }
+    `)).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
+    }));
+  });
+
+  test('rejects emoji in source filenames', () => {
+    expect(() => compileCanvasLocal(`
+      import React from 'react';
+      export default function Page() {
+        return <div>ok</div>;
+      }
+    `, {
+      sourcePath: 'pages/src/home-✅.canvas.jsx',
+    })).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+    }));
+  });
+
   test('rejects unsupported bare package binding imports before runtime', () => {
     const src = `
       import { useDataBinding } from 'some-package';

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -1501,4 +1501,22 @@ describe('CLI offline smoke', () => {
     expect(result.output).toContain('missing-publish-source.oyd.jsx');
     expect(result.output).not.toContain(path.join(ROOT, 'FORM-XXX'));
   });
+
+  test('Canvas publish rejects emoji in source filenames before login', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-publish-canvas-'));
+    try {
+      const sourcePath = path.join(workspace, 'pages', 'src', 'home-✅.canvas.jsx');
+      fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+      fs.writeFileSync(sourcePath, 'export default function Page() { return <div>ok</div>; }\n', 'utf8');
+
+      const result = runAny(['publish', sourcePath, 'APP_TEST', 'FORM-TEST', '--no-open']);
+
+      expect(result.status).toBe(1);
+      expect(result.output).toMatch(/OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN|contains emoji/);
+      expect(result.output).not.toContain('读取登录态');
+      expect(result.output).not.toContain('Read login credentials');
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -76,4 +76,23 @@ describe('compile command', () => {
     expect(fs.existsSync(compiledPath)).toBe(true);
     expect(fs.statSync(compiledPath).size).toBeGreaterThan(1000);
   });
+
+  test('rejects emoji even when lint is skipped', () => {
+    const sourcePath = path.join(tmpDir, 'pages', 'src', 'emoji.jsx');
+    fs.writeFileSync(sourcePath, `
+export function renderJsx() {
+  return <div>✅ 已完成</div>;
+}
+`, 'utf8');
+
+    expect(() => execFileSync(process.execPath, [BIN, 'compile', 'pages/src/emoji.jsx', '--skip-lint'], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    })).toThrow(/contains emoji/);
+
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'emoji.js'))).toBe(false);
+  });
 });

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -95,4 +95,42 @@ export function renderJsx() {
 
     expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'emoji.js'))).toBe(false);
   });
+
+  test('rejects unicode escape emoji before writing compiled output', () => {
+    const sourcePath = path.join(tmpDir, 'pages', 'src', 'escaped.jsx');
+    fs.writeFileSync(sourcePath, `
+export function renderJsx() {
+  return <div>{"\\u2705"}</div>;
+}
+`, 'utf8');
+
+    expect(() => execFileSync(process.execPath, [BIN, 'compile', 'pages/src/escaped.jsx', '--skip-lint'], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    })).toThrow(/contains emoji/);
+
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'escaped.js'))).toBe(false);
+  });
+
+  test('rejects emoji in source filenames', () => {
+    const sourcePath = path.join(tmpDir, 'pages', 'src', 'home-✅.jsx');
+    fs.writeFileSync(sourcePath, `
+export function renderJsx() {
+  return <div>ok</div>;
+}
+`, 'utf8');
+
+    expect(() => execFileSync(process.execPath, [BIN, 'compile', 'pages/src/home-✅.jsx', '--skip-lint'], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    })).toThrow(/contains emoji/);
+
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'home-✅.js'))).toBe(false);
+  });
 });

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -1005,6 +1005,25 @@ describe('form compiler field bindings', () => {
     }));
   });
 
+  test('compileFormDefinition rejects emoji before returning a schema', () => {
+    expect(() => formCompiler.compileFormDefinition({
+      formTitle: '访客登记',
+      fields: [
+        { key: 'status', type: 'TextField', label: '✅ 状态' },
+      ],
+    })).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_FORM_SCHEMA_EMOJI_FORBIDDEN',
+      details: expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining('label'),
+            emoji: '✅',
+          }),
+        ]),
+      }),
+    }));
+  });
+
   test('compileFormDefinition rejects dots inside semantic keys', () => {
     expect(() => formCompiler.compileFormDefinition({
       formTitle: '访客登记',

--- a/tests/generate-page.test.js
+++ b/tests/generate-page.test.js
@@ -117,6 +117,33 @@ describe('generate-page command', () => {
     expect(fs.existsSync(path.join(projectDir, 'project', 'pages', 'src', 'visitor-dashboard.canvas.jsx'))).toBe(false);
   });
 
+  test('rejects specs that would render emoji into generated page source before writing files', () => {
+    const specPath = path.join(tmpDir, 'emoji-page.json');
+    fs.writeFileSync(specPath, JSON.stringify({
+      template: 'product-homepage',
+      output: 'pages/src/emoji-home.canvas.jsx',
+      brandName: '客户工作台 ✅',
+      heroText: '查看客户进度',
+      compile: true,
+    }), 'utf8');
+
+    expect(() => execFileSync(process.execPath, [
+      BIN,
+      'generate-page',
+      '--spec',
+      specPath,
+    ], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    })).toThrow(/contains emoji/);
+
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'src', 'emoji-home.canvas.jsx'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'emoji-home.canvas.js'))).toBe(false);
+  });
+
   test('accepts --theme-profile as a visual profile alias', () => {
     execFileSync(process.execPath, [BIN, 'generate-page', 'product-homepage', '--theme-profile', 'custom-theme', '--compile'], {
       cwd: tmpDir,

--- a/tests/generate-page.test.js
+++ b/tests/generate-page.test.js
@@ -144,6 +144,28 @@ describe('generate-page command', () => {
     expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'emoji-home.canvas.js'))).toBe(false);
   });
 
+  test('rejects emoji in generated output filenames before writing files', () => {
+    expect(() => execFileSync(process.execPath, [
+      BIN,
+      'generate-page',
+      'product-homepage',
+      '--brand-name',
+      '客户工作台',
+      '--output',
+      'pages/src/home-✅.canvas.jsx',
+      '--compile',
+    ], {
+      cwd: tmpDir,
+      env: cliEnv(),
+      encoding: 'utf8',
+      timeout: 10000,
+      stdio: 'pipe',
+    })).toThrow(/contains emoji/);
+
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'src', 'home-✅.canvas.jsx'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'home-✅.canvas.js'))).toBe(false);
+  });
+
   test('accepts --theme-profile as a visual profile alias', () => {
     execFileSync(process.execPath, [BIN, 'generate-page', 'product-homepage', '--theme-profile', 'custom-theme', '--compile'], {
       cwd: tmpDir,

--- a/tests/no-emoji-guard.test.js
+++ b/tests/no-emoji-guard.test.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const {
+  assertNoEmojiInArtifactName,
   assertNoEmojiInText,
   assertNoEmojiInValue,
+  findEmojiInArtifactName,
   findEmojiInText,
   findEmojiInValue,
 } = require('../lib/core/no-emoji-guard');
@@ -39,6 +41,33 @@ describe('no emoji artifact guard', () => {
     });
   });
 
+  test('finds unicode escape sequences that decode to emoji', () => {
+    const issues = findEmojiInText('const icon = "\\u2705";\nconst chart = "\\u{1F4CA}";\nconst rocket = "\\uD83D\\uDE80";\n', {
+      artifact: 'page.jsx',
+    });
+
+    expect(issues.map(issue => ({
+      emoji: issue.emoji,
+      escape: issue.escape,
+      escaped: issue.escaped,
+    }))).toEqual([
+      { emoji: '✅', escape: '\\u2705', escaped: true },
+      { emoji: '📊', escape: '\\u{1F4CA}', escaped: true },
+      { emoji: '🚀', escape: '\\uD83D\\uDE80', escaped: true },
+    ]);
+  });
+
+  test('finds emoji in artifact filenames', () => {
+    const issues = findEmojiInArtifactName('pages/src/home-✅.jsx');
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      artifact: 'pages/src/home-✅.jsx',
+      path: 'filePath',
+      emoji: '✅',
+    });
+  });
+
   test('throws artifact errors with machine-readable details', () => {
     expect(() => assertNoEmojiInText('<div>✅ 已完成</div>', {
       artifact: 'home.canvas.jsx',
@@ -54,5 +83,11 @@ describe('no emoji artifact guard', () => {
     expect(() => assertNoEmojiInValue({ title: '任务 🚀' }, {
       artifact: 'form schema',
     })).toThrow(/contains emoji/);
+
+    expect(() => assertNoEmojiInArtifactName('pages/src/home-📊.jsx', {
+      code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+    })).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
+    }));
   });
 });

--- a/tests/no-emoji-guard.test.js
+++ b/tests/no-emoji-guard.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const {
+  assertNoEmojiInText,
+  assertNoEmojiInValue,
+  findEmojiInText,
+  findEmojiInValue,
+} = require('../lib/core/no-emoji-guard');
+
+describe('no emoji artifact guard', () => {
+  test('finds emoji in text with stable line and column', () => {
+    const issues = findEmojiInText('const title = "已完成 ✅";\nconst ok = true;\n', {
+      artifact: 'page.jsx',
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      artifact: 'page.jsx',
+      emoji: '✅',
+      line: 1,
+      column: 20,
+    });
+  });
+
+  test('finds emoji recursively in schema-like objects', () => {
+    const issues = findEmojiInValue({
+      fields: [
+        { label: '客户状态 📊' },
+      ],
+    }, {
+      artifact: 'form schema',
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      artifact: 'form schema',
+      path: 'fields[0].label',
+      emoji: '📊',
+    });
+  });
+
+  test('throws artifact errors with machine-readable details', () => {
+    expect(() => assertNoEmojiInText('<div>✅ 已完成</div>', {
+      artifact: 'home.canvas.jsx',
+      code: 'OPENYIDA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+    })).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+      details: expect.objectContaining({
+        artifact: 'home.canvas.jsx',
+        issues: expect.any(Array),
+      }),
+    }));
+
+    expect(() => assertNoEmojiInValue({ title: '任务 🚀' }, {
+      artifact: 'form schema',
+    })).toThrow(/contains emoji/);
+  });
+});

--- a/tests/page-linter.test.js
+++ b/tests/page-linter.test.js
@@ -34,6 +34,23 @@ export default function App() {
     expect(errorRules).toContain('controlled-input');
   });
 
+  test('blocks emoji in UI copy and code constants', () => {
+    const source = `
+export function renderJsx() {
+  var statusTitle = '✅ 已完成';
+  return <div>{statusTitle}</div>;
+}
+`;
+
+    const result = lintYidaSource(source, '/tmp/emoji.jsx');
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        rule: 'emoji-forbidden',
+        line: 3,
+      }),
+    ]));
+  });
+
   test('flags Yida runtime traps in otherwise JSX-shaped pages', () => {
     const source = `
 export function renderJsx() {

--- a/tests/page-linter.test.js
+++ b/tests/page-linter.test.js
@@ -51,6 +51,22 @@ export function renderJsx() {
     ]));
   });
 
+  test('blocks emoji in page filenames', () => {
+    const source = `
+export function renderJsx() {
+  return <div>ok</div>;
+}
+`;
+
+    const result = lintYidaSource(source, '/tmp/home-✅.jsx');
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        rule: 'emoji-forbidden',
+        line: 1,
+      }),
+    ]));
+  });
+
   test('flags Yida runtime traps in otherwise JSX-shaped pages', () => {
     const source = `
 export function renderJsx() {

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -212,6 +212,26 @@ describe('publish prechecks', () => {
     }));
   });
 
+  test('publish schema builders reject unicode escape emoji in stored page source', () => {
+    expect(() => buildSchemaContent(
+      'export function renderJsx() { return React.createElement("div", null, "\\u2705"); }',
+      'function renderJsx(){return React.createElement("div",null,"\\u2705");}',
+      'FORM-PAGE',
+      { silent: true }
+    )).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+    }));
+
+    expect(() => buildCanvasSchemaContent(
+      'export default function Page() { return <div>{"\\u2705"}</div>; }',
+      'var YidaComp = function Page(){ return window.React.createElement("div", null, "\\u2705"); };',
+      '["react"]',
+      'FORM-CANVAS'
+    )).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+    }));
+  });
+
   test.each([
     ['login expiry', { success: false, errorCode: '307' }],
     ['CSRF expiry', { success: false, errorCode: 'TIANSHU_000030' }],

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -192,6 +192,26 @@ describe('publish prechecks', () => {
     });
   });
 
+  test('publish schema builders reject emoji in stored page source', () => {
+    expect(() => buildSchemaContent(
+      'export function renderJsx() { return React.createElement("div", null, "✅"); }',
+      'function renderJsx(){return React.createElement("div",null,"✅");}',
+      'FORM-PAGE',
+      { silent: true }
+    )).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+    }));
+
+    expect(() => buildCanvasSchemaContent(
+      'export default function Page() { return <div>📊</div>; }',
+      'var YidaComp = function Page(){ return window.React.createElement("div", null, "📊"); };',
+      '["react"]',
+      'FORM-CANVAS'
+    )).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+    }));
+  });
+
   test.each([
     ['login expiry', { success: false, errorCode: '307' }],
     ['CSRF expiry', { success: false, errorCode: 'TIANSHU_000030' }],

--- a/tests/schema-page-foundation.test.js
+++ b/tests/schema-page-foundation.test.js
@@ -343,6 +343,28 @@ describe('SAC-09A offline page foundation', () => {
     }));
   });
 
+  test('Canvas compiler rejects unicode escape emoji before producing runtime code', () => {
+    writeSource(
+      'pages/escaped.canvas.jsx',
+      'import React from "react";\nexport default function Page() { return <div>{"\\u2705"}</div>; }\n'
+    );
+
+    expect(() => compileCanvasPageSource(load('pages/escaped.canvas.jsx'))).toThrow(expect.objectContaining({
+      code: 'SCHEMA_PAGE_SOURCE_EMOJI_FORBIDDEN',
+    }));
+  });
+
+  test('Canvas schema builder rejects unicode escape emoji in stored source or runtime code', () => {
+    expect(() => buildCanvasPageSchemaContent(
+      'export default function Page() { return <div>{"\\u2705"}</div>; }',
+      'var YidaComp = function Page(){ return window.React.createElement("div", null, "\\u2705"); };',
+      '["react"]',
+      'FORM-CANVAS'
+    )).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_PAGE_SCHEMA_EMOJI_FORBIDDEN',
+    }));
+  });
+
   test('projects saved Canvas pages from YidaCodeCanvas props without native shell fingerprints', () => {
     const compiledPage = compileCanvas();
     const firstSchema = makeCanvasSavedSchema(compiledPage, {

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -227,7 +227,7 @@ schema-managed create/update 必须等待用户对当前 `planId` 显式批准�
 
 1. **技能加载唯一入口**：执行任何子技能前，支持 `use_skill` 的宿主必须调用 `use_skill("<技能名>", "<本阶段目的>")` 加载对应技能；不要用 `Read` / `read_file` / `cat` 读取 SKILL.md 路径，不凭记忆猜参数格式。
 2. **corpId 一致性检查**：创建或发布页面前对比 prd/resource context 与当前 auth snapshot（本地 OAuth token session 或 snapshot 明确返回的宿主注入 env token）中的 corpId，不一致必须询问用户（重新登录到目标组织，或确认在当前组织继续操作已解析资源/缺失资源）。
-3. **发布前本地校验**：普通自定义页面 `.oyd.jsx` / `.jsx` 发布前跑 `openyida check-page` + `openyida compile`；Code Canvas `.canvas.jsx` 不跑这两个普通自定义页面检查，改由 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检校验；JSON 配置写盘后先解析校验，再调用平台命令。OpenYida 生成产物硬禁 emoji：页面源码、Canvas 源码、表单 Schema 和发布 Schema 出现 emoji 时必须改源码/字段 JSON，不得用 `--skip-lint` 或重复发布绕过。
+3. **发布前本地校验**：普通自定义页面 `.oyd.jsx` / `.jsx` 发布前跑 `openyida check-page` + `openyida compile`；Code Canvas `.canvas.jsx` 不跑这两个普通自定义页面检查，改由 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检校验；JSON 配置写盘后先解析校验，再调用平台命令。OpenYida 生成产物硬禁 emoji：页面源码、Canvas 源码、表单 Schema、发布 Schema 和产物文件路径出现 emoji 时必须改源码/字段 JSON/路径，不得用 `--skip-lint` 或重复发布绕过。
 4. **页面源码修改必须发布闭环**：只要本轮 Write/Edit/Create 了页面源码 `project/pages/src/*.{canvas.jsx,canvas.tsx,oyd.jsx,jsx,tsx}`（含完整搭建、补齐、已有页面 update path、单点优化），final 前必须看到成功的 `openyida publish <source> <appType> <displayPageFormUuid>` 命令结果；本地文件编辑、diff、本地校验或编译只证明源码可发布，不等于远端页面已更新。若没有 publish 成功证据，final 只能说“源码已修改，尚未发布”，禁止说“页面已更新 / 已重新发布 / 已上线”。
 5. **命令输入文件禁止 shell 写入**：当 OpenYida 命令需要 JSON/YAML/CSV/config/script 文件参数时，先使用当前 agent 运行时提供的结构化文件写入工具（如 create_file / Write / file edit tool）创建文件，再把路径传给命令；禁止用 shell heredoc、`cat`/`echo`/`printf`/`tee` 加输出重定向，或把命令 stdout 重定向成业务文件。
 6. **读文件少用 Bash 噪声**：读取或定位 workspace 文件优先用宿主的 Read / Glob / Grep；OpenYida CLI 已返回成功 JSON、URL 或 `formUuid/appType` 时，不要再用 Bash `cat`/`ls` 做无意义复核。

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -227,7 +227,7 @@ schema-managed create/update 必须等待用户对当前 `planId` 显式批准�
 
 1. **技能加载唯一入口**：执行任何子技能前，支持 `use_skill` 的宿主必须调用 `use_skill("<技能名>", "<本阶段目的>")` 加载对应技能；不要用 `Read` / `read_file` / `cat` 读取 SKILL.md 路径，不凭记忆猜参数格式。
 2. **corpId 一致性检查**：创建或发布页面前对比 prd/resource context 与当前 auth snapshot（本地 OAuth token session 或 snapshot 明确返回的宿主注入 env token）中的 corpId，不一致必须询问用户（重新登录到目标组织，或确认在当前组织继续操作已解析资源/缺失资源）。
-3. **发布前本地校验**：普通自定义页面 `.oyd.jsx` / `.jsx` 发布前跑 `openyida check-page` + `openyida compile`；Code Canvas `.canvas.jsx` 不跑这两个普通自定义页面检查，改由 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检校验；JSON 配置写盘后先解析校验，再调用平台命令。
+3. **发布前本地校验**：普通自定义页面 `.oyd.jsx` / `.jsx` 发布前跑 `openyida check-page` + `openyida compile`；Code Canvas `.canvas.jsx` 不跑这两个普通自定义页面检查，改由 `openyida publish` 的 Canvas 编译阶段或 `compileCanvasLocal` 快检校验；JSON 配置写盘后先解析校验，再调用平台命令。OpenYida 生成产物硬禁 emoji：页面源码、Canvas 源码、表单 Schema 和发布 Schema 出现 emoji 时必须改源码/字段 JSON，不得用 `--skip-lint` 或重复发布绕过。
 4. **页面源码修改必须发布闭环**：只要本轮 Write/Edit/Create 了页面源码 `project/pages/src/*.{canvas.jsx,canvas.tsx,oyd.jsx,jsx,tsx}`（含完整搭建、补齐、已有页面 update path、单点优化），final 前必须看到成功的 `openyida publish <source> <appType> <displayPageFormUuid>` 命令结果；本地文件编辑、diff、本地校验或编译只证明源码可发布，不等于远端页面已更新。若没有 publish 成功证据，final 只能说“源码已修改，尚未发布”，禁止说“页面已更新 / 已重新发布 / 已上线”。
 5. **命令输入文件禁止 shell 写入**：当 OpenYida 命令需要 JSON/YAML/CSV/config/script 文件参数时，先使用当前 agent 运行时提供的结构化文件写入工具（如 create_file / Write / file edit tool）创建文件，再把路径传给命令；禁止用 shell heredoc、`cat`/`echo`/`printf`/`tee` 加输出重定向，或把命令 stdout 重定向成业务文件。
 6. **读文件少用 Bash 噪声**：读取或定位 workspace 文件优先用宿主的 Read / Glob / Grep；OpenYida CLI 已返回成功 JSON、URL 或 `formUuid/appType` 时，不要再用 Bash `cat`/`ls` 做无意义复核。

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -160,7 +160,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 
 - **模板路径**：先写业务化 `page-spec.json`，再执行 `openyida generate-page ... --spec <page-spec.json> --compile`。生成后只读取 `.openyida-page.json` / CLI 摘要判断 `domainFidelity` 和 dataBinding 状态；若需要补业务语义或样式，基于生成文件做小范围 Edit/patch。禁止在 `generate-page` 后立即 Read 500+ 行源码再全量 Write 覆盖同一路径。
 - **手写路径**：如果已经明确最终页面结构、数据桥和视觉细节，跳过 `generate-page`，直接 Write 最终 `.canvas.jsx`，再做本地快检和 publish。不要先生成模板再把模板完全覆盖。
-- **emoji 硬门禁**：表单字段 JSON、页面 spec、`.canvas.jsx` / `.oyd.jsx` 源码和发布 Schema 都不能包含 emoji。OpenYida 报 emoji 错误时修改字段文案、spec 或源码；不要用 `--skip-lint`、重复 create/publish 或全量 rewrite 试图绕过。
+- **emoji 硬门禁**：表单字段 JSON、页面 spec、`.canvas.jsx` / `.oyd.jsx` 源码、发布 Schema 和产物文件路径都不能包含 emoji。OpenYida 报 emoji 错误时修改字段文案、spec、源码或路径；不要用 `--skip-lint`、重复 create/publish 或全量 rewrite 试图绕过。
 
 选择模板路径时必须：
 

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -160,6 +160,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 
 - **模板路径**：先写业务化 `page-spec.json`，再执行 `openyida generate-page ... --spec <page-spec.json> --compile`。生成后只读取 `.openyida-page.json` / CLI 摘要判断 `domainFidelity` 和 dataBinding 状态；若需要补业务语义或样式，基于生成文件做小范围 Edit/patch。禁止在 `generate-page` 后立即 Read 500+ 行源码再全量 Write 覆盖同一路径。
 - **手写路径**：如果已经明确最终页面结构、数据桥和视觉细节，跳过 `generate-page`，直接 Write 最终 `.canvas.jsx`，再做本地快检和 publish。不要先生成模板再把模板完全覆盖。
+- **emoji 硬门禁**：表单字段 JSON、页面 spec、`.canvas.jsx` / `.oyd.jsx` 源码和发布 Schema 都不能包含 emoji。OpenYida 报 emoji 错误时修改字段文案、spec 或源码；不要用 `--skip-lint`、重复 create/publish 或全量 rewrite 试图绕过。
 
 选择模板路径时必须：
 

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -106,7 +106,7 @@ openyida sample yida-canvas-custom-page portal-native-components --output projec
 9. **自定义主题必须页面内注入**：`--theme` 只接受平台预置 key；如果页面设计使用非预置主题（例如活力橙、深玫红、自定义暗黑金），Canvas 页面必须在自身源码中注入 `style#yida-global-theme` 或等价 scoped CSS vars，并在根节点设置 `data-theme-scope="page"`。官方 sample 每个页面都要做，避免宿主应用 `black` 主题把页面染成黑灰。
 10. **真实交付不使用前端 seed 冒充业务数据**：`openyida sample` 原样发布可以保留 sample/seed 数据，但必须在页面上标注为 sample/seed。完整应用或真实交付页只要需要列表、看板、详情记录，并且本轮已经创建/解析业务表单，就必须在 `page-spec.json` 写入 `dataBinding.mode=form`、真实 `appType/formUuid` 和字段映射，让页面从表单读取。若需要演示数据，先通过表单数据写入链路创建 demo/mock records，再由 Canvas 读取这些真实表单记录；未写入 demo records 且没有真实数据时展示空态、表单入口、刷新/登记按钮。
 11. **页面生成二选一**：选择模板路径时，`openyida generate-page ... --spec ... --compile` 之后只读取 CLI 摘要或 `.openyida-page.json` 判断 `domainFidelity` / dataBinding，并对生成源码做小范围 Edit/patch；禁止立刻 Read 大段源码后全量 Write 覆盖同一路径。选择手写路径时，直接 Write 最终 `.canvas.jsx` 并快检/发布，不要先跑 `generate-page` 再完全覆盖。
-12. **Canvas 产物硬禁 emoji**：`.canvas.jsx` 源码、模板 spec 会渲染到页面的文案、JS 注释和数据常量都不能包含 emoji。`generate-page --compile`、`compileCanvasLocal` 或 `publish` 报 emoji 错误时，先改 spec/源码；不要尝试跳过 lint 或重复发布。
+12. **Canvas 产物硬禁 emoji**：`.canvas.jsx` 源码、模板 spec 会渲染到页面的文案、JS 注释、数据常量和产物文件路径都不能包含 emoji。`generate-page --compile`、`compileCanvasLocal` 或 `publish` 报 emoji 错误时，先改 spec/源码/路径；不要尝试跳过 lint 或重复发布。
 
 ## 数据真实性边界
 

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -106,6 +106,7 @@ openyida sample yida-canvas-custom-page portal-native-components --output projec
 9. **自定义主题必须页面内注入**：`--theme` 只接受平台预置 key；如果页面设计使用非预置主题（例如活力橙、深玫红、自定义暗黑金），Canvas 页面必须在自身源码中注入 `style#yida-global-theme` 或等价 scoped CSS vars，并在根节点设置 `data-theme-scope="page"`。官方 sample 每个页面都要做，避免宿主应用 `black` 主题把页面染成黑灰。
 10. **真实交付不使用前端 seed 冒充业务数据**：`openyida sample` 原样发布可以保留 sample/seed 数据，但必须在页面上标注为 sample/seed。完整应用或真实交付页只要需要列表、看板、详情记录，并且本轮已经创建/解析业务表单，就必须在 `page-spec.json` 写入 `dataBinding.mode=form`、真实 `appType/formUuid` 和字段映射，让页面从表单读取。若需要演示数据，先通过表单数据写入链路创建 demo/mock records，再由 Canvas 读取这些真实表单记录；未写入 demo records 且没有真实数据时展示空态、表单入口、刷新/登记按钮。
 11. **页面生成二选一**：选择模板路径时，`openyida generate-page ... --spec ... --compile` 之后只读取 CLI 摘要或 `.openyida-page.json` 判断 `domainFidelity` / dataBinding，并对生成源码做小范围 Edit/patch；禁止立刻 Read 大段源码后全量 Write 覆盖同一路径。选择手写路径时，直接 Write 最终 `.canvas.jsx` 并快检/发布，不要先跑 `generate-page` 再完全覆盖。
+12. **Canvas 产物硬禁 emoji**：`.canvas.jsx` 源码、模板 spec 会渲染到页面的文案、JS 注释和数据常量都不能包含 emoji。`generate-page --compile`、`compileCanvasLocal` 或 `publish` 报 emoji 错误时，先改 spec/源码；不要尝试跳过 lint 或重复发布。
 
 ## 数据真实性边界
 

--- a/yida-skills/skills/yida-create-form-page/SKILL.md
+++ b/yida-skills/skills/yida-create-form-page/SKILL.md
@@ -92,6 +92,7 @@ Divider > Field
 - 复杂业务表单应自然使用多种字段类型，例如文本、数值、日期、选择、成员/部门、附件、子表、关联表单；字段类型多样性服务于业务语义。
 - `TableField` 必须提供 `children` 子字段，`AssociationFormField` 必须提供关联表单信息。
 - 审批人、审批状态、审批节点等流程运行字段由流程能力承载；表单只收集业务数据。
+- 表单标题、字段 label/title、选项、提示语、校验文案、动作源码和字段 JSON 常量都禁止 emoji；`create-form` / schema compiler 报 emoji 错误时必须改字段 JSON，不能重复 create 或用同义命令绕过。
 
 ## Divider 主题规则
 

--- a/yida-skills/skills/yida-create-form-page/SKILL.md
+++ b/yida-skills/skills/yida-create-form-page/SKILL.md
@@ -92,7 +92,7 @@ Divider > Field
 - 复杂业务表单应自然使用多种字段类型，例如文本、数值、日期、选择、成员/部门、附件、子表、关联表单；字段类型多样性服务于业务语义。
 - `TableField` 必须提供 `children` 子字段，`AssociationFormField` 必须提供关联表单信息。
 - 审批人、审批状态、审批节点等流程运行字段由流程能力承载；表单只收集业务数据。
-- 表单标题、字段 label/title、选项、提示语、校验文案、动作源码和字段 JSON 常量都禁止 emoji；`create-form` / schema compiler 报 emoji 错误时必须改字段 JSON，不能重复 create 或用同义命令绕过。
+- 表单标题、字段 label/title、选项、提示语、校验文案、动作源码、字段 JSON 常量和字段 JSON 文件路径都禁止 emoji；`create-form` / schema compiler 报 emoji 错误时必须改字段 JSON 或路径，不能重复 create 或用同义命令绕过。
 
 ## Divider 主题规则
 

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -56,7 +56,7 @@ description: 宜搭普通自定义页面 JSX / Jsx 组件开发规范（React 16
 10. **Tabs 显隐控制**：下拉值变更后自动回退到第一个可见 Tab，内容区用 `display: none` 保留 DOM
 11. **加载态必须可恢复**：列表/看板页默认保留空态或演示数据；接口失败、超时或返回异常时必须把 `loading` 置回 `false`，不要只渲染“正在加载...”挡住整页
 12. **禁止可见原生下拉**：筛选、预约、审批等用户可见下拉交互不要使用 `<select>`；普通自定义页也不要把表单设计器里的 `SelectField` 当 React 筛选组件直接渲染。默认使用 Tailwind className 组合 `button + menu + option` 的自定义下拉组件，并带 `.oyd-select-arrow` 下箭头、`.oyd-select-check` 选中标记和页面级 focus reset；light 模式下选中项整块背景必须用 `--oyd-control-selected-bg` 这类低透明度浅色 token，不要直接用 `--color-brand1-1`
-13. **严禁 emoji**：页面渲染出来的任何位置（标题、按钮、标签、状态、空态文案、图表标题等）**一律禁止出现 emoji**（😀🚀✅⚠️📦📊 等一切彩色符号字符）。需要图标一律用功能性内联 SVG（见 `skills/yida-page-uiux` 图标策略）；需要状态标记用文字 + 语义色标签。emoji 是最明显的 AI 味来源之一，且跨端显示不一致。JS 注释里也不要留装饰性符号。
+13. **严禁 emoji**：页面渲染出来的任何位置（标题、按钮、标签、状态、空态文案、图表标题等）**一律禁止出现 emoji**（😀🚀✅⚠️📦📊 等一切彩色符号字符）。需要图标一律用功能性内联 SVG（见 `skills/yida-page-uiux` 图标策略）；需要状态标记用文字 + 语义色标签。emoji 是最明显的 AI 味来源之一，且跨端显示不一致。JS 注释、文件名、数据常量和示例数组里也不要留装饰性符号；`check-page` / `compile` / `publish` 报 emoji 错误时必须删除或改为 SVG/图标组件，不能用 `--skip-lint` 绕过。
 14. **light 页面禁灰黑主题**：普通业务列表、协同表、录入表、工作台和门户默认不要用近黑按钮、近黑描边、灰黑重阴影作为主题；主操作、选中态、筛选焦点和批量操作使用品牌色或 sample 自带主题色，边框用浅色品牌混合。只有用户明确要求暗色/高对比时才使用深色主视觉。
 15. **发布前必须跑检查链路**：先执行 `openyida check-page <file>` 和 `openyida compile <file>`；若出现 warning/error，按规则修复后再发布
 16. **源码修改发布闭环**：只要本轮 Write/Edit/Create 了 `project/pages/src/*.{oyd.jsx,jsx,tsx}` 普通自定义页面源码，`check-page` / `compile` 只证明源码可发布，不等于远端页面已更新；final 前必须看到成功的 `openyida publish <source> <appType> <displayPageFormUuid>`。没有 publish 成功证据时，只能说“源码已修改，尚未发布”，不能说“页面已更新 / 已重新发布”。

--- a/yida-skills/skills/yida-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-custom-page/SKILL.md
@@ -56,7 +56,7 @@ description: 宜搭普通自定义页面 JSX / Jsx 组件开发规范（React 16
 10. **Tabs 显隐控制**：下拉值变更后自动回退到第一个可见 Tab，内容区用 `display: none` 保留 DOM
 11. **加载态必须可恢复**：列表/看板页默认保留空态或演示数据；接口失败、超时或返回异常时必须把 `loading` 置回 `false`，不要只渲染“正在加载...”挡住整页
 12. **禁止可见原生下拉**：筛选、预约、审批等用户可见下拉交互不要使用 `<select>`；普通自定义页也不要把表单设计器里的 `SelectField` 当 React 筛选组件直接渲染。默认使用 Tailwind className 组合 `button + menu + option` 的自定义下拉组件，并带 `.oyd-select-arrow` 下箭头、`.oyd-select-check` 选中标记和页面级 focus reset；light 模式下选中项整块背景必须用 `--oyd-control-selected-bg` 这类低透明度浅色 token，不要直接用 `--color-brand1-1`
-13. **严禁 emoji**：页面渲染出来的任何位置（标题、按钮、标签、状态、空态文案、图表标题等）**一律禁止出现 emoji**（😀🚀✅⚠️📦📊 等一切彩色符号字符）。需要图标一律用功能性内联 SVG（见 `skills/yida-page-uiux` 图标策略）；需要状态标记用文字 + 语义色标签。emoji 是最明显的 AI 味来源之一，且跨端显示不一致。JS 注释、文件名、数据常量和示例数组里也不要留装饰性符号；`check-page` / `compile` / `publish` 报 emoji 错误时必须删除或改为 SVG/图标组件，不能用 `--skip-lint` 绕过。
+13. **严禁 emoji**：页面渲染出来的任何位置（标题、按钮、标签、状态、空态文案、图表标题等）**一律禁止出现 emoji**（😀🚀✅⚠️📦📊 等一切彩色符号字符）。需要图标一律用功能性内联 SVG（见 `skills/yida-page-uiux` 图标策略）；需要状态标记用文字 + 语义色标签。emoji 是最明显的 AI 味来源之一，且跨端显示不一致。JS 注释、文件路径、数据常量和示例数组里也不要留装饰性符号；`check-page` / `compile` / `publish` 报 emoji 错误时必须删除或改为 SVG/图标组件，不能用 `--skip-lint` 绕过。
 14. **light 页面禁灰黑主题**：普通业务列表、协同表、录入表、工作台和门户默认不要用近黑按钮、近黑描边、灰黑重阴影作为主题；主操作、选中态、筛选焦点和批量操作使用品牌色或 sample 自带主题色，边框用浅色品牌混合。只有用户明确要求暗色/高对比时才使用深色主视觉。
 15. **发布前必须跑检查链路**：先执行 `openyida check-page <file>` 和 `openyida compile <file>`；若出现 warning/error，按规则修复后再发布
 16. **源码修改发布闭环**：只要本轮 Write/Edit/Create 了 `project/pages/src/*.{oyd.jsx,jsx,tsx}` 普通自定义页面源码，`check-page` / `compile` 只证明源码可发布，不等于远端页面已更新；final 前必须看到成功的 `openyida publish <source> <appType> <displayPageFormUuid>`。没有 publish 成功证据时，只能说“源码已修改，尚未发布”，不能说“页面已更新 / 已重新发布”。


### PR DESCRIPTION
## Summary
- add a shared no-emoji artifact guard for generated form/page schemas and page sources
- wire the guard into create-form, generate-page, native/Canvas compile, publish schema builders, and schema-managed compilers
- document the hard gate in OpenYida skills and add focused regression tests

## Tests
- npx jest tests/no-emoji-guard.test.js tests/page-linter.test.js tests/compile.test.js tests/generate-page.test.js tests/create-form.test.js tests/publish-precheck.test.js --runInBand
- npx jest tests/canvas-compile.test.js tests/schema-page-foundation.test.js tests/schema-page-data-source-builder.test.js --runInBand
- node --check lib/core/no-emoji-guard.js lib/app/page-linter.js lib/app/page-compiler.js lib/app/canvas-compile.js lib/app/generate-page.js lib/app/create-form.js lib/app/services/form-compiler.js
- node --check lib/app/services/native-page-schema-builder.js lib/app/services/canvas-page-schema-builder.js lib/app/services/native-page-compiler.js lib/app/services/canvas-page-compiler.js
- npm run check:skills
- npm run check:i18n
- git diff --check