### PR TITLE
fix: harden trace low-risk CLI paths

### DIFF
--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -381,6 +381,27 @@ function validateContainerChildrenArray(field, fieldPath, componentName) {
   return field.children;
 }
 
+function hasNonEmptyAssociationFormUuid(field) {
+  const associationForm = field && field.associationForm;
+  if (!associationForm || typeof associationForm !== 'object' || Array.isArray(associationForm)) {
+    return false;
+  }
+  return typeof associationForm.formUuid === 'string' && associationForm.formUuid.trim().length > 0;
+}
+
+function validateAssociationFormFieldDefinition(field, fieldPath) {
+  if (hasNonEmptyAssociationFormUuid(field)) {
+    return;
+  }
+  throwInvalidFieldDefinition(
+    'AssociationFormField.associationForm.formUuid 必须是非空字符串: ' + fieldPath,
+    'CREATE_FORM_ASSOCIATION_FORM_UUID_MISSING',
+    field,
+    fieldPath,
+    { componentName: 'AssociationFormField' }
+  );
+}
+
 function validateFieldDefinition(field, fieldPath, options) {
   const validationOptions = options || {};
   validatePlainFieldObject(field, fieldPath);
@@ -436,6 +457,10 @@ function validateFieldDefinition(field, fieldPath, options) {
       fieldPath,
       { componentName }
     );
+  }
+
+  if (componentName === 'AssociationFormField') {
+    validateAssociationFormFieldDefinition(field, fieldPath);
   }
 
   if (componentName === 'TableField') {

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -573,12 +573,31 @@ async function ensurePublishTargetOrExit(appType, formUuid, authRef, options = {
 
 function sendHealthCheckRequest(pageUrl, cookies) {
   return new Promise((resolve) => {
-    const parsedUrl = new URL(pageUrl);
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(pageUrl);
+    } catch (urlError) {
+      resolve({ ok: false, statusCode: 0, error: urlError.message });
+      return;
+    }
     const isHttps = parsedUrl.protocol === 'https:';
     const requestModule = isHttps ? https : http;
-    const cookieHeader = cookies
+    const cookieHeader = Array.isArray(cookies) ? cookies
+      .filter((cookie) => cookie && cookie.name !== undefined && cookie.value !== undefined)
       .map((cookie) => `${cookie.name}=${cookie.value}`)
-      .join('; ');
+      .join('; ') : '';
+
+    if (!cookieHeader) {
+      resolve({
+        ok: false,
+        skipped: true,
+        reason: 'missing_cookies',
+        statusCode: 0,
+        error: t('common.request_failed'),
+      });
+      return;
+    }
+
     const requestOptions = {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port || (isHttps ? 443 : 80),
@@ -591,22 +610,28 @@ function sendHealthCheckRequest(pageUrl, cookies) {
       timeout: 30000,
     };
 
-    const request = requestModule.request(requestOptions, (response) => {
-      let responseData = '';
-      response.on('data', (chunk) => {
-        if (responseData.length < 2000) {
-          responseData += chunk;
-        }
-      });
-      response.on('end', () => {
-        const statusCode = response.statusCode || 0;
-        resolve({
-          ok: statusCode >= 200 && statusCode < 400,
-          statusCode,
-          snippet: responseData.substring(0, 300).replace(/\s+/g, ' ').trim(),
+    let request;
+    try {
+      request = requestModule.request(requestOptions, (response) => {
+        let responseData = '';
+        response.on('data', (chunk) => {
+          if (responseData.length < 2000) {
+            responseData += chunk;
+          }
+        });
+        response.on('end', () => {
+          const statusCode = response.statusCode || 0;
+          resolve({
+            ok: statusCode >= 200 && statusCode < 400,
+            statusCode,
+            snippet: responseData.substring(0, 300).replace(/\s+/g, ' ').trim(),
+          });
         });
       });
-    });
+    } catch (requestError) {
+      resolve({ ok: false, statusCode: 0, error: requestError.message });
+      return;
+    }
 
     request.on('timeout', () => {
       request.destroy();
@@ -776,7 +801,15 @@ async function main(argv) {
   let healthCheckResult = null;
   if (healthCheck) {
     step(5, t('publish.step_health_check'));
-    healthCheckResult = await sendHealthCheckRequest(pageUrl, cookies);
+    try {
+      healthCheckResult = await sendHealthCheckRequest(pageUrl, cookies);
+    } catch (healthCheckError) {
+      healthCheckResult = {
+        ok: false,
+        statusCode: 0,
+        error: healthCheckError && healthCheckError.message ? healthCheckError.message : t('common.unknown_error'),
+      };
+    }
     if (healthCheckResult.ok) {
       success(t('publish.health_check_ok', healthCheckResult.statusCode));
     } else {

--- a/lib/app/services/form-compiler.js
+++ b/lib/app/services/form-compiler.js
@@ -582,16 +582,25 @@ function hasNonEmptyAssociationFormUuid(field) {
   return typeof associationForm.formUuid === 'string' && associationForm.formUuid.trim().length > 0;
 }
 
+function hasManagedAssociationFormReference(field) {
+  if (!field || field.form === undefined || field.form === null) {
+    return false;
+  }
+  const formReference = String(field.form).trim();
+  return /^form:[A-Za-z][A-Za-z0-9_-]*$/.test(formReference);
+}
+
 function assertAssociationFormFieldDefinition(field, details) {
-  if (hasNonEmptyAssociationFormUuid(field)) {
+  if (hasNonEmptyAssociationFormUuid(field) || hasManagedAssociationFormReference(field)) {
     return;
   }
   throw createFormCompilerError(
-    'AssociationFormField.associationForm.formUuid 必须是非空字符串',
+    'AssociationFormField 必须配置 associationForm.formUuid 或 form: 引用',
     'FORM_COMPILER_ASSOCIATION_FORM_UUID_MISSING',
     Object.assign({
       label: field && field.label,
       title: field && field.title,
+      form: field && field.form,
       componentName: ASSOCIATION_FORM_FIELD_TYPE,
     }, details || {})
   );

--- a/lib/app/services/form-compiler.js
+++ b/lib/app/services/form-compiler.js
@@ -574,6 +574,29 @@ function assertSupportedFieldDefinition(field, details) {
   return componentName;
 }
 
+function hasNonEmptyAssociationFormUuid(field) {
+  const associationForm = field && field.associationForm;
+  if (!associationForm || typeof associationForm !== 'object' || Array.isArray(associationForm)) {
+    return false;
+  }
+  return typeof associationForm.formUuid === 'string' && associationForm.formUuid.trim().length > 0;
+}
+
+function assertAssociationFormFieldDefinition(field, details) {
+  if (hasNonEmptyAssociationFormUuid(field)) {
+    return;
+  }
+  throw createFormCompilerError(
+    'AssociationFormField.associationForm.formUuid 必须是非空字符串',
+    'FORM_COMPILER_ASSOCIATION_FORM_UUID_MISSING',
+    Object.assign({
+      label: field && field.label,
+      title: field && field.title,
+      componentName: ASSOCIATION_FORM_FIELD_TYPE,
+    }, details || {})
+  );
+}
+
 const COMPONENT_ALIAS_META = Symbol('openyida.componentAlias');
 
 function normalizeComponentAlias(field) {
@@ -612,6 +635,9 @@ function buildFieldComponent(field, options) {
   const semanticPath = semanticKey
     ? (compilerOptions.semanticPath ? compilerOptions.semanticPath + '.' + semanticKey : semanticKey)
     : '';
+  if (componentName === ASSOCIATION_FORM_FIELD_TYPE) {
+    assertAssociationFormFieldDefinition(field, { semanticPath });
+  }
   const fieldId = resolveFieldId(componentName, semanticPath, compilerOptions);
   const nodeId = nextNodeId();
   recordFieldBinding(compilerOptions, semanticPath, fieldId, componentName);

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -471,6 +471,49 @@ describe('form presentation components', () => {
     }));
   });
 
+  test('AssociationFormField requires associationForm.formUuid in nested definitions', () => {
+    expect(() => createForm._private.validateFormFieldDefinitions([
+      {
+        type: 'TableField',
+        label: '明细',
+        children: [
+          { type: 'AssociationFormField', label: '关联客户', associationForm: { formUuid: '' } },
+        ],
+      },
+    ])).toThrow(expect.objectContaining({
+      code: 'CREATE_FORM_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        path: 'fields[0].children[0]',
+        label: '关联客户',
+      }),
+    }));
+
+    expect(() => createForm._private.validateFormFieldDefinitions([
+      {
+        type: 'ColumnContainer',
+        children: [
+          [
+            { type: 'AssociationFormField', label: '关联订单', associationForm: {} },
+          ],
+        ],
+      },
+    ])).toThrow(expect.objectContaining({
+      code: 'CREATE_FORM_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        path: 'fields[0].children[0][0]',
+        label: '关联订单',
+      }),
+    }));
+
+    expect(() => createForm._private.validateFormFieldDefinitions([
+      {
+        type: 'AssociationFormField',
+        label: '关联车辆',
+        associationForm: { formUuid: 'FORM_VEHICLE' },
+      },
+    ])).not.toThrow();
+  });
+
   test('TableField children reject presentation components before schema build', () => {
     const fields = [
       {
@@ -756,6 +799,37 @@ describe('create-form create recovery guardrails', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  test('missing AssociationFormField formUuid fails before saveFormSchemaInfo creates a blank form', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-missing-association-'));
+    const fieldsPath = path.join(tmpDir, 'fields.json');
+    fs.writeFileSync(fieldsPath, JSON.stringify([
+      {
+        type: 'AssociationFormField',
+        label: '关联车辆',
+        associationForm: { appType: 'APP_TEST' },
+      },
+    ]));
+
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand();
+
+    await expect(isolatedCreateForm.run([
+      'create',
+      'APP_TEST',
+      '用车申请',
+      fieldsPath,
+    ])).rejects.toMatchObject({
+      code: 'CREATE_FORM_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        path: 'fields[0]',
+        label: '关联车辆',
+      }),
+    });
+
+    expect(mockUtils.httpPost).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
   test('post-create getFormSchema failure emits structured recovery JSON with formUuid', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-post-create-'));
     const fieldsPath = path.join(tmpDir, 'fields.json');
@@ -1003,6 +1077,56 @@ describe('form compiler field bindings', () => {
     })).toThrow(expect.objectContaining({
       code: 'FORM_COMPILER_UNSUPPORTED_FIELD_TYPE',
     }));
+  });
+
+  test('compileFormDefinition validates AssociationFormField associationForm.formUuid', () => {
+    expect(() => formCompiler.compileFormDefinition({
+      formTitle: '缺关联配置',
+      fields: [
+        { key: 'customer', type: 'AssociationFormField', label: '关联客户', associationForm: {} },
+      ],
+    })).toThrow(expect.objectContaining({
+      code: 'FORM_COMPILER_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        semanticPath: 'customer',
+        label: '关联客户',
+      }),
+    }));
+
+    expect(() => formCompiler.compileFormDefinition({
+      formTitle: '子表缺关联配置',
+      fields: [
+        {
+          key: 'items',
+          type: 'TableField',
+          label: '明细',
+          children: [
+            { key: 'vehicle', type: 'AssociationFormField', label: '关联车辆', associationForm: { formUuid: ' ' } },
+          ],
+        },
+      ],
+    })).toThrow(expect.objectContaining({
+      code: 'FORM_COMPILER_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        semanticPath: 'items.vehicle',
+        label: '关联车辆',
+      }),
+    }));
+
+    const compiled = formCompiler.compileFormDefinition({
+      formTitle: '合法关联配置',
+      fields: [
+        {
+          key: 'customer',
+          type: 'AssociationFormField',
+          label: '关联客户',
+          associationForm: { appType: 'APP_CUSTOMER', formUuid: 'FORM_CUSTOMER' },
+        },
+      ],
+    });
+
+    expect(JSON.stringify(compiled.schema)).toContain('FORM_CUSTOMER');
+    expect(compiled.fieldBindingComponents.customer).toBe('AssociationFormField');
   });
 
   test('compileFormDefinition rejects dots inside semantic keys', () => {

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -1079,7 +1079,7 @@ describe('form compiler field bindings', () => {
     }));
   });
 
-  test('compileFormDefinition validates AssociationFormField associationForm.formUuid', () => {
+  test('compileFormDefinition validates AssociationFormField association targets', () => {
     expect(() => formCompiler.compileFormDefinition({
       formTitle: '缺关联配置',
       fields: [
@@ -1112,6 +1112,33 @@ describe('form compiler field bindings', () => {
         label: '关联车辆',
       }),
     }));
+
+    expect(() => formCompiler.compileFormDefinition({
+      formTitle: '非法 schema-managed 引用',
+      fields: [
+        { key: 'customer', type: 'AssociationFormField', label: '关联客户', form: 'customer' },
+      ],
+    })).toThrow(expect.objectContaining({
+      code: 'FORM_COMPILER_ASSOCIATION_FORM_UUID_MISSING',
+      details: expect.objectContaining({
+        semanticPath: 'customer',
+        form: 'customer',
+      }),
+    }));
+
+    const managedReferenceCompiled = formCompiler.compileFormDefinition({
+      formTitle: 'schema-managed 引用',
+      fields: [
+        {
+          key: 'customer',
+          type: 'AssociationFormField',
+          label: '关联客户',
+          form: 'form:customer',
+        },
+      ],
+    });
+
+    expect(managedReferenceCompiled.fieldBindingComponents.customer).toBe('AssociationFormField');
 
     const compiled = formCompiler.compileFormDefinition({
       formTitle: '合法关联配置',

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -20,6 +20,7 @@ const {
   extractPageDataSource,
   findDuplicateSourceMismatches,
   mergePageDataSource,
+  sendHealthCheckRequest,
   sendSaveRequestOnce,
   verifyPublishTarget,
 } = require('../lib/app/publish');
@@ -190,6 +191,165 @@ describe('publish prechecks', () => {
         importedModules: '["react"]',
       },
     });
+  });
+
+  test('health check skips safely when cookies are missing', async () => {
+    const requestSpy = jest.spyOn(https, 'request');
+
+    await expect(sendHealthCheckRequest('https://example.test/APP_XXX/workbench/FORM-PAGE')).resolves.toMatchObject({
+      ok: false,
+      skipped: true,
+      reason: 'missing_cookies',
+    });
+
+    await expect(sendHealthCheckRequest('https://example.test/APP_XXX/workbench/FORM-PAGE', [])).resolves.toMatchObject({
+      ok: false,
+      skipped: true,
+      reason: 'missing_cookies',
+    });
+
+    expect(requestSpy).not.toHaveBeenCalled();
+    requestSpy.mockRestore();
+  });
+
+  test('publish main treats health check transport errors as non-fatal after save succeeds', async () => {
+    const sourcePath = path.join(workspace, 'home.canvas.jsx');
+    fs.writeFileSync(sourcePath, 'export default function Page() { return null; }\n', 'utf8');
+
+    jest.resetModules();
+    const previousQuiet = process.env.YIDA_QUIET;
+    process.env.YIDA_QUIET = '1';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error('process.exit ' + code);
+    });
+    const warnMock = jest.fn();
+    const resultMock = jest.fn();
+    const requestSpy = jest.spyOn(https, 'request').mockImplementation((options, callback) => {
+      if (options && options.method === 'GET') {
+        throw new Error('health transport broke');
+      }
+      const response = new EventEmitter();
+      response.statusCode = 200;
+      const request = new EventEmitter();
+      request.write = jest.fn();
+      request.end = jest.fn(() => {
+        callback(response);
+        response.emit('data', JSON.stringify({ success: true }));
+        response.emit('end');
+      });
+      request.destroy = jest.fn();
+      return request;
+    });
+    const mockUtils = {
+      findProjectRoot: jest.fn(() => workspace),
+      isLoginExpired: jest.fn(() => false),
+      isCsrfTokenExpired: jest.fn(() => false),
+      httpGet: jest.fn(() => Promise.resolve({
+        success: true,
+        content: { pages: [], gmtModified: 100 },
+      })),
+      httpPost: jest.fn(() => Promise.resolve({
+        success: true,
+        content: { formUuid: 'FORM-PAGE', version: 7 },
+      })),
+      requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+    };
+
+    jest.doMock('../lib/core/utils', () => mockUtils);
+    jest.doMock('../lib/core/yida-client', () => ({
+      createAuthRef: jest.fn(() => ({
+        baseUrl: 'https://example.test',
+        csrfToken: 'csrf',
+        cookies: [{ name: 'session', value: 'private' }],
+        authMode: 'token',
+        authSource: 'token',
+        authData: { auth_mode: 'token', auth_source: 'token' },
+      })),
+      isTokenAuthRef: jest.fn(() => true),
+    }));
+    jest.doMock('../lib/core/chalk', () => ({
+      banner: jest.fn(),
+      step: jest.fn(),
+      label: jest.fn(),
+      success: jest.fn(),
+      fail: jest.fn(),
+      warn: warnMock,
+      info: jest.fn(),
+      error: jest.fn(),
+      result: resultMock,
+      usage: jest.fn(),
+      hint: jest.fn(),
+    }));
+    jest.doMock('../lib/core/browser-handoff', () => ({
+      parseOpenOption: jest.fn((args) => ({
+        args: args.filter((arg) => arg !== '--no-open'),
+        mode: false,
+      })),
+      withBrowserHandoff: jest.fn((payload) => payload),
+    }));
+    jest.doMock('../lib/core/legacy-schema-guard', () => ({
+      assertLegacyDirectWriteAllowed: jest.fn(),
+      extractLegacyGuardArgs: jest.fn((args) => ({ args, guardOptions: {} })),
+    }));
+    jest.doMock('../lib/app/canvas-compile', () => ({
+      compileCanvas: jest.fn(() => Promise.resolve({
+        runtimeCode: 'var YidaComp = function Page() { return null; };',
+        importedModules: '[]',
+      })),
+    }));
+    jest.doMock('../lib/app/services/canvas-page-schema-builder', () => ({
+      buildCanvasPageSchemaContent: jest.fn(() => JSON.stringify({ pages: [] })),
+    }));
+
+    try {
+      const isolatedPublish = require('../lib/app/publish');
+      await expect(isolatedPublish([
+        sourcePath,
+        'APP_XXX',
+        'FORM-PAGE',
+        '--canvas',
+        '--force',
+        '--skip-lint',
+        '--health-check',
+        '--no-open',
+      ])).resolves.toBeUndefined();
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(resultMock).toHaveBeenCalledWith(true, expect.any(String), expect.any(Array));
+      expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('health transport broke'));
+      const outputPayload = consoleSpy.mock.calls
+        .map((call) => call[0])
+        .filter((line) => typeof line === 'string' && line.startsWith('{'))
+        .map((line) => JSON.parse(line))
+        .find((payload) => payload && payload.success === true);
+      expect(outputPayload).toMatchObject({
+        success: true,
+        appType: 'APP_XXX',
+        formUuid: 'FORM-PAGE',
+        healthCheck: {
+          ok: false,
+          error: 'health transport broke',
+        },
+      });
+    } finally {
+      requestSpy.mockRestore();
+      exitSpy.mockRestore();
+      consoleSpy.mockRestore();
+      jest.dontMock('../lib/core/utils');
+      jest.dontMock('../lib/core/yida-client');
+      jest.dontMock('../lib/core/chalk');
+      jest.dontMock('../lib/core/browser-handoff');
+      jest.dontMock('../lib/core/legacy-schema-guard');
+      jest.dontMock('../lib/app/canvas-compile');
+      jest.dontMock('../lib/app/services/canvas-page-schema-builder');
+      jest.resetModules();
+      if (previousQuiet === undefined) {
+        delete process.env.YIDA_QUIET;
+      } else {
+        process.env.YIDA_QUIET = previousQuiet;
+      }
+    }
   });
 
   test.each([


### PR DESCRIPTION
## Summary
- validate AssociationFormField associationForm.formUuid before create-form writes a blank form
- add matching form compiler validation for association fields
- make publish health checks cookie-safe and non-fatal after publish succeeds

## Tests
- npx jest tests/create-form.test.js --runInBand
- npx jest tests/publish-precheck.test.js --runInBand
- node --check lib/app/create-form.js
- node --check lib/app/services/form-compiler.js
- node --check lib/app/publish.js
- npm run check:i18n
- git diff --check
- npx eslint lib/app/create-form.js lib/app/services/form-compiler.js lib/app/publish.js tests/create-form.test.js tests/publish-precheck.test.js