### PR TITLE
fix: 保留结构化集成的宜搭设计器元数据

### DIFF
--- a/lib/integration/integration-create.js
+++ b/lib/integration/integration-create.js
@@ -9,6 +9,7 @@ const { fetchFormPageList } = require('../app/form-navigation');
 const {
   readIntegrationSpec,
   validateIntegrationSpec,
+  normalizeStringArray,
   buildSpecProcessAndViewJson,
   collectAddDataFormUuids,
 } = require('./integration-spec-builder');
@@ -208,6 +209,17 @@ async function run(args) {
     }
   }
 
+  const specEventInput = integrationSpec
+    ? (integrationSpec.events || integrationSpec.formEventTypes || formEventTypes)
+    : formEventTypes;
+  const summaryFormEventTypes = mapEventTypes(Array.isArray(specEventInput) ? specEventInput : formEventTypes);
+  const summaryApprovalActions = integrationSpec && Array.isArray(integrationSpec.approvalActions)
+    ? normalizeStringArray(integrationSpec.approvalActions)
+    : approvalActions;
+  const summaryApprovalNodeIds = integrationSpec && Array.isArray(integrationSpec.approvalNodeIds)
+    ? normalizeStringArray(integrationSpec.approvalNodeIds)
+    : approvalNodeIds;
+
   if (formEventTypes.includes('processFinish') && approvalActions.length === 0) {
     warn('审批事件触发时必须传入 --approval-actions agree,disagree,terminated 中的至少一项');
     process.exit(1);
@@ -378,12 +390,12 @@ async function run(args) {
   if (processCodeInput) {
     warn(t('integration.create_process_code', processCodeInput));
   }
-  warn(t('integration.create_events', formEventTypes.join(', ')));
-  if (approvalActions.length > 0) {
-    warn(`审批动作: ${approvalActions.join(', ')}`);
+  warn(t('integration.create_events', summaryFormEventTypes.join(', ')));
+  if (summaryApprovalActions.length > 0) {
+    warn(`审批动作: ${summaryApprovalActions.join(', ')}`);
   }
-  if (approvalNodeIds.length > 0) {
-    warn(`审批节点: ${approvalNodeIds.join(', ')}`);
+  if (summaryApprovalNodeIds.length > 0) {
+    warn(`审批节点: ${summaryApprovalNodeIds.join(', ')}`);
   }
   if (triggerRecursively) {
     warn('允许自动触发: true');

--- a/lib/integration/integration-spec-builder.js
+++ b/lib/integration/integration-spec-builder.js
@@ -9,6 +9,7 @@ const {
   buildDataRetrieveCondition,
   buildDataCreateAssignments,
   buildConnectorCallAssignments,
+  resolveConnectorMode,
 } = require('./integration-process-builder');
 const { buildAddDataChildList } = require('./integration-view-builder');
 const {
@@ -29,6 +30,12 @@ function readIntegrationSpec(filePath) {
 
 function asArray(value) {
   return Array.isArray(value) ? value : [];
+}
+
+function normalizeStringArray(value) {
+  return asArray(value)
+    .map((item) => String(item === null || item === undefined ? '' : item).trim())
+    .filter(Boolean);
 }
 
 function getSpecNodes(spec) {
@@ -55,8 +62,16 @@ function validateIntegrationSpec(spec, fallbackEvents = ['insert']) {
   if (getSpecNodes(spec).length === 0) {
     throw new Error('integration spec must contain a non-empty nodes array');
   }
-  if (mapSpecEventTypes(spec, fallbackEvents).length === 0) {
+  const formEventTypes = mapSpecEventTypes(spec, fallbackEvents);
+  if (formEventTypes.length === 0) {
     throw new Error('integration spec must contain at least one valid event');
+  }
+  const hasApprovalEvent = formEventTypes.includes('processFinish') || formEventTypes.includes('activityTask');
+  if (hasApprovalEvent && normalizeStringArray(spec.approvalActions).length === 0) {
+    throw new Error('integration spec approvalActions must contain at least one approval action');
+  }
+  if (formEventTypes.includes('activityTask') && normalizeStringArray(spec.approvalNodeIds).length === 0) {
+    throw new Error('integration spec approvalNodeIds must contain at least one approval node for activityTask');
   }
 }
 
@@ -351,10 +366,16 @@ function buildDataRetrieveViewNode(node, nodeId, context) {
           appType: context.appType,
           appName: '',
           formItem: {
-            formType: 'receipt',
+            formType: node.formType || (
+              node.type === 'getSelf' && context.formEventTypes.some(
+                (eventType) => eventType === 'processFinish' || eventType === 'activityTask',
+              )
+                ? 'process'
+                : 'receipt'
+            ),
             advanceProc: 'n',
             formUuid: props.sourceId,
-            title: '',
+            title: node.formName || node.sourceName || node.sourceTitle || '',
             fields: null,
             hasTableField: null,
           },
@@ -502,10 +523,12 @@ function buildDataUpdateViewNode(node, nodeId, context) {
 }
 
 function buildConnectorProcessNode(node, nodeId, nextNodeId, context) {
+  const connectorMode = resolveConnectorMode(node.connectorId, node.connectorMode || node.mode);
+  const connectionId = node.connectionId || node.connection || '';
   return {
     name: { zh_CN: node.name || '连接器', en_US: '' },
     description: node.description || '请选择连接器',
-    type: 'innerConnector',
+    type: connectorMode === 5 ? 'httpConnector' : 'innerConnector',
     nodeId,
     prevId: '',
     nextId: [nextNodeId],
@@ -514,7 +537,9 @@ function buildConnectorProcessNode(node, nodeId, nextNodeId, context) {
         url: '',
         method: '',
         body: '',
-        connection: '',
+        connection: connectionId,
+        connectionId,
+        connectorMode,
         connectorId: node.connectorId,
         actionId: node.actionId,
         assignments: buildConnectorCallAssignments(normalizeAssignments(node.assignments || node.connectorAssignments, context)),
@@ -542,7 +567,10 @@ function buildConnectorViewNode(node, nodeId, context) {
   }
   const assignments = normalizeAssignments(node.assignments || node.connectorAssignments, context);
   const connectorRulesArray = buildConnectorRulesFromInputs(normalizedInputs, assignments);
-  const connectorDisplayName = node.name || '连接器';
+  const connectorMode = resolveConnectorMode(node.connectorId, node.connectorMode || node.mode);
+  const connectionId = node.connectionId || node.connection || '';
+  const connectorDisplayName = node.connectorDisplayName || node.displayName || node.name || '连接器';
+  const connectorInternalName = node.connectorName || node.connectorId || '';
   return {
     componentName: 'ConnectorNode',
     id: nodeId,
@@ -552,16 +580,19 @@ function buildConnectorViewNode(node, nodeId, context) {
         allStepCounts: 2,
         currentStep: 1,
         connectorId: node.connectorId,
-        connectionId: '',
+        connectionId,
         actionId: node.actionId,
         connector: {
           config: null,
           connectorCorpId: '',
           connectorId: node.connectorId,
+          connectorName: connectorInternalName,
+          connectorMode,
           containTriggers: null,
           description: connectorDisplayName,
+          displayName: connectorDisplayName,
           iconUrl: node.icon || '',
-          mode: 1,
+          mode: connectorMode,
           name: connectorDisplayName,
           orgId: 0,
           prioirty: 0,
@@ -796,7 +827,20 @@ function buildStartNodes(spec, context, triggerNodeId, firstNodeId) {
   const triggerConditionObject = triggerConditions.length > 0
     ? buildTriggerCondition(normalizeTriggerConditions(triggerConditions, context), spec.triggerConditionLogic || 'AND')
     : null;
-  const startFormEventTypes = formEventTypes;
+  const isApprovalNodeEvent = formEventTypes.includes('activityTask');
+  const isApprovalProcessEvent = formEventTypes.includes('processFinish');
+  const normalFormEventTypes = formEventTypes.filter((eventType) => eventType !== 'processFinish' && eventType !== 'activityTask');
+  const startFormEventTypes = isApprovalProcessEvent || isApprovalNodeEvent
+    ? ['processEvents', ...normalFormEventTypes]
+    : formEventTypes;
+  const approvalActions = normalizeStringArray(spec.approvalActions);
+  const approvalNodeIds = normalizeStringArray(spec.approvalNodeIds);
+  const activityTask = isApprovalNodeEvent
+    ? approvalNodeIds.map((activityId) => ({
+      activityId: [activityId],
+      activityAction: approvalActions,
+    }))
+    : [];
   const processNode = {
     name: {
       en_US: 'Form event trigger',
@@ -814,10 +858,10 @@ function buildStartNodes(spec, context, triggerNodeId, firstNodeId) {
         formEventField: '',
         formUuid: context.formUuid,
         conditions: triggerConditionObject,
-        activityAction: asArray(spec.approvalActions),
+        activityAction: isApprovalProcessEvent || isApprovalNodeEvent ? approvalActions : [],
         triggerFormEventRecursively: Boolean(spec.triggerRecursively),
-        activityId: asArray(spec.approvalNodeIds),
-        activityTask: [],
+        activityId: isApprovalNodeEvent ? approvalNodeIds : [],
+        activityTask,
       },
       triggerType: 'FormEvent',
     },
@@ -835,7 +879,8 @@ function buildStartNodes(spec, context, triggerNodeId, firstNodeId) {
       },
       nodeError: '',
       start: {
-        examineApproveType: 'processFinish',
+        // The designer stores one approval subtype; match the standard builder by preferring activityTask.
+        examineApproveType: isApprovalNodeEvent ? 'activityTask' : 'processFinish',
         formEventType: startFormEventTypes,
         formEventField: '',
         dataFilterType: triggerConditions.length > 0 ? 'byRule' : 'all',
@@ -855,9 +900,9 @@ function buildStartNodes(spec, context, triggerNodeId, firstNodeId) {
         triggerType: 'FormEvent',
         type: 'form',
         triggerFormEventRecursively: Boolean(spec.triggerRecursively),
-        examineApproveNode: '',
-        examineApproveActiveList: asArray(spec.approvalActions),
-        examineApproveActiveTask: [],
+        examineApproveNode: isApprovalNodeEvent ? (approvalNodeIds[0] || '') : '',
+        examineApproveActiveList: isApprovalProcessEvent || isApprovalNodeEvent ? approvalActions : [],
+        examineApproveActiveTask: activityTask,
       },
     },
   };
@@ -896,6 +941,7 @@ function buildSpecProcessAndViewJson(options) {
     formUuid: options.formUuid,
     flowName: options.flowName || '',
     defaultFormEventTypes: options.formEventTypes || ['insert'],
+    formEventTypes: mapSpecEventTypes(spec, options.formEventTypes || ['insert']),
     defaultNotificationTitle: options.notificationTitle,
     defaultNotificationContent: options.notificationContent,
     defaultToUsers: options.toUsers || [],
@@ -964,6 +1010,7 @@ function collectAddDataFormUuids(spec) {
 module.exports = {
   readIntegrationSpec,
   validateIntegrationSpec,
+  normalizeStringArray,
   buildSpecProcessAndViewJson,
   collectAddDataFormUuids,
   _private: {

--- a/tests/integration-create.test.js
+++ b/tests/integration-create.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 jest.mock('../lib/core/utils', () => ({
   loadAuthData: jest.fn(() => ({
     auth_mode: 'token',
@@ -38,7 +42,12 @@ jest.mock('../lib/integration/integration-api', () => ({
   saveProcess: jest.fn(),
 }));
 
+jest.mock('../lib/core/chalk', () => ({
+  warn: jest.fn(),
+}));
+
 const { fetchFormPageList } = require('../lib/app/form-navigation');
+const { warn } = require('../lib/core/chalk');
 const integrationApi = require('../lib/integration/integration-api');
 const { run } = require('../lib/integration/integration-create');
 
@@ -271,6 +280,44 @@ describe('integration create command', () => {
     const viewNode = saveParams.viewJson.schema.children.find((node) => node.componentName === 'ConnectorNode');
     expect(viewNode.props.connectorRules.connector.mode).toBe(5);
     expect(viewNode.props.connectorRules.connector.connectorMode).toBe(5);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test('reports events and approval actions from structured specs', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-integration-create-'));
+    const specFile = path.join(dir, 'approval-flow.json');
+    fs.writeFileSync(specFile, JSON.stringify({
+      events: ['processFinish'],
+      approvalActions: [' agree ', ''],
+      nodes: [{ type: 'getSelf' }],
+    }), 'utf8');
+    integrationApi.saveProcess.mockResolvedValue({ success: true });
+
+    try {
+      await run([
+        'APP_TEST',
+        'FORM-PROCESS',
+        'Approval completion flow',
+        '--process-code',
+        'LPROC-TEST',
+        '--spec',
+        specFile,
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+
+    const output = warn.mock.calls.flat().join('\n');
+    const eventSummary = warn.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes('processFinish'));
+    const approvalSummary = warn.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes('审批动作:'));
+    expect(eventSummary).toBeDefined();
+    expect(eventSummary).not.toContain('insert');
+    expect(approvalSummary).toBe('审批动作: agree');
+    expect(output).toContain('审批动作: agree');
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/integration-spec-builder.test.js
+++ b/tests/integration-spec-builder.test.js
@@ -170,6 +170,15 @@ describe('integration spec builder', () => {
     expect(() => validateIntegrationSpec({ nodes: [{ type: 'getSelf' }] }, ['insert'])).not.toThrow();
     expect(() => validateIntegrationSpec({ events: ['insert'], nodes: [] })).toThrow(/non-empty nodes array/);
     expect(() => validateIntegrationSpec({ events: ['unknown'], nodes: [{ type: 'getSelf' }] })).toThrow(/valid event/);
+    expect(() => validateIntegrationSpec({
+      events: ['processFinish'],
+      nodes: [{ type: 'getSelf' }],
+    })).toThrow(/approvalActions/);
+    expect(() => validateIntegrationSpec({
+      events: ['activityTask'],
+      approvalActions: ['agree'],
+      nodes: [{ type: 'getSelf' }],
+    })).toThrow(/approvalNodeIds/);
   });
 
   test('accepts route condition objects with explicit logic', () => {
@@ -320,6 +329,204 @@ describe('integration spec builder', () => {
     expect(lookup.props.condition.rules[0]).toMatchObject({
       id: 'textField_b',
       value: `\${${built.nodeIdMap.self}}.textField_a`,
+    });
+  });
+
+  test('maps process completion events to designer trigger metadata', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['processFinish'],
+        approvalActions: ['agree'],
+        nodes: [{ id: 'self', type: 'getSelf' }],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-PROCESS',
+      flowName: 'Approval completion flow',
+    });
+
+    const processTrigger = built.processJson.nodes[0];
+    expect(processTrigger.props.inputs).toMatchObject({
+      formEventType: ['processFinish'],
+      activityAction: ['agree'],
+    });
+
+    const viewTrigger = built.viewJson.schema.children[0].props.start;
+    expect(viewTrigger).toMatchObject({
+      formEventType: ['processEvents'],
+      examineApproveType: 'processFinish',
+      examineApproveActiveList: ['agree'],
+    });
+  });
+
+  test('preserves ordinary events when combined with process completion', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert', 'processFinish'],
+        approvalActions: ['agree'],
+        nodes: [{ id: 'self', type: 'getSelf' }],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-PROCESS',
+      flowName: 'Mixed event flow',
+    });
+
+    expect(built.processJson.nodes[0].props.inputs.formEventType).toEqual([
+      'insert',
+      'processFinish',
+    ]);
+    expect(built.viewJson.schema.children[0].props.start).toMatchObject({
+      formEventType: ['processEvents', 'insert'],
+      examineApproveType: 'processFinish',
+    });
+  });
+
+  test('maps approval task events and selected nodes to designer trigger metadata', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['activityTask'],
+        approvalActions: [' agree ', ''],
+        approvalNodeIds: [' approval-node-1 ', ''],
+        nodes: [{ id: 'self', type: 'getSelf' }],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-PROCESS',
+      flowName: 'Approval task flow',
+    });
+
+    const expectedTask = [{
+      activityId: ['approval-node-1'],
+      activityAction: ['agree'],
+    }];
+    expect(built.processJson.nodes[0].props.inputs).toMatchObject({
+      formEventType: ['activityTask'],
+      activityAction: ['agree'],
+      activityId: ['approval-node-1'],
+      activityTask: expectedTask,
+    });
+
+    const viewTrigger = built.viewJson.schema.children[0].props.start;
+    expect(viewTrigger).toMatchObject({
+      formEventType: ['processEvents'],
+      examineApproveType: 'activityTask',
+      examineApproveNode: 'approval-node-1',
+      examineApproveActiveList: ['agree'],
+      examineApproveActiveTask: expectedTask,
+    });
+  });
+
+  test('keeps HTTP connector metadata in spec process and designer nodes', () => {
+    const connectorId = 'Http_1234567890abcdef1234567890abcdef';
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [
+          {
+            id: 'submit',
+            type: 'connector',
+            name: 'Submit import',
+            connectorId,
+            connectorName: connectorId,
+            connectorDisplayName: 'BI backend',
+            actionId: 'submit_import',
+            connectionId: '10001',
+            assignments: [
+              { column: 'month', valueType: 'processVar', value: 'dateField_month' },
+            ],
+          },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-A',
+      flowName: 'HTTP connector flow',
+    });
+
+    const processConnector = built.processJson.nodes.find((node) => node.nodeId === built.nodeIdMap.submit);
+    expect(processConnector).toMatchObject({
+      type: 'httpConnector',
+      props: {
+        inputs: {
+          connection: '10001',
+          connectionId: '10001',
+          connectorMode: 5,
+          connectorId,
+          actionId: 'submit_import',
+        },
+      },
+    });
+
+    const viewConnector = built.viewJson.schema.children.find((node) => node.id === built.nodeIdMap.submit);
+    expect(viewConnector.props.name).toBe('BI backend');
+    expect(viewConnector.props.connectorRules).toMatchObject({
+      connectionId: '10001',
+      connectorId,
+      actionId: 'submit_import',
+      connector: {
+        connectorId,
+        connectorName: connectorId,
+        connectorMode: 5,
+        mode: 5,
+        name: 'BI backend',
+        displayName: 'BI backend',
+      },
+    });
+  });
+
+  test('marks getSelf targets as process forms and preserves display metadata', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['processFinish'],
+        approvalActions: ['agree'],
+        nodes: [
+          {
+            id: 'self',
+            type: 'getSelf',
+            name: 'Get current request',
+            formName: 'Monthly import request',
+            description: 'Load the current request by form instance ID',
+          },
+        ],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-PROCESS',
+      flowName: 'Get current request flow',
+    });
+
+    const getSelf = built.viewJson.schema.children.find((node) => node.id === built.nodeIdMap.self);
+    expect(getSelf.props.description).toBe('Load the current request by form instance ID');
+    expect(getSelf.props.getData.targetItem.formItem).toMatchObject({
+      formType: 'process',
+      formUuid: 'FORM-PROCESS',
+      title: 'Monthly import request',
+    });
+    expect(getSelf.props.getData.condition.rules[0]).toMatchObject({
+      id: 'pid',
+      value: '__masterdata_form_inst_id',
+      opCode: 'Equal',
+    });
+  });
+
+  test('keeps getSelf targets as receipt forms for ordinary form events', () => {
+    const built = buildSpecProcessAndViewJson({
+      spec: {
+        events: ['insert'],
+        nodes: [{ id: 'self', type: 'getSelf', formName: 'Submission' }],
+      },
+      processCode: 'LPROC-SPEC',
+      appType: 'APP-SPEC',
+      formUuid: 'FORM-RECEIPT',
+      flowName: 'Get current submission flow',
+    });
+
+    const getSelf = built.viewJson.schema.children.find((node) => node.id === built.nodeIdMap.self);
+    expect(getSelf.props.getData.targetItem.formItem).toMatchObject({
+      formType: 'receipt',
+      formUuid: 'FORM-RECEIPT',
+      title: 'Submission',
     });
   });
 

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -251,6 +251,45 @@ openyida integration create APP_XXX FORM-XXX "获取自身后分支更新" \
   --publish
 ```
 
+审批完成后调用 HTTP 自定义连接器时，spec 中应同时保留连接器类型推断、鉴权连接和设计器展示所需的元信息：
+
+```json
+{
+  "events": ["processFinish"],
+  "approvalActions": ["agree"],
+  "nodes": [
+    {
+      "id": "self",
+      "type": "getSelf",
+      "formName": "导入申请",
+      "description": "按当前表单实例ID获取导入申请"
+    },
+    {
+      "id": "submit",
+      "type": "connector",
+      "connectorId": "Http_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "connectorName": "Http_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "connectorDisplayName": "BI 后端",
+      "actionId": "submit_import",
+      "connectionId": "10001",
+      "assignments": [
+        {
+          "column": "month",
+          "valueType": "column",
+          "value": "${self}.dateField_month"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`connectorId` 以 `Http_` 开头时会自动使用 `connectorMode=5` 和 `httpConnector`；也可以在节点中显式指定 `"connectorMode": 5`。`connectionId` 是连接器鉴权连接 ID，不能用连接器 ID 或动作 ID 替代。
+
+`processFinish` 事件必须提供非空 `approvalActions`；`activityTask` 事件还必须提供非空 `approvalNodeIds`，否则命令会在保存流程前终止。
+
+同时声明 `processFinish` 和 `activityTask` 时，执行模型会保留两种事件；设计器只能保存一种审批触发子类型，因此 `examineApproveType` 与普通构建器保持一致，优先使用 `activityTask`。
+
 > `--spec` 文件先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；从 workspace 根执行命令时路径加 `project/` 前缀。
 
 ## 字段变量引用格式


### PR DESCRIPTION
## 变更摘要

- 修复通过 `--spec` 创建集成自动化时，自定义 HTTP 连接器类型、鉴权连接和展示元数据丢失的问题。
- 正确生成审批完成/审批节点事件所需的执行模型与宜搭设计器元数据。
- 保留 `getSelf` 节点的表单类型和展示信息，避免节点在设计器中显示为未配置。
- CLI 摘要展示 spec 的实际触发条件，并与构建器共用审批动作、审批节点的规范化逻辑。

## 问题背景

结构化 spec builder 与普通 process/view builder 的部分默认值不一致，导致自动化虽然能够保存，但重新打开宜搭设计器时可能出现以下问题：

- 自定义 HTTP 连接器被识别为内置连接器，右侧配置面板无法正确反查连接器详情。
- 审批事件未转换为设计器要求的 `processEvents` 表示，触发器显示未正确绑定。
- `getSelf` 节点丢失流程表单类型和表单名称。
- CLI 摘要显示命令行默认事件，或显示未经规范化的 spec 数组，而不是实际生成值。

## 实现方案

- 复用 `resolveConnectorMode()`，使结构化 spec 与普通 builder 保持相同的 `Http_*` 自动推断行为。
- 在执行节点和设计器节点中保留 `connection`、`connectionId`、`connectorMode`、`connectorName` 和 `displayName`。
- 按现有 builder 的数据结构生成 `processFinish` / `activityTask` 审批元数据，并标准化动作和节点 ID 列表。
- CLI 摘要复用 `normalizeStringArray()`，确保展示值与实际生成值一致，同时保留现有 CLI 参数回退行为。
- 对审批 spec 增加前置校验，防止缺少 `approvalActions` 或 `approvalNodeIds` 时生成半配置流程。
- 混合事件在执行模型中完整保留；设计器视图使用 `processEvents`，并保留普通表单事件。
- 设计器只能保存一种审批触发子类型；同时声明两种审批事件时，与普通 builder 一致优先使用 `activityTask`，该规则已写入技能文档。
- 根据标准化后的触发事件识别 `getSelf` 的流程/普通表单类型，同时允许显式 `formType` 覆盖推断。

## 验证结果

- 聚焦测试：分别在默认 locale 与 `OPENYIDA_LANG=en` 下执行，均为 23/23 通过。
- 完整测试：117 个测试套件、1523 个测试全部通过。
- `npm run check:quick`：通过；332 个 JavaScript 文件通过语法检查，ESLint 为 0 error（14 个基线 warning）。
- `npm run build:skills` 与 `npm run check:skills`：通过；155 个 Markdown 文件完成校验。
- `npm run check:package`：通过。
- 分支已重放到 `upstream/main` 的 `v2026.7.26-beta.1`，无代码冲突。
- 已在真实宜搭环境中发布并重新打开包含 `getSelf` 和自定义 HTTP 连接器的审批触发自动化，触发绑定和节点编辑状态正常。

## 兼容性

本次变更未移除 CLI 参数或现有 spec 字段。显式传入的 `formType` 和 `connectorMode` 仍优先于自动推断。