### PR TITLE
fix: expose login commands and harden Canvas entry compile

### DIFF
--- a/lib/app/canvas-compile.js
+++ b/lib/app/canvas-compile.js
@@ -25,7 +25,7 @@
  *      这些 UMD 依赖由画布运行时依据 importedModules 白名单按需注入。
  *
  * 因此本地编译 = Babel 把 JSX/TS 转成 ES5 → 把 import 改写成 window 别名引用、
- * 把 export default 改写成 `var YidaComp = ...` → 正则抽出依赖包名。
+ * 把 export default 改写成画布入口 `YidaComp` → 正则抽出依赖包名。
  */
 
 const Babel = require('@babel/standalone');
@@ -152,6 +152,15 @@ function esmToWindowPlugin({ types: t }, options = {}) {
     );
   }
 
+  function hasProgramBinding(path, name) {
+    const program = path.findParent((parentPath) => parentPath.isProgram());
+    return Boolean(program && program.scope.hasBinding(name));
+  }
+
+  function isExistingYidaCompDefault(path, decl) {
+    return t.isIdentifier(decl, { name: 'YidaComp' }) && hasProgramBinding(path, 'YidaComp');
+  }
+
   return {
     name: 'yida-esm-to-window',
     visitor: {
@@ -217,6 +226,10 @@ function esmToWindowPlugin({ types: t }, options = {}) {
         const decl = path.node.declaration;
         if (t.isFunctionDeclaration(decl) || t.isClassDeclaration(decl)) {
           if (decl.id) {
+            if (decl.id.name === 'YidaComp') {
+              path.replaceWith(decl);
+              return;
+            }
             // 具名声明：保留声明本体，再补 `var YidaComp = <name>;`
             const idName = decl.id.name;
             path.replaceWithMultiple([
@@ -233,6 +246,10 @@ function esmToWindowPlugin({ types: t }, options = {}) {
           path.replaceWith(
             t.variableDeclaration('var', [t.variableDeclarator(t.identifier('YidaComp'), expr)])
           );
+          return;
+        }
+        if (isExistingYidaCompDefault(path, decl)) {
+          path.remove();
           return;
         }
         // export default <表达式>
@@ -256,6 +273,32 @@ function esmToWindowPlugin({ types: t }, options = {}) {
       },
     },
   };
+}
+
+function buildCanvasRuntimeWrapper(runtimeCode) {
+  return (
+    'return function(iframeWindow, parentWindow){ const window = iframeWindow; '
+    + runtimeCode
+    + ' return YidaComp; }'
+  );
+}
+
+function assertCanvasRuntimeParseable(runtimeCode, options = {}) {
+  try {
+    // 只编译 wrapper，不执行 factory 或用户组件，避免触发源码里的运行期副作用。
+    // eslint-disable-next-line no-new-func
+    new Function(buildCanvasRuntimeWrapper(runtimeCode));
+  } catch (error) {
+    const detail = error && error.message ? error.message : String(error);
+    const sourceLabel = options.sourcePath ? ` (${options.sourcePath})` : '';
+    const compileError = new Error(
+      `Code Canvas runtimeCode 无法通过画布运行时装配校验${sourceLabel}: ${detail}`
+      + '。请检查默认导出、YidaComp 入口或 window 等运行时保留变量是否重复声明。'
+    );
+    compileError.code = 'OPENYIDA_CANVAS_RUNTIME_PARSE_FAILED';
+    compileError.cause = error;
+    throw compileError;
+  }
 }
 
 /**
@@ -322,6 +365,7 @@ function compileCanvasLocal(source, options = {}) {
     artifact: options.sourcePath ? options.sourcePath + ' runtime' : 'Code Canvas runtime',
     code: 'OPENYIDA_CANVAS_SOURCE_EMOJI_FORBIDDEN',
   });
+  assertCanvasRuntimeParseable(runtimeCode, options);
   return {
     runtimeCode,
     importedModules: JSON.stringify(importedModules),
@@ -356,5 +400,6 @@ module.exports = {
   extractImportedModules,
   resolveWindowAlias,
   shouldAllowUnsupportedBareImports,
+  assertCanvasRuntimeParseable,
   MODULE_ALIAS_MAP,
 };

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -4334,6 +4334,106 @@ function sanitizeFailureResult(result) {
   return sanitized;
 }
 
+function getUpdateFormConfigRetryDelays() {
+  const rawDelays = process.env.OPENYIDA_UPDATE_FORM_CONFIG_RETRY_DELAYS_MS;
+  if (rawDelays === undefined) {
+    return [500, 1000];
+  }
+  return String(rawDelays)
+    .split(',')
+    .map(function (part) { return Number(part.trim()); })
+    .filter(function (delay) { return Number.isFinite(delay) && delay >= 0; });
+}
+
+function waitForUpdateFormConfigRetry(delayMs) {
+  if (!delayMs) {
+    return Promise.resolve();
+  }
+  return new Promise(function (resolve) {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function getUpdateFormConfigErrorText(result) {
+  if (!result || typeof result !== 'object') {
+    return '';
+  }
+  return [
+    result.errorMsg,
+    result.message,
+    result.error,
+    result.errorCode,
+    result.code,
+  ]
+    .filter(function (part) { return part !== undefined && part !== null; })
+    .map(function (part) { return String(part); })
+    .join(' ');
+}
+
+function getUpdateFormConfigWarningMessage(result) {
+  if (!result || typeof result !== 'object') {
+    return t('common.request_failed');
+  }
+  return result.errorMsg || result.message || result.error || result.errorCode || result.code || t('common.unknown_error');
+}
+
+function isRetryablePostSaveUpdateConfigResult(result) {
+  if (!result || result.success || result.__needLogin || result.__csrfExpired) {
+    return false;
+  }
+  const status = Number(result.__httpStatus || result.status || result.statusCode);
+  if (status === 400 || status === 401 || status === 403 || status >= 500) {
+    return false;
+  }
+  const text = getUpdateFormConfigErrorText(result);
+  const lowerText = text.toLowerCase();
+  const normalizedText = lowerText.replace(/[\s_-]/g, '');
+  if (/csrf|auth|login|permission|forbidden|unauthori[sz]ed|invalid|param|权限|登录|认证|授权|参数/.test(lowerText)) {
+    return false;
+  }
+  if (text.indexOf('表单') !== -1 && text.indexOf('不存在') !== -1) {
+    return true;
+  }
+  if (text.indexOf('表单') !== -1 && text.indexOf('未找到') !== -1) {
+    return true;
+  }
+  if (
+    normalizedText.indexOf('formnotfound') !== -1 ||
+    normalizedText.indexOf('formnotexist') !== -1 ||
+    normalizedText.indexOf('formdoesnotexist') !== -1
+  ) {
+    return true;
+  }
+  return lowerText.indexOf('not found') !== -1 && /form|formuuid|form uuid/.test(lowerText);
+}
+
+async function sendPostSaveUpdateConfigRequest(authRef, appType, formUuid, version) {
+  const retryDelays = getUpdateFormConfigRetryDelays();
+  let attemptIndex = 0;
+  while (true) {
+    let configResult;
+    try {
+      configResult = await requestWithAutoLogin(function (auth) {
+        return sendUpdateConfigRequest(auth.baseUrl, appType, formUuid, version || 1, 0, auth);
+      }, authRef);
+    } catch (err) {
+      return {
+        success: false,
+        errorMsg: err && err.message ? err.message : String(err || 'request failed'),
+        errorCode: err && err.code ? err.code : 'CREATE_FORM_UPDATE_CONFIG_FAILED',
+      };
+    }
+    if (configResult && configResult.success) {
+      return configResult;
+    }
+    if (attemptIndex >= retryDelays.length || !isRetryablePostSaveUpdateConfigResult(configResult)) {
+      return configResult;
+    }
+    await waitForUpdateFormConfigRetry(retryDelays[attemptIndex]);
+    attemptIndex += 1;
+  }
+}
+
 function buildCreateFormPostCreateFailurePayload(context) {
   const errorObject = context && context.error;
   const payload = {
@@ -4387,6 +4487,7 @@ function assertNoEmojiInDefinitionFileName(value) {
 // ── 保存 Schema 并更新表单配置（create/update 共用）──
 //
 // 封装了 saveFormSchema + updateFormConfig 两步，以及各自的 302 自动重登录重试。
+// direct create-form 语义：saveFormSchema 成功后，updateFormConfig 只是后置配置通知。
 // 返回 { saveResult, configResult }。
 
 async function saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, version, stepOffset, failureContext) {
@@ -4447,9 +4548,7 @@ async function saveSchemaAndUpdateConfig(authRef, appType, formUuid, schema, ver
   step(configStep, t('create_form.step_update_config', configStep));
   info(t('create_form.sending_config'));
 
-  const configResult = await requestWithAutoLogin(function (auth) {
-    return sendUpdateConfigRequest(auth.baseUrl, appType, formUuid, version || 1, 0, auth);
-  }, authRef);
+  const configResult = await sendPostSaveUpdateConfigRequest(authRef, appType, formUuid, version);
 
   return { saveResult: saveResult, configResult: configResult };
 }
@@ -4571,31 +4670,29 @@ async function mainCreate(parsedArgs, authRef) {
       parsedArgs.browserOpenMode
     )));
   } else {
-    const configErrorMsg = configResult ? configResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
-    result(false, t('create_form.config_failed', configErrorMsg), [
+    const configErrorMsg = getUpdateFormConfigWarningMessage(configResult);
+    result(true, t('create_form.create_success'), [
       ['Form UUID', formUuid],
       ['URL', formUrl],
     ]);
+    warn(t('create_form.config_failed', configErrorMsg));
     hint(t('create_form.schema_ok_config_failed'));
-    const configError = createCreateFormError(configErrorMsg, 'CREATE_FORM_UPDATE_CONFIG_FAILED', {
-      appType,
-      formUuid,
-      result: sanitizeFailureResult(configResult),
-    });
-    console.log(JSON.stringify(Object.assign(
-      buildCreateFormPostCreateFailurePayload({
+    console.log(JSON.stringify(withBrowserHandoff(
+      {
+        success: true,
         appType,
         formTitle,
         formUuid,
         fieldCount,
-        stage: 'updateFormConfig',
-        error: configError,
-      }),
-      {
         url: formUrl,
+        stage: 'updateFormConfig',
         schemaSaved: true,
         configWarning: configErrorMsg,
-      }
+        configResult: sanitizeFailureResult(configResult),
+      },
+      formUrl,
+      { stage: 'create_form_success', title: formTitle },
+      parsedArgs.browserOpenMode
     )));
   }
 }
@@ -5517,15 +5614,27 @@ async function mainUpdate(parsedArgs, authRef) {
       parsedArgs.browserOpenMode
     )));
   } else {
-    const configErrorMsg = configResult ? configResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
-    result(false, t('create_form.config_failed', configErrorMsg), [
+    const configErrorMsg = getUpdateFormConfigWarningMessage(configResult);
+    result(true, t('create_form.update_success'), [
       ['Form UUID', formUuid],
       ['URL', formUrl],
       ['Changes', String(appliedChanges.length)],
     ]);
+    warn(t('create_form.config_failed', configErrorMsg));
     hint(t('create_form.schema_ok_config_failed'));
     console.log(JSON.stringify(withBrowserHandoff(
-      { success: true, formUuid, appType, changesApplied: appliedChanges.length, changes: appliedChanges, url: formUrl, configWarning: configErrorMsg },
+      {
+        success: true,
+        formUuid,
+        appType,
+        changesApplied: appliedChanges.length,
+        changes: appliedChanges,
+        url: formUrl,
+        stage: 'updateFormConfig',
+        schemaSaved: true,
+        configWarning: configErrorMsg,
+        configResult: sanitizeFailureResult(configResult),
+      },
       formUrl,
       { stage: 'update_form_success', title: formUuid },
       parsedArgs.browserOpenMode

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -4409,8 +4409,7 @@ function isRetryablePostSaveUpdateConfigResult(result) {
 
 async function sendPostSaveUpdateConfigRequest(authRef, appType, formUuid, version) {
   const retryDelays = getUpdateFormConfigRetryDelays();
-  let attemptIndex = 0;
-  while (true) {
+  for (let attemptIndex = 0; attemptIndex <= retryDelays.length; attemptIndex += 1) {
     let configResult;
     try {
       configResult = await requestWithAutoLogin(function (auth) {
@@ -4430,8 +4429,12 @@ async function sendPostSaveUpdateConfigRequest(authRef, appType, formUuid, versi
       return configResult;
     }
     await waitForUpdateFormConfigRetry(retryDelays[attemptIndex]);
-    attemptIndex += 1;
   }
+  return {
+    success: false,
+    errorMsg: t('common.request_failed'),
+    errorCode: 'CREATE_FORM_UPDATE_CONFIG_FAILED',
+  };
 }
 
 function buildCreateFormPostCreateFailurePayload(context) {

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -38,6 +38,9 @@ function hasEnvTokenCredential(env = process.env) {
 const BUILDER_CORE_COMMAND_IDS = Object.freeze([
   'agent-capabilities',
   'commands',
+  'login',
+  'logout',
+  'auth',
   'app-list',
   'list-forms',
   'get-schema',

--- a/tests/canvas-compile.test.js
+++ b/tests/canvas-compile.test.js
@@ -24,6 +24,12 @@ function assembleRuntime(runtimeCode, stubWindow) {
   return factory(stubWindow, stubWindow);
 }
 
+function expectCanvasEntry(runtimeCode) {
+  expect(runtimeCode).toMatch(
+    /\b(?:function|class)\s+YidaComp\b|\b(?:var|let|const)\s+YidaComp\b|YidaComp\s*=/
+  );
+}
+
 function stubReactWindow(extra) {
   const calls = [];
   const React = {
@@ -373,6 +379,117 @@ describe('compileCanvasLocal', () => {
     }
   });
 
+  test('does not redeclare const YidaComp when it is the default export', () => {
+    const src = `
+      const YidaComp = () => <div>ok</div>;
+      export default YidaComp;
+    `;
+
+    const { runtimeCode } = compileCanvasLocal(src);
+
+    expect(runtimeCode).toMatch(/const YidaComp\b/);
+    expect(runtimeCode).not.toMatch(/var YidaComp\s*=\s*YidaComp/);
+
+    const Comp = assembleRuntime(runtimeCode, stubReactWindow());
+    expect(typeof Comp).toBe('function');
+    expect(Comp({}).type).toBe('div');
+  });
+
+  test('does not redeclare let YidaComp when it is the default export', () => {
+    const src = `
+      let YidaComp = function Page() {
+        return <section>let entry</section>;
+      };
+      export default YidaComp;
+    `;
+
+    const { runtimeCode } = compileCanvasLocal(src);
+
+    expect(runtimeCode).toMatch(/let YidaComp\b/);
+    expect(runtimeCode).not.toMatch(/var YidaComp\s*=\s*YidaComp/);
+
+    const Comp = assembleRuntime(runtimeCode, stubReactWindow());
+    expect(typeof Comp).toBe('function');
+    expect(Comp({}).type).toBe('section');
+  });
+
+  test('does not redeclare class YidaComp when it is the default export', () => {
+    const src = `
+      class YidaComp {
+        constructor(props) {
+          this.props = props;
+        }
+        render() {
+          return <main>{this.props.title}</main>;
+        }
+      }
+      export default YidaComp;
+    `;
+
+    const { runtimeCode } = compileCanvasLocal(src);
+
+    expect(runtimeCode).toMatch(/class YidaComp\b/);
+    expect(runtimeCode).not.toMatch(/var YidaComp\s*=\s*YidaComp/);
+
+    const Comp = assembleRuntime(runtimeCode, stubReactWindow());
+    expect(typeof Comp).toBe('function');
+    expect(new Comp({ title: 'class entry' }).render().type).toBe('main');
+  });
+
+  test('keeps function YidaComp default export parseable', () => {
+    const src = `
+      function YidaComp(props) {
+        return <b>{props.name}</b>;
+      }
+      export default YidaComp;
+    `;
+
+    const { runtimeCode } = compileCanvasLocal(src);
+
+    expect(runtimeCode).toMatch(/function YidaComp\b/);
+    expect(runtimeCode).not.toMatch(/var YidaComp\s*=\s*YidaComp/);
+
+    const Comp = assembleRuntime(runtimeCode, stubReactWindow());
+    expect(Comp({ name: 'function entry' }).type).toBe('b');
+  });
+
+  test('still aliases non-YidaComp default exports to YidaComp', () => {
+    const src = `
+      const App = () => <i>app entry</i>;
+      export default App;
+    `;
+
+    const { runtimeCode } = compileCanvasLocal(src);
+
+    expect(runtimeCode).toMatch(/const App\b/);
+    expect(runtimeCode).toMatch(/var YidaComp\s*=\s*App/);
+
+    const Comp = assembleRuntime(runtimeCode, stubReactWindow());
+    expect(Comp({}).type).toBe('i');
+  });
+
+  test('reports Canvas wrapper parse failures before publish/runtime', () => {
+    const src = `
+      const window = {};
+      export default function App() {
+        return <div>ok</div>;
+      }
+    `;
+
+    let error;
+    try {
+      compileCanvasLocal(src, { sourcePath: 'pages/src/bad.canvas.jsx' });
+    } catch (compileError) {
+      error = compileError;
+    }
+
+    expect(error).toBeTruthy();
+    expect(error.code).toBe('OPENYIDA_CANVAS_RUNTIME_PARSE_FAILED');
+    expect(error.message).toContain('运行时装配校验');
+    expect(error.message).toContain('window');
+    expect(error.message).toContain('pages/src/bad.canvas.jsx');
+  });
+
   test('produces new Function-compatible runtimeCode that yields a rendering YidaComp', () => {
     const src = `
       import React, { useState } from 'react';
@@ -397,7 +514,7 @@ describe('compileCanvasLocal', () => {
     expect(runtimeCode).toMatch(/window\.React/);
     expect(runtimeCode).toMatch(/window\.antd/);
     // 收敛出 YidaComp 绑定
-    expect(runtimeCode).toMatch(/YidaComp\s*=/);
+    expectCanvasEntry(runtimeCode);
 
     // importedModules 是 JSON 数组字符串；副作用 CSS 不计入
     const mods = JSON.parse(importedModules);
@@ -484,7 +601,7 @@ describe('compileCanvasLocal', () => {
     expect(runtimeCode).toMatch(/window\.antd/);
     expect(runtimeCode).toMatch(/window\.Recharts/);
     expect(runtimeCode).toMatch(/window\.ahooks/);
-    expect(runtimeCode).toMatch(/YidaComp\s*=/);
+    expectCanvasEntry(runtimeCode);
     expect(runtimeCode).not.toMatch(/\bimport\s/);
     expect(runtimeCode).not.toMatch(/\bexport\s/);
   });
@@ -506,7 +623,7 @@ describe('compileCanvasLocal', () => {
     expect(runtimeCode).toMatch(/window\.YidaNativeComponents/);
     expect(runtimeCode).toMatch(/window\.Deep/);
     expect(runtimeCode).toMatch(/window\.DeepYida/);
-    expect(runtimeCode).toMatch(/YidaComp\s*=/);
+    expectCanvasEntry(runtimeCode);
     expect(runtimeCode).not.toMatch(/\bimport\s/);
     expect(runtimeCode).not.toMatch(/\bexport\s/);
     expect(runtimeCode).not.toMatch(/@ali\/deep/);
@@ -532,7 +649,7 @@ describe('compileCanvasLocal', () => {
     expect(runtimeCode).toMatch(/window\.YidaNativeComponents/);
     expect(runtimeCode).toMatch(/DataManageViews/);
     expect(runtimeCode).toMatch(/formUuid/);
-    expect(runtimeCode).toMatch(/YidaComp\s*=/);
+    expectCanvasEntry(runtimeCode);
     expect(runtimeCode).not.toMatch(/\bimport\s/);
     expect(runtimeCode).not.toMatch(/\bexport\s/);
     expect(runtimeCode).not.toMatch(/@ali\/deep/);
@@ -560,7 +677,7 @@ describe('compileCanvasLocal', () => {
     expect(source).toMatch(/oy-store-band/);
     expect(JSON.parse(importedModules)).toEqual(['antd', 'react']);
     expect(runtimeCode).not.toMatch(/window\.ahooks/);
-    expect(runtimeCode).toMatch(/YidaComp\s*=/);
+    expectCanvasEntry(runtimeCode);
   });
 
   test('business-list raw sample renders marked seed rows', () => {

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -735,6 +735,9 @@ describe('CLI offline smoke', () => {
           canonical_builder_command_ids: expect.arrayContaining([
             'agent-capabilities',
             'commands',
+            'login',
+            'logout',
+            'auth',
             'app-list',
             'list-forms',
             'get-schema',
@@ -881,6 +884,11 @@ describe('CLI offline smoke', () => {
     expect(parsed.commands.permission_mode_counts.allow).toBeGreaterThan(0);
     expect(parsed.commands.permission_mode_counts.ask).toBeGreaterThan(0);
     expect(parsed.commands.allow_command_ids).toContain('agent-capabilities');
+    expect(parsed.commands.allow_command_ids).toEqual(expect.arrayContaining([
+      'login',
+      'logout',
+      'auth',
+    ]));
     expect(parsed.commands.allow_command_ids).toContain('create-app');
     expect(parsed.commands.ask_command_ids).toEqual([
       'connector.delete',
@@ -958,6 +966,9 @@ describe('CLI offline smoke', () => {
     expect(parsed.builder_fast_path.command_contract.canonical_builder_commands.map(entry => entry.id)).toEqual(expect.arrayContaining([
       'agent-capabilities',
       'commands',
+      'login',
+      'logout',
+      'auth',
       'app-list',
       'list-forms',
       'get-schema',

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -760,6 +760,7 @@ describe('create-form module API', () => {
 
 describe('create-form create recovery guardrails', () => {
   afterEach(() => {
+    delete process.env.OPENYIDA_UPDATE_FORM_CONFIG_RETRY_DELAYS_MS;
     jest.restoreAllMocks();
     jest.dontMock('../lib/core/utils');
     jest.dontMock('../lib/core/chalk');
@@ -878,12 +879,65 @@ describe('create-form create recovery guardrails', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('post-create updateFormConfig failure reports success false with recovery advice', async () => {
+  test('post-create updateFormConfig retries transient form not found and then succeeds', async () => {
+    process.env.OPENYIDA_UPDATE_FORM_CONFIG_RETRY_DELAYS_MS = '0,0';
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-config-retry-'));
+    const fieldsPath = path.join(tmpDir, 'fields.json');
+    fs.writeFileSync(fieldsPath, JSON.stringify([
+      { type: 'TextField', label: '姓名' },
+    ]));
+
+    let updateConfigAttempts = 0;
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
+      httpPost: jest.fn((baseUrl, requestPath) => {
+        if (requestPath.includes('saveFormSchemaInfo')) {
+          return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_RETRY' } });
+        }
+        if (requestPath.includes('updateFormConfig')) {
+          updateConfigAttempts += 1;
+          if (updateConfigAttempts === 1) {
+            return Promise.resolve({ success: false, errorMsg: '表单不存在' });
+          }
+          return Promise.resolve({ success: true });
+        }
+        return Promise.resolve({ success: true });
+      }),
+    });
+
+    await expect(isolatedCreateForm.run([
+      'create',
+      'APP_TEST',
+      '配置重试表单',
+      fieldsPath,
+    ])).resolves.toBeUndefined();
+
+    const payload = consoleSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line) => typeof line === 'string' && line.startsWith('{'))
+      .map((line) => JSON.parse(line))
+      .find((item) => item && item.formUuid === 'FORM_CONFIG_RETRY');
+
+    expect(payload).toMatchObject({
+      success: true,
+      appType: 'APP_TEST',
+      formTitle: '配置重试表单',
+      formUuid: 'FORM_CONFIG_RETRY',
+      fieldCount: 1,
+    });
+    expect(payload).not.toHaveProperty('configWarning');
+    expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(2);
+
+    consoleSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('post-create updateFormConfig retry exhaustion reports post-save warning', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-config-failed-'));
     const fieldsPath = path.join(tmpDir, 'fields.json');
     fs.writeFileSync(fieldsPath, JSON.stringify([
       { type: 'TextField', label: '姓名' },
     ]));
+    process.env.OPENYIDA_UPDATE_FORM_CONFIG_RETRY_DELAYS_MS = '0,0';
 
     const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
       httpPost: jest.fn((baseUrl, requestPath) => {
@@ -891,7 +945,7 @@ describe('create-form create recovery guardrails', () => {
           return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_FAILED' } });
         }
         if (requestPath.includes('updateFormConfig')) {
-          return Promise.resolve({ success: false, errorMsg: 'config failed', content: { shouldNotLeak: true } });
+          return Promise.resolve({ success: false, errorMsg: '表单不存在', content: { shouldNotLeak: true } });
         }
         return Promise.resolve({ success: true });
       }),
@@ -911,22 +965,124 @@ describe('create-form create recovery guardrails', () => {
       .find((payload) => payload && payload.formUuid === 'FORM_CONFIG_FAILED');
 
     expect(recoveryPayload).toMatchObject({
-      success: false,
+      success: true,
       appType: 'APP_TEST',
       formTitle: '配置失败表单',
       formUuid: 'FORM_CONFIG_FAILED',
       stage: 'updateFormConfig',
-      error: 'config failed',
-      errorCode: 'CREATE_FORM_UPDATE_CONFIG_FAILED',
       schemaSaved: true,
-      configWarning: 'config failed',
+      configWarning: '表单不存在',
+      configResult: {
+        success: false,
+        errorMsg: '表单不存在',
+      },
     });
-    expect(recoveryPayload.retryAdvice).toContain('list-forms APP_TEST');
+    expect(recoveryPayload.retryAdvice).toBeUndefined();
     expect(JSON.stringify(recoveryPayload)).not.toContain('shouldNotLeak');
-    expect(mockUtils.httpPost).toHaveBeenCalledTimes(3);
+    expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(3);
 
     consoleSpy.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('post-create updateFormConfig does not retry non-retryable permission errors', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-config-permission-'));
+    const fieldsPath = path.join(tmpDir, 'fields.json');
+    fs.writeFileSync(fieldsPath, JSON.stringify([
+      { type: 'TextField', label: '姓名' },
+    ]));
+
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
+      httpPost: jest.fn((baseUrl, requestPath) => {
+        if (requestPath.includes('saveFormSchemaInfo')) {
+          return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_PERMISSION' } });
+        }
+        if (requestPath.includes('updateFormConfig')) {
+          return Promise.resolve({ success: false, errorMsg: '权限不足', errorCode: 'PERMISSION_DENIED' });
+        }
+        return Promise.resolve({ success: true });
+      }),
+    });
+
+    await expect(isolatedCreateForm.run([
+      'create',
+      'APP_TEST',
+      '配置权限表单',
+      fieldsPath,
+    ])).resolves.toBeUndefined();
+
+    const warningPayload = consoleSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line) => typeof line === 'string' && line.startsWith('{'))
+      .map((line) => JSON.parse(line))
+      .find((payload) => payload && payload.formUuid === 'FORM_CONFIG_PERMISSION');
+
+    expect(warningPayload).toMatchObject({
+      success: true,
+      appType: 'APP_TEST',
+      formTitle: '配置权限表单',
+      formUuid: 'FORM_CONFIG_PERMISSION',
+      stage: 'updateFormConfig',
+      schemaSaved: true,
+      configWarning: '权限不足',
+      configResult: {
+        success: false,
+        errorMsg: '权限不足',
+        errorCode: 'PERMISSION_DENIED',
+      },
+    });
+    expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(1);
+
+    consoleSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('update mode keeps success true when post-save updateFormConfig fails', async () => {
+    const initial = formCompiler.compileFormDefinition({
+      formTitle: 'Update Warning',
+      fields: [{ key: 'name', type: 'TextField', label: '姓名' }],
+    }, {
+      appType: 'APP_TEST',
+      formUuid: 'FORM_UPDATE_WARNING',
+    }).schema;
+    initial.gmtModified = 100;
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedLegacyForm(initial);
+    mockUtils.httpPost.mockImplementation((baseUrl, requestPath) => {
+      if (requestPath.includes('updateFormConfig')) {
+        return Promise.resolve({ success: false, errorMsg: '权限不足', errorCode: 'PERMISSION_DENIED' });
+      }
+      return Promise.resolve({ success: true });
+    });
+
+    await expect(isolatedCreateForm.run([
+      'update',
+      'APP_TEST',
+      'FORM_UPDATE_WARNING',
+      JSON.stringify([{ action: 'add', field: { type: 'TextField', label: '备注' } }]),
+    ])).resolves.toBeUndefined();
+
+    const warningPayload = consoleSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line) => typeof line === 'string' && line.startsWith('{'))
+      .map((line) => JSON.parse(line))
+      .find((payload) => payload && payload.formUuid === 'FORM_UPDATE_WARNING');
+
+    expect(warningPayload).toMatchObject({
+      success: true,
+      appType: 'APP_TEST',
+      formUuid: 'FORM_UPDATE_WARNING',
+      stage: 'updateFormConfig',
+      schemaSaved: true,
+      configWarning: '权限不足',
+      configResult: {
+        success: false,
+        errorMsg: '权限不足',
+        errorCode: 'PERMISSION_DENIED',
+      },
+    });
+    expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(1);
+
+    consoleSpy.mockRestore();
   });
 });
 

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -66,6 +66,11 @@ describe('OpenYida skill contracts', () => {
     expect(form.negative_signals).toEqual(expect.arrayContaining(['新增记录']));
     expect(form.command_ids).toEqual(expect.arrayContaining(['create-form.create']));
 
+    const login = byName.get('yida-login');
+    const logout = byName.get('yida-logout');
+    expect(login.command_ids).toEqual(expect.arrayContaining(['agent-capabilities', 'login', 'auth']));
+    expect(logout.command_ids).toEqual(expect.arrayContaining(['logout', 'auth']));
+
     const data = byName.get('yida-data-management');
     expect(data.positive_signals).toEqual(expect.arrayContaining(['新增记录']));
     expect(data.negative_signals).toEqual(expect.arrayContaining(['修改表单结构']));

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -724,6 +724,11 @@
       ],
       "aliases": [
         "登录态"
+      ],
+      "command_ids": [
+        "agent-capabilities",
+        "login",
+        "auth"
       ]
     },
     {
@@ -739,6 +744,10 @@
       ],
       "aliases": [
         "登出"
+      ],
+      "command_ids": [
+        "logout",
+        "auth"
       ]
     },
     {

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -24,6 +24,7 @@ Code Canvas 是宜搭的代码画布自定义页面链路：以 `YidaCodeCanvas`
 - Canvas 源码写成 `.canvas.jsx` / `.canvas.tsx`，`openyida publish` 会自动走 Canvas 链路。
 - 页面源码路径按 Bash cwd 选择：从仓库根执行命令时用 `project/pages/src/...`；如果 cwd 已是 `<workspace>/project`，用 `pages/src/...`，不要写成 `project/pages/src/...`。
 - `runtimeCode` 在宿主页真实 `window` 中执行，入口必须返回 `YidaComp` / `YidaComp.default` / 组件函数。
+- 推荐入口写法是 `function YidaComp(props) { ... }`，或 `const App = ...; export default App;`。CLI 已兼容 `const/let/class YidaComp; export default YidaComp`，但生成新代码时优先避开同名默认导出，减少不同 Canvas 运行态装配器下的重复声明风险。
 - Canvas 组件没有普通页面实例上下文；数据读写通过 fetch、开放 API、连接器代理或显式 props 数据桥完成。
 - 第三方依赖走白名单；React、antd、ahooks、d3、recharts、Radix、framer-motion 等可按规则 import。
 - 宜搭运行态组件通过“原生组件桥 + fallback + 值归一化”接入；不改 `vc-deep-yida` 时，以宿主已存在的 `window.Deep` / `window.DeepYida` 探测为主，`window.YidaNativeComponents` 仅作为兼容入口。需要嵌入门户数据管理视图时探测 `DataManageViews`，并显式传入目标表单 `form.value/formUuid`。


### PR DESCRIPTION
## Summary
- add login/logout/auth to agent-facing builder command listings and skill command hints
- avoid duplicate YidaComp declarations during Code Canvas compile
- add Canvas runtime wrapper parse validation before publish/runtime

## Verification
- node --check lib/app/canvas-compile.js
- git diff --check HEAD~2..HEAD
- npx jest tests/canvas-compile.test.js tests/cli-smoke.test.js tests/skill-contracts.test.js --runInBand
- npm run check:commands
- npm run build:skills && npm run check:skills

No real Yida remote write operations were run.