### PR TITLE
feat(auth): 添加企业业务上下文缓存支持以优化token刷新

### DIFF
--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -17,6 +17,7 @@ const {
   loadTokenSession,
   maskToken,
   normalizeTokenSession,
+  saveBusinessContext,
   saveTokenSession,
 } = require('./token-store');
 
@@ -380,6 +381,7 @@ async function tokenRefresh(options = {}) {
   });
   requireOkResponse(response);
   const data = getTokenPayload(response);
+  const responseBusinessBaseUrl = data.base_url || data.baseUrl;
   const businessBaseUrl = session.base_url || authBaseUrlValue;
   const normalized = normalizeTokenResponse({
     ...data,
@@ -396,6 +398,17 @@ async function tokenRefresh(options = {}) {
       can_auto_use: false,
       message: normalized.message || 'auth service did not return access_token',
     };
+  }
+  if (responseBusinessBaseUrl && normalized.corp_id) {
+    try {
+      saveBusinessContext({
+        corp_id: normalized.corp_id,
+        base_url: responseBusinessBaseUrl,
+      }, options);
+    } catch {
+      // The refresh result remains usable in this process even when the
+      // cross-process business context cache cannot be written.
+    }
   }
   const env = options.env || process.env;
   if (isHostInjectedTokenMode(env) && session.auth_source === 'env') {

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 
 const TOKEN_FILE_PREFIX = 'auth-token';
+const BUSINESS_CONTEXT_FILE_PREFIX = 'auth-token-business-context';
+const BUSINESS_CONTEXT_VERSION = 1;
 
 function sanitizeEnvName(envName) {
   return String(envName || 'public').replace(/[^a-zA-Z0-9._-]/g, '_');
@@ -36,14 +38,91 @@ function getTokenFilePath(options = {}) {
   return path.join(root, '.cache', `${TOKEN_FILE_PREFIX}-${envName}.json`);
 }
 
+function getBusinessContextFilePath(options = {}) {
+  const root = resolveProjectRoot(options);
+  const envName = resolveEnvName(options);
+  return path.join(
+    root,
+    '.cache',
+    'openyida',
+    `${BUSINESS_CONTEXT_FILE_PREFIX}-${envName}.json`
+  );
+}
+
 function normalizeBaseUrl(value) {
   if (!value) {
     return undefined;
   }
   try {
-    return new URL(String(value)).origin.replace(/\/+$/, '');
+    const parsed = new URL(String(value));
+    if (
+      !['http:', 'https:'].includes(parsed.protocol) ||
+      parsed.username ||
+      parsed.password
+    ) {
+      return undefined;
+    }
+    return parsed.origin.replace(/\/+$/, '');
   } catch {
     return undefined;
+  }
+}
+
+function normalizeBusinessContext(value = {}) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const corpId = String(value.corp_id || value.corpId || '').trim();
+  const baseUrl = normalizeBaseUrl(value.base_url || value.baseUrl);
+  if (!corpId || !baseUrl) {
+    return null;
+  }
+  return {
+    version: BUSINESS_CONTEXT_VERSION,
+    corp_id: corpId,
+    base_url: baseUrl,
+    updated_at: value.updated_at || value.updatedAt || new Date().toISOString(),
+  };
+}
+
+function saveBusinessContext(value, options = {}) {
+  const normalized = normalizeBusinessContext(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const contextFile = getBusinessContextFilePath(options);
+  const tempFile = `${contextFile}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  fs.mkdirSync(path.dirname(contextFile), { recursive: true });
+  try {
+    fs.writeFileSync(tempFile, JSON.stringify(normalized, null, 2), { mode: 0o600 });
+    fs.renameSync(tempFile, contextFile);
+    try {
+      fs.chmodSync(contextFile, 0o600);
+    } catch {
+      // chmod is best-effort on non-POSIX filesystems.
+    }
+  } finally {
+    try {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    } catch {
+      // Cleanup is best-effort.
+    }
+  }
+  return normalized;
+}
+
+function loadBusinessContext(options = {}) {
+  const contextFile = getBusinessContextFilePath(options);
+  if (!fs.existsSync(contextFile)) {
+    return null;
+  }
+  try {
+    return normalizeBusinessContext(JSON.parse(fs.readFileSync(contextFile, 'utf8')));
+  } catch {
+    return null;
   }
 }
 
@@ -160,7 +239,17 @@ function loadTokenSession(options = {}) {
   const env = options.env || process.env;
   const envSession = loadEnvTokenSession(env);
   if (isHostInjectedTokenMode(env)) {
-    return envSession;
+    if (!envSession || !envSession.corp_id) {
+      return envSession;
+    }
+    const businessContext = loadBusinessContext(options);
+    if (!businessContext || businessContext.corp_id !== envSession.corp_id) {
+      return envSession;
+    }
+    return normalizeTokenSession({
+      ...envSession,
+      base_url: businessContext.base_url,
+    });
   }
 
   const localSession = loadLocalTokenSession(options);
@@ -221,8 +310,11 @@ function maskToken(token) {
 
 module.exports = {
   getTokenFilePath,
+  getBusinessContextFilePath,
   loadTokenSession,
   saveTokenSession,
+  loadBusinessContext,
+  saveBusinessContext,
   clearTokenSession,
   normalizeTokenSession,
   loadEnvTokenSession,

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -612,8 +612,8 @@ function isHttpAuthStatus(statusCode) {
  * 从 cookieData 中解析 base_url，支持多环境配置优先级。
  *
  * 优先级（高 → 低）：
- *   1. OPENYIDA_ENDPOINT 环境变量
- *   2. cookieData.base_url（登录后实际跳转域名）
+ *   1. cookieData.base_url（鉴权服务返回的企业业务域名）
+ *   2. OPENYIDA_ENDPOINT 环境变量（鉴权端点兼业务兜底）
  *   3. 当前激活的私有化环境配置
  *   4. 当前激活的环境配置（公有云默认）
  *   5. defaultBaseUrl 参数 / 公有云兜底
@@ -623,8 +623,15 @@ function isHttpAuthStatus(statusCode) {
  * @returns {string}
  */
 function resolveBaseUrl(cookieData, defaultBaseUrl) {
-  const { resolveEndpoint } = require('./env-manager');
-  const resolved = resolveEndpoint(cookieData, undefined);
+  const { normalizeBaseUrl, resolveEndpoint } = require('./env-manager');
+  const businessBaseUrl = normalizeBaseUrl(
+    cookieData && cookieData.base_url,
+    null
+  );
+  if (businessBaseUrl) {
+    return businessBaseUrl;
+  }
+  const resolved = resolveEndpoint(null, undefined);
   if (defaultBaseUrl && resolved === 'https://www.aliwork.com' && (!cookieData || !cookieData.base_url)) {
     return defaultBaseUrl.replace(/\/+$/, '');
   }

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -6,7 +6,12 @@ const os = require('os');
 const path = require('path');
 
 const { getAccessToken, tokenRefresh, tokenStatus } = require('../lib/auth/token-auth');
-const { getTokenFilePath, saveTokenSession } = require('../lib/auth/token-store');
+const {
+  getBusinessContextFilePath,
+  getTokenFilePath,
+  loadTokenSession,
+  saveTokenSession,
+} = require('../lib/auth/token-store');
 
 function listen(server) {
   return new Promise((resolve) => {
@@ -244,7 +249,7 @@ describe('token-auth', () => {
     }
   });
 
-  test('host-injected token refresh updates only the provided env object', async () => {
+  test('host-injected token refresh caches only the returned business base_url', async () => {
     let refreshBody;
     const server = http.createServer((req, res) => {
       const chunks = [];
@@ -259,6 +264,8 @@ describe('token-auth', () => {
             accessToken: 'new-env-access-token',
             refreshToken: 'new-env-refresh-token',
             expiresIn: 1800,
+            base_url: 'https://customer.example.com/path',
+            corp_id: 'corp-env',
           },
         }));
       });
@@ -268,6 +275,7 @@ describe('token-auth', () => {
       YIDA_AUTH_ENABLED: 'true',
       OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
       OPENYIDA_ENDPOINT: `http://127.0.0.1:${port}`,
+      OPENYIDA_TOKEN_CORP_ID: 'corp-env',
     };
 
     try {
@@ -286,6 +294,24 @@ describe('token-auth', () => {
       expect(env.OPENYIDA_ACCESS_TOKEN).toBe('new-env-access-token');
       expect(env.OPENYIDA_REFRESH_TOKEN).toBe('new-env-refresh-token');
       expect(fs.existsSync(getTokenFilePath({ projectRoot: tmpDir }))).toBe(false);
+      const contextFile = getBusinessContextFilePath({ projectRoot: tmpDir });
+      const context = JSON.parse(fs.readFileSync(contextFile, 'utf8'));
+      expect(context).toMatchObject({
+        version: 1,
+        corp_id: 'corp-env',
+        base_url: 'https://customer.example.com',
+      });
+      expect(context).not.toHaveProperty('access_token');
+      expect(context).not.toHaveProperty('refresh_token');
+      expect(loadTokenSession({
+        projectRoot: tmpDir,
+        env: {
+          YIDA_AUTH_ENABLED: 'true',
+          OPENYIDA_REFRESH_TOKEN: 'next-process-refresh-token',
+          OPENYIDA_ENDPOINT: `http://127.0.0.1:${port}`,
+          OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+        },
+      }).base_url).toBe('https://customer.example.com');
     } finally {
       await closeServer(server);
     }

--- a/tests/token-store.test.js
+++ b/tests/token-store.test.js
@@ -6,10 +6,13 @@ const path = require('path');
 
 const {
   clearTokenSession,
+  getBusinessContextFilePath,
   getTokenFilePath,
   isAccessTokenUsable,
+  loadBusinessContext,
   loadTokenSession,
   maskToken,
+  saveBusinessContext,
   saveTokenSession,
 } = require('../lib/auth/token-store');
 
@@ -123,6 +126,70 @@ describe('token-store', () => {
     expect(loaded.access_token).toBe('env-access-token');
     expect(loaded.refresh_token).toBe('env-refresh-token');
     expect(loaded.auth_source).toBe('env');
+  });
+
+  test('host-injected token mode uses cached business base_url for the same corp', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_ENDPOINT: 'https://www.aliwork.com',
+        OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+      },
+    };
+    saveBusinessContext({
+      corp_id: 'corp-env',
+      base_url: 'https://customer.example.com/path',
+    }, options);
+
+    const loaded = loadTokenSession(options);
+    const contextFile = getBusinessContextFilePath(options);
+    const raw = JSON.parse(fs.readFileSync(contextFile, 'utf8'));
+
+    expect(loaded.base_url).toBe('https://customer.example.com');
+    expect(loadBusinessContext(options)).toMatchObject({
+      version: 1,
+      corp_id: 'corp-env',
+      base_url: 'https://customer.example.com',
+    });
+    expect(raw).not.toHaveProperty('access_token');
+    expect(raw).not.toHaveProperty('refresh_token');
+  });
+
+  test('host-injected token mode ignores cached business base_url for another corp', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      env: {
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_ACCESS_TOKEN: 'env-access-token',
+        OPENYIDA_ENDPOINT: 'https://www.aliwork.com',
+        OPENYIDA_TOKEN_CORP_ID: 'corp-current',
+      },
+    };
+    saveBusinessContext({
+      corp_id: 'corp-previous',
+      base_url: 'https://previous-customer.example.com',
+    }, options);
+
+    expect(loadTokenSession(options).base_url).toBe('https://www.aliwork.com');
+  });
+
+  test('business context rejects non-http URLs and embedded credentials', () => {
+    const options = { projectRoot, envName: 'public' };
+
+    expect(saveBusinessContext({
+      corp_id: 'corp-env',
+      base_url: 'javascript:alert(1)',
+    }, options)).toBeNull();
+    expect(saveBusinessContext({
+      corp_id: 'corp-env',
+      base_url: 'https://user:password@customer.example.com',
+    }, options)).toBeNull();
+    expect(fs.existsSync(getBusinessContextFilePath(options))).toBe(false);
   });
 
   test('host-injected token mode returns null when the host provides no token', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -98,6 +98,23 @@ describe('resolveBaseUrl', () => {
       }
     }
   });
+
+  test('鉴权服务返回的业务 base_url 优先于 OPENYIDA_ENDPOINT', () => {
+    const originalEndpoint = process.env.OPENYIDA_ENDPOINT;
+    process.env.OPENYIDA_ENDPOINT = 'https://www.aliwork.com';
+
+    try {
+      expect(resolveBaseUrl({
+        base_url: 'https://customer.example.com/path',
+      })).toBe('https://customer.example.com');
+    } finally {
+      if (originalEndpoint === undefined) {
+        delete process.env.OPENYIDA_ENDPOINT;
+      } else {
+        process.env.OPENYIDA_ENDPOINT = originalEndpoint;
+      }
+    }
+  });
 });
 
 // ── isLoginExpired ────────────────────────────────────────────────────
@@ -338,47 +355,58 @@ describe('requestWithAutoLogin', () => {
 
   test('登录失效且 refresh 成功时刷新 token 并重试原请求', async () => {
     jest.resetModules();
-    const tokenRefresh = jest.fn().mockResolvedValue({
-      access_token: 'new-access-token',
-      refresh_token: 'refresh-token',
-      base_url: 'https://www.aliwork.com',
-      corp_id: 'ding-corp',
-      user_id: 'user-1',
-    });
-    const isRefreshAuthRequired = jest.fn(() => false);
-    jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh, isRefreshAuthRequired }));
-    const utils = require('../lib/core/utils');
-    const requestFn = jest.fn()
-      .mockResolvedValueOnce({ __needLogin: true })
-      .mockResolvedValueOnce({ success: true, content: { ok: true } });
-    const authRef = {
-      baseUrl: 'https://www.aliwork.com',
-      authData: {
+    const originalEndpoint = process.env.OPENYIDA_ENDPOINT;
+    process.env.OPENYIDA_ENDPOINT = 'https://www.aliwork.com';
+    try {
+      const tokenRefresh = jest.fn().mockResolvedValue({
+        access_token: 'new-access-token',
+        refresh_token: 'refresh-token',
+        base_url: 'https://customer.example.com',
+        corp_id: 'ding-corp',
+        user_id: 'user-1',
+      });
+      const isRefreshAuthRequired = jest.fn(() => false);
+      jest.doMock('../lib/auth/token-auth', () => ({ tokenRefresh, isRefreshAuthRequired }));
+      const utils = require('../lib/core/utils');
+      const requestFn = jest.fn()
+        .mockResolvedValueOnce({ __needLogin: true })
+        .mockResolvedValueOnce({ success: true, content: { ok: true } });
+      const authRef = {
+        baseUrl: 'https://www.aliwork.com',
+        authData: {
+          auth_mode: 'token',
+          auth_source: 'token',
+          base_url: 'https://www.aliwork.com',
+          client_id: 'suite9xvlxxerybljwheo',
+        },
+        authMode: 'token',
+        authSource: 'token',
+      };
+
+      const result = await utils.requestWithAutoLogin(requestFn, authRef);
+
+      expect(tokenRefresh).toHaveBeenCalledWith(expect.objectContaining({
+        baseUrl: 'https://www.aliwork.com',
+        clientId: 'suite9xvlxxerybljwheo',
+      }));
+      expect(requestFn).toHaveBeenCalledTimes(2);
+      expect(authRef.authData).toMatchObject({
         auth_mode: 'token',
-        auth_source: 'token',
-        base_url: 'https://www.aliwork.com',
-        client_id: 'suite9xvlxxerybljwheo',
-      },
-      authMode: 'token',
-      authSource: 'token',
-    };
-
-    const result = await utils.requestWithAutoLogin(requestFn, authRef);
-
-    expect(tokenRefresh).toHaveBeenCalledWith(expect.objectContaining({
-      baseUrl: 'https://www.aliwork.com',
-      clientId: 'suite9xvlxxerybljwheo',
-    }));
-    expect(requestFn).toHaveBeenCalledTimes(2);
-    expect(authRef.authData).toMatchObject({
-      auth_mode: 'token',
-      base_url: 'https://www.aliwork.com',
-      corp_id: 'ding-corp',
-      user_id: 'user-1',
-    });
-    expect(result).toEqual({ success: true, content: { ok: true } });
-    jest.dontMock('../lib/auth/token-auth');
-    jest.resetModules();
+        base_url: 'https://customer.example.com',
+        corp_id: 'ding-corp',
+        user_id: 'user-1',
+      });
+      expect(authRef.baseUrl).toBe('https://customer.example.com');
+      expect(result).toEqual({ success: true, content: { ok: true } });
+    } finally {
+      if (originalEndpoint === undefined) {
+        delete process.env.OPENYIDA_ENDPOINT;
+      } else {
+        process.env.OPENYIDA_ENDPOINT = originalEndpoint;
+      }
+      jest.dontMock('../lib/auth/token-auth');
+      jest.resetModules();
+    }
   });
 });
 


### PR DESCRIPTION
- 新增业务上下文缓存文件，存储corp_id与base_url信息
- 增加saveBusinessContext与loadBusinessContext接口实现业务上下文的存取
- token-auth模块刷新token时保存业务上下文，支持跨进程复用
- 优化token-store模块，结合业务上下文返回base_url信息
- 修改resolveBaseUrl优先使用鉴权服务返回的业务base_url
- 测试中新增业务上下文相关用例，覆盖缓存读写及边界情况
- token-refresh测试调整验证业务上下文缓存行为及环境变量映射
- 保障非http协议及含认证信息URL不会被缓存为业务上下文
- 保证业务上下文缓存文件权限严格限制为600避免泄露 to #84106791

## 改动概述

<!-- 请说明本 PR 解决什么问题、采用什么方案，以及对用户或 Agent 工作流的影响。 -->

## 改动类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级
- [ ] 🌐 国际化（i18n）
- [ ] 🎨 UI / 终端输出优化
- [ ] 📦 发布 / 打包流程调整

## 关联 Issue / 需求

<!-- 如有关联 Issue，请填写：Closes #123；如来自内部需求或讨论，请补充背景链接。 -->

## 主要变更

<!-- 建议按模块列出关键文件和行为变化，便于 reviewer 快速理解。 -->

- `...`：
- `...`：

## 兼容性与风险

- [ ] 无破坏性变更
- [ ] 涉及 CLI 参数或输出格式变更，已说明兼容策略
- [ ] 涉及登录态、Cookie、组织上下文或私有化环境，已确认无敏感信息泄露
- [ ] 涉及宜搭真实数据写入，已说明影响范围和回滚方式

## 测试与验证

<!-- 请勾选已完成项，并在必要时粘贴关键命令输出。 -->

- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run check:syntax`
- [ ] `npm run check:skills`（如涉及 `yida-skills/`）
- [ ] `npm run build:skills`（如涉及 Wukong 技能包）
- [ ] `npm run check:package`（如涉及发布包内容）
- [ ] 已在真实宜搭环境验证相关功能（如适用）
- [ ] 私有化部署场景已验证或确认不受影响（如适用）

## 文档与 Agent 技能

- [ ] 新增或调整 CLI 命令时，已更新 `README.md` 命令一览表
- [ ] 新增用户可见文案时，已同步 `lib/core/locales/` 下所有语言包
- [ ] 涉及 Agent 工作流变化时，已更新 `yida-skills/` 相关技能说明
- [ ] 涉及 GitHub Release / npm 发布行为时，已更新 `CHANGELOG.md`

## 截图 / 录屏

<!-- 如有 UI、终端输出、二维码、浏览器 handoff 或页面行为变化，请附截图或录屏。 -->

## Reviewer 关注点

<!-- 可列出希望 reviewer 重点关注的设计取舍、边界条件或风险点。 -->
