### PR TITLE
feat: add process diagnostics for command recovery

### DIFF
--- a/lib/app/page-compiler.js
+++ b/lib/app/page-compiler.js
@@ -17,9 +17,10 @@ const { warnLargePageSource } = require('./page-size-guard');
 /**
  * 编译宜搭自定义页面 JSX/JS 源码。
  * @param {string} sourcePath
+ * @param {{ sourceCode?: string }} [options]
  * @returns {{ sourceCode: string, compiledCode: string, compiledPath: string }}
  */
-function compileSource(sourcePath) {
+function compileSource(sourcePath, options = {}) {
   assertNoEmojiInArtifactName(sourcePath, {
     code: 'OPENYIDA_PAGE_FILENAME_EMOJI_FORBIDDEN',
   });
@@ -29,7 +30,9 @@ function compileSource(sourcePath) {
   const compiledPath = path.join(findProjectRoot(), 'pages', 'dist', compiledFileName);
 
   info(t('publish.reading_source', sourceFileName));
-  const rawSourceCode = fs.readFileSync(sourcePath, 'utf-8');
+  const rawSourceCode = options.sourceCode === undefined
+    ? fs.readFileSync(sourcePath, 'utf-8')
+    : String(options.sourceCode);
   warnLargePageSource(rawSourceCode, sourcePath);
   const runtimeResult = ensureYidaRuntimeContract(rawSourceCode);
   const sourceCode = runtimeResult.code;

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -40,6 +40,7 @@ const { warnLargePageSource } = require('./page-size-guard');
 const { fetchFormPageList } = require('./form-navigation');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 const { assertNoEmojiInValue } = require('../core/no-emoji-guard');
+const { loadPageSource } = require('./services/page-source-loader');
 const {
   buildDefaultPageDataSource,
   buildNativePageSchemaContent,
@@ -141,6 +142,31 @@ function buildMissingSourceHints(sourceFile, cwd = process.cwd()) {
 
   return Array.from(new Set(candidates))
     .filter(candidate => fs.existsSync(path.resolve(cwd, candidate)));
+}
+
+function isPathInside(rootPath, targetPath) {
+  const relative = path.relative(rootPath, targetPath);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function loadPublishSource(sourcePath, options = {}) {
+  const absolutePath = path.resolve(sourcePath);
+  const workspaceRoot = path.resolve(options.workspaceRoot || process.cwd());
+
+  if (isPathInside(workspaceRoot, absolutePath)) {
+    const relativePath = path.relative(workspaceRoot, absolutePath) || path.basename(absolutePath);
+    const loaded = loadPageSource(relativePath, { workspaceRoot });
+    return Object.assign({}, loaded, { absolutePath });
+  }
+
+  return {
+    absolutePath,
+    byteLength: fs.statSync(absolutePath).size,
+    profile: 'absolute/raw-file',
+    relativePath: absolutePath,
+    source: fs.readFileSync(absolutePath, 'utf-8'),
+    sourceHash: null,
+  };
 }
 
 // ── 2. 读取并构建 Schema ────────────────────────────
@@ -679,7 +705,9 @@ async function main(argv) {
   // --canvas 作为显式覆盖（用于扩展名不规范但确为 canvas 源码的场景）。
   const isCanvas = canvasFlag || /\.canvas\.(jsx|tsx)$/i.test(sourcePath);
 
-  const initialSourceCode = fs.readFileSync(sourcePath, 'utf-8');
+  const initialSource = loadPublishSource(sourcePath);
+  sourcePath = initialSource.absolutePath;
+  const initialSourceCode = initialSource.source;
   warnLargePageSource(initialSourceCode, sourcePath);
 
   let sourceCode = initialSourceCode;
@@ -712,12 +740,13 @@ async function main(argv) {
       success(t('build_page.output', sourcePath));
     }
     warnDuplicateSourceMismatches(sourcePath);
+    const currentSource = loadPublishSource(sourcePath);
+    sourcePath = currentSource.absolutePath;
 
     // Step 0: 宜搭编码规范预检（可通过 --skip-lint 跳过）
     if (!skipLint) {
       step(0, t('publish.step_lint'));
-      const lintSource = fs.readFileSync(sourcePath, 'utf-8');
-      const lintPassed = runLintCheck(lintSource, sourcePath, { successMessage: false });
+      const lintPassed = runLintCheck(currentSource.source, sourcePath, { successMessage: false });
       if (!lintPassed) {
         process.exit(1);
       }
@@ -727,7 +756,7 @@ async function main(argv) {
     }
 
     step(1, t('publish.step_compile'));
-    const compiled = compileSource(sourcePath);
+    const compiled = compileSource(sourcePath, { sourceCode: currentSource.source });
     sourceCode = compiled.sourceCode;
     compiledCode = compiled.compiledCode;
   }
@@ -864,6 +893,7 @@ if (require.main === module) {
   module.exports.normalizePublishArgs = normalizePublishArgs;
   module.exports.buildMissingSourceHints = buildMissingSourceHints;
   module.exports.findDuplicateSourceMismatches = findDuplicateSourceMismatches;
+  module.exports.loadPublishSource = loadPublishSource;
   module.exports.sendHealthCheckRequest = sendHealthCheckRequest;
   module.exports.normalizeFormType = normalizeFormType;
   module.exports.findPublishTarget = findPublishTarget;

--- a/lib/core/cli-error.js
+++ b/lib/core/cli-error.js
@@ -26,7 +26,19 @@ function toErrorPayload(error) {
   };
 
   if (isCliError(error) && error.details !== undefined) {
-    payload.details = redactSensitive(error.details);
+    const details = redactSensitive(error.details);
+    if (details && typeof details === 'object' && !Array.isArray(details)) {
+      if (details.stage) {
+        payload.stage = details.stage;
+      }
+      if (Array.isArray(details.completedStages)) {
+        payload.completedStages = details.completedStages.slice();
+      }
+      if (details.nextStep) {
+        payload.nextStep = details.nextStep;
+      }
+    }
+    payload.details = details;
   }
 
   return payload;

--- a/lib/core/redact.js
+++ b/lib/core/redact.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const SENSITIVE_KEY_PATTERN = /(^|[_-])(authorization|auth|cookie|csrf|token|secret|password|passwd|api[_-]?key|access[_-]?key|signature|sign)([_-]|$)/i;
+const SENSITIVE_CAMEL_KEY_PATTERN = /^(?:authorization|auth|cookie|csrf|token|secret|password|passwd|apiKey|accessKey|signature|sign)(?:[A-Z]|$)|(?:Authorization|Auth|Cookie|Csrf|Token|Secret|Password|Passwd|ApiKey|AccessKey|Signature|Sign)$/;
 const EMAIL_PATTERN = /([A-Z0-9._%+-])([A-Z0-9._%+-]*)(@[A-Z0-9.-]+\.[A-Z]{2,})/gi;
 const MAINLAND_PHONE_PATTERN = /(^|[^\d])(1[3-9]\d)(\d{4})(\d{4})(?!\d)/g;
 
@@ -42,7 +43,8 @@ function isPlainObject(value) {
 }
 
 function shouldMaskKey(key) {
-  return SENSITIVE_KEY_PATTERN.test(String(key || ''));
+  const text = String(key || '');
+  return SENSITIVE_KEY_PATTERN.test(text) || SENSITIVE_CAMEL_KEY_PATTERN.test(text);
 }
 
 function redactSensitive(value, options = {}) {

--- a/lib/process/configure-process.js
+++ b/lib/process/configure-process.js
@@ -11,6 +11,7 @@ const { CliError } = require('../core/cli-error');
 const { createAuthRef } = require('../core/yida-client');
 const { t } = require('../core/i18n');
 const { warn } = require('../core/chalk');
+const { createStageTracker, summarizeRemoteResult } = require('./process-diagnostics');
 const {
   buildApproverConfig,
   buildProcessAndViewJson,
@@ -46,7 +47,7 @@ function formatApiError(result) {
   if (!result) {
     return 'empty response';
   }
-  return result.errorMsg || result.message || JSON.stringify(result);
+  return result.errorMsg || result.message || JSON.stringify(summarizeRemoteResult(result));
 }
 
 // ── 主流程 ───────────────────────────────────────────
@@ -57,6 +58,21 @@ async function run(args) {
   const formUuid = parsed.formUuid;
   const processDefinitionFile = parsed.processDefinitionFile;
   const processCodeArg = parsed.processCodeArg;
+  const stageTracker = createStageTracker();
+  let processCode = processCodeArg;
+  let newProcessId = null;
+  let newVersion = null;
+
+  function context(extra) {
+    return Object.assign({
+      appType,
+      formUuid,
+      processCode: processCode || null,
+      processId: newProcessId || null,
+      processVersion: newVersion,
+      processDefinitionFile,
+    }, extra || {});
+  }
 
   warn('🔧 ' + t('configure_process.title'));
   warn('  ' + t('configure_process.app_id') + ': ' + appType);
@@ -72,7 +88,9 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.file_not_found') + ': ' + processDefinitionFile);
     throw new CliError(t('configure_process.file_not_found') + ': ' + processDefinitionFile, {
       code: 'CONFIGURE_PROCESS_FILE_NOT_FOUND',
-      details: { processDefinitionFile },
+      details: stageTracker.failure('read_definition', {
+        context: context(),
+      }),
     });
   }
 
@@ -83,49 +101,65 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.parse_failed') + ': ' + e.message);
     throw new CliError(t('configure_process.parse_failed') + ': ' + e.message, {
       code: 'CONFIGURE_PROCESS_INVALID_JSON',
-      details: { processDefinitionFile },
+      details: stageTracker.failure('read_definition', {
+        context: context(),
+        cause: e,
+      }),
     });
   }
   warn('  ✅ ' + t('configure_process.definition_loaded') + ' (' + (definition.nodes || []).length + ' ' + t('configure_process.nodes') + ')');
+  stageTracker.complete('read_definition');
 
   // 2. 读取登录态
   warn('\n🔑 ' + t('configure_process.loading_auth') + '...');
   const authRef = createAuthRef();
   warn('  ✅ ' + t('configure_process.auth_loaded') + ', baseUrl: ' + authRef.baseUrl);
+  stageTracker.complete('load_auth');
 
   // 3. 获取 processCode
   warn('\n🔍 ' + t('configure_process.getting_process_code') + '...');
-  let processCode = processCodeArg;
 
   if (!processCode) {
-    // 确保表单是流程表单
-    warn('  ' + t('configure_process.switching_form_type') + '...');
-    const switchResult = await switchFormType(authRef, appType, formUuid);
-    if (switchResult.success) {
-      warn('  ✅ ' + t('configure_process.switch_success'));
-    } else {
-      const switchMsg = switchResult.errorMsg || '';
-      if (switchMsg.indexOf('已转换') >= 0 || switchMsg.indexOf('已经是') >= 0) {
-        warn('  ✅ ' + t('configure_process.already_process'));
+    try {
+      // 确保表单是流程表单
+      warn('  ' + t('configure_process.switching_form_type') + '...');
+      const switchResult = await switchFormType(authRef, appType, formUuid);
+      if (switchResult.success) {
+        warn('  ✅ ' + t('configure_process.switch_success'));
+        stageTracker.complete('switch_form_type');
       } else {
-        warn('  ⚠️ ' + t('configure_process.switch_warning') + ': ' + switchMsg);
+        const switchMsg = switchResult.errorMsg || '';
+        if (switchMsg.indexOf('已转换') >= 0 || switchMsg.indexOf('已经是') >= 0) {
+          warn('  ✅ ' + t('configure_process.already_process'));
+          stageTracker.complete('switch_form_type');
+        } else {
+          warn('  ⚠️ ' + t('configure_process.switch_warning') + ': ' + switchMsg);
+        }
       }
-    }
 
-    // 方法 1: 从精确表单流程绑定接口提取
-    warn('  ' + t('configure_process.method1') + '...');
-    processCode = await getProcessCodeFromAppParam(authRef, appType, formUuid);
-    if (processCode) {
-      warn('  ✅ ' + t('configure_process.got_process_code') + ': ' + processCode);
-    }
-
-    // 方法 2: 从 getFormSchema 中提取
-    if (!processCode) {
-      warn('  ' + t('configure_process.method2') + '...');
-      processCode = await getProcessCodeFromSchema(authRef, appType, formUuid);
+      // 方法 1: 从精确表单流程绑定接口提取
+      warn('  ' + t('configure_process.method1') + '...');
+      processCode = await getProcessCodeFromAppParam(authRef, appType, formUuid);
       if (processCode) {
-        warn('  ✅ ' + t('configure_process.got_from_schema') + ': ' + processCode);
+        warn('  ✅ ' + t('configure_process.got_process_code') + ': ' + processCode);
       }
+
+      // 方法 2: 从 getFormSchema 中提取
+      if (!processCode) {
+        warn('  ' + t('configure_process.method2') + '...');
+        processCode = await getProcessCodeFromSchema(authRef, appType, formUuid);
+        if (processCode) {
+          warn('  ✅ ' + t('configure_process.got_from_schema') + ': ' + processCode);
+        }
+      }
+    } catch (lookupError) {
+      throw new CliError(t('configure_process.no_process_code') + ': ' + lookupError.message, {
+        code: 'CONFIGURE_PROCESS_CODE_LOOKUP_FAILED',
+        details: stageTracker.failure('resolve_process_code', {
+          context: context(),
+          cause: lookupError,
+        }),
+      });
     }
   }
 
@@ -134,41 +168,54 @@ async function run(args) {
     warn('  💡 ' + t('configure_process.manual_hint'));
     throw new CliError(t('configure_process.no_process_code'), {
       code: 'CONFIGURE_PROCESS_CODE_NOT_FOUND',
-      details: { appType, formUuid },
+      details: stageTracker.failure('resolve_process_code', {
+        context: context(),
+      }),
     });
   }
   warn('  ✅ processCode: ' + processCode);
+  stageTracker.complete('resolve_process_code');
 
   // 4. 查询流程版本列表
   warn('\n🔍 ' + t('configure_process.querying_versions') + '...');
-  const publishedResult = await queryProcessVersions(authRef, appType, processCode, 'PUBLISHED');
+  let publishedResult;
 
   let latestProcessId = null;
   let latestVersion = 0;
 
-  if (publishedResult.success && publishedResult.content && publishedResult.content.data && publishedResult.content.data.length > 0) {
-    const publishedVersion = publishedResult.content.data[0];
-    latestProcessId = publishedVersion.id;
-    latestVersion = parseInt(publishedVersion.version, 10);
-    warn('  ✅ ' + t('configure_process.found_published') + ': processId=' + latestProcessId + ', version=' + latestVersion);
-  } else {
-    warn('  ℹ️ ' + t('configure_process.no_published') + '...');
-    const allVersionsResult = await queryProcessVersions(authRef, appType, processCode, '');
-    if (allVersionsResult.success && allVersionsResult.content && allVersionsResult.content.data && allVersionsResult.content.data.length > 0) {
-      const latestItem = allVersionsResult.content.data[0];
-      latestProcessId = latestItem.id;
-      latestVersion = parseInt(latestItem.version, 10);
-      warn('  ✅ ' + t('configure_process.found_latest') + ': processId=' + latestProcessId + ', version=' + latestVersion);
+  try {
+    publishedResult = await queryProcessVersions(authRef, appType, processCode, 'PUBLISHED');
+    if (publishedResult.success && publishedResult.content && publishedResult.content.data && publishedResult.content.data.length > 0) {
+      const publishedVersion = publishedResult.content.data[0];
+      latestProcessId = publishedVersion.id;
+      latestVersion = parseInt(publishedVersion.version, 10);
+      warn('  ✅ ' + t('configure_process.found_published') + ': processId=' + latestProcessId + ', version=' + latestVersion);
+    } else {
+      warn('  ℹ️ ' + t('configure_process.no_published') + '...');
+      const allVersionsResult = await queryProcessVersions(authRef, appType, processCode, '');
+      if (allVersionsResult.success && allVersionsResult.content && allVersionsResult.content.data && allVersionsResult.content.data.length > 0) {
+        const latestItem = allVersionsResult.content.data[0];
+        latestProcessId = latestItem.id;
+        latestVersion = parseInt(latestItem.version, 10);
+        warn('  ✅ ' + t('configure_process.found_latest') + ': processId=' + latestProcessId + ', version=' + latestVersion);
+      }
     }
+  } catch (versionError) {
+    throw new CliError(t('configure_process.querying_versions') + ': ' + versionError.message, {
+      code: 'CONFIGURE_PROCESS_QUERY_VERSIONS_FAILED',
+      details: stageTracker.failure('query_process_versions', {
+        context: context(),
+        cause: versionError,
+      }),
+    });
   }
+  stageTracker.complete('query_process_versions');
 
-  const newVersion = latestVersion + 1;
+  newVersion = latestVersion + 1;
 
   // 5. 创建新流程版本草稿
   warn('\n📝 ' + t('configure_process.creating_draft') + '...');
   const draftResult = await newDraftProcess(authRef, appType, processCode, formUuid, latestProcessId, newVersion);
-
-  let newProcessId = null;
 
   if (draftResult.success && draftResult.content && draftResult.content.processId) {
     // content 是对象，包含 processId 字段
@@ -194,7 +241,10 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.draft_failed') + ': ' + errorMsg);
     throw new CliError(t('configure_process.draft_failed') + ': ' + errorMsg, {
       code: 'CONFIGURE_PROCESS_DRAFT_FAILED',
-      details: { appType, formUuid, processCode, result: draftResult },
+      details: stageTracker.failure('create_draft', {
+        context: context(),
+        cause: draftResult,
+      }),
     });
   }
 
@@ -202,24 +252,40 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.no_draft_id'));
     throw new CliError(t('configure_process.no_draft_id'), {
       code: 'CONFIGURE_PROCESS_DRAFT_ID_NOT_FOUND',
-      details: { appType, formUuid, processCode, draftResult },
+      details: stageTracker.failure('create_draft', {
+        context: context(),
+        cause: draftResult,
+      }),
     });
   }
+  stageTracker.complete('create_draft');
 
   // 6. 构建 processJson 和 viewJson
   warn('\n🏗️  ' + t('configure_process.building_json') + '...');
-  const result = buildProcessAndViewJson(
-    definition,
-    processCode,
-    formUuid,
-    authRef.baseUrl,
-    appType,
-    { onWarning: warn }
-  );
+  let result;
+  try {
+    result = buildProcessAndViewJson(
+      definition,
+      processCode,
+      formUuid,
+      authRef.baseUrl,
+      appType,
+      { onWarning: warn }
+    );
+  } catch (buildError) {
+    throw new CliError(t('configure_process.building_json') + ': ' + buildError.message, {
+      code: 'CONFIGURE_PROCESS_BUILD_FAILED',
+      details: stageTracker.failure('build_definition', {
+        context: context(),
+        cause: buildError,
+      }),
+    });
+  }
   const processJsonStr = JSON.stringify(result.processJson);
   const viewJsonStr = JSON.stringify(result.viewJson);
   warn('  ✅ processJson: ' + processJsonStr.length + ' chars');
   warn('  ✅ viewJson: ' + viewJsonStr.length + ' chars');
+  stageTracker.complete('build_definition');
 
   // 7. 保存流程
   warn('\n💾 ' + t('configure_process.saving') + '...');
@@ -235,9 +301,13 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.save_failed') + ': ' + errorMsg);
     throw new CliError(t('configure_process.save_failed') + ': ' + errorMsg, {
       code: 'CONFIGURE_PROCESS_SAVE_FAILED',
-      details: { appType, formUuid, processCode, processId: newProcessId, result: saveResult },
+      details: stageTracker.failure('save_definition', {
+        context: context(),
+        cause: saveResult,
+      }),
     });
   }
+  stageTracker.complete('save_definition');
 
   // 8. 发布流程
   warn('\n🚀 ' + t('configure_process.publishing') + '...');
@@ -252,9 +322,13 @@ async function run(args) {
     warn('  ❌ ' + t('configure_process.publish_failed') + ': ' + errorMsg);
     throw new CliError(t('configure_process.publish_failed') + ': ' + errorMsg, {
       code: 'CONFIGURE_PROCESS_PUBLISH_FAILED',
-      details: { appType, formUuid, processCode, processId: newProcessId, result: publishResult },
+      details: stageTracker.failure('publish_process', {
+        context: context(),
+        cause: publishResult,
+      }),
     });
   }
+  stageTracker.complete('publish_process');
 
   // 9. 输出结果
   const output = {

--- a/lib/process/create-process.js
+++ b/lib/process/create-process.js
@@ -20,6 +20,7 @@ const { createAuthRef, isAuthRefReady } = require('../core/yida-client');
 const { t } = require('../core/i18n');
 const { warn } = require('../core/chalk');
 const { createFormForLegacyProcess } = require('../app/create-form');
+const { createStageTracker, summarizeRemoteResult } = require('./process-diagnostics');
 const {
   getProcessCodeFromAppParam,
   getProcessCodeFromSchema,
@@ -86,6 +87,50 @@ async function run(args) {
   const useExistingForm = !!existingFormUuid;
   const fieldsJsonFile = parsed.fieldsJsonFile ? path.resolve(parsed.fieldsJsonFile) : null;
   const processDefinitionFile = path.resolve(parsed.processDefinitionFile);
+  const stageTracker = createStageTracker();
+  let formUuid;
+  let fieldCount = 0;
+
+  function context(extra) {
+    return Object.assign({
+      appType,
+      formUuid: formUuid || existingFormUuid || null,
+      processDefinitionFile,
+    }, extra || {});
+  }
+
+  function buildRetryCommand() {
+    return 'openyida create-process ' + appType + ' --formUuid ' + formUuid + ' ' + path.basename(processDefinitionFile);
+  }
+
+  function buildConfigureFailureDetails(configError) {
+    const retryCommand = buildRetryCommand();
+    const outerDetails = stageTracker.failure('configure_process', {
+      context: context({ processCode, retryCommand }),
+      cause: configError,
+    });
+    const innerDetails = configError && configError.isCliError && configError.details && configError.details.stage
+      ? configError.details
+      : null;
+    if (!innerDetails) {
+      return outerDetails;
+    }
+    const configureProcess = {
+      stage: innerDetails.stage,
+      completedStages: Array.isArray(innerDetails.completedStages)
+        ? innerDetails.completedStages.slice()
+        : [],
+    };
+    if (innerDetails.nextStep) {
+      configureProcess.nextStep = innerDetails.nextStep;
+    }
+    return Object.assign({}, outerDetails, {
+      stage: innerDetails.stage,
+      nextStep: innerDetails.nextStep || outerDetails.nextStep,
+      createProcessStage: 'configure_process',
+      configureProcess,
+    });
+  }
 
   warn('═'.repeat(60));
   warn('  🔧 ' + t('create_process.title'));
@@ -107,14 +152,18 @@ async function run(args) {
     warn('  ❌ ' + t('create_process.fields_not_found') + ': ' + fieldsJsonFile);
     throw new CliError(t('create_process.fields_not_found') + ': ' + fieldsJsonFile, {
       code: 'CREATE_PROCESS_FIELDS_NOT_FOUND',
-      details: { fieldsJsonFile },
+      details: stageTracker.failure('validate_inputs', {
+        context: context({ fieldsJsonFile }),
+      }),
     });
   }
   if (!fs.existsSync(processDefinitionFile)) {
     warn('  ❌ ' + t('create_process.process_def_not_found') + ': ' + processDefinitionFile);
     throw new CliError(t('create_process.process_def_not_found') + ': ' + processDefinitionFile, {
       code: 'CREATE_PROCESS_DEFINITION_NOT_FOUND',
-      details: { processDefinitionFile },
+      details: stageTracker.failure('validate_inputs', {
+        context: context(),
+      }),
     });
   }
 
@@ -124,18 +173,20 @@ async function run(args) {
   if (!isAuthRefReady(authRef)) {
     throw new CliError('未获取到有效宜搭登录态，请先执行 openyida login', {
       code: 'NEED_LOGIN',
+      details: stageTracker.failure('load_auth', {
+        context: context(),
+      }),
     });
   }
   warn('  ✅ ' + t('create_process.auth_loaded') + ', baseUrl: ' + authRef.baseUrl);
+  stageTracker.complete('load_auth');
 
   // Step 1: 创建或复用表单
-  let formUuid;
-  let fieldCount = 0;
-
   if (useExistingForm) {
     warn('\n📋 Step 1: ' + t('create_process.reusing_form') + '...');
     formUuid = existingFormUuid;
     warn('  ✅ ' + t('create_process.using_form') + ': ' + formUuid);
+    stageTracker.complete('reuse_form');
   } else {
     warn('\n📋 Step 1: ' + t('create_process.creating_form') + '...');
     try {
@@ -146,23 +197,34 @@ async function run(args) {
       });
 
       if (!createFormResult || !createFormResult.success || !createFormResult.formUuid) {
-        warn('  ❌ ' + t('create_process.create_form_failed') + ': ' + JSON.stringify(createFormResult));
+        warn('  ❌ ' + t('create_process.create_form_failed') + ': ' + JSON.stringify(summarizeRemoteResult(createFormResult)));
         throw new CliError(t('create_process.create_form_failed'), {
           code: 'CREATE_PROCESS_CREATE_FORM_FAILED',
-          details: createFormResult,
+          details: stageTracker.failure('create_form', {
+            context: context({ formTitle, fieldsJsonFile }),
+            cause: createFormResult,
+          }),
         });
       }
 
       formUuid = createFormResult.formUuid;
       fieldCount = createFormResult.fieldCount || 0;
       warn('  ✅ ' + t('create_process.form_created') + ': ' + formUuid);
+      stageTracker.complete('create_form');
     } catch (createError) {
       warn('  ❌ ' + t('create_process.create_form_failed') + ': ' + createError.message);
       if (createError.stderr) {
         warn('  ' + createError.stderr.substring(0, 1000));
       }
+      if (createError && createError.isCliError && createError.details && createError.details.stage) {
+        throw createError;
+      }
       throw new CliError(t('create_process.create_form_failed') + ': ' + createError.message, {
         code: 'CREATE_PROCESS_CREATE_FORM_FAILED',
+        details: stageTracker.failure('create_form', {
+          context: context({ formTitle, fieldsJsonFile }),
+          cause: createError,
+        }),
       });
     }
   }
@@ -180,32 +242,49 @@ async function run(args) {
       warn('  ❌ ' + t('create_process.switch_failed') + ': ' + switchMsg);
       throw new CliError(t('create_process.switch_failed') + ': ' + switchMsg, {
         code: 'CREATE_PROCESS_SWITCH_FAILED',
-        details: switchResult,
+        details: stageTracker.failure('switch_form_type', {
+          context: context(),
+          cause: switchResult,
+        }),
       });
     }
   }
+  stageTracker.complete('switch_form_type');
 
   // Step 3: 获取 processCode
   warn('\n🔍 Step 3: ' + t('create_process.getting_process_code') + '...');
   let processCode = null;
 
-  // 方法 1: 从精确表单流程绑定接口提取
-  warn('  ' + t('create_process.method1') + '...');
-  processCode = await getProcessCodeFromAppParam(authRef, appType, formUuid);
-  if (processCode) {
-    warn('  ✅ ' + t('create_process.got_process_code') + ': ' + processCode);
-  }
-
-  // 方法 2: 从 getFormSchema 中提取
-  if (!processCode) {
-    warn('  ' + t('create_process.method2') + '...');
-    processCode = await getProcessCodeFromSchema(authRef, appType, formUuid);
+  try {
+    // 方法 1: 从精确表单流程绑定接口提取
+    warn('  ' + t('create_process.method1') + '...');
+    processCode = await getProcessCodeFromAppParam(authRef, appType, formUuid);
     if (processCode) {
-      warn('  ✅ ' + t('create_process.got_from_schema') + ': ' + processCode);
+      warn('  ✅ ' + t('create_process.got_process_code') + ': ' + processCode);
     }
+
+    // 方法 2: 从 getFormSchema 中提取
+    if (!processCode) {
+      warn('  ' + t('create_process.method2') + '...');
+      processCode = await getProcessCodeFromSchema(authRef, appType, formUuid);
+      if (processCode) {
+        warn('  ✅ ' + t('create_process.got_from_schema') + ': ' + processCode);
+      }
+    }
+  } catch (lookupError) {
+    throw new CliError(t('create_process.no_process_code') + ': ' + lookupError.message, {
+      code: 'CREATE_PROCESS_CODE_LOOKUP_FAILED',
+      details: stageTracker.failure('resolve_process_code', {
+        context: context(),
+        cause: lookupError,
+      }),
+    });
   }
 
   if (!processCode) {
+    const failureDetails = stageTracker.failure('resolve_process_code', {
+      context: context(),
+    });
     warn('  ❌ ' + t('create_process.no_process_code'));
     warn('  💡 ' + t('create_process.manual_hint', formUuid));
     console.log(JSON.stringify({
@@ -215,24 +294,30 @@ async function run(args) {
       appType: appType,
       fieldCount: fieldCount,
       error: t('create_process.no_process_code'),
+      stage: failureDetails.stage,
+      completedStages: failureDetails.completedStages,
+      nextStep: failureDetails.nextStep,
     }));
     throw new CliError(t('create_process.no_process_code'), {
       code: 'CREATE_PROCESS_CODE_NOT_FOUND',
-      details: { appType, formUuid },
+      details: failureDetails,
     });
   }
+  stageTracker.complete('resolve_process_code');
 
   // Step 4: 配置并发布流程
   warn('\n⚙️  Step 4: ' + t('create_process.configuring_process') + '...');
   try {
     const { run: runConfigureProcess } = require('./configure-process');
     await runConfigureProcess([appType, formUuid, processDefinitionFile, processCode]);
+    stageTracker.complete('configure_process');
   } catch (configError) {
+    const failureDetails = buildConfigureFailureDetails(configError);
     warn('  ❌ ' + t('create_process.configure_failed') + ': ' + configError.message);
     // 提示用户可以使用 --formUuid 复用已创建的表单
     warn('');
     warn('  💡 ' + t('create_process.retry_hint'));
-    warn('     openyida create-process ' + appType + ' --formUuid ' + formUuid + ' ' + path.basename(processDefinitionFile));
+    warn('     ' + buildRetryCommand());
     warn('');
     console.log(JSON.stringify({
       success: false,
@@ -241,10 +326,15 @@ async function run(args) {
       appType: appType,
       fieldCount: fieldCount,
       error: t('create_process.configure_failed') + ': ' + configError.message,
+      stage: failureDetails.stage,
+      completedStages: failureDetails.completedStages,
+      nextStep: failureDetails.nextStep,
+      retryCommand: failureDetails.context && failureDetails.context.retryCommand,
+      configureProcess: failureDetails.configureProcess,
     }));
     throw new CliError(t('create_process.configure_failed') + ': ' + configError.message, {
       code: 'CREATE_PROCESS_CONFIGURE_FAILED',
-      details: { appType, formUuid, processCode },
+      details: failureDetails,
     });
   }
 

--- a/lib/process/process-diagnostics.js
+++ b/lib/process/process-diagnostics.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const DEFAULT_TEXT_LIMIT = 240;
+const DEFAULT_KEY_LIMIT = 12;
+
+function truncateText(value, limit = DEFAULT_TEXT_LIMIT) {
+  const text = value === undefined || value === null ? '' : String(value);
+  if (text.length <= limit) {
+    return text;
+  }
+  return text.slice(0, Math.max(0, limit - 3)) + '...';
+}
+
+function isPrimitive(value) {
+  return value === null || ['string', 'number', 'boolean'].includes(typeof value);
+}
+
+function summarizeContent(content) {
+  if (content === undefined) {
+    return undefined;
+  }
+  if (content === null) {
+    return null;
+  }
+  if (typeof content === 'string') {
+    return { type: 'string', sample: truncateText(content) };
+  }
+  if (Array.isArray(content)) {
+    return { type: 'array', length: content.length };
+  }
+  if (typeof content !== 'object') {
+    return content;
+  }
+
+  const summary = { type: 'object' };
+  ['processId', 'processCode', 'formUuid', 'version', 'id', 'status'].forEach((key) => {
+    if (isPrimitive(content[key])) {
+      summary[key] = content[key];
+    }
+  });
+  if (Array.isArray(content.data)) {
+    summary.dataLength = content.data.length;
+  }
+  const keys = Object.keys(content).slice(0, DEFAULT_KEY_LIMIT);
+  if (keys.length > 0) {
+    summary.keys = keys;
+  }
+  return summary;
+}
+
+function summarizeRemoteResult(result) {
+  if (result === undefined) {
+    return undefined;
+  }
+  if (result === null) {
+    return null;
+  }
+  if (result instanceof Error) {
+    const summary = {
+      name: result.name,
+      message: truncateText(result.message),
+    };
+    if (result.code) {
+      summary.code = result.code;
+    }
+    if (result.details && typeof result.details === 'object') {
+      ['stage', 'nextStep'].forEach((key) => {
+        if (isPrimitive(result.details[key])) {
+          summary[key] = result.details[key];
+        }
+      });
+      if (Array.isArray(result.details.completedStages)) {
+        summary.completedStages = result.details.completedStages.slice();
+      }
+    }
+    return summary;
+  }
+  if (isPrimitive(result)) {
+    return truncateText(result);
+  }
+  if (Array.isArray(result)) {
+    return { type: 'array', length: result.length };
+  }
+  if (typeof result !== 'object') {
+    return String(result);
+  }
+
+  const summary = {};
+  [
+    'success',
+    'errorCode',
+    'errorMsg',
+    'message',
+    'code',
+    'status',
+    'statusCode',
+    'throwable',
+    'requestId',
+    '__needLogin',
+    '__csrfExpired',
+    'stage',
+    'nextStep',
+  ].forEach((key) => {
+    if (isPrimitive(result[key])) {
+      summary[key] = typeof result[key] === 'string'
+        ? truncateText(result[key])
+        : result[key];
+    }
+  });
+  if (Array.isArray(result.completedStages)) {
+    summary.completedStages = result.completedStages.slice();
+  }
+  if (result.content !== undefined) {
+    summary.content = summarizeContent(result.content);
+  }
+  const included = new Set(Object.keys(summary).concat(['content']));
+  const keys = Object.keys(result).filter(key => !included.has(key)).slice(0, DEFAULT_KEY_LIMIT);
+  if (keys.length > 0) {
+    summary.keys = keys;
+  }
+  return summary;
+}
+
+function createStageTracker() {
+  const completedStages = [];
+  return {
+    complete(stage) {
+      if (stage && !completedStages.includes(stage)) {
+        completedStages.push(stage);
+      }
+    },
+    getCompletedStages() {
+      return completedStages.slice();
+    },
+    failure(stage, options = {}) {
+      const details = {
+        stage,
+        completedStages: completedStages.slice(),
+        nextStep: options.nextStep || defaultNextStep(stage),
+      };
+      if (options.context && typeof options.context === 'object') {
+        details.context = options.context;
+      }
+      if (options.cause !== undefined) {
+        details.cause = summarizeRemoteResult(options.cause);
+      }
+      return details;
+    },
+  };
+}
+
+function defaultNextStep(stage) {
+  switch (stage) {
+    case 'validate_inputs':
+      return '检查命令参数和本地 JSON 文件路径后重试。';
+    case 'load_auth':
+      return '执行 openyida login 后重试。';
+    case 'create_form':
+      return '检查表单字段 JSON 后重试；如果已创建表单，可改用 --formUuid 复用。';
+    case 'reuse_form':
+      return '确认 formUuid 属于当前应用后重试。';
+    case 'switch_form_type':
+      return '确认当前账号有表单管理权限，或在宜搭控制台检查表单类型。';
+    case 'resolve_process_code':
+      return '确认表单已转为流程表单；必要时先运行 configure-process 并显式传入 processCode。';
+    case 'configure_process':
+      return '修正流程定义后使用 --formUuid 复用已创建表单重试。';
+    case 'read_definition':
+      return '检查流程定义 JSON 文件内容后重试。';
+    case 'query_process_versions':
+      return '确认 processCode 有效，并检查账号流程管理权限。';
+    case 'create_draft':
+      return '确认流程可编辑并检查账号流程管理权限后重试。';
+    case 'build_definition':
+      return '修正流程节点 DSL 后重试。';
+    case 'save_definition':
+      return '检查流程节点配置、字段引用和账号权限后重试。';
+    case 'publish_process':
+      return '确认流程草稿已保存成功，检查发布权限后重试。';
+    default:
+      return '按错误信息修正后重试。';
+  }
+}
+
+module.exports = {
+  createStageTracker,
+  summarizeRemoteResult,
+};

--- a/tests/cli-error.test.js
+++ b/tests/cli-error.test.js
@@ -31,4 +31,31 @@ describe('CliError', () => {
       errorMsg: 'Boom',
     });
   });
+
+  test('promotes actionable stage details for JSON callers', () => {
+    const error = new CliError('Save failed', {
+      code: 'SAVE_FAILED',
+      details: {
+        stage: 'save_definition',
+        completedStages: ['read_definition', 'build_definition'],
+        nextStep: '检查流程节点配置后重试。',
+        authToken: 'private-token',
+      },
+    });
+
+    expect(toErrorPayload(error)).toEqual({
+      success: false,
+      errorCode: 'SAVE_FAILED',
+      errorMsg: 'Save failed',
+      stage: 'save_definition',
+      completedStages: ['read_definition', 'build_definition'],
+      nextStep: '检查流程节点配置后重试。',
+      details: {
+        stage: 'save_definition',
+        completedStages: ['read_definition', 'build_definition'],
+        nextStep: '检查流程节点配置后重试。',
+        authToken: 'priv***oken',
+      },
+    });
+  });
 });

--- a/tests/configure-process.test.js
+++ b/tests/configure-process.test.js
@@ -463,4 +463,94 @@ describe('configure-process command runner', () => {
 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
+
+  test('reports save stage with compact remote response details', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-configure-process-'));
+    const definitionFile = path.join(tempDir, 'process.json');
+    fs.writeFileSync(definitionFile, JSON.stringify({ nodes: [] }));
+
+    const mockAuthRef = {
+      baseUrl: 'https://www.aliwork.com',
+    };
+    const mockGet = jest.fn().mockResolvedValueOnce({
+      success: true,
+      content: { data: [{ id: 100, version: '2' }] },
+    });
+    const mockPostForm = jest.fn()
+      .mockResolvedValueOnce({ success: true, content: { processId: 101 } })
+      .mockResolvedValueOnce({
+        success: false,
+        errorMsg: 'save denied',
+        content: {
+          nested: 'x'.repeat(2000),
+          token: 'private-token-value',
+        },
+      });
+
+    jest.resetModules();
+    jest.doMock('../lib/core/yida-client', () => ({
+      createAuthRef: jest.fn(() => mockAuthRef),
+      createYidaClient: jest.fn(() => ({
+        get: mockGet,
+        postForm: mockPostForm,
+      })),
+    }));
+
+    const freshConfigureProcess = require('../lib/process/configure-process');
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should not be called');
+    });
+
+    let thrown;
+    try {
+      await freshConfigureProcess.run([
+        'APP_TEST',
+        'FORM_TEST',
+        definitionFile,
+        'TPROC_TEST',
+      ]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({
+      isCliError: true,
+      code: 'CONFIGURE_PROCESS_SAVE_FAILED',
+      details: {
+        stage: 'save_definition',
+        completedStages: [
+          'read_definition',
+          'load_auth',
+          'resolve_process_code',
+          'query_process_versions',
+          'create_draft',
+          'build_definition',
+        ],
+        context: {
+          appType: 'APP_TEST',
+          formUuid: 'FORM_TEST',
+          processCode: 'TPROC_TEST',
+          processId: 101,
+          processVersion: 3,
+          processDefinitionFile: definitionFile,
+        },
+        cause: {
+          success: false,
+          errorMsg: 'save denied',
+          content: {
+            type: 'object',
+            keys: ['nested', 'token'],
+          },
+        },
+      },
+    });
+    expect(thrown.details.nextStep).toContain('流程节点配置');
+    expect(JSON.stringify(thrown.details)).not.toContain('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+    expect(mockPostForm).toHaveBeenCalledTimes(2);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
 });

--- a/tests/process-small.test.js
+++ b/tests/process-small.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const querystring = require('querystring');
+const { CliError } = require('../lib/core/cli-error');
 
 jest.mock('child_process', () => ({
   spawnSync: jest.fn(() => ({ status: 0 })),
@@ -151,6 +152,123 @@ describe('small process commands', () => {
     });
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual(result);
+  });
+
+  test('create-process reports switch stage with compact failure details', async () => {
+    const processDefPath = path.join(tmpDir, 'process.json');
+    fs.writeFileSync(processDefPath, JSON.stringify({ nodes: [] }), 'utf8');
+    utils.httpPost.mockResolvedValueOnce({
+      success: false,
+      errorMsg: 'permission denied',
+      content: {
+        nested: 'x'.repeat(2000),
+        token: 'private-token-value',
+      },
+    });
+
+    let thrown;
+    try {
+      await createProcess.run(['APP_XXX', '--formUuid', 'FORM_1', processDefPath]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toMatchObject({
+      isCliError: true,
+      code: 'CREATE_PROCESS_SWITCH_FAILED',
+      details: {
+        stage: 'switch_form_type',
+        completedStages: ['load_auth', 'reuse_form'],
+        context: {
+          appType: 'APP_XXX',
+          formUuid: 'FORM_1',
+          processDefinitionFile: processDefPath,
+        },
+        cause: {
+          success: false,
+          errorMsg: 'permission denied',
+          content: {
+            type: 'object',
+            keys: ['nested', 'token'],
+          },
+        },
+      },
+    });
+    expect(thrown.details.nextStep).toContain('表单管理权限');
+    expect(JSON.stringify(thrown.details)).not.toContain('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+  });
+
+  test('create-process preserves configure-process inner failure stage', async () => {
+    const processDefPath = path.join(tmpDir, 'process.json');
+    fs.writeFileSync(processDefPath, JSON.stringify({ nodes: [] }), 'utf8');
+    utils.httpPost.mockResolvedValueOnce({ success: true });
+    utils.httpGet.mockResolvedValueOnce({
+      success: true,
+      content: {
+        appType: 'APP_XXX',
+        procCode: 'TPROC_1',
+      },
+    });
+    configureProcess.run.mockRejectedValueOnce(new CliError('save denied', {
+      code: 'CONFIGURE_PROCESS_SAVE_FAILED',
+      details: {
+        stage: 'save_definition',
+        completedStages: ['read_definition', 'load_auth', 'build_definition'],
+        nextStep: '检查流程节点配置后重试。',
+      },
+    }));
+
+    let thrown;
+    try {
+      await createProcess.run(['APP_XXX', '--formUuid', 'FORM_1', processDefPath]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const payload = logSpy.mock.calls
+      .map(call => call[0])
+      .filter(line => typeof line === 'string' && line.startsWith('{'))
+      .map(line => JSON.parse(line))
+      .find(item => item && item.success === false);
+
+    expect(payload).toMatchObject({
+      success: false,
+      formUuid: 'FORM_1',
+      appType: 'APP_XXX',
+      error: expect.stringContaining('save denied'),
+      stage: 'save_definition',
+      completedStages: ['load_auth', 'reuse_form', 'switch_form_type', 'resolve_process_code'],
+      nextStep: '检查流程节点配置后重试。',
+      retryCommand: 'openyida create-process APP_XXX --formUuid FORM_1 ' + path.basename(processDefPath),
+      configureProcess: {
+        stage: 'save_definition',
+        completedStages: ['read_definition', 'load_auth', 'build_definition'],
+        nextStep: '检查流程节点配置后重试。',
+      },
+    });
+    expect(payload.stage).not.toBe('configure_process');
+    expect(thrown).toMatchObject({
+      isCliError: true,
+      code: 'CREATE_PROCESS_CONFIGURE_FAILED',
+      details: {
+        stage: 'save_definition',
+        completedStages: ['load_auth', 'reuse_form', 'switch_form_type', 'resolve_process_code'],
+        nextStep: '检查流程节点配置后重试。',
+        createProcessStage: 'configure_process',
+        context: {
+          appType: 'APP_XXX',
+          formUuid: 'FORM_1',
+          processCode: 'TPROC_1',
+          retryCommand: 'openyida create-process APP_XXX --formUuid FORM_1 ' + path.basename(processDefPath),
+        },
+        configureProcess: {
+          stage: 'save_definition',
+          completedStages: ['read_definition', 'load_auth', 'build_definition'],
+          nextStep: '检查流程节点配置后重试。',
+        },
+      },
+    });
+    expect(thrown.details.stage).not.toBe('configure_process');
   });
 
   test('preview-process writes an HTML preview and returns metadata', async () => {

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -19,6 +19,7 @@ const {
   countCustomPageDataSources,
   extractPageDataSource,
   findDuplicateSourceMismatches,
+  loadPublishSource,
   mergePageDataSource,
   sendHealthCheckRequest,
   sendSaveRequestOnce,
@@ -74,6 +75,23 @@ describe('publish prechecks', () => {
     expect(buildMissingSourceHints('pages/src/home.oyd.jsx', workspace)).toEqual([
       'project/pages/src/home.oyd.jsx',
     ]);
+  });
+
+  test('loads workspace page source through the trusted source loader', () => {
+    const sourceDir = path.join(workspace, 'project', 'pages', 'src');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    const sourcePath = path.join(sourceDir, 'home.oyd.jsx');
+    fs.writeFileSync(sourcePath, 'export function renderJsx() { return <div>ok</div>; }\n', 'utf8');
+
+    const loaded = loadPublishSource(sourcePath, { workspaceRoot: workspace });
+
+    expect(loaded).toMatchObject({
+      absolutePath: sourcePath,
+      profile: 'native/default',
+      relativePath: 'project/pages/src/home.oyd.jsx',
+      source: expect.stringContaining('renderJsx'),
+      sourceHash: expect.stringMatching(/^sha256:/),
+    });
   });
 
   test('allows publishing only to display custom pages', async () => {


### PR DESCRIPTION
## Summary
- add compact process stage diagnostics for create-process/configure-process failures
- promote actionable stage fields in JSON error payloads and redact camelCase secrets
- reuse trusted page source loading for workspace publish sources while preserving external absolute path compatibility

## Validation
- npm test -- --runTestsByPath tests/process-small.test.js tests/configure-process.test.js tests/cli-error.test.js tests/publish-precheck.test.js tests/create-form.test.js --runInBand
- git diff --check
- node --check changed JS files
- npm run check:i18n
- npm run check:syntax

## Notes
- Does not restore the retired schema control plane.
- Builder mock E2E and deeper page structural patching remain follow-up work.