### PR TITLE
fix: support sandbox page source identity fallback

### DIFF
--- a/lib/app/services/page-source-loader.js
+++ b/lib/app/services/page-source-loader.js
@@ -53,7 +53,7 @@ function loadPageSource(sourcePath, options = {}) {
     if (!before || typeof before.isFile !== 'function' || !before.isFile()) {
       sourceError('SCHEMA_PAGE_SOURCE_INVALID', 'Page source must be a regular file.');
     }
-    if (!sameFileIdentityOrDefaultWindowsStatMatch(initialPathStat, before, fsImpl)) {
+    if (!sameFileIdentityOrStatFingerprint(initialPathStat, before)) {
       sourceError('SCHEMA_PAGE_SOURCE_READ_FAILED', 'Page source changed while it was being opened.');
     }
     assertPageSourceSize(before.size, maxBytes);
@@ -61,7 +61,7 @@ function loadPageSource(sourcePath, options = {}) {
     const buffer = readBounded(fsImpl, fd, maxBytes);
     const after = fsImpl.fstatSync(fd);
     if (
-      !sameFileIdentityOrDefaultWindowsStatMatch(before, after, fsImpl) ||
+      !sameFileIdentityOrStatFingerprint(before, after) ||
       after.size !== before.size ||
       buffer.length !== after.size
     ) {
@@ -160,7 +160,7 @@ function verifyPathAfterRead(fsImpl, rootRealPath, absolutePath, initialRealPath
   }
   if (
     currentPathStat.isSymbolicLink() ||
-    !sameFileIdentityOrDefaultWindowsStatMatch(currentPathStat, fdStat, fsImpl)
+    !sameFileIdentityOrStatFingerprint(currentPathStat, fdStat)
   ) {
     sourceError('SCHEMA_PAGE_SOURCE_READ_FAILED', 'Page source changed while it was being read.');
   }
@@ -241,12 +241,9 @@ function sameFileIdentity(left, right) {
   );
 }
 
-function sameFileIdentityOrDefaultWindowsStatMatch(left, right, fsImpl) {
+function sameFileIdentityOrStatFingerprint(left, right) {
   if (sameFileIdentity(left, right)) {
     return true;
-  }
-  if (process.platform !== 'win32' || fsImpl !== fs) {
-    return false;
   }
   return sameRegularFileStatFingerprint(left, right);
 }

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -12,6 +12,9 @@ jest.mock('../lib/app/form-navigation', () => ({
 
 const { fetchFormPageList } = require('../lib/app/form-navigation');
 const {
+  loadPageSource,
+} = require('../lib/app/services/page-source-loader');
+const {
   buildMissingSourceHints,
   buildDefaultPageDataSource,
   buildCanvasSchemaContent,
@@ -25,6 +28,41 @@ const {
   sendSaveRequestOnce,
   verifyPublishTarget,
 } = require('../lib/app/publish');
+
+function cloneStat(stat, overrides = {}) {
+  return {
+    dev: overrides.dev === undefined ? stat.dev : overrides.dev,
+    ino: overrides.ino === undefined ? stat.ino : overrides.ino,
+    mode: stat.mode,
+    size: overrides.size === undefined ? stat.size : overrides.size,
+    mtimeMs: overrides.mtimeMs === undefined ? stat.mtimeMs : overrides.mtimeMs,
+    ctimeMs: overrides.ctimeMs === undefined ? stat.ctimeMs : overrides.ctimeMs,
+    birthtimeMs: overrides.birthtimeMs === undefined ? stat.birthtimeMs : overrides.birthtimeMs,
+    isFile: () => stat.isFile(),
+    isSymbolicLink: () => stat.isSymbolicLink(),
+  };
+}
+
+function createSandboxIdentityFs(options = {}) {
+  return {
+    ...fs,
+    lstatSync(targetPath) {
+      const stat = fs.lstatSync(targetPath);
+      return cloneStat(stat, {
+        dev: 1001,
+        ino: 2001,
+      });
+    },
+    fstatSync(fd) {
+      const stat = fs.fstatSync(fd);
+      return cloneStat(stat, {
+        dev: 3001,
+        ino: 4001,
+        mtimeMs: options.driftFingerprint ? stat.mtimeMs + 5000 : stat.mtimeMs,
+      });
+    },
+  };
+}
 
 describe('publish prechecks', () => {
   let workspace;
@@ -92,6 +130,40 @@ describe('publish prechecks', () => {
       source: expect.stringContaining('renderJsx'),
       sourceHash: expect.stringMatching(/^sha256:/),
     });
+  });
+
+  test('loads page source when sandbox path and fd identities differ but stat fingerprint matches', () => {
+    const relativePath = path.join('project', 'pages', 'src', 'home.oyd.jsx');
+    const sourcePath = path.join(workspace, relativePath);
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, 'export function renderJsx() { return <div>ok</div>; }\n', 'utf8');
+
+    const loaded = loadPageSource(relativePath, {
+      fsImpl: createSandboxIdentityFs(),
+      workspaceRoot: workspace,
+    });
+
+    expect(loaded).toMatchObject({
+      profile: 'native/default',
+      relativePath: 'project/pages/src/home.oyd.jsx',
+      source: expect.stringContaining('renderJsx'),
+      sourceHash: expect.stringMatching(/^sha256:/),
+    });
+  });
+
+  test('rejects page source when sandbox identity and stat fingerprint both differ', () => {
+    const relativePath = path.join('project', 'pages', 'src', 'home.oyd.jsx');
+    const sourcePath = path.join(workspace, relativePath);
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, 'export function renderJsx() { return <div>ok</div>; }\n', 'utf8');
+
+    expect(() => loadPageSource(relativePath, {
+      fsImpl: createSandboxIdentityFs({ driftFingerprint: true }),
+      workspaceRoot: workspace,
+    })).toThrow(expect.objectContaining({
+      code: 'SCHEMA_PAGE_SOURCE_READ_FAILED',
+      message: 'Page source changed while it was being opened.',
+    }));
   });
 
   test('allows publishing only to display custom pages', async () => {


### PR DESCRIPTION
## Summary\n- allow page source loader to fall back to existing stat fingerprint checks when dev/ino identity differs\n- cover sandbox-style lstat/fstat identity mismatch with focused publish precheck tests\n- keep strict identity first and still reject mismatched fingerprints\n\n## Validation\n- node --check lib/app/services/page-source-loader.js\n- npm test -- --runTestsByPath tests/publish-precheck.test.js\n- npm run lint (0 errors, existing warnings only)\n\n## Notes\n- No env escape hatch, content hash, publish flow, login, agent/runtime, or skill changes.\n