### PR TITLE
fix: remove automatic app rename guidance from skills

### DIFF
--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -81,19 +81,17 @@ OpenYida builder 默认使用 `create-app / create-form / create-page / generate
   "app": {
     "appType": "APP_xxx",
     "source": "explicit_prompt|url|agent_bound|workspace_cache",
-    "precreated": true,
-    "placeholderName": "新应用",
     "allowCreate": false,
-    "allowRename": true
+    "precreated": true
   },
   "page": { "formUuid": "FORM_xxx", "source": "explicit_prompt|url|agent_bound|workspace_cache", "allowCreate": false },
   "form": { "formUuid": "FORM_xxx", "source": "explicit_prompt|url|workspace_cache", "allowCreate": false }
 }
 ```
 
-`precreated` 表示该 app 由 agent / 宿主提前创建并绑定到本轮任务；`placeholderName` 是宿主创建时的占位名；`allowRename` 控制 OpenYida 是否可在语义名稳定后修正应用名称。这些字段都是可选提示：缺失时按普通已有资源处理，不作为运行前置。
+`precreated` 表示该 app 由 agent / 宿主提前创建并绑定到本轮任务。这些字段都是可选提示：缺失时按普通已有资源处理，不作为运行前置。
 
-**预创建占位 app 改名**：当 `app.source === "agent_bound"`，且满足 `precreated === true` 或当前名称 / `placeholderName` 命中“新应用 / 未命名 / 占位 / APP_xxx”等占位样式，并且 `allowRename !== false`、用户没有明确要求保留原应用名称、已从本轮需求确定稳定语义应用名时，`yida-app` 应复用该 `appType` 并调用 `openyida update-app APP_xxx --name "语义应用名"`。该动作只修正 agent 预创建占位应用名称；不要按标题发现/adopt 其他应用，不要 cleanup orphan，不要对非占位已有业务应用自动改名，不要让 `yida-create-app` 参与改名。
+**绑定 app 只复用不改名**：OpenYida 技能侧不自动修改应用名称；即使目标 app 来自 agent / 宿主预创建资源，也只复用该 `appType` 继续创建、更新或发布资源。应用名修正如有需要由宿主或 yida-agent 侧负责；技能不得因为占位名、页面标题或业务语义推导触发应用名修改。
 
 ### create-or-update 判定
 
@@ -206,7 +204,6 @@ OpenYida builder 默认使用 `create-app / create-form / create-page / generate
 
 | 意图 | 直接执行 |
 |------|------|
-| 修改当前 app 信息 / 预创建占位 app 改名 | `openyida update-app` |
 | 聚合表 / 虚拟视图 | `openyida aggregate-table` |
 | 流程表单 AI 审批提示 | `openyida ai-form-setting` |
 | 文生文 / 识图通用 AI 能力 | `openyida ai` |

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -23,7 +23,7 @@
       "name": "yida-app",
       "path": "skills/yida-app/SKILL.md",
       "display_name": "宜搭完整应用开发",
-      "description": "完整搭建或补齐普通 OpenYida 应用的流程编排技能。默认 fast_build 先解析并复用 app/page/form/process 上下文，只创建缺失且允许创建的应用、表单或页面；预创建占位应用在语义名称稳定后通过 update-app 重命名；不默认使用未绑定 dataSourceMap，导航、示例数据和深度设计按需后置。",
+      "description": "完整搭建或补齐普通 OpenYida 应用的流程编排技能。默认 fast_build 先解析并复用 app/page/form/process 上下文，只创建缺失且允许创建的应用、表单或页面；绑定或预创建应用只复用不改名；不默认使用未绑定 dataSourceMap，导航、示例数据和深度设计按需后置。",
       "done_when": "若本轮 Write/Edit 页面源码，必须真实执行成功 openyida publish <source> <appType> <displayPageFormUuid> 并返回访问 URL；没有 publish 证据只能声明源码已修改，尚未发布。",
       "category": "yida-skills/app",
       "tags": [
@@ -298,7 +298,7 @@
       "name": "yida-create-app",
       "path": "skills/yida-create-app/SKILL.md",
       "display_name": "创建宜搭应用",
-      "description": "仅在没有目标 app 且允许创建时创建宜搭应用并返回 appType。已绑定或预创建 app 不调用 create-app，应交给 yida-app 复用，并在需要时通过 update-app 重命名。",
+      "description": "仅在没有目标 app 且允许创建时创建宜搭应用并返回 appType。已绑定或预创建 app 不调用 create-app，也不由 OpenYida 技能侧自动改名，应交给 yida-app 复用。",
       "category": "yida-skills/app",
       "tags": [
         "创建应用",

--- a/yida-skills/skills/yida-app/SKILL.md
+++ b/yida-skills/skills/yida-app/SKILL.md
@@ -24,7 +24,7 @@ description: 宜搭完整应用开发编排技能。对普通 OpenYida 应用做
 - 来源优先级：本轮显式 `appType` / `formUuid` / URL → agent bound context → workspace config/cache → 会话历史 → 明确从零创建。
 - agent bound context 只是默认候选，不是锁定目标；如果用户本轮明确提到另一个 app/page/form/process，必须重新解析本轮目标，能唯一解析则切换，不能唯一解析才问用户。
 - 已有 app 时在该 app 内补齐资源，不加载 `yida-create-app`；只有无 app 且用户意图允许创建时才创建。
-- 若已有 app 来自 agent 预创建占位资源，先记录 `app.source`、`precreated`、`placeholderName`、`allowRename` 和用户是否要求保留原名，后续在语义应用名稳定后决定是否改名。
+- 若已有 app 来自 agent 预创建资源，OpenYida 技能侧只复用该 `appType`，不自动修改应用名称；应用名修正由宿主或 yida-agent 侧负责。
 - 已有主页面 URL / `formUuid` / bound page 时，直接写源码并发布到该页面，不加载 `yida-create-page`；已有页面 update path 也必须在本轮源码 Write/Edit 后执行真实 `openyida publish <source> <appType> <displayPageFormUuid>`，只有缺少 display page 且本次意图允许新增页面时才创建。
 - 已有表单 context 时，字段诉求走 `yida-create-form-page` 的 update/patch/rule/bind-datasource；只有已有 app 但缺少业务数据表时才 create form。
 - 已有流程表单或 `processCode` 时，流程诉求走 `yida-process-rule`；只有没有表单/流程且用户要新建审批表单时才进入 `yida-create-process`。
@@ -41,17 +41,9 @@ description: 宜搭完整应用开发编排技能。对普通 OpenYida 应用做
 
 该阶段只决定常规 resource context；不要在本技能里绕过资源前置解析或自动新建同类资源。
 
-## 阶段 1：resolve app name / rename placeholder app
+## 阶段 1：resolve app
 
-完成最小需求分析后，先确定稳定语义应用名（如“访客管理系统”“CRM 客户管理系统”），再进入表单或页面创建/更新。若目标 app 来自 agent 预创建占位资源，且满足以下条件，必须复用当前 `appType` 并执行改名：
-
-- `app.source === "agent_bound"`；
-- `precreated === true`，或当前名称 / `placeholderName` 命中“新应用 / 未命名 / 占位 / APP_xxx”等占位样式；
-- `allowRename !== false`；
-- 用户没有明确要求“保持应用名称不变”或指定保留原名称；
-- 已从本轮需求得到稳定语义应用名，且该名称不是占位名。
-
-命令固定使用现有 CLI：`openyida update-app <appType> --name "<语义应用名>"`。该调用应在创建表单/页面前执行；若受信息收集顺序限制，最晚在发布前执行。不要在本技能中重写平台 API，不要加载 `yida-create-app` 处理改名，不要按标题发现/adopt 其他应用，不要 cleanup orphan，不要对已命名的真实业务应用自动改名。
+完成最小需求分析后，只确认本轮目标 `appType` 是复用已有资源还是允许创建新应用。若目标 app 来自 agent / 宿主预创建资源，也只复用当前 `appType`；不得因为占位名称、页面标题或业务语义推导触发应用名修改。应用名修正如有需要由宿主或 yida-agent 侧负责。
 
 ## 模式
 
@@ -176,7 +168,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 | 阶段 | 子技能 | 必做动作 | doneWhen |
 |------|--------|----------|----------|
 | 0. 解析资源上下文 | 无 | 合并本轮显式资源、agent bound context、workspace config/cache、会话历史；本轮显式目标覆盖 bound context；判定 app/page/form/process 的 `source` 和 `allowCreate` | 明确复用、创建缺口或需要 ask_human |
-| 1. resolve app + app name | `yida-create-app` 仅在 app 缺失且允许创建时加载；`openyida update-app` 仅用于预创建占位 app 改名 | 已有 `appType`/应用 URL/bound app 时直接复用；若 bound/precreated app 仍是占位名，在语义名稳定后执行 `openyida update-app <appType> --name "<语义应用名>"`；否则创建应用并提取真实 `appType` | 拿到真实目标 `appType`，预创建占位 app 已改成语义名或明确跳过，且不会重复创建同类 app |
+| 1. resolve app | `yida-create-app` 仅在 app 缺失且允许创建时加载；不自动修改应用名称 | 已有 `appType`/应用 URL/bound app 时直接复用；否则创建应用并提取真实 `appType` | 拿到真实目标 `appType`，且不会重复创建同类 app |
 | 2. 记录最小需求 | 无 | 写 `prd/<项目名>.md`：只记录 MVP 假设、核心表单/页面、完成标准；写/更新 `.cache/<项目名>-schema.json` 本地 ID 映射；不要写长 PRD | 业务语义和 ID 存储位置明确 |
 | 3. resolve forms | `yida-create-form-page` | 已有目标表单时 update/patch/rule/bind-datasource；简单字段属性更新直接用 compact changes 让 CLI 内部按 label 读 schema/定位字段并输出 resolved evidence；缺少支撑 MVP 的核心表单且允许创建时才 create；字段配置文件写入 `.cache/openyida/<项目名>/`；页面/数据/流程/公式确需多字段映射时，对每个目标表单最多一次性获取完整 `--field-map-json` 并合并写回 `.cache/<项目名>-schema.json` | 拿到或确认表单 `formUuid`，并在需要时拿到真实 `fieldId` |
 | 4. resolve main page | `yida-create-page` 仅在主页面缺失且允许创建时加载 | 已有页面 URL / `formUuid` / bound page 时直接作为主页面；否则创建一个用户主入口 display page | 拿到真实目标页面 `formUuid`，且不会重复创建页面 |
@@ -284,7 +276,7 @@ UI 不是独立替代主流程的步骤，而是按模式插入到页面生成�
 - corpId 与目标组织不一致时先停下，让用户选择重新登录或在当前组织继续。
 - 已有目标 app/page/form/process 时默认复用；只有用户明确要求新建另一个同类资源，或目标缺失且本次意图允许创建时，才加载 create 类子技能。
 - 当前轮用户明确指定的资源优先于 agent bound context；例如会话绑定页面 A、用户要求修复页面 B 时，先解析 B，不能唯一解析才问用户，不要默认改 A。
-- agent 预创建占位 app 只作为默认资源；满足改名条件时只调用 `openyida update-app` 修正语义名，不创建新 app，不改非占位真实业务 app。
+- agent 预创建 app 只作为默认资源；OpenYida 技能侧只复用该 `appType`，不创建新 app，也不自动修改应用名称。
 - 多个同优先级资源候选或当前轮显式资源冲突时，先问用户确认目标，不要通过重复创建规避冲突。
 - 输入 JSON/YAML/CSV/JSX 等业务文件必须用结构化文件写入工具创建，不用 shell heredoc、`cat`、`echo`、`printf`、`tee` 或重定向。
 - 用户要求删除应用时，必须展示应用名称、应用 ID、影响范围，并等待用户明确回复“确认删除”后才可执行。

--- a/yida-skills/skills/yida-create-app/SKILL.md
+++ b/yida-skills/skills/yida-create-app/SKILL.md
@@ -17,7 +17,7 @@ description: 创建宜搭应用并返回 appType；仅当没有目标 app 且用
 
 若已解析到 `appType`、应用 URL、bound app 或 workspace 中可确认的 app，必须复用该 app 并继续后续表单/页面/发布步骤，不得调用 `openyida create-app`。若用户说“新建另一个应用”，先确认目标组织和新应用名，再执行本技能。
 
-若该 app 是 yida-agent / 宿主预创建的占位 app（例如名称为“新应用”“未命名”“占位”或 `APP_xxx` 样式，且 context 标记 `source=agent_bound`、`precreated=true`、`allowRename !== false`），也仍然视为“已有目标 app”：不得调用 `openyida create-app`。占位名修正由 `yida-app` 在最小需求分析得到稳定语义应用名后调用 `openyida update-app <appType> --name "<语义应用名>"` 完成；本技能只负责在确实没有目标 app 且允许创建时新建应用。
+若该 app 是 yida-agent / 宿主预创建的 app（context 标记 `source=agent_bound` 或 `precreated=true`），也仍然视为“已有目标 app”：不得调用 `openyida create-app`，也不得在本技能中修改应用名称。本技能只负责在确实没有目标 app 且允许创建时新建应用。
 
 ## 严格禁止 (NEVER DO)
 - 不要编造 appType，必须从命令返回的 JSON 中提取


### PR DESCRIPTION
## Summary
- remove skill-side guidance that renamed precreated/bound apps automatically
- make yida-app and yida-create-app reuse bound/precreated appType without modifying app names
- keep app rename responsibility on host/yida-agent side and leave CLI manual update-app capability untouched

## Validation
- npm run check:skills
- npm run build:skills
- git diff --check

## Notes
- This only changes skill guidance. It does not remove the manual openyida update-app --name command.
