### PR TITLE
chore: 发布 2026.7.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.26-beta.3",
+  "version": "2026.7.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.26-beta.3",
+      "version": "2026.7.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.26-beta.3",
+  "version": "2026.7.27",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",


### PR DESCRIPTION
## 变更
- 将包版本从 `2026.7.26-beta.3` 升级到 `2026.7.27`
- 同步 `package-lock.json` 版本字段

## 校验
- `npm run build:skills`
- `npm run check:skills`
- `npm run check:package`
- `npm run check:package-size`
- `npm run check:release`
- `git diff --check`

## 合并后发版
- 基于最新 `main` 创建并推送 `v2026.7.27` tag
- 创建 GitHub Release，确保 GitHub 上可见
- 发布 `openyida@2026.7.27` 到 npm，确保 npm 上可见