### PR TITLE
chore: 升级版本号到 2026.7.29-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.7.29-beta.1",
+  "version": "2026.7.29-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.7.29-beta.1",
+      "version": "2026.7.29-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.7.29-beta.1",
+  "version": "2026.7.29-beta.2",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",


### PR DESCRIPTION
## 变更
- 将 openyida 版本从 2026.7.29-beta.1 升级到 2026.7.29-beta.2

## 验证
- 已确认 package.json、package-lock.json 顶层版本与 packages[''].version 均为 2026.7.29-beta.2