### PR TITLE
feat: add command contract validation and builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 
 | Command | Description |
 |---------|-------------|
-| `openyida create-form create <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a form page |
+| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a form page |
 | `openyida create-form validate-fields <fieldsJsonOrFile> [--json]` | Validate form field JSON locally |
 | `openyida create-form update <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Update a form page |
 | `openyida create-form patch <appType> <formUuid> <patchJsonOrFile> [--open\|--no-open]` | Update a form page |

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -284,7 +284,7 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 
 | 命令 | 说明 |
 |------|------|
-| `openyida create-form create <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建表单页面 |
+| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建表单页面 |
 | `openyida create-form validate-fields <fieldsJsonOrFile> [--json]` | 本地校验表单字段 JSON |
 | `openyida create-form update <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 更新表单页面 |
 | `openyida create-form patch <appType> <formUuid> <patchJsonOrFile> [--open\|--no-open]` | 更新表单页面 |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -549,6 +549,11 @@ async function main() {
 
   switch (command) {
     case 'commands': {
+      if (args[0] === 'validate' || args[0] === 'build') {
+        const { runCommandsContract } = require('../lib/core/command-contract');
+        await runCommandsContract(args);
+        break;
+      }
       const manifest = buildCommandManifest({ t, version: currentVersion });
       console.log(JSON.stringify(manifest, null, 2));
       break;

--- a/lib/app/create-form/args.js
+++ b/lib/app/create-form/args.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { detectDeprecatedCreateFormInvocation } = require('../../core/command-contract');
+
 function parseMaybeJsonValue(value) {
   if (typeof value !== 'string') {
     return value;
@@ -267,6 +269,22 @@ function createParseArgs(dependencies) {
         newOptions: args.slice(4).filter(function (arg) { return !arg.startsWith('--'); }),
         ...options
       };
+    }
+
+    const deprecatedInvocation = detectDeprecatedCreateFormInvocation(args, {
+      assumeCreateFormRoot: true,
+    });
+    if (deprecatedInvocation) {
+      if (!options.json) {
+        hint(deprecatedInvocation.suggestion.display);
+        hint(deprecatedInvocation.suggestion.note);
+      }
+      throwCreateFormError(deprecatedInvocation.message, deprecatedInvocation.code, {
+        command_id: deprecatedInvocation.command_id,
+        canonical: deprecatedInvocation.canonical,
+        suggestion: deprecatedInvocation.suggestion,
+        pattern: deprecatedInvocation.pattern,
+      });
     }
 
     if (args.length >= 3 && mode !== 'create' && mode !== 'update' && mode !== 'patch' && mode !== 'rule' && mode !== 'rules' && mode !== 'validation' && mode !== 'validate' && mode !== 'validations' && mode !== 'bind-datasource' && mode !== 'datasource' && mode !== 'data-source') {

--- a/lib/core/command-contract.js
+++ b/lib/core/command-contract.js
@@ -1,0 +1,558 @@
+'use strict';
+
+const { buildCommandManifest } = require('./command-manifest');
+
+const CREATE_FORM_CREATE_COMMAND_ID = 'create-form.create';
+
+let manifestCache = null;
+
+function cloneJson(value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function getContractManifest() {
+  if (!manifestCache) {
+    manifestCache = buildCommandManifest({
+      t: key => key,
+      version: null,
+    });
+  }
+  return manifestCache;
+}
+
+function getCommandEntry(commandId) {
+  return getContractManifest().commands.find(entry => entry.id === commandId) || null;
+}
+
+function getCreateFormCreateEntry() {
+  const entry = getCommandEntry(CREATE_FORM_CREATE_COMMAND_ID);
+  if (!entry) {
+    throw new Error('Missing command manifest entry: ' + CREATE_FORM_CREATE_COMMAND_ID);
+  }
+  return entry;
+}
+
+function normalizeInvocationArgv(argv = [], options = {}) {
+  const normalized = (Array.isArray(argv) ? argv : [])
+    .map(value => String(value === undefined || value === null ? '' : value).trim())
+    .filter(Boolean);
+
+  while (normalized[0] === '--') {
+    normalized.shift();
+  }
+  if (normalized[0] === 'openyida' || normalized[0] === 'yida') {
+    normalized.shift();
+  }
+  if (options.assumeCreateFormRoot && normalized[0] !== 'create-form') {
+    normalized.unshift('create-form');
+  }
+  return normalized;
+}
+
+function optionNameToken(name) {
+  return String(name || '').replace(/_/g, '-');
+}
+
+function optionKey(name) {
+  return optionNameToken(name).replace(/^--/, '').replace(/-/g, '_');
+}
+
+function findOptionValue(tokens, names) {
+  const accepted = new Set((names || []).map(optionNameToken));
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    const eqIndex = token.indexOf('=');
+    if (eqIndex > 0) {
+      const name = token.slice(0, eqIndex);
+      if (accepted.has(name)) {
+        return {
+          found: true,
+          name,
+          value: token.slice(eqIndex + 1),
+        };
+      }
+    }
+    if (accepted.has(token)) {
+      const next = tokens[index + 1];
+      if (next !== undefined && !String(next).startsWith('--')) {
+        return {
+          found: true,
+          name: token,
+          value: next,
+        };
+      }
+      return {
+        found: true,
+        name: token,
+        value: true,
+      };
+    }
+  }
+  return {
+    found: false,
+    name: null,
+    value: undefined,
+  };
+}
+
+function parseOptionArgs(tokens = []) {
+  const options = {};
+  const optionNames = {};
+  const positionals = [];
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (token === '--') {
+      positionals.push(...tokens.slice(index + 1));
+      break;
+    }
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      continue;
+    }
+
+    const eqIndex = token.indexOf('=');
+    if (eqIndex > 0) {
+      const name = token.slice(0, eqIndex);
+      const key = optionKey(name);
+      options[key] = token.slice(eqIndex + 1);
+      optionNames[key] = name;
+      continue;
+    }
+
+    const key = optionKey(token);
+    const next = tokens[index + 1];
+    if (next !== undefined && !String(next).startsWith('--')) {
+      options[key] = next;
+      optionNames[key] = token;
+      index++;
+    } else {
+      options[key] = true;
+      optionNames[key] = token;
+    }
+  }
+
+  return {
+    options,
+    optionNames,
+    positionals,
+  };
+}
+
+function looksLikeInlineJson(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const trimmed = value.trim();
+  return (
+    (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+    (trimmed.startsWith('{') && trimmed.endsWith('}'))
+  );
+}
+
+function quoteDisplayArg(value, force) {
+  const text = String(value === undefined || value === null ? '' : value);
+  if (!force && /^[A-Za-z0-9_./:@%+=,-]+$/.test(text)) {
+    return text;
+  }
+  return `"${text.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function normalizeEntryArgs(entry) {
+  return (entry.args || [])
+    .slice()
+    .sort((left, right) => (left.position || 0) - (right.position || 0));
+}
+
+function getCreateFormCreateCanonical(entry = getCreateFormCreateEntry()) {
+  return cloneJson(entry.canonical, null);
+}
+
+function canonicalPath(entry) {
+  const canonical = getCreateFormCreateCanonical(entry);
+  return canonical && Array.isArray(canonical.path)
+    ? canonical.path
+    : entry.path;
+}
+
+function canonicalTemplate(entry) {
+  const canonical = getCreateFormCreateCanonical(entry);
+  return canonical && Array.isArray(canonical.argv_template)
+    ? canonical.argv_template
+    : entry.path;
+}
+
+function getArgPlaceholder(entry, arg) {
+  const pathLength = canonicalPath(entry).length;
+  const template = canonicalTemplate(entry);
+  return template[pathLength + (arg.position || 0)] || `<${arg.name}>`;
+}
+
+function buildCreateFormCreateCommand(params = {}, entry = getCreateFormCreateEntry()) {
+  const args = normalizeEntryArgs(entry);
+  const argv = [
+    ...canonicalPath(entry),
+    ...args.map(arg => String(params[arg.name] || getArgPlaceholder(entry, arg))),
+  ];
+  return {
+    argv,
+    display: [
+      'openyida',
+      ...canonicalPath(entry),
+      ...args.map(arg => quoteDisplayArg(params[arg.name] || getArgPlaceholder(entry, arg), !!arg.display_quote)),
+    ].join(' '),
+  };
+}
+
+function getPrimaryRepairPattern(entry) {
+  return (entry.repair_patterns || [])[0] || {};
+}
+
+function buildCreateFormSuggestion(params = {}, entry = getCreateFormCreateEntry()) {
+  const fieldsArg = normalizeEntryArgs(entry).find(arg => arg.name === 'fieldsJsonFile');
+  const placeholderFile = params.fieldsJsonFile || (fieldsArg ? getArgPlaceholder(entry, fieldsArg) : '<fieldsJsonFile>');
+  const command = buildCreateFormCreateCommand({
+    appType: params.appType,
+    formTitle: params.formTitle,
+    fieldsJsonFile: placeholderFile,
+  }, entry);
+  const repair = getPrimaryRepairPattern(entry);
+  return {
+    command_id: entry.id,
+    argv: command.argv,
+    display: command.display,
+    note: repair.note || 'Write the --fields JSON to a file, then pass that file path as <fieldsJsonFile>.',
+    requires_fields_json_file: true,
+    fields_inline_value_present: !!params.fieldsInline,
+  };
+}
+
+function collectKnownCreateFormSubcommands() {
+  return new Set(getContractManifest().commands
+    .map(entry => entry.path || [])
+    .filter(path => path[0] === 'create-form' && path[1])
+    .map(path => path[1]));
+}
+
+function getCreateFormDeprecatedPattern(entry = getCreateFormCreateEntry()) {
+  return (entry.deprecated_patterns || []).find(pattern => {
+    const matcher = pattern.matcher || {};
+    return matcher.type === 'argv_shape' && matcher.root === 'create-form';
+  }) || null;
+}
+
+function buildDeprecatedCreateFormPattern(pattern, tokens, params) {
+  return {
+    ...cloneJson(pattern, {}),
+    received: {
+      argv: [...tokens],
+      appType: params.appType,
+      formTitle: params.formTitle,
+      fields: params.fields,
+    },
+  };
+}
+
+function createDeprecatedCreateFormResult(entry, pattern, tokens, params) {
+  const suggestion = buildCreateFormSuggestion({
+    appType: params.appType,
+    formTitle: params.formTitle,
+    fieldsInline: looksLikeInlineJson(params.fields),
+  }, entry);
+  const resultPattern = buildDeprecatedCreateFormPattern(pattern, tokens, params);
+  const message = [
+    'Unsupported create-form option shape.',
+    `\`${pattern.pattern}\` is not supported.`,
+    `Use: ${suggestion.display}.`,
+    suggestion.note,
+  ].join(' ');
+
+  return {
+    ok: false,
+    status: 'invalid',
+    code: pattern.code || 'COMMAND_CONTRACT_DEPRECATED_PATTERN',
+    message,
+    command_id: entry.id,
+    canonical: getCreateFormCreateCanonical(entry),
+    suggestion,
+    pattern: resultPattern,
+  };
+}
+
+function detectDeprecatedCreateFormInvocation(argv = [], options = {}) {
+  const entry = getCreateFormCreateEntry();
+  const pattern = getCreateFormDeprecatedPattern(entry);
+  if (!pattern) {
+    return null;
+  }
+
+  const matcher = pattern.matcher || {};
+  const tokens = normalizeInvocationArgv(argv, options);
+  if (tokens[0] !== matcher.root) {
+    return null;
+  }
+
+  const maybeAppType = tokens[matcher.app_type_position];
+  if (!maybeAppType || (matcher.app_type_must_not_be_known_subcommand && collectKnownCreateFormSubcommands().has(maybeAppType))) {
+    return null;
+  }
+
+  const captures = matcher.capture_options || {};
+  const name = findOptionValue(tokens, captures.formTitle);
+  const fields = findOptionValue(tokens, captures.fields);
+  if (!name.found || !fields.found) {
+    return null;
+  }
+
+  return createDeprecatedCreateFormResult(entry, pattern, tokens, {
+    appType: maybeAppType,
+    formTitle: name.value,
+    fields: fields.value,
+  });
+}
+
+function validateCreateFormCreateInvocation(tokens, entry = getCreateFormCreateEntry()) {
+  const path = canonicalPath(entry);
+  const args = normalizeEntryArgs(entry);
+  const params = {};
+  const missing = [];
+
+  args.forEach(arg => {
+    const value = tokens[path.length + (arg.position || 0)];
+    if (value) {
+      params[arg.name] = value;
+    } else if (arg.required) {
+      missing.push(arg.name);
+    }
+  });
+
+  if (missing.length === 0) {
+    const command = buildCreateFormCreateCommand(params, entry);
+    return {
+      ok: true,
+      status: 'ok',
+      code: 'OK',
+      command_id: entry.id,
+      path: cloneJson(entry.path, []),
+      argv: [...tokens],
+      canonical: getCreateFormCreateCanonical(entry),
+      matched_pattern: 'canonical.create-form.create',
+      params,
+      display: command.display,
+    };
+  }
+
+  return {
+    ok: false,
+    status: 'invalid',
+    code: 'COMMAND_CONTRACT_MISSING_ARGUMENTS',
+    message: `Missing required ${entry.id} argument(s): ${missing.join(', ')}.`,
+    command_id: entry.id,
+    canonical: getCreateFormCreateCanonical(entry),
+    suggestion: buildCreateFormSuggestion(params, entry),
+    missing,
+  };
+}
+
+function validateCommandInvocation(argv = []) {
+  const deprecated = detectDeprecatedCreateFormInvocation(argv);
+  if (deprecated) {
+    return deprecated;
+  }
+
+  const entry = getCreateFormCreateEntry();
+  const tokens = normalizeInvocationArgv(argv);
+  const path = canonicalPath(entry);
+  if (path.every((token, index) => tokens[index] === token)) {
+    return validateCreateFormCreateInvocation(tokens, entry);
+  }
+
+  return {
+    ok: false,
+    status: 'unsupported',
+    code: 'COMMAND_CONTRACT_UNSUPPORTED',
+    message: 'No MVP command contract covers this invocation yet.',
+    argv: tokens,
+  };
+}
+
+function readParam(parsed, arg, fallback) {
+  for (const option of arg.builder_options || []) {
+    const normalizedKey = optionKey(option);
+    if (parsed.options[normalizedKey] !== undefined) {
+      return {
+        value: parsed.options[normalizedKey],
+        option,
+      };
+    }
+  }
+  return {
+    value: fallback,
+    option: null,
+  };
+}
+
+function buildCreateFormCreateFromArgs(args = [], entry = getCreateFormCreateEntry()) {
+  const parsed = parseOptionArgs(args);
+  const params = {};
+  const missing = [];
+  let rejectedInlineJson = false;
+
+  normalizeEntryArgs(entry).forEach(arg => {
+    const source = readParam(parsed, arg, parsed.positionals[arg.position || 0]);
+    const rejectedOptions = new Set(arg.inline_json_rejected_options || []);
+    const rejectedInlineValue = source.option && rejectedOptions.has(source.option) && looksLikeInlineJson(source.value);
+
+    if (rejectedInlineValue) {
+      rejectedInlineJson = true;
+    }
+
+    if (source.value !== undefined && !rejectedInlineValue) {
+      params[arg.name] = source.value;
+    } else if (arg.required) {
+      missing.push(arg.name);
+    }
+  });
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      status: 'invalid',
+      code: rejectedInlineJson
+        ? 'COMMAND_BUILD_REQUIRES_FIELDS_JSON_FILE'
+        : 'COMMAND_BUILD_MISSING_ARGUMENTS',
+      message: rejectedInlineJson
+        ? 'commands build does not write inline --fields JSON; pass --fields-json-file <fieldsJsonFile>.'
+        : `Missing required ${entry.id} build parameter(s): ${missing.join(', ')}.`,
+      command_id: entry.id,
+      canonical: getCreateFormCreateCanonical(entry),
+      suggestion: buildCreateFormSuggestion({
+        ...params,
+        fieldsInline: rejectedInlineJson,
+      }, entry),
+      missing,
+    };
+  }
+
+  const command = buildCreateFormCreateCommand(params, entry);
+  return {
+    ok: true,
+    status: 'ok',
+    code: 'OK',
+    command_id: entry.id,
+    execute: false,
+    argv: command.argv,
+    display: command.display,
+    canonical: getCreateFormCreateCanonical(entry),
+    params,
+  };
+}
+
+function buildCommandInvocation(commandId, args = []) {
+  if (commandId === CREATE_FORM_CREATE_COMMAND_ID) {
+    return buildCreateFormCreateFromArgs(args);
+  }
+  return {
+    ok: false,
+    status: 'unsupported',
+    code: 'COMMAND_BUILD_UNSUPPORTED',
+    message: `No MVP command builder covers command id: ${commandId || '<missing>'}.`,
+    command_id: commandId || null,
+  };
+}
+
+function stripJsonFlag(args = []) {
+  const stripped = [];
+  let json = false;
+  for (const arg of args) {
+    if (arg === '--json') {
+      json = true;
+    } else {
+      stripped.push(arg);
+    }
+  }
+  return { args: stripped, json };
+}
+
+function parseValidateArgs(args = []) {
+  const delimiter = args.indexOf('--');
+  const beforeDelimiter = delimiter === -1 ? args : args.slice(0, delimiter);
+  const afterDelimiter = delimiter === -1 ? [] : args.slice(delimiter + 1);
+  const parsedGlobals = stripJsonFlag(beforeDelimiter);
+
+  return {
+    json: parsedGlobals.json,
+    args: delimiter === -1 ? parsedGlobals.args : afterDelimiter,
+  };
+}
+
+function printCommandContractResult(result, json) {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.ok && result.display) {
+    console.log(result.display);
+  } else {
+    console.error(result.message || result.code || 'Command contract failed.');
+    if (result.suggestion && result.suggestion.display) {
+      console.error(`Suggestion: ${result.suggestion.display}`);
+    }
+  }
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+async function runCommandsContract(args = []) {
+  const action = args[0];
+
+  if (action === 'validate') {
+    const parsed = parseValidateArgs(args.slice(1));
+    const result = parsed.args.length > 0
+      ? validateCommandInvocation(parsed.args)
+      : {
+        ok: false,
+        status: 'invalid',
+        code: 'COMMAND_CONTRACT_EMPTY_INVOCATION',
+        message: 'Usage: openyida commands validate --json -- <command...>',
+      };
+    printCommandContractResult(result, parsed.json);
+    return result;
+  }
+
+  if (action === 'build') {
+    const parsed = stripJsonFlag(args.slice(1));
+    const commandId = parsed.args[0];
+    const result = commandId
+      ? buildCommandInvocation(commandId, parsed.args.slice(1))
+      : {
+        ok: false,
+        status: 'invalid',
+        code: 'COMMAND_BUILD_MISSING_COMMAND_ID',
+        message: 'Usage: openyida commands build <command-id> ... --json',
+      };
+    printCommandContractResult(result, parsed.json);
+    return result;
+  }
+
+  const result = {
+    ok: false,
+    status: 'invalid',
+    code: 'COMMAND_CONTRACT_UNKNOWN_ACTION',
+    message: 'Usage: openyida commands [--json] | commands validate --json -- <command...> | commands build <command-id> ... --json',
+  };
+  printCommandContractResult(result, args.includes('--json'));
+  return result;
+}
+
+module.exports = {
+  CREATE_FORM_CREATE_COMMAND_ID,
+  buildCommandInvocation,
+  buildCreateFormCreateCommand,
+  detectDeprecatedCreateFormInvocation,
+  getCreateFormCreateCanonical,
+  runCommandsContract,
+  validateCommandInvocation,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -237,6 +237,13 @@ function clonePermission(metadata) {
   return cloned;
 }
 
+function cloneJsonMetadata(value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
 function listCommandSideEffectIds() {
   return [...COMMAND_SIDE_EFFECTS.keys()].sort();
 }
@@ -933,6 +940,15 @@ const FORBIDDEN_ALIASES = Object.freeze([
     message_args: ['create-page', '--app-type'],
   }),
   Object.freeze({
+    id: 'forbidden-alias.create-form-name-fields-options',
+    pattern: 'create-form <appType> --name <formTitle> --fields <fieldsJson>',
+    matcher: { type: 'command_has_option', command: 'create-form', option: '--fields' },
+    suggested_command_id: 'create-form.create',
+    suggested_usage: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+    message_key: 'cli.forbidden_alias_create_form_name_fields_options',
+    message_args: ['create-form', '--name', '--fields'],
+  }),
+  Object.freeze({
     id: 'forbidden-alias.get-schema-app-type-option',
     pattern: 'get-schema --app-type',
     matcher: { type: 'command_has_option', command: 'get-schema', option: '--app-type' },
@@ -973,7 +989,11 @@ function command(id, path, usage, descriptionKey, options = {}) {
     requiresLogin: options.requiresLogin !== false,
     output: options.output || 'text',
     aliases: options.aliases || [],
-    examples: options.examples || [],
+    args: cloneJsonMetadata(options.args, []),
+    canonical: cloneJsonMetadata(options.canonical, null),
+    deprecatedPatterns: cloneJsonMetadata(options.deprecatedPatterns, []),
+    repairPatterns: cloneJsonMetadata(options.repairPatterns, []),
+    examples: cloneJsonMetadata(options.examples, []),
     hidden: options.hidden === true,
     sideEffect: cloneSideEffect(commandSideEffect),
     permission: clonePermission(normalizedPermission),
@@ -1026,7 +1046,76 @@ const COMMAND_GROUPS = [
     id: 'form',
     titleKey: 'help.group_form',
     commands: [
-      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> ... [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_form'),
+      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_form', {
+        args: [
+          {
+            name: 'appType',
+            type: 'string',
+            required: true,
+            source: 'positional',
+            position: 0,
+            builder_options: ['--app-type', '--appType', '--app_type'],
+            description: 'Yida application id, such as APP_XXX.',
+          },
+          {
+            name: 'formTitle',
+            type: 'string',
+            required: true,
+            source: 'positional',
+            position: 1,
+            display_quote: true,
+            builder_options: ['--form-title', '--formTitle', '--form_title', '--name'],
+            description: 'Form page title.',
+          },
+          {
+            name: 'fieldsJsonFile',
+            type: 'file',
+            required: true,
+            source: 'positional',
+            position: 2,
+            builder_options: ['--fields-json-file', '--fields-file', '--fieldsJsonFile', '--fields_json_file', '--fields'],
+            inline_json_rejected_options: ['--fields'],
+            description: 'Path to a local JSON file containing field definitions.',
+          },
+        ],
+        canonical: {
+          command_id: 'create-form.create',
+          path: ['create-form', 'create'],
+          argv_template: ['create-form', 'create', '<appType>', '<formTitle>', '<fieldsJsonFile>'],
+          display: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+          builder: 'openyida commands build create-form.create --app-type <appType> --form-title "<formTitle>" --fields-json-file <fieldsJsonFile> --json',
+        },
+        deprecatedPatterns: [
+          {
+            id: 'deprecated.create-form.name-fields-options',
+            pattern: 'create-form <appType> --name <formTitle> --fields <fieldsJson>',
+            matcher: {
+              type: 'argv_shape',
+              root: 'create-form',
+              app_type_position: 1,
+              app_type_must_not_be_known_subcommand: true,
+              capture_options: {
+                formTitle: ['--name'],
+                fields: ['--fields'],
+              },
+            },
+            code: 'CREATE_FORM_DEPRECATED_OPTION_SHAPE',
+            reason: 'create-form requires the explicit create subcommand and a fields JSON file path.',
+          },
+        ],
+        repairPatterns: [
+          {
+            id: 'repair.create-form.name-fields-to-create',
+            from: 'create-form <appType> --name <formTitle> --fields <fieldsJson>',
+            to: 'create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+            note: 'Write the inline --fields JSON to a local file, then pass that file path.',
+          },
+        ],
+        examples: [
+          'openyida create-form create APP_XXX "访客登记" .cache/openyida/visitor/fields.json',
+          'openyida commands build create-form.create --app-type APP_XXX --form-title "访客登记" --fields-json-file .cache/openyida/visitor/fields.json --json',
+        ],
+      }),
       command('create-form.validate-fields', ['create-form', 'validate-fields'], 'create-form validate-fields <fieldsJsonOrFile> [--json]', 'help.cmd_validate_form', {
         requiresLogin: false,
       }),
@@ -1238,6 +1327,10 @@ function localizeCommand(entry, translate) {
     requires_login: entry.requiresLogin,
     output: entry.output,
     aliases: entry.aliases,
+    args: cloneJsonMetadata(entry.args, []),
+    canonical: cloneJsonMetadata(entry.canonical, null),
+    deprecated_patterns: cloneJsonMetadata(entry.deprecatedPatterns, []),
+    repair_patterns: cloneJsonMetadata(entry.repairPatterns, []),
     examples: entry.examples,
     hidden: entry.hidden,
     side_effect: cloneSideEffect(entry.sideEffect),

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -243,6 +243,7 @@ Examples:
     forbidden_alias_get_app: '`{0}` is ambiguous; use `{1}` for app name search, `{2}` for form/schema lookup, or `{3}` for bound context preflight.',
     forbidden_alias_create_app_json: '`{0}` is not a separate command contract; use canonical `{1}` output.',
     forbidden_alias_create_page_app_type_option: '`{0}` takes appType as the first positional argument, not `{1}`.',
+    forbidden_alias_create_form_name_fields_options: '`{0}` form creation must use the explicit `create` subcommand; `{1}` / `{2}` option shape is not supported.',
     forbidden_alias_get_schema_app_type_option: '`{0}` takes appType as the first positional argument, not `{1}`.',
     forbidden_alias_get_schema_form_uuid_option: '`{0}` takes formUuid as the second positional argument, not `{1}`.',
     nearest_command_suggestion: 'Unknown OpenYida command root "{0}". Did you mean "{1}"?',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -244,6 +244,7 @@ openyida - 宜搭命令行工具
     forbidden_alias_get_app: '`{0}` 含义不明确；按应用名称搜索请用 `{1}`，查询表单/字段结构请用 `{2}`，读取绑定上下文请用 `{3}`。',
     forbidden_alias_create_app_json: '`{0}` 不是独立命令契约；请使用规范的 `{1}` 输出。',
     forbidden_alias_create_page_app_type_option: '`{0}` 使用第一个位置参数传入 appType，不使用 `{1}`。',
+    forbidden_alias_create_form_name_fields_options: '`{0}` 创建表单必须显式使用 `create` 子命令；不支持 `{1}` / `{2}` 选项形态。',
     forbidden_alias_get_schema_app_type_option: '`{0}` 使用第一个位置参数传入 appType，不使用 `{1}`。',
     forbidden_alias_get_schema_form_uuid_option: '`{0}` 使用第二个位置参数传入 formUuid，不使用 `{1}`。',
     nearest_command_suggestion: '未知 OpenYida 命令根「{0}」。你是不是想用「{1}」？',

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -111,6 +111,11 @@ function runAny(args) {
   };
 }
 
+function readManifestCommand(commandId) {
+  const manifest = JSON.parse(runOk(['commands', '--json']));
+  return manifest.commands.find(entry => entry.id === commandId);
+}
+
 function resolveManifestCommand(commands, args) {
   return commands
     .filter(entry => entry.path.every((token, index) => args[index] === token))
@@ -372,6 +377,12 @@ describe('CLI offline smoke', () => {
         suggested_usage: expect.stringContaining('create-page <appType>'),
       }),
       expect.objectContaining({
+        pattern: 'create-form <appType> --name <formTitle> --fields <fieldsJson>',
+        matcher: { type: 'command_has_option', command: 'create-form', option: '--fields' },
+        suggested_command_id: 'create-form.create',
+        suggested_usage: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+      }),
+      expect.objectContaining({
         pattern: 'get-schema --app-type',
         suggested_usage: expect.stringContaining('get-schema <appType>'),
       }),
@@ -388,6 +399,7 @@ describe('CLI offline smoke', () => {
         'list-apps',
         'get-app',
         'create-app --json',
+        'create-form <appType> --name <formTitle> --fields <fieldsJson>',
       ]),
     });
     expect(parsed.summary.side_effect_counts.remote_write).toBeGreaterThan(0);
@@ -531,6 +543,39 @@ describe('CLI offline smoke', () => {
       kind: 'local_read',
       mutates_yida: false,
       mutates_local: false,
+    });
+    expect(commandById['create-form.create']).toMatchObject({
+      path: ['create-form', 'create'],
+      permission: {
+        mode: 'allow',
+        effect: 'write',
+      },
+      args: [
+        expect.objectContaining({ name: 'appType', source: 'positional', required: true }),
+        expect.objectContaining({ name: 'formTitle', source: 'positional', required: true }),
+        expect.objectContaining({ name: 'fieldsJsonFile', source: 'positional', required: true }),
+      ],
+      canonical: {
+        command_id: 'create-form.create',
+        path: ['create-form', 'create'],
+        argv_template: ['create-form', 'create', '<appType>', '<formTitle>', '<fieldsJsonFile>'],
+        display: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+        builder: expect.stringContaining('commands build create-form.create'),
+      },
+      deprecated_patterns: [
+        expect.objectContaining({
+          id: 'deprecated.create-form.name-fields-options',
+          code: 'CREATE_FORM_DEPRECATED_OPTION_SHAPE',
+        }),
+      ],
+      repair_patterns: [
+        expect.objectContaining({
+          id: 'repair.create-form.name-fields-to-create',
+        }),
+      ],
+      examples: expect.arrayContaining([
+        expect.stringContaining('openyida create-form create APP_XXX'),
+      ]),
     });
     expect(commandById['generate-page'].side_effect).toMatchObject({
       kind: 'local_write',
@@ -734,6 +779,160 @@ describe('CLI offline smoke', () => {
     expect(classifyManifestInvocation(parsed.commands, ['app-permission', 'remove'])).toMatchObject({
       entry: { id: 'app-permission' },
       decision: 'ask',
+    });
+  });
+
+  test('commands validate accepts canonical create-form create invocation', () => {
+    const manifestEntry = readManifestCommand('create-form.create');
+    const output = runOk([
+      'commands',
+      'validate',
+      '--json',
+      '--',
+      'create-form',
+      'create',
+      'APP_xxx',
+      '访客登记',
+      '.cache/openyida/visitor/fields.json',
+    ]);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      status: 'ok',
+      command_id: 'create-form.create',
+      matched_pattern: 'canonical.create-form.create',
+      params: {
+        appType: 'APP_xxx',
+        formTitle: '访客登记',
+        fieldsJsonFile: '.cache/openyida/visitor/fields.json',
+      },
+      path: manifestEntry.path,
+      canonical: manifestEntry.canonical,
+    });
+  });
+
+  test('commands validate rejects hallucinated create-form name fields shape', () => {
+    const manifestEntry = readManifestCommand('create-form.create');
+    const deprecatedPattern = manifestEntry.deprecated_patterns[0];
+    const result = runAny([
+      'commands',
+      'validate',
+      '--json',
+      '--',
+      'create-form',
+      'APP_xxx',
+      '--name',
+      '访客登记',
+      '--fields',
+      '[{"type":"TextField","label":"姓名"}]',
+    ]);
+    const parsed = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(parsed).toMatchObject({
+      ok: false,
+      status: 'invalid',
+      code: deprecatedPattern.code,
+      command_id: 'create-form.create',
+      canonical: manifestEntry.canonical,
+      suggestion: {
+        argv: ['create-form', 'create', 'APP_xxx', '访客登记', '<fieldsJsonFile>'],
+        fields_inline_value_present: true,
+      },
+      pattern: {
+        id: deprecatedPattern.id,
+        code: deprecatedPattern.code,
+        matcher: deprecatedPattern.matcher,
+        received: {
+          appType: 'APP_xxx',
+          formTitle: '访客登记',
+        },
+      },
+    });
+  });
+
+  test('commands validate preserves target argv after delimiter including --json', () => {
+    const output = runOk([
+      'commands',
+      'validate',
+      '--json',
+      '--',
+      'create-form',
+      'create',
+      'APP_xxx',
+      '访客登记',
+      '.cache/openyida/visitor/fields.json',
+      '--json',
+    ]);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      command_id: 'create-form.create',
+    });
+    expect(parsed.argv).toEqual([
+      'create-form',
+      'create',
+      'APP_xxx',
+      '访客登记',
+      '.cache/openyida/visitor/fields.json',
+      '--json',
+    ]);
+  });
+
+  test('commands build renders canonical create-form argv without executing', () => {
+    const manifestEntry = readManifestCommand('create-form.create');
+    const output = runOk([
+      'commands',
+      'build',
+      'create-form.create',
+      '--app-type',
+      'APP_xxx',
+      '--form-title',
+      '访客登记',
+      '--fields-json-file',
+      '.cache/openyida/visitor/fields.json',
+      '--json',
+    ]);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      status: 'ok',
+      command_id: 'create-form.create',
+      execute: false,
+      argv: ['create-form', 'create', 'APP_xxx', '访客登记', '.cache/openyida/visitor/fields.json'],
+      display: 'openyida create-form create APP_xxx "访客登记" .cache/openyida/visitor/fields.json',
+      canonical: manifestEntry.canonical,
+    });
+    expect(parsed.argv.slice(0, manifestEntry.path.length)).toEqual(manifestEntry.path);
+  });
+
+  test('direct create-form hallucinated shape returns clean JSON error before execution', () => {
+    const manifestEntry = readManifestCommand('create-form.create');
+    const result = runAny([
+      'create-form',
+      'APP_xxx',
+      '--name',
+      '访客登记',
+      '--fields',
+      '[{"type":"TextField","label":"姓名"}]',
+      '--json',
+    ]);
+    const parsed = JSON.parse(result.jsonOutput);
+
+    expect(result.status).toBe(1);
+    expect(parsed).toMatchObject({
+      success: false,
+      errorCode: 'CREATE_FORM_DEPRECATED_OPTION_SHAPE',
+      details: {
+        command_id: 'create-form.create',
+        canonical: manifestEntry.canonical,
+        suggestion: {
+          argv: ['create-form', 'create', 'APP_xxx', '访客登记', '<fieldsJsonFile>'],
+        },
+      },
     });
   });
 

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -1602,6 +1602,52 @@ describe('create-form module API', () => {
       }),
     });
   });
+
+  test('parseArgs keeps legacy positional create compatibility', () => {
+    expect(createForm.parseArgs([
+      'APP_XXX',
+      '访客登记',
+      '.cache/openyida/visitor/fields.json',
+    ])).toMatchObject({
+      mode: 'create',
+      appType: 'APP_XXX',
+      formTitle: '访客登记',
+      fieldsJsonOrFile: '.cache/openyida/visitor/fields.json',
+    });
+  });
+
+  test('parseArgs rejects create-form name fields option hallucination before legacy fallback', () => {
+    let thrown;
+    try {
+      createForm.parseArgs([
+        'APP_XXX',
+        '--name',
+        '访客登记',
+        '--fields',
+        '[{"type":"TextField","label":"姓名"}]',
+        '--json',
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toMatchObject({
+      code: 'CREATE_FORM_DEPRECATED_OPTION_SHAPE',
+      details: {
+        command_id: 'create-form.create',
+        canonical: {
+          display: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
+        },
+        suggestion: {
+          argv: ['create-form', 'create', 'APP_XXX', '访客登记', '<fieldsJsonFile>'],
+          fields_inline_value_present: true,
+        },
+        pattern: {
+          id: 'deprecated.create-form.name-fields-options',
+        },
+      },
+    });
+  });
 });
 
 describe('create-form create recovery guardrails', () => {
@@ -1612,6 +1658,25 @@ describe('create-form create recovery guardrails', () => {
     jest.dontMock('../lib/core/utils');
     jest.dontMock('../lib/core/chalk');
     jest.resetModules();
+  });
+
+  test('hallucinated name fields shape fails before remote write', async () => {
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand();
+
+    await expect(isolatedCreateForm.run([
+      'APP_TEST',
+      '--name',
+      '访客登记',
+      '--fields',
+      '[{"type":"TextField","label":"姓名"}]',
+    ])).rejects.toMatchObject({
+      code: 'CREATE_FORM_DEPRECATED_OPTION_SHAPE',
+    });
+
+    expect(mockUtils.httpGet).not.toHaveBeenCalled();
+    expect(mockUtils.httpPost).not.toHaveBeenCalled();
+    expect(mockUtils.requestWithAutoLogin).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 
   test('invalid field definitions fail before saveFormSchemaInfo creates a blank form', async () => {


### PR DESCRIPTION
## Summary
- add a shared OpenYida command-contract MVP for create-form.create validation/building
- keep command manifest schema_version 1 while adding args/canonical/deprecated_patterns/repair_patterns metadata
- block hallucinated create-form <appType> --name ... --fields ... before legacy fallback or remote writes
- cover manifest, validate/build, direct create-form guardrails, legacy compatibility, and delimiter-preserving --json behavior

## Validation
- npx jest tests/cli-smoke.test.js --runInBand
- npx jest tests/create-form.test.js --runInBand
- npx jest tests/cli-smoke.test.js tests/create-form.test.js --runInBand
- npm run check:commands
- npm run check:docs
- npm run check:i18n
- npm run check:syntax
- npx eslint bin/yida.js lib/core/command-contract.js lib/core/command-manifest.js lib/app/create-form/args.js tests/cli-smoke.test.js tests/create-form.test.js
- git diff --check
- npm run check:ci