### PR TITLE
fix: 修复千问办公登录浏览器打开

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
+## [2026.8.3-2] - 2026-08-03
+
+### Fixed
+- 千问办公登录优化。
+
 
 ## [2026.8.3] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
-## [2026.8.3-2] - 2026-08-03
+## [2026.8.4] - 2026-08-04
 
 ### Fixed
 - 千问办公登录优化。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ openyida/
 ├── bin/yida.js          # CLI entry point, command routing
 ├── lib/                 # Command implementation modules
 │   ├── core/            # Environment detection, i18n, utilities
-│   ├── auth/            # Login, Codex login, QR login, organizations
+│   ├── auth/            # OAuth login, token sessions, organizations
 │   ├── app/             # Application, form, page commands
 │   └── ...
 ├── project/             # User workspace template

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -35,11 +35,15 @@ function isAgentEnvironment(env) {
     env.QODER_IDE ||
     env.QODER_AGENT ||
     env.QODERCLI_INTEGRATION_MODE ||
+    env.QWENWORK_INTEGRATION_MODE ||
+    env.QWENWORKCN_INTEGRATION_MODE ||
     env.CURSOR_TRACE_ID ||
     env.AGENT_WORK_ROOT ||
     env.OPENYIDA_AGENT_MODE ||
     (env.__CFBundleIdentifier || '').toLowerCase().includes('codex') ||
-    (env.__CFBundleIdentifier || '').toLowerCase().includes('qoder')
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('qoder') ||
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('qwenwork') ||
+    (env.__CFBundleIdentifier || '').toLowerCase().includes('qwen-work')
   );
 }
 

--- a/docs/project-risk-and-optimization-2026-07-19.md
+++ b/docs/project-risk-and-optimization-2026-07-19.md
@@ -14,7 +14,7 @@
 | 风险点 | 现状证据 | 影响 | 建议 |
 |---|---|---|---|
 | npm 包未包含完整功能列表文档 | `package.json` 的 `files` 白名单原本只包含 `README.md`，未包含 README 链接的 `docs/capabilities.md` | npm 包或包页面上的“完整功能列表”可能无法随包分发 | 已补充 `docs/capabilities.md` 到 `files` 白名单；后续若 README 新增 docs 链接，也要同步白名单 |
-| 中文 README 登录说明滞后 | `README_zhCN.md` 仍描述 Chrome/Edge/Chromium CDP 与二维码 handoff | Agent 可能引导用户走旧登录方式，偏离 OAuth token session 主线 | 已改为 OAuth loopback + token session，并强调不要提取 Cookie 或手写 `.cache/cookies.json` |
+| 中文 README 登录说明滞后 | `README_zhCN.md` 曾描述 Chrome/Edge/Chromium CDP 与旧二维码 handoff | Agent 可能引导用户走旧登录方式，偏离 OAuth token session 主线 | 已改为 OAuth loopback + token session，并强调不要提取 Cookie 或手写 `.cache/cookies.json` |
 | 功能列表不是自动校验目标 | `check:docs` 只校验 README 自动生成区块；`docs/capabilities.md` 需要人工维护 | 新增命令后功能列表容易漏项，之前缺少 `auth`、`agent-capabilities`、`asset`、`eval`、`get-form-config`、`integration enable/disable` 的可搜索条目 | 建议新增 `scripts/validate-capabilities-doc.js`，用 command manifest 检查 `docs/capabilities.md` 至少覆盖所有可见命令根或指定例外 |
 
 ## P1：近期优化

--- a/lib/auth/oauth-loopback.js
+++ b/lib/auth/oauth-loopback.js
@@ -287,55 +287,128 @@ function resolveBrowserLauncher(url, platform = process.platform, openMode = 'le
   return { command: 'xdg-open', args: [url] };
 }
 
-function launchBrowserLauncher(launcher, onError) {
+function isQwenWorkEnvironment(env = process.env) {
+  const bundleId = String(env.__CFBundleIdentifier || '').toLowerCase();
+  const product = String(env.QODER_WORK_INTEGRATION_PRODUCT || '').toLowerCase();
+  const qoderConfigDir = String(env.QODER_CONFIG_DIR || env.QODERCN_CONFIG_DIR || '');
+  return !!(
+    env.QWENWORK_INTEGRATION_MODE ||
+    env.QWENWORKCN_INTEGRATION_MODE ||
+    product.includes('qwenwork') ||
+    product.includes('qwen-work') ||
+    qoderConfigDir.includes('.qwenworkcn') ||
+    bundleId.includes('qwenwork') ||
+    bundleId.includes('qwen-work')
+  );
+}
+
+function browserLaunchFailureMessage(launcher, error) {
+  const detail = error && error.message ? ` (${error.message})` : '';
+  return `OpenYida could not auto-open the browser via ${launcher.command}${detail}. Please use the login URL above.`;
+}
+
+function launchBrowserLauncher(launcher, onError, deps = {}) {
+  const spawnImpl = deps.spawn || spawn;
+  let handledFailure = false;
+  const notifyFailure = (error) => {
+    if (handledFailure) {
+      return false;
+    }
+    handledFailure = true;
+    if (onError) {
+      return onError(error) === true;
+    }
+    return false;
+  };
+
   try {
-    const child = spawn(launcher.command, launcher.args, {
+    const child = spawnImpl(launcher.command, launcher.args, {
       detached: true,
       stdio: 'ignore',
     });
-    child.unref();
+    if (child && typeof child.unref === 'function') {
+      child.unref();
+    }
     if (onError) {
-      child.once('error', onError);
+      child.once('error', notifyFailure);
+      child.once('exit', (code, signal) => {
+        if (code && code !== 0) {
+          notifyFailure(new Error(`browser launcher exited with code ${code}`));
+        } else if (signal) {
+          notifyFailure(new Error(`browser launcher exited with signal ${signal}`));
+        }
+      });
     }
     return true;
-  } catch {
-    if (onError) {
-      onError();
-    }
-    return false;
+  } catch (error) {
+    return notifyFailure(error);
   }
 }
 
-function openBrowser(url) {
-  if (process.env.OPENYIDA_NO_BROWSER === '1') {
+function openBrowser(url, options = {}) {
+  const env = options.env || process.env;
+  if (env.OPENYIDA_NO_BROWSER === '1') {
     return false;
   }
 
-  const platform = process.platform;
+  const platform = options.platform || process.platform;
+  const detectBrowser = options.detectDefaultBrowser || detectDefaultBrowser;
+  const launchDeps = { spawn: options.spawn };
+  const warnLaunchFailure = (launcher) => (error) => {
+    process.stderr.write(`${browserLaunchFailureMessage(launcher, error)}\n`);
+  };
   const legacyLauncher = resolveBrowserLauncher(url, platform, 'legacy');
-  const runLegacy = () => launchBrowserLauncher(legacyLauncher);
+  const runLegacy = (onError = warnLaunchFailure(legacyLauncher)) =>
+    launchBrowserLauncher(legacyLauncher, onError, launchDeps);
 
   let browser = null;
   try {
-    browser = detectDefaultBrowser(platform);
+    browser = detectBrowser(platform);
   } catch {
     browser = null;
   }
 
-  // Default browser detected and supported → open a real new window in that
-  // browser, falling back to the plain default-browser open if launch errors.
-  if (browser && SUPPORTED_BROWSER_FAMILIES.has(browser.family)) {
-    const newWindowLauncher = resolveBrowserLauncher(url, platform, 'newWindow', browser);
+  const hasNewWindowFallback = browser && SUPPORTED_BROWSER_FAMILIES.has(browser.family);
+  const newWindowLauncher = hasNewWindowFallback
+    ? resolveBrowserLauncher(url, platform, 'newWindow', browser)
+    : null;
+
+  // QwenWork runs inside a desktop shell. Prefer the OS default-browser opener
+  // first so the login page is visible outside the host app; use new-window
+  // launch only as a fallback when the system opener itself fails.
+  if (isQwenWorkEnvironment(env)) {
     let fallbackUsed = false;
-    const runFallback = () => {
+    const runNewWindowFallback = (error) => {
       if (fallbackUsed) {
         return false;
       }
       fallbackUsed = true;
-      return runLegacy();
+      if (newWindowLauncher) {
+        return launchBrowserLauncher(
+          newWindowLauncher,
+          warnLaunchFailure(newWindowLauncher),
+          launchDeps
+        );
+      }
+      warnLaunchFailure(legacyLauncher)(error);
+      return false;
+    };
+    return runLegacy(runNewWindowFallback);
+  }
+
+  // Default browser detected and supported → open a real new window in that
+  // browser, falling back to the plain default-browser open if launch errors.
+  if (newWindowLauncher) {
+    let fallbackUsed = false;
+    const runFallback = (error) => {
+      if (fallbackUsed) {
+        return false;
+      }
+      fallbackUsed = true;
+      return runLegacy(warnLaunchFailure(legacyLauncher)) || warnLaunchFailure(newWindowLauncher)(error);
     };
 
-    const launched = launchBrowserLauncher(newWindowLauncher, runFallback);
+    const launched = launchBrowserLauncher(newWindowLauncher, runFallback, launchDeps);
     if (!launched) {
       return runFallback();
     }
@@ -506,6 +579,9 @@ module.exports = {
   buildDingtalkOAuthUrl,
   resolveBrowserLauncher,
   detectDefaultBrowser,
+  openBrowser,
+  isQwenWorkEnvironment,
+  launchBrowserLauncher,
   classifyMacBundleId,
   classifyWindowsProgId,
   classifyLinuxDesktop,

--- a/lib/bridge/bridge.js
+++ b/lib/bridge/bridge.js
@@ -557,7 +557,7 @@ function sanitizeQrLoginStart(result = {}, loginSessionId) {
     qrImageOpened: !!result.qr_image_opened,
     pollable: true,
     pollIntervalMs: 1000,
-    message: result.message || 'Scan the QR code with DingTalk, then poll login status.',
+    message: result.message || 'Complete login in the browser, then poll login status.',
   };
 }
 
@@ -623,7 +623,7 @@ async function defaultStartLogin() {
     status: 'token_login_required',
     auth_mode: 'token',
     can_auto_use: false,
-    message: 'Token-only auth does not support bridge QR login. Run openyida login first.',
+    message: 'Token-only auth does not support bridge-managed login. Run openyida login first.',
   };
 }
 
@@ -632,7 +632,7 @@ async function defaultPollLogin() {
     status: 'token_login_required',
     auth_mode: 'token',
     can_auto_use: false,
-    message: 'Token-only auth does not support bridge QR polling. Run openyida login first.',
+    message: 'Token-only auth does not support bridge login polling. Run openyida login first.',
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.8.3-2",
+  "version": "2026.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.8.3-2",
+      "version": "2026.8.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.8.3",
+  "version": "2026.8.3-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.8.3",
+      "version": "2026.8.3-2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.8.3-2",
+  "version": "2026.8.4",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.8.3",
+  "version": "2026.8.3-2",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/scripts/eval/scenarios/routing-full.json
+++ b/scripts/eval/scenarios/routing-full.json
@@ -581,10 +581,10 @@
   },
   {
     "id": "login-pos-2",
-    "prompt": "我要扫码登录宜搭平台",
+    "prompt": "我要通过浏览器登录宜搭平台",
     "expectedSkill": "yida-login",
     "type": "positive",
-    "note": "扫码登录"
+    "note": "浏览器 OAuth 登录"
   },
   {
     "id": "login-neg-1",

--- a/tests/oauth-loopback.test.js
+++ b/tests/oauth-loopback.test.js
@@ -1,9 +1,13 @@
 'use strict';
 
+const EventEmitter = require('events');
+
 const {
   buildDingtalkOAuthUrl,
   resolveBrowserLauncher,
   detectDefaultBrowser,
+  openBrowser,
+  isQwenWorkEnvironment,
   classifyMacBundleId,
   classifyWindowsProgId,
   classifyLinuxDesktop,
@@ -144,6 +148,119 @@ describe('resolveBrowserLauncher', () => {
     });
     expect(command).toBe('/usr/bin/google-chrome-stable');
     expect(args).toEqual(['--new-window', oauthUrl]);
+  });
+});
+
+describe('openBrowser launch policy', () => {
+  const oauthUrl = buildDingtalkOAuthUrl({
+    clientId: 'suite9xvlxxerybljwheo',
+    redirectUri: 'http://127.0.0.1:34882/oauth/callback',
+    state: 'abc123',
+    scope: 'openid corpid',
+  });
+
+  function createChild() {
+    const child = new EventEmitter();
+    child.unref = jest.fn();
+    return child;
+  }
+
+  test('detects QwenWork desktop shell signals', () => {
+    expect(isQwenWorkEnvironment({ QWENWORK_INTEGRATION_MODE: '1' })).toBe(true);
+    expect(isQwenWorkEnvironment({ QWENWORKCN_INTEGRATION_MODE: '1' })).toBe(true);
+    expect(isQwenWorkEnvironment({ __CFBundleIdentifier: 'com.alibaba.qwenwork' })).toBe(true);
+    expect(isQwenWorkEnvironment({ QODER_WORK_INTEGRATION_PRODUCT: 'qwen-work' })).toBe(true);
+    expect(isQwenWorkEnvironment({ __CFBundleIdentifier: 'com.openai.codex' })).toBe(false);
+  });
+
+  test('QwenWork opens the system default browser before new-window fallback', () => {
+    const calls = [];
+    const child = createChild();
+    const ok = openBrowser(oauthUrl, {
+      env: { QWENWORKCN_INTEGRATION_MODE: '1' },
+      platform: 'darwin',
+      detectDefaultBrowser: () => ({ family: 'chromium', bundleId: 'com.google.Chrome' }),
+      spawn: (command, args) => {
+        calls.push({ command, args });
+        return child;
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([{ command: 'open', args: [oauthUrl] }]);
+  });
+
+  test('QwenWork falls back to the new-window launcher when system open fails', () => {
+    const calls = [];
+    const children = [createChild(), createChild()];
+    const ok = openBrowser(oauthUrl, {
+      env: { __CFBundleIdentifier: 'com.alibaba.qwen-work' },
+      platform: 'darwin',
+      detectDefaultBrowser: () => ({ family: 'chromium', bundleId: 'com.google.Chrome' }),
+      spawn: (command, args) => {
+        calls.push({ command, args });
+        return children[calls.length - 1];
+      },
+    });
+
+    children[0].emit('exit', 1, null);
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([
+      { command: 'open', args: [oauthUrl] },
+      {
+        command: 'open',
+        args: ['-b', 'com.google.Chrome', '-n', '--args', '--new-window', oauthUrl],
+      },
+    ]);
+  });
+
+  test('QwenWork reports success when synchronous system-open failure falls back', () => {
+    const calls = [];
+    const child = createChild();
+    const ok = openBrowser(oauthUrl, {
+      env: { QWENWORKCN_INTEGRATION_MODE: '1' },
+      platform: 'darwin',
+      detectDefaultBrowser: () => ({ family: 'chromium', bundleId: 'com.google.Chrome' }),
+      spawn: (command, args) => {
+        calls.push({ command, args });
+        if (calls.length === 1) {
+          throw new Error('spawn failed');
+        }
+        return child;
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([
+      { command: 'open', args: [oauthUrl] },
+      {
+        command: 'open',
+        args: ['-b', 'com.google.Chrome', '-n', '--args', '--new-window', oauthUrl],
+      },
+    ]);
+  });
+
+  test('non-QwenWork agents still prefer a real browser new window', () => {
+    const calls = [];
+    const child = createChild();
+    const ok = openBrowser(oauthUrl, {
+      env: { CODEX_SHELL: '1' },
+      platform: 'darwin',
+      detectDefaultBrowser: () => ({ family: 'chromium', bundleId: 'com.google.Chrome' }),
+      spawn: (command, args) => {
+        calls.push({ command, args });
+        return child;
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([
+      {
+        command: 'open',
+        args: ['-b', 'com.google.Chrome', '-n', '--args', '--new-window', oauthUrl],
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- 千问办公环境登录优先使用系统默认浏览器打开 OAuth URL
- 系统浏览器启动失败时回退到现有新窗口 launcher 或手动 URL 提示
- 清理会误导 agent 使用旧 QR 登录方式的文案与评测样例

## Tests
- node --check lib/auth/oauth-loopback.js
- node --check lib/bridge/bridge.js
- node --check bin/yida.js
- npx jest tests/oauth-loopback.test.js --runInBand
- npx jest tests/bridge.test.js --runInBand
- git diff --check
- npm run check:release-risks