### PR TITLE
fix: 同步路由测试断言

### DIFF
--- a/tests/skill-routing-hygiene.test.js
+++ b/tests/skill-routing-hygiene.test.js
@@ -38,7 +38,7 @@ describe('skill resource boundary copy', () => {
 
     expect(root).toMatch(/默认使用 `create-app \/ create-form \/ create-page \/ publish`/);
     expect(root).toMatch(/resolve_resource_context/);
-    expect(root).toMatch(/resolve forms\/processes → reserve main page/);
+    expect(root).toMatch(/resolve forms\/processes → seed records → reserve main page/);
     expect(root).toMatch(/字段级命令内置解析/);
     expect(root).not.toMatch(RETIRED_ARCHITECTURE_PATTERN);
   });


### PR DESCRIPTION
## 变更内容
- 将 `skill-routing-hygiene` 中默认链路断言对齐当前 `yida-skills/SKILL.md`：`resolve forms/processes → seed records → reserve main page`。

## 验证
- `npm test -- --runInBand --cacheDirectory=.cache/jest tests/skill-routing-hygiene.test.js`
- `npx eslint tests/skill-routing-hygiene.test.js`