### PR TITLE
fix: 兼容 safe-json 告警语言

### DIFF
--- a/tests/safe-json.test.js
+++ b/tests/safe-json.test.js
@@ -31,7 +31,8 @@ describe('safe-json preprocessing (#3)', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     try {
       expect(safeParseJson(input)).toEqual({ name: 'OpenKuma' });
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('智能引号'));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toMatch(/智能引号|smart \/ curly quotes/);
     } finally {
       errorSpy.mockRestore();
     }


### PR DESCRIPTION
## 变更内容
- `safe-json` 智能引号恢复 warning 测试同时兼容中文和英文运行环境。
- 保留 warning 只打印一次的断言，避免 CI 因语言环境差异失败。

## 验证
- `npm test -- --runInBand --cacheDirectory=.cache/jest tests/safe-json.test.js`
- `npx eslint tests/safe-json.test.js`