### PR TITLE
feat: add app lifecycle commands and skill to #83584385

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida corp-efficiency [overview\|details\|detail\|groups\|notify] [options] [--open\|--no-open]` | Query enterprise efficiency overview and detail reports |
 | `openyida create-app "<name>"\|--name <name> [options] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a Yida app |
 | `openyida update-app <appType> [--name "..."] [--layout slide\|ver] [--theme deepBlue]` | Update app info |
+| `openyida app-online <appType> [--to-ding-app-center] [--show-app-center]` | Enable a Yida app |
+| `openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]` | Disable a Yida app |
 | `openyida nav-group <list\|create\|rename\|delete\|move\|order\|auto-order\|hide\|show> <appType> ...` | Manage app sidebar navigation groups |
 | `openyida app-permission <get\|set\|add\|remove\|search-user> ...` | Manage app primary, data, and developer admins |
 | `openyida i18n <overview\|config\|languages\|list\|upsert\|delete\|translate\|translate-all\|upgrade> <appType> ...` | Manage app multilingual copy and language config |

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -259,6 +259,8 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 | `openyida corp-efficiency [overview\|details\|detail\|groups\|notify] [options] [--open\|--no-open]` | 查询企业效能概览和明细报表 |
 | `openyida create-app "<name>"\|--name <name> [options] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建宜搭应用 |
 | `openyida update-app <appType> [--name "..."] [--layout slide\|ver] [--theme deepBlue]` | 更新应用信息 |
+| `openyida app-online <appType> [--to-ding-app-center] [--show-app-center]` | 启用宜搭应用 |
+| `openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]` | 停用宜搭应用 |
 | `openyida nav-group <list\|create\|rename\|delete\|move\|order\|auto-order\|hide\|show> <appType> ...` | 管理应用左侧导航分组 |
 | `openyida app-permission <get\|set\|add\|remove\|search-user> ...` | 管理应用主管理员、数据管理员和开发成员 |
 | `openyida i18n <overview\|config\|languages\|list\|upsert\|delete\|translate\|translate-all\|upgrade> <appType> ...` | 管理应用多语言文案和语言配置 |

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -841,6 +841,13 @@ async function main() {
       break;
     }
 
+    case 'app-online':
+    case 'app-offline': {
+      const { run: runAppLifecycle } = require('../lib/app/app-lifecycle');
+      await runAppLifecycle(command === 'app-online' ? 'online' : 'offline', args);
+      break;
+    }
+
     case 'nav-group':
     case 'group': {
       const { run: runNavGroup } = require('../lib/app/nav-group');

--- a/lib/app/app-lifecycle.js
+++ b/lib/app/app-lifecycle.js
@@ -1,0 +1,128 @@
+/**
+ * app-lifecycle.js - 启用或停用宜搭应用
+ *
+ * 用法：
+ *   openyida app-online <appType> [--to-ding-app-center] [--show-app-center]
+ *   openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]
+ */
+
+'use strict';
+
+const querystring = require('querystring');
+const { httpPost, requestWithAutoLogin } = require('../core/utils');
+const { createAuthRef } = require('../core/yida-client');
+const { t } = require('../core/i18n');
+const { throwCommandError, throwUsage } = require('../core/command-errors');
+
+const ACTIONS = Object.freeze({
+  online: Object.freeze({ endpoint: 'onlineApp', api: 'App.goOnline' }),
+  offline: Object.freeze({ endpoint: 'offlineApp', api: 'App.goOffline' }),
+});
+
+function parseArgs(args = []) {
+  const params = {
+    appType: null,
+    toDingAppCenter: false,
+    showAppCenter: false,
+    help: false,
+  };
+
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      params.help = true;
+    } else if (arg === '--to-ding-app-center') {
+      params.toDingAppCenter = true;
+    } else if (arg === '--show-app-center') {
+      params.showAppCenter = true;
+    } else if (!arg.startsWith('-') && !params.appType) {
+      params.appType = arg;
+    } else {
+      throwUsage(t('app_lifecycle.invalid_argument', arg));
+    }
+  }
+
+  return params;
+}
+
+function buildRequestPath(action, appType, stamp = Date.now()) {
+  const config = ACTIONS[action];
+  if (!config) {
+    throw new Error(t('app_lifecycle.invalid_action', action));
+  }
+  return `/dingtalk/web/${encodeURIComponent(appType)}/query/app/${config.endpoint}.json` +
+    `?_api=${encodeURIComponent(config.api)}&_mock=false&_stamp=${stamp}`;
+}
+
+function buildPostData(params, authRef) {
+  return querystring.stringify({
+    _csrf_token: authRef.csrfToken || '',
+    _locale_time_zone_offset: '28800000',
+    isToDingAppCenter: params.toDingAppCenter ? 'y' : 'n',
+    showAppCenter: params.showAppCenter ? 'y' : 'n',
+  });
+}
+
+async function changeAppLifecycle(action, params, authRef = createAuthRef()) {
+  const response = await requestWithAutoLogin((auth) => httpPost(
+    auth.baseUrl,
+    buildRequestPath(action, params.appType),
+    buildPostData(params, auth),
+    auth.cookies
+  ), authRef);
+
+  if (!response || response.success !== true || response.content !== true) {
+    const errorMsg = response && (response.errorMsg || response.message || response.errorCode);
+    throwCommandError(errorMsg || t('app_lifecycle.request_failed'), {
+      code: action === 'online' ? 'APP_ONLINE_FAILED' : 'APP_OFFLINE_FAILED',
+      details: { action, appType: params.appType },
+    });
+  }
+
+  return {
+    success: true,
+    action,
+    appType: params.appType,
+    isToDingAppCenter: params.toDingAppCenter,
+    showAppCenter: params.showAppCenter,
+  };
+}
+
+function printUsage(action) {
+  const { usage } = require('../core/chalk');
+  usage(t(`app_lifecycle.${action}_usage`), t(`app_lifecycle.${action}_example`));
+}
+
+async function run(action, args = []) {
+  if (!ACTIONS[action]) {
+    throwCommandError(t('app_lifecycle.invalid_action', action), {
+      code: 'APP_LIFECYCLE_INVALID_ACTION',
+    });
+  }
+
+  const params = parseArgs(args);
+  if (params.help) {
+    printUsage(action);
+    return { success: true, help: true };
+  }
+  if (!params.appType) {
+    printUsage(action);
+    throwUsage(t('app_lifecycle.missing_app_type'), t(`app_lifecycle.${action}_usage`), {
+      code: 'APP_LIFECYCLE_USAGE',
+    });
+  }
+
+  const output = await changeAppLifecycle(action, params);
+  const { result } = require('../core/chalk');
+  result(true, t(`app_lifecycle.${action}_success`), [['appType', params.appType]]);
+  console.log(JSON.stringify(output));
+  return output;
+}
+
+module.exports = {
+  ACTIONS,
+  buildPostData,
+  buildRequestPath,
+  changeAppLifecycle,
+  parseArgs,
+  run,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -430,6 +430,8 @@ const COMMAND_SIDE_EFFECTS = new Map([
 
   ...sideEffectEntries([
     'add-validation',
+    'app-offline',
+    'app-online',
     'append-chart',
     'cdn-refresh',
     'cdn-upload',
@@ -667,6 +669,7 @@ const COMMAND_PERMISSIONS = new Map([
 
   ...permissionEntries([
     'add-validation',
+    'app-online',
     'append-chart',
     'build-page',
     'cdn-config',
@@ -727,10 +730,11 @@ const COMMAND_PERMISSIONS = new Map([
   })),
 
   ...permissionEntries([
+    'app-offline',
     'connector.delete',
     'connector.delete-action',
   ], permission('ask', 'destructive', {
-    reason: 'Deletes or removes existing configuration.',
+    reason: 'Deletes, removes, or disables existing remote state.',
   })),
 
   ...permissionEntries([
@@ -1032,6 +1036,8 @@ const COMMAND_GROUPS = [
       }),
       command('create-app', ['create-app'], 'create-app "<name>"|--name <name> [options] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_app'),
       command('update-app', ['update-app'], 'update-app <appType> [--name "..."] [--layout slide|ver] [--theme deepBlue]', 'help.cmd_update_app'),
+      command('app-online', ['app-online'], 'app-online <appType> [--to-ding-app-center] [--show-app-center]', 'help.cmd_app_online'),
+      command('app-offline', ['app-offline'], 'app-offline <appType> [--to-ding-app-center] [--show-app-center]', 'help.cmd_app_offline'),
       command('nav-group', ['nav-group'], 'nav-group <list|create|rename|delete|move|order|auto-order|hide|show> <appType> ...', 'help.cmd_nav_group', {
         output: 'json',
         aliases: ['group'],

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -23,6 +23,8 @@ module.exports = {
     cmd_corp_efficiency: 'Query enterprise efficiency overview and detail reports',
     cmd_create_app: 'Create a Yida app',
     cmd_update_app: 'Update app info',
+    cmd_app_online: 'Enable a Yida app',
+    cmd_app_offline: 'Disable a Yida app',
     cmd_nav_group: 'Manage app sidebar navigation groups',
     cmd_app_permission: 'Manage app primary, data, and developer admins',
     cmd_i18n: 'Manage app multilingual copy and language config',
@@ -958,6 +960,19 @@ Examples:
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.',
+  },
+
+  app_lifecycle: {
+    online_usage: 'Usage: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Example: openyida app-online APP_XXX',
+    offline_usage: 'Usage: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Example: openyida app-offline APP_XXX',
+    missing_app_type: 'Error: missing appType argument',
+    invalid_argument: 'Unsupported argument: {0}',
+    invalid_action: 'Unsupported app lifecycle action: {0}',
+    request_failed: 'App lifecycle operation failed',
+    online_success: 'App enabled',
+    offline_success: 'App disabled',
   },
 
   // ── lib/update-form-config.js ──────────────────────

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -23,6 +23,8 @@ module.exports = {
     cmd_corp_efficiency: '查询企业效能概览和明细报表',
     cmd_create_app: '创建宜搭应用',
     cmd_update_app: '更新应用信息',
+    cmd_app_online: '启用宜搭应用',
+    cmd_app_offline: '停用宜搭应用',
     cmd_nav_group: '管理应用左侧导航分组',
     cmd_app_permission: '管理应用主管理员、数据管理员和开发成员',
     cmd_i18n: '管理应用多语言文案和语言配置',
@@ -887,6 +889,19 @@ openyida - 宜搭命令行工具
     name_label: '  应用名称: {0}',
     failed: '  ❌ 更新失败: {0}',
     layout_notice: '提示：layoutDirection 由宜搭应用外壳在创建/刷新时消费；若后台切换后顶部操作栏未立即恢复，请重新打开工作台或使用目标 layout 重新创建应用。',
+  },
+
+  app_lifecycle: {
+    online_usage: '用法: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: '示例: openyida app-online APP_XXX',
+    offline_usage: '用法: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: '示例: openyida app-offline APP_XXX',
+    missing_app_type: '错误: 缺少 appType 参数',
+    invalid_argument: '不支持的参数: {0}',
+    invalid_action: '不支持的应用生命周期操作: {0}',
+    request_failed: '应用生命周期操作失败',
+    online_success: '应用已启用',
+    offline_success: '应用已停用',
   },
 
   // ── lib/process/create-process.js ─────────────────

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'استعلام عن نظرة عامة على كفاءة المؤسسة وتقارير التفاصيل',
     cmd_create_app: 'إنشاء تطبيق Yida',
     cmd_update_app: 'تحديث معلومات التطبيق',
+    cmd_app_online: 'تفعيل تطبيق Yida',
+    cmd_app_offline: 'تعطيل تطبيق Yida',
     cmd_nav_group: 'إدارة مجموعات التنقل الجانبية للتطبيق',
     cmd_app_permission: 'إدارة مسؤولي التطبيق الأساسيين والبيانات والتطوير',
     cmd_i18n: 'إدارة نصوص التطبيق متعددة اللغات وإعداداتها',
@@ -916,6 +918,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'الاستخدام: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'مثال: openyida app-online APP_XXX',
+    offline_usage: 'الاستخدام: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'مثال: openyida app-offline APP_XXX',
+    missing_app_type: 'خطأ: وسيطة appType مفقودة',
+    invalid_argument: 'وسيطة غير مدعومة: {0}',
+    invalid_action: 'إجراء دورة حياة تطبيق غير مدعوم: {0}',
+    request_failed: 'فشلت عملية دورة حياة التطبيق',
+    online_success: 'تم تفعيل التطبيق',
+    offline_success: 'تم تعطيل التطبيق',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'Unternehmenseffizienz-Übersicht und Detailberichte abrufen',
     cmd_create_app: 'Yida-App erstellen',
     cmd_update_app: 'App-Informationen aktualisieren',
+    cmd_app_online: 'Yida-App aktivieren',
+    cmd_app_offline: 'Yida-App deaktivieren',
     cmd_nav_group: 'Navigationsgruppen der App-Seitenleiste verwalten',
     cmd_app_permission: 'App-Haupt-, Daten- und Entwicklungsadmins verwalten',
     cmd_i18n: 'Mehrsprachige App-Texte und Sprachen verwalten',
@@ -916,6 +918,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'Verwendung: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Beispiel: openyida app-online APP_XXX',
+    offline_usage: 'Verwendung: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Beispiel: openyida app-offline APP_XXX',
+    missing_app_type: 'Fehler: appType-Argument fehlt',
+    invalid_argument: 'Nicht unterstütztes Argument: {0}',
+    invalid_action: 'Nicht unterstützte App-Lebenszyklusaktion: {0}',
+    request_failed: 'App-Lebenszyklusaktion fehlgeschlagen',
+    online_success: 'App aktiviert',
+    offline_success: 'App deaktiviert',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'Consultar resumen de eficiencia empresarial e informes detallados',
     cmd_create_app: 'Crear una aplicación Yida',
     cmd_update_app: 'Actualizar información de la aplicación',
+    cmd_app_online: 'Activar una aplicación Yida',
+    cmd_app_offline: 'Desactivar una aplicación Yida',
     cmd_nav_group: 'Gestionar grupos de navegación lateral de la aplicación',
     cmd_app_permission: 'Gestionar admins principales, de datos y desarrollo de la app',
     cmd_i18n: 'Gestionar textos multilingües e idiomas de la app',
@@ -918,6 +920,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'Uso: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Ejemplo: openyida app-online APP_XXX',
+    offline_usage: 'Uso: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Ejemplo: openyida app-offline APP_XXX',
+    missing_app_type: 'Error: falta el argumento appType',
+    invalid_argument: 'Argumento no compatible: {0}',
+    invalid_action: 'Acción de ciclo de vida no compatible: {0}',
+    request_failed: 'Falló la operación del ciclo de vida de la aplicación',
+    online_success: 'Aplicación activada',
+    offline_success: 'Aplicación desactivada',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: "Consulter l'aperçu de l'efficacité entreprise et les rapports détaillés",
     cmd_create_app: 'Créer une application Yida',
     cmd_update_app: "Mettre à jour les infos de l'application",
+    cmd_app_online: "Activer une application Yida",
+    cmd_app_offline: "Désactiver une application Yida",
     cmd_nav_group: "Gérer les groupes de navigation latérale de l'application",
     cmd_app_permission: "Gérer les admins principaux, données et développement de l'app",
     cmd_i18n: "Gérer les textes multilingues et langues de l'app",
@@ -918,6 +920,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'Utilisation : openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Exemple : openyida app-online APP_XXX',
+    offline_usage: 'Utilisation : openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Exemple : openyida app-offline APP_XXX',
+    missing_app_type: "Erreur : argument appType manquant",
+    invalid_argument: 'Argument non pris en charge : {0}',
+    invalid_action: "Action de cycle de vie d'application non prise en charge : {0}",
+    request_failed: "Échec de l'opération de cycle de vie de l'application",
+    online_success: 'Application activée',
+    offline_success: 'Application désactivée',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'एंटरप्राइज दक्षता अवलोकन और विवरण रिपोर्ट क्वेरी करें',
     cmd_create_app: 'Yida ऐप बनाएं',
     cmd_update_app: 'ऐप जानकारी अपडेट करें',
+    cmd_app_online: 'Yida ऐप सक्षम करें',
+    cmd_app_offline: 'Yida ऐप अक्षम करें',
     cmd_nav_group: 'ऐप साइडबार नेविगेशन समूह प्रबंधित करें',
     cmd_app_permission: 'ऐप प्राथमिक, डेटा और डेवलपमेंट एडमिन प्रबंधित करें',
     cmd_i18n: 'ऐप की बहुभाषी कॉपी और भाषा कॉन्फिग प्रबंधित करें',
@@ -916,6 +918,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'उपयोग: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'उदाहरण: openyida app-online APP_XXX',
+    offline_usage: 'उपयोग: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'उदाहरण: openyida app-offline APP_XXX',
+    missing_app_type: 'त्रुटि: appType आर्ग्युमेंट अनुपस्थित है',
+    invalid_argument: 'असमर्थित आर्ग्युमेंट: {0}',
+    invalid_action: 'असमर्थित ऐप जीवनचक्र कार्रवाई: {0}',
+    request_failed: 'ऐप जीवनचक्र कार्रवाई विफल हुई',
+    online_success: 'ऐप सक्षम किया गया',
+    offline_success: 'ऐप अक्षम किया गया',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: '企業効率の概要と明細レポートを取得',
     cmd_create_app: '宜搭アプリを作成',
     cmd_update_app: 'アプリ情報を更新',
+    cmd_app_online: 'Yida アプリを有効化',
+    cmd_app_offline: 'Yida アプリを無効化',
     cmd_nav_group: 'アプリのサイドバーナビゲーショングループを管理',
     cmd_app_permission: 'アプリ主管理者、データ管理者、開発メンバーを管理',
     cmd_i18n: 'アプリの多言語文言と言語設定を管理',
@@ -870,6 +872,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: '使用方法: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: '例: openyida app-online APP_XXX',
+    offline_usage: '使用方法: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: '例: openyida app-offline APP_XXX',
+    missing_app_type: 'エラー: appType 引数がありません',
+    invalid_argument: 'サポートされていない引数: {0}',
+    invalid_action: 'サポートされていないアプリライフサイクル操作: {0}',
+    request_failed: 'アプリライフサイクル操作に失敗しました',
+    online_success: 'アプリを有効化しました',
+    offline_success: 'アプリを無効化しました',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: '기업 효율 개요 및 상세 보고서 조회',
     cmd_create_app: 'Yida 앱 생성',
     cmd_update_app: '앱 정보 업데이트',
+    cmd_app_online: 'Yida 앱 활성화',
+    cmd_app_offline: 'Yida 앱 비활성화',
     cmd_nav_group: '앱 사이드바 내비게이션 그룹 관리',
     cmd_app_permission: '앱 주관리자, 데이터 관리자, 개발 멤버 관리',
     cmd_i18n: '앱 다국어 문구와 언어 설정 관리',
@@ -917,6 +919,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: '사용법: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: '예: openyida app-online APP_XXX',
+    offline_usage: '사용법: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: '예: openyida app-offline APP_XXX',
+    missing_app_type: '오류: appType 인수가 없습니다',
+    invalid_argument: '지원되지 않는 인수: {0}',
+    invalid_action: '지원되지 않는 앱 수명 주기 작업: {0}',
+    request_failed: '앱 수명 주기 작업 실패',
+    online_success: '앱이 활성화되었습니다',
+    offline_success: '앱이 비활성화되었습니다',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'Consultar visão geral de eficiência empresarial e relatórios detalhados',
     cmd_create_app: 'Criar um aplicativo Yida',
     cmd_update_app: 'Atualizar informações do aplicativo',
+    cmd_app_online: 'Ativar um aplicativo Yida',
+    cmd_app_offline: 'Desativar um aplicativo Yida',
     cmd_nav_group: 'Gerenciar grupos de navegação lateral do aplicativo',
     cmd_app_permission: 'Gerenciar admins principais, de dados e desenvolvimento do app',
     cmd_i18n: 'Gerenciar textos multilíngues e idiomas do app',
@@ -918,6 +920,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'Uso: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Exemplo: openyida app-online APP_XXX',
+    offline_usage: 'Uso: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Exemplo: openyida app-offline APP_XXX',
+    missing_app_type: 'Erro: argumento appType ausente',
+    invalid_argument: 'Argumento não suportado: {0}',
+    invalid_action: 'Ação de ciclo de vida não suportada: {0}',
+    request_failed: 'Falha na operação do ciclo de vida do aplicativo',
+    online_success: 'Aplicativo ativado',
+    offline_success: 'Aplicativo desativado',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: 'Truy vấn tổng quan hiệu quả doanh nghiệp và báo cáo chi tiết',
     cmd_create_app: 'Tạo ứng dụng Yida',
     cmd_update_app: 'Cập nhật thông tin ứng dụng',
+    cmd_app_online: 'Bật ứng dụng Yida',
+    cmd_app_offline: 'Tắt ứng dụng Yida',
     cmd_nav_group: 'Quản lý nhóm điều hướng thanh bên của ứng dụng',
     cmd_app_permission: 'Quản lý quản trị chính, dữ liệu và phát triển của ứng dụng',
     cmd_i18n: 'Quản lý nội dung đa ngôn ngữ và cấu hình ngôn ngữ của ứng dụng',
@@ -916,6 +918,18 @@ module.exports = {
     name_label: '  App name: {0}',
     failed: '  ❌ Update failed: {0}',
     layout_notice: 'Note: layoutDirection is consumed by the Yida app shell during creation/refresh. If the top action bar does not recover immediately after a backend switch, reopen the workbench or recreate the app with the target layout.'
+  },
+  app_lifecycle: {
+    online_usage: 'Cách dùng: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: 'Ví dụ: openyida app-online APP_XXX',
+    offline_usage: 'Cách dùng: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: 'Ví dụ: openyida app-offline APP_XXX',
+    missing_app_type: 'Lỗi: thiếu tham số appType',
+    invalid_argument: 'Tham số không được hỗ trợ: {0}',
+    invalid_action: 'Thao tác vòng đời ứng dụng không được hỗ trợ: {0}',
+    request_failed: 'Thao tác vòng đời ứng dụng thất bại',
+    online_success: 'Đã bật ứng dụng',
+    offline_success: 'Đã tắt ứng dụng',
   },
   create_process: {
     title: 'Yida Process Form Creation',

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -21,6 +21,8 @@ module.exports = {
     cmd_corp_efficiency: '查詢企業效能概覽和明細報表',
     cmd_create_app: '建立宜搭應用程式',
     cmd_update_app: '更新應用程式資料',
+    cmd_app_online: '啟用宜搭應用程式',
+    cmd_app_offline: '停用宜搭應用程式',
     cmd_nav_group: '管理應用程式左側導航分組',
     cmd_app_permission: '管理應用主管理員、資料管理員和開發成員',
     cmd_i18n: '管理應用多語言文案和語言設定',
@@ -856,6 +858,18 @@ module.exports = {
     name_label: '  应用名称: {0}',
     failed: '  ❌ 更新失败: {0}',
     layout_notice: '提示：layoutDirection 由宜搭應用外殼在建立/重新整理時消費；若後台切換後頂部操作欄未立即恢復，請重新開啟工作台或使用目標 layout 重新建立應用。'
+  },
+  app_lifecycle: {
+    online_usage: '用法: openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+    online_example: '範例: openyida app-online APP_XXX',
+    offline_usage: '用法: openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+    offline_example: '範例: openyida app-offline APP_XXX',
+    missing_app_type: '錯誤: 缺少 appType 參數',
+    invalid_argument: '不支援的參數: {0}',
+    invalid_action: '不支援的應用生命週期操作: {0}',
+    request_failed: '應用生命週期操作失敗',
+    online_success: '應用已啟用',
+    offline_success: '應用已停用',
   },
   create_process: {
     title: '宜搭流程表单一体化创建',

--- a/scripts/e2e-real/skill-coverage.js
+++ b/scripts/e2e-real/skill-coverage.js
@@ -10,6 +10,7 @@ const SKILLS_DIR = path.join(ROOT, 'yida-skills', 'skills');
 
 const SKILL_COVERAGE = {
   'yida-app': { level: 'real-e2e', stages: ['app', 'form', 'page', 'data', 'report', 'dashboard'] },
+  'yida-app-lifecycle': { level: 'offline-unit', tests: ['tests/app-lifecycle.test.js', 'tests/cli-smoke.test.js'], reason: 'online/offline commands change real app availability; request contracts and agent permission metadata are validated with mocks and never run in shared real E2E' },
   'yida-app-permission': { level: 'offline-unit', tests: ['tests/app-permission.test.js'], reason: 'app admin mutations affect real application access; shared real E2E only validates safe read paths' },
   'yida-design': { level: 'offline-unit', tests: ['skill metadata and packaging validation', 'routing eval scenarios', 'tests/create-form.test.js', 'tests/skill-contracts.test.js'], reason: 'application experience blueprint, visual direction and theme token guidance produce PRD/design artifacts before missing app/form/process/page resources are created; validate routing, packaging, skill contracts and form theme payloads rather than mutating Yida resources or tenant-wide theme config' },
   'yida-basic-info': { level: 'offline-unit', tests: ['tests/basic-info.test.js'], reason: 'basic-info reads org admin metadata and can update domains; unit coverage avoids mutating shared real org settings' },

--- a/tests/app-lifecycle.test.js
+++ b/tests/app-lifecycle.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const querystring = require('querystring');
+
+jest.mock('../lib/core/utils', () => ({
+  httpPost: jest.fn(),
+  requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+}));
+
+jest.mock('../lib/core/yida-client', () => ({
+  createAuthRef: jest.fn(),
+}));
+
+const utils = require('../lib/core/utils');
+const { createAuthRef } = require('../lib/core/yida-client');
+const {
+  buildRequestPath,
+  changeAppLifecycle,
+  parseArgs,
+  run,
+} = require('../lib/app/app-lifecycle');
+
+const AUTH_REF = {
+  baseUrl: 'https://www.aliwork.com',
+  csrfToken: 'csrf-value',
+  cookies: [{ name: 'session', value: 'redacted' }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  createAuthRef.mockReturnValue(AUTH_REF);
+});
+
+describe('app lifecycle requests', () => {
+  test('online builds App.goOnline URL and default form body', async () => {
+    utils.httpPost.mockResolvedValue({ success: true, content: true });
+
+    const output = await changeAppLifecycle('online', parseArgs(['APP_1']));
+    const [baseUrl, requestPath, rawBody, cookies] = utils.httpPost.mock.calls[0];
+
+    expect(baseUrl).toBe('https://www.aliwork.com');
+    expect(requestPath).toMatch(/^\/dingtalk\/web\/APP_1\/query\/app\/onlineApp\.json\?_api=App\.goOnline&_mock=false&_stamp=\d+$/);
+    expect(querystring.parse(rawBody)).toEqual({
+      _csrf_token: 'csrf-value',
+      _locale_time_zone_offset: '28800000',
+      isToDingAppCenter: 'n',
+      showAppCenter: 'n',
+    });
+    expect(cookies).toBe(AUTH_REF.cookies);
+    expect(output).toMatchObject({ success: true, action: 'online', appType: 'APP_1' });
+  });
+
+  test('offline builds App.goOffline URL and enables explicit app center flags', async () => {
+    utils.httpPost.mockResolvedValue({ success: true, content: true });
+
+    const params = parseArgs(['APP_2', '--to-ding-app-center', '--show-app-center']);
+    const output = await changeAppLifecycle('offline', params);
+    const requestPath = utils.httpPost.mock.calls[0][1];
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+
+    expect(requestPath).toMatch(/^\/dingtalk\/web\/APP_2\/query\/app\/offlineApp\.json\?_api=App\.goOffline&_mock=false&_stamp=\d+$/);
+    expect(body).toMatchObject({
+      isToDingAppCenter: 'y',
+      showAppCenter: 'y',
+    });
+    expect(output).toMatchObject({
+      action: 'offline',
+      isToDingAppCenter: true,
+      showAppCenter: true,
+    });
+  });
+
+  test('failed or false-content response rejects with a CLI error', async () => {
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: false,
+      errorCode: 'APP_STATE_REJECTED',
+      errorMsg: 'operation rejected',
+    });
+
+    await expect(changeAppLifecycle('offline', parseArgs(['APP_3'])))
+      .rejects.toMatchObject({
+        isCliError: true,
+        code: 'APP_OFFLINE_FAILED',
+        message: 'operation rejected',
+      });
+  });
+
+  test('missing appType and help never issue a remote request', async () => {
+    await expect(run('online', [])).rejects.toMatchObject({
+      isCliError: true,
+      code: 'APP_LIFECYCLE_USAGE',
+    });
+    await expect(run('offline', ['--help'])).resolves.toMatchObject({ help: true });
+
+    expect(createAuthRef).not.toHaveBeenCalled();
+    expect(utils.httpPost).not.toHaveBeenCalled();
+  });
+
+  test('request path encodes appType and rejects unsupported actions', () => {
+    expect(buildRequestPath('online', 'APP/unsafe', 123))
+      .toBe('/dingtalk/web/APP%2Funsafe/query/app/onlineApp.json?_api=App.goOnline&_mock=false&_stamp=123');
+    expect(() => buildRequestPath('delete', 'APP_1', 123)).toThrow('delete');
+  });
+});

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -220,6 +220,8 @@ describe('CLI offline smoke', () => {
     const cases = [
       { args: ['create-form', '--help'], text: 'create-form create' },
       { args: ['create-page', '--help'], text: 'create-page' },
+      { args: ['app-online', '--help'], text: 'openyida app-online' },
+      { args: ['app-offline', '--help'], text: 'openyida app-offline' },
       { args: ['sample', '--help'], text: 'Code Templates' },
       { args: ['publish', '--help'], text: 'openyida publish' },
     ];
@@ -421,6 +423,7 @@ describe('CLI offline smoke', () => {
       'formula.evaluate',
     ]));
     expect(parsed.summary.ask_command_ids).toEqual([
+      'app-offline',
       'connector.delete',
       'connector.delete-action',
     ]);
@@ -459,6 +462,8 @@ describe('CLI offline smoke', () => {
     expect(commands).toContain('login');
     expect(commands).toContain('org');
     expect(commands).toContain('corp-efficiency');
+    expect(commands).toContain('app-online');
+    expect(commands).toContain('app-offline');
     expect(commands).toContain('nav-group');
     expect(commands).toContain('create-form.create');
     expect(commands).toContain('create-form.patch');
@@ -509,6 +514,18 @@ describe('CLI offline smoke', () => {
     expect(parsed.commands.find(entry => entry.id === 'ai')).toMatchObject({
       usage: 'openyida ai <text|image> [options]',
       output: 'text|json',
+      requires_login: true,
+    });
+    expect(parsed.commands.find(entry => entry.id === 'app-online')).toMatchObject({
+      usage: 'openyida app-online <appType> [--to-ding-app-center] [--show-app-center]',
+      side_effect: { kind: 'remote_write', mutates_yida: true },
+      permission: { mode: 'allow', effect: 'write' },
+      requires_login: true,
+    });
+    expect(parsed.commands.find(entry => entry.id === 'app-offline')).toMatchObject({
+      usage: 'openyida app-offline <appType> [--to-ding-app-center] [--show-app-center]',
+      side_effect: { kind: 'remote_write', mutates_yida: true },
+      permission: { mode: 'ask', effect: 'destructive' },
       requires_login: true,
     });
     expect(parsed.commands.find(entry => entry.id === 'integration.diagnose')).toMatchObject({
@@ -1158,6 +1175,7 @@ describe('CLI offline smoke', () => {
     ]));
     expect(parsed.commands.allow_command_ids).toContain('create-app');
     expect(parsed.commands.ask_command_ids).toEqual([
+      'app-offline',
       'connector.delete',
       'connector.delete-action',
     ]);

--- a/tests/e2e-real-skill-coverage.test.js
+++ b/tests/e2e-real-skill-coverage.test.js
@@ -51,4 +51,12 @@ describe('real E2E skill coverage matrix', () => {
       commands: ['configure-process'],
     });
   });
+
+  test('app lifecycle stays offline because it changes real app availability', () => {
+    expect(SKILL_COVERAGE['yida-app-lifecycle']).toMatchObject({
+      level: 'offline-unit',
+      tests: expect.arrayContaining(['tests/app-lifecycle.test.js']),
+      reason: expect.stringMatching(/availability|never run/i),
+    });
+  });
 });

--- a/tests/safe-json.test.js
+++ b/tests/safe-json.test.js
@@ -4,6 +4,8 @@ const { safeParseJson, preprocessJsonInput, normalizeSmartQuotes } = require('..
 const { setLanguage } = require('../lib/core/i18n');
 
 describe('safe-json preprocessing (#3)', () => {
+  beforeAll(() => setLanguage('zh'));
+
   test('parses plain valid JSON', () => {
     expect(safeParseJson('{"a":1,"b":[2,3]}')).toEqual({ a: 1, b: [2, 3] });
   });
@@ -39,8 +41,6 @@ describe('safe-json preprocessing (#3)', () => {
 });
 
 describe('safe-json friendly diagnostics (#2)', () => {
-  beforeAll(() => setLanguage('zh'));
-
   function messageOf(input) {
     try {
       safeParseJson(input, { recoverSmartQuotes: false });

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -121,6 +121,15 @@ describe('OpenYida skill contracts', () => {
     expect(login.command_ids).toEqual(expect.arrayContaining(['agent-capabilities', 'login', 'auth']));
     expect(logout.command_ids).toEqual(expect.arrayContaining(['logout', 'auth']));
 
+    const lifecycle = byName.get('yida-app-lifecycle');
+    expect(lifecycle.positive_signals).toEqual(expect.arrayContaining(['启用应用', '停用应用', '上线应用', '下线应用']));
+    expect(lifecycle.negative_signals).toEqual(expect.arrayContaining(['发布页面', '禁用集成自动化']));
+    expect(lifecycle.command_ids).toEqual(['app-online', 'app-offline']);
+    const lifecycleSkill = readSkill('yida-skills/skills/yida-app-lifecycle/SKILL.md');
+    expect(lifecycleSkill).toContain('只有用户明确说');
+    expect(lifecycleSkill).toContain('`app-offline` 会让现有应用停止服务');
+    expect(lifecycleSkill).toContain('不得在测试、评测或默认 shared real E2E 中执行真实启用/停用');
+
     const data = byName.get('yida-data-management');
     expect(data.positive_signals).toEqual(expect.arrayContaining(['新增记录']));
     expect(data.negative_signals).toEqual(expect.arrayContaining(['修改表单结构']));

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -20,7 +20,7 @@ function listMarkdownAndJsonFiles(dir) {
 }
 
 function isSampleRoutingGuidanceFile(file) {
-  const relativePath = path.relative(ROOT, file);
+  const relativePath = path.relative(ROOT, file).replace(/\\/g, '/');
   if (relativePath.includes('yida-skills/skills/yida-design/references/style-designs/')) {
     return false;
   }

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -165,7 +165,7 @@ OpenYida builder 默认使用 `create-app / create-form / create-page / publish`
 | 大类目录 | 第一层意图信号 | 子技能 |
 |------|------|------|
 | `yida-skills/context` | 登录、退出、切换组织、组织版本/容量、Schema、fieldId、只读预检 | `yida-login`、`yida-logout`、`yida-basic-info`、`yida-get-schema`、`yida-corp-efficiency` |
-| `yida-skills/app` | 从零搭应用、完整系统、应用导航、多语言 | `yida-app`、`yida-create-app`、`yida-nav-group`、`yida-i18n` |
+| `yida-skills/app` | 从零搭应用、完整系统、应用启停、应用导航、多语言 | `yida-app`、`yida-create-app`、`yida-app-lifecycle`、`yida-nav-group`、`yida-i18n` |
 | `yida-skills/design` | 完整应用产品设计、单页 UI 改造、主页面视觉设计、应用主题色、全局换肤、PRD 和 design.md | `yida-design` |
 | `yida-skills/form` | 表单字段、公式、校验、业务关联规则、详情页、批量录入、数据记录 | `yida-create-form-page`、`yida-formula`、`yida-formula-evaluate`、`yida-business-rule`、`yida-form-detail`、`yida-canvas-table-form`、`yida-table-form`、`yida-data-management` |
 | `yida-skills/process` | 审批、流程表单、流程规则、节点/分支/字段权限、流程代理 | `yida-create-process`、`yida-process-rule`、`yida-agent-center` |
@@ -186,6 +186,7 @@ OpenYida builder 默认使用 `create-app / create-form / create-page / publish`
 | 用户给 taskUuid 并要求转 PRD | 先用 `yida-tingji` 读取听记内容，再把已有内容交给 `yida-flash-note-to-prd` 生成 PRD |
 | 已有会议纪要/闪记内容转 PRD | `yida-flash-note-to-prd`，只处理已有内容，不负责按 taskUuid 拉取听记 |
 | 只创建应用壳并拿 appType | `yida-create-app`；创建成功后把真实 `appType` 交给 `yida-design` 生成或更新 `prd/<项目名>/prd.md` 和 `prd/<项目名>/design.md`，后续表单、流程、页面和发布都消费这两份文件 |
+| 启用/上线或停用/下线已有应用 | `yida-app-lifecycle`；只有用户明确要求时执行，`app-offline` 执行前需再次确认目标应用 |
 | 创建自定义展示页资源 | `yida-create-page`，之后默认接 `yida-canvas-custom-page` 和 `yida-publish-page` |
 | 开发表单字段结构 / 增删改字段 | 先加载 `yida-form-detail` 做表单视觉引导并合并 Divider 分割线，再用 `yida-create-form-page` 落地字段结构 |
 | 创建带审批的流程表单 | `yida-create-process` |

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -103,6 +103,40 @@
       ]
     },
     {
+      "name": "yida-app-lifecycle",
+      "path": "skills/yida-app-lifecycle/SKILL.md",
+      "display_name": "应用启用与停用",
+      "description": "宜搭应用启用与停用。仅当用户明确要求启用、停用、上线或下线某个已有应用时使用；不用于创建应用、发布页面或发布到钉钉应用中心。",
+      "category": "yida-skills/app",
+      "tags": [
+        "启用应用",
+        "停用应用",
+        "上线应用",
+        "下线应用"
+      ],
+      "aliases": [
+        "应用生命周期",
+        "应用上下线"
+      ],
+      "positive_signals": [
+        "启用应用",
+        "停用应用",
+        "上线应用",
+        "下线应用"
+      ],
+      "negative_signals": [
+        "发布页面",
+        "更新应用信息",
+        "禁用集成自动化",
+        "关闭公开访问"
+      ],
+      "command_ids": [
+        "app-online",
+        "app-offline"
+      ],
+      "done_when": "CLI 返回 success:true 且 action 与用户明确意图一致；app-offline 执行前已确认目标 appType，失败时不得宣称状态改变。"
+    },
+    {
       "name": "yida-basic-info",
       "path": "skills/yida-basic-info/SKILL.md",
       "display_name": "组织基础信息查询",
@@ -1160,6 +1194,10 @@
         "创建应用",
         "完整应用",
         "管理系统",
+        "启用应用",
+        "停用应用",
+        "上线应用",
+        "下线应用",
         "导航分组",
         "多语言"
       ]

--- a/yida-skills/skills/yida-app-lifecycle/SKILL.md
+++ b/yida-skills/skills/yida-app-lifecycle/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: yida-app-lifecycle
+description: 宜搭应用启用与停用。仅当用户明确要求启用、停用、上线或下线某个已有应用时使用；不用于创建应用、发布页面或发布到钉钉应用中心。
+---
+
+# 宜搭应用启用与停用
+
+## 严格要求 (MUST DO)
+
+- 只有用户明确说“启用应用 / 上线应用 / 停用应用 / 下线应用”时，才允许调用本技能的远程写命令；不得从“发布页面”“更新应用”“应用不可用”等间接描述推断执行。
+- 执行前必须确认唯一的 `appType` 和当前登录组织；目标不明确时先询问用户。
+- `app-offline` 会让现有应用停止服务，执行前必须向用户展示目标 `appType` 与完整命令并获得确认。
+- 默认保持 `isToDingAppCenter=n`、`showAppCenter=n`。只有用户明确要求同步钉钉应用中心或显示应用中心时，才添加对应开关。
+- 命令失败后完整展示错误并停止；不得无修改连续重试，也不得改用浏览器抓包中的 Cookie、token 或 `sec-*` header 绕过认证。
+
+## 严格禁止 (NEVER DO)
+
+- 不得把首次创建应用、表单/页面发布、应用信息更新自动升级为应用启用。
+- 不得把“暂时隐藏页面”“禁用集成自动化”“关闭公开访问”路由为应用停用。
+- 不得在测试、评测或默认 shared real E2E 中执行真实启用/停用。
+- 不得把本能力扩展为钉钉应用中心完整发布流程。
+
+## 意图与命令
+
+启用或上线已有应用：
+
+```bash
+openyida app-online <appType>
+```
+
+停用或下线已有应用（需确认）：
+
+```bash
+openyida app-offline <appType>
+```
+
+仅在用户明确要求应用中心相关行为时使用：
+
+```bash
+openyida app-online <appType> --to-ding-app-center --show-app-center
+openyida app-offline <appType> --to-ding-app-center --show-app-center
+```
+
+## 完成条件
+
+- CLI 返回 `success: true`，且返回的 `action` 与用户意图一致。
+- 向用户说明目标 `appType` 已启用或已停用；失败时不得宣称状态已改变。
+
+## 异常处理
+
+| 异常场景 | 处理方式 |
+|---------|----------|
+| 缺少或存在多个 appType 候选 | 停止并要求用户确认唯一目标 |
+| 登录态失效 / 组织不符 | 重新登录或切换到目标组织后再执行 |
+| 权限不足 | 停止并提示使用具备应用管理权限的账号 |
+| 平台返回 `success: false` 或 `content: false` | 展示 `errorMsg` / `errorCode`，不得重试或宣称成功 |


### PR DESCRIPTION

## Summary
- add explicit `app-online` and `app-offline` CLI commands for Yida app lifecycle changes
- add `yida-app-lifecycle` skill routing, skill index metadata, and offline-unit coverage entry
- register command manifest permissions: `app-online` as remote write, `app-offline` as ask/destructive

## Validation
- node --check for changed JS entry points
- focused Jest: `tests/app-lifecycle.test.js`, `tests/cli-smoke.test.js`, `tests/e2e-real-skill-coverage.test.js`, `tests/skill-contracts.test.js` passed, 78/78
- `scripts/validate-command-manifest.js` passed
- `scripts/generate-command-docs.js --check` passed
- `scripts/validate-i18n.js --check` passed, only existing optional-language warnings
- `scripts/build-skills-package.js` passed
- `scripts/validate-skills.js` passed after rebuilding dist

No real Yida remote write was executed.
