### PR TITLE
fix: add display page schema summary signals

### DIFF
--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -187,6 +187,117 @@ function buildComponentAliasMaps(schemaResult) {
   return { aliasByFieldId, fieldIdByAlias };
 }
 
+function parseJsonObject(value) {
+  if (typeof value !== 'string') {
+    return value && typeof value === 'object' ? value : null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveSchemaContent(schemaResult) {
+  if (!schemaResult) {
+    return null;
+  }
+  const content = schemaResult.content !== undefined ? schemaResult.content : schemaResult;
+  return parseJsonObject(content);
+}
+
+function addImportedModules(target, value) {
+  let modules = value;
+  if (typeof modules === 'string') {
+    const trimmed = modules.trim();
+    if (!trimmed) {
+      return;
+    }
+    try {
+      modules = JSON.parse(trimmed);
+    } catch {
+      modules = [trimmed];
+    }
+  }
+  if (!Array.isArray(modules)) {
+    return;
+  }
+  modules
+    .map(item => String(item || '').trim())
+    .filter(Boolean)
+    .forEach((item) => {
+      if (!target.includes(item)) {
+        target.push(item);
+      }
+    });
+}
+
+function codeBytes(value) {
+  return typeof value === 'string' ? Buffer.byteLength(value, 'utf8') : 0;
+}
+
+function isComponentInstance(node) {
+  return !!(node && typeof node === 'object' && (node.id || node.props || node.children));
+}
+
+function extractDisplayPageSummary(schemaResult) {
+  const content = resolveSchemaContent(schemaResult);
+  if (!content || typeof content !== 'object') {
+    return null;
+  }
+
+  const displayPage = {
+    hasYidaCodeCanvas: false,
+    hasNativeJsx: false,
+    runtimeCodeBytes: 0,
+    sourceCodeBytes: 0,
+    compiledCodeBytes: 0,
+    importedModules: [],
+    componentCount: 0,
+  };
+
+  function traverse(node) {
+    if (!node) {
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(traverse);
+      return;
+    }
+    if (typeof node !== 'object') {
+      return;
+    }
+
+    if (node.componentName === 'YidaCodeCanvas' && isComponentInstance(node)) {
+      const props = node.props || {};
+      displayPage.hasYidaCodeCanvas = true;
+      displayPage.componentCount++;
+      displayPage.runtimeCodeBytes += codeBytes(props.runtimeCode);
+      displayPage.sourceCodeBytes += codeBytes(props.code);
+      addImportedModules(displayPage.importedModules, props.importedModules);
+    } else if (node.componentName === 'Jsx' && isComponentInstance(node)) {
+      displayPage.hasNativeJsx = true;
+      displayPage.componentCount++;
+    }
+
+    Object.keys(node).forEach((key) => traverse(node[key]));
+  }
+
+  traverse(content.pages || content);
+
+  const module = content.actions && content.actions.module;
+  if (displayPage.hasNativeJsx && module && typeof module === 'object') {
+    displayPage.sourceCodeBytes += codeBytes(module.source);
+    displayPage.compiledCodeBytes += codeBytes(module.compiled);
+  }
+
+  if (!displayPage.hasYidaCodeCanvas && !displayPage.hasNativeJsx) {
+    return null;
+  }
+  return displayPage;
+}
+
 function parsePositiveInt(value, fallback, min, max) {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed < min) {
@@ -402,7 +513,7 @@ function printFieldSummary(result) {
 
 function buildSchemaSummary(appType, formUuid, schemaResult, meta = {}) {
   const fields = extractFieldSummary(schemaResult);
-  return {
+  const summary = {
     success: true,
     appType,
     formUuid,
@@ -410,6 +521,11 @@ function buildSchemaSummary(appType, formUuid, schemaResult, meta = {}) {
     fieldCount: fields.length,
     fields,
   };
+  const displayPage = extractDisplayPageSummary(schemaResult);
+  if (displayPage) {
+    summary.displayPage = displayPage;
+  }
+  return summary;
 }
 
 function filterForms(forms, keyword) {

--- a/lib/app/get-schema.js
+++ b/lib/app/get-schema.js
@@ -570,7 +570,7 @@ async function fetchSchemaRecord(appType, form, authRef, retries) {
     try {
       const result = await fetchSchema(appType, form.formUuid, authRef);
       if (isSuccessfulSchemaResult(result)) {
-        return {
+        const record = {
           formUuid: form.formUuid,
           formName: form.formName,
           formType: form.formType,
@@ -580,6 +580,11 @@ async function fetchSchemaRecord(appType, form, authRef, retries) {
           fieldSummary: extractFieldSummary(result),
           schema: result,
         };
+        const displayPage = extractDisplayPageSummary(result);
+        if (displayPage) {
+          record.displayPage = displayPage;
+        }
+        return record;
       }
       lastError = new Error(result ? result.errorMsg || t('common.unknown_error') : t('common.request_failed'));
     } catch (error) {

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -408,42 +408,82 @@ describe('run --all', () => {
 
   test('summary-json keeps batch stdout and index compact', async () => {
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-schemas-compact-'));
+    const canvasSource = 'export default function Page() { return React.createElement("div", null, "ok"); }';
+    const canvasRuntime = 'var YidaComp = function Page(){ return window.React.createElement("div", null, "ok"); };';
+    const nativeSource = 'export function renderJsx() { return React.createElement("div", null, "ok"); }';
+    const nativeCompiled = 'function renderJsx(){return React.createElement("div",null,"ok");}';
     fetchFormPageList.mockResolvedValue([
       { formUuid: 'FORM-A', formName: '客户信息', formType: 'form', pathName: 'customer' },
+      { formUuid: 'FORM-CANVAS', formName: 'Canvas 页', formType: 'display', pathName: 'canvas' },
+      { formUuid: 'FORM-NATIVE', formName: 'Native 页', formType: 'display', pathName: 'native' },
     ]);
-    utils.httpGet.mockResolvedValue({
-      success: true,
-      content: {
-        pages: [
-          {
-            componentsTree: [
-              {
-                componentName: 'FormContainer',
-                children: [
-                  {
-                    componentName: 'TextField',
-                    props: { fieldId: 'textField_name', label: '姓名' },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    });
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          pages: [
+            {
+              componentsTree: [
+                {
+                  componentName: 'FormContainer',
+                  children: [
+                    {
+                      componentName: 'TextField',
+                      props: { fieldId: 'textField_name', label: '姓名' },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: buildCanvasPageSchemaContent(
+          canvasSource,
+          canvasRuntime,
+          '["react","antd"]',
+          'FORM-CANVAS'
+        ),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: buildNativePageSchemaContent(nativeSource, nativeCompiled, 'FORM-NATIVE'),
+      });
 
     const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
-    await run(['APP_XXX', '--all', '--summary-json', '--output-dir', outputDir]);
+    await run(['APP_XXX', '--all', '--summary-json', '--output-dir', outputDir, '--concurrency', '1']);
 
     const index = JSON.parse(fs.readFileSync(path.join(outputDir, 'index.json'), 'utf-8'));
     expect(index[0]).toHaveProperty('fieldSummary');
     expect(index[0]).toHaveProperty('schemaFile');
     expect(index[0]).not.toHaveProperty('schema');
+    expect(index[0]).not.toHaveProperty('displayPage');
+    expect(index[1].displayPage).toMatchObject({
+      hasYidaCodeCanvas: true,
+      hasNativeJsx: false,
+      runtimeCodeBytes: Buffer.byteLength(canvasRuntime, 'utf8'),
+      sourceCodeBytes: Buffer.byteLength(canvasSource, 'utf8'),
+      importedModules: ['react', 'antd'],
+      componentCount: 1,
+    });
+    expect(index[2].displayPage).toMatchObject({
+      hasYidaCodeCanvas: false,
+      hasNativeJsx: true,
+      runtimeCodeBytes: 0,
+      sourceCodeBytes: Buffer.byteLength(nativeSource, 'utf8'),
+      compiledCodeBytes: Buffer.byteLength(nativeCompiled, 'utf8'),
+      importedModules: [],
+      componentCount: 1,
+    });
 
     const output = JSON.parse(mockLog.mock.calls[mockLog.mock.calls.length - 1][0]);
     expect(output.summaryOnly).toBe(true);
     expect(output.forms[0]).toHaveProperty('fieldSummary');
     expect(output.forms[0]).not.toHaveProperty('schema');
+    expect(output.forms[1].displayPage.hasYidaCodeCanvas).toBe(true);
+    expect(output.forms[2].displayPage.hasNativeJsx).toBe(true);
     mockLog.mockRestore();
   });
 });

--- a/tests/get-schema.test.js
+++ b/tests/get-schema.test.js
@@ -18,6 +18,8 @@ jest.mock('../lib/app/form-navigation', () => ({
 
 const utils = require('../lib/core/utils');
 const { fetchFormPageList } = require('../lib/app/form-navigation');
+const { buildCanvasPageSchemaContent } = require('../lib/app/services/canvas-page-schema-builder');
+const { buildNativePageSchemaContent } = require('../lib/app/services/native-page-schema-builder');
 const {
   extractFieldSummary,
   extractOptionSummary,
@@ -289,6 +291,57 @@ describe('buildSchemaSummary', () => {
     });
     expect(summary).not.toHaveProperty('content');
     expect(summary).not.toHaveProperty('pages');
+    expect(summary).not.toHaveProperty('displayPage');
+  });
+
+  test('adds Code Canvas display page signals without exposing schema content', () => {
+    const sourceCode = 'export default function Page() { return React.createElement("div", null, "ok"); }';
+    const runtimeCode = 'var YidaComp = function Page(){ return window.React.createElement("div", null, "ok"); };';
+    const summary = buildSchemaSummary('APP_XXX', 'FORM-CANVAS', {
+      content: buildCanvasPageSchemaContent(
+        sourceCode,
+        runtimeCode,
+        '["react","antd"]',
+        'FORM-CANVAS'
+      ),
+    });
+
+    expect(summary).toMatchObject({
+      success: true,
+      appType: 'APP_XXX',
+      formUuid: 'FORM-CANVAS',
+      fieldCount: 0,
+      fields: [],
+      displayPage: {
+        hasYidaCodeCanvas: true,
+        hasNativeJsx: false,
+        runtimeCodeBytes: Buffer.byteLength(runtimeCode, 'utf8'),
+        sourceCodeBytes: Buffer.byteLength(sourceCode, 'utf8'),
+        compiledCodeBytes: 0,
+        importedModules: ['react', 'antd'],
+        componentCount: 1,
+      },
+    });
+    expect(summary).not.toHaveProperty('content');
+    expect(summary).not.toHaveProperty('pages');
+  });
+
+  test('adds native custom page signals for legacy display pages', () => {
+    const sourceCode = 'export function renderJsx() { return React.createElement("div", null, "ok"); }';
+    const compiledCode = 'function renderJsx(){return React.createElement("div",null,"ok");}';
+    const summary = buildSchemaSummary('APP_XXX', 'FORM-NATIVE', {
+      content: buildNativePageSchemaContent(sourceCode, compiledCode, 'FORM-NATIVE'),
+    });
+
+    expect(summary.displayPage).toMatchObject({
+      hasYidaCodeCanvas: false,
+      hasNativeJsx: true,
+      runtimeCodeBytes: 0,
+      sourceCodeBytes: Buffer.byteLength(sourceCode, 'utf8'),
+      compiledCodeBytes: Buffer.byteLength(compiledCode, 'utf8'),
+      importedModules: [],
+      componentCount: 1,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add display/custom page content signals to get-schema --summary-json
- detect YidaCodeCanvas runtimeCode/importedModules and legacy native Jsx code sizes
- cover Canvas and native display page summaries in get-schema tests

## Tests
- node --check lib/app/get-schema.js
- npx eslint lib/app/get-schema.js tests/get-schema.test.js
- npm test -- --runTestsByPath tests/get-schema.test.js
- npm test -- --runTestsByPath tests/publish-precheck.test.js