### PR TITLE
fix: add runtime auth fast path to agent capabilities summary

### DIFF
--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const crypto = require('crypto');
+const fs = require('fs');
 const path = require('path');
 const { version } = require('../../package.json');
 const { t } = require('./i18n');
 const { buildCommandManifest } = require('./command-manifest');
 const { buildEnvironmentSnapshot } = require('./env');
-const { getAuthStatus } = require('./utils');
+const { findProjectRoot, getAuthStatus } = require('./utils');
 
 function redactLogin(login) {
   const redacted = { ...login };
@@ -33,6 +34,21 @@ function hasEnvTokenCredential(env = process.env) {
     String(env.OPENYIDA_ACCESS_TOKEN || '').trim() ||
     String(env.OPENYIDA_REFRESH_TOKEN || '').trim()
   );
+}
+
+function hasRuntimeProvisionedAccessToken(env = process.env) {
+  return isTruthyEnv(env.YIDA_AUTH_ENABLED) &&
+    !!String(env.OPENYIDA_ACCESS_TOKEN || '').trim();
+}
+
+function buildRuntimeProvisionedLoginStatus() {
+  return {
+    ok: true,
+    auth_mode: 'token',
+    auth_source: 'env',
+    status: 'ok',
+    can_auto_use: true,
+  };
 }
 
 const BUILDER_CORE_COMMAND_IDS = Object.freeze([
@@ -84,8 +100,10 @@ function buildAuthPath(login, env = process.env) {
   const envTokenPresent = hasEnvTokenCredential(env);
   const authSource = login.auth_source || (hostInjectedTokenMode || envTokenPresent ? 'env' : 'token_session');
   const hostTokenEnvDetected = hostInjectedTokenMode || envTokenPresent || authSource === 'env';
-
-  return {
+  const runtimeAuthProvisioned = hasRuntimeProvisionedAccessToken(env) &&
+    authSource === 'env' &&
+    login.status === 'ok';
+  const authPath = {
     mode: login.auth_mode || 'token',
     source: authSource,
     can_auto_use: login.can_auto_use === true,
@@ -109,6 +127,10 @@ function buildAuthPath(login, env = process.env) {
       ? 'STOP_AND_REQUEST_HOST_TOKEN'
       : 'RUN_OPENYIDA_LOGIN_IF_USER_APPROVES',
   };
+  if (runtimeAuthProvisioned) {
+    authPath.runtime_auth_provisioned = true;
+  }
+  return authPath;
 }
 
 function buildBuilderPath(login, projectRoot, manifest, env = process.env) {
@@ -222,13 +244,14 @@ function compactBuilderPath(builderPath) {
   return {
     schema_version: builderPath.schema_version,
     preflight: builderPath.preflight,
-    auth: {
+    auth: Object.fromEntries(Object.entries({
       mode: builderPath.auth.mode,
       source: builderPath.auth.source,
       can_auto_use: builderPath.auth.can_auto_use,
       host_injected_token_mode: builderPath.auth.host_injected_token_mode,
       host_token_env_detected: builderPath.auth.host_token_env_detected,
       env_token_present: builderPath.auth.env_token_present,
+      runtime_auth_provisioned: builderPath.auth.runtime_auth_provisioned,
       interactive_login_allowed: builderPath.auth.interactive_login_allowed,
       browser_session_auth_allowed: builderPath.auth.browser_session_auth_allowed,
       auth_runtime: builderPath.auth.auth_runtime,
@@ -237,7 +260,7 @@ function compactBuilderPath(builderPath) {
       playwright_cookie_check_required: builderPath.auth.playwright_cookie_check_required,
       qr_login_required: builderPath.auth.qr_login_required,
       missing_token_action: builderPath.auth.missing_token_action,
-    },
+    }).filter(([, value]) => value !== undefined)),
     environment_check_simplification: {
       minimal_probe_commands: environment.minimal_probe_commands,
       can_skip_default_exploration_when_summary_ok: environment.can_skip_default_exploration_when_summary_ok,
@@ -319,8 +342,37 @@ function buildCommandManifestDigest(manifest) {
 }
 
 function buildAgentCapabilitiesSummary() {
-  const envSnapshot = buildEnvironmentSnapshot();
   const manifest = buildCommandManifest({ t, version });
+
+  if (hasRuntimeProvisionedAccessToken(process.env)) {
+    const projectRoot = findProjectRoot();
+    const loginStatus = buildRuntimeProvisionedLoginStatus();
+    const builderPath = compactBuilderPath(
+      buildBuilderPath(loginStatus, projectRoot, manifest)
+    );
+
+    return {
+      schema_version: 1,
+      name: 'openyida-agent-capabilities-summary',
+      version,
+      login: compactLogin(loginStatus),
+      precheck: {
+        skipped: true,
+        reason: 'runtime_auth_provisioned',
+      },
+      workdir: projectRoot,
+      workdir_exists: fs.existsSync(projectRoot),
+      cache_dir: path.join(projectRoot, '.cache'),
+      openyida_task_cache_dir: path.join(projectRoot, '.cache', 'openyida'),
+      command_manifest_digest: buildCommandManifestDigest(manifest),
+      command_manifest_digest_algorithm: 'sha256',
+      command_count: manifest.summary.command_count,
+      full_capabilities_command: 'openyida agent-capabilities --json',
+      builder_path: builderPath,
+    };
+  }
+
+  const envSnapshot = buildEnvironmentSnapshot();
   const projectRoot = envSnapshot.active.projectRoot;
   const loginStatus = getAuthStatus({ projectRoot, includeSecrets: false });
   const builderPath = compactBuilderPath(

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -240,27 +240,30 @@ function compactBuilderPath(builderPath) {
   const commandContract = builderPath.command_contract;
   const resourceContext = builderPath.resource_context_resolution;
   const paths = builderPath.paths;
+  const auth = {
+    mode: builderPath.auth.mode,
+    source: builderPath.auth.source,
+    can_auto_use: builderPath.auth.can_auto_use,
+    host_injected_token_mode: builderPath.auth.host_injected_token_mode,
+    host_token_env_detected: builderPath.auth.host_token_env_detected,
+    env_token_present: builderPath.auth.env_token_present,
+    interactive_login_allowed: builderPath.auth.interactive_login_allowed,
+    browser_session_auth_allowed: builderPath.auth.browser_session_auth_allowed,
+    auth_runtime: builderPath.auth.auth_runtime,
+    cookie_auth_supported: builderPath.auth.cookie_auth_supported,
+    cookie_check_required: builderPath.auth.cookie_check_required,
+    playwright_cookie_check_required: builderPath.auth.playwright_cookie_check_required,
+    qr_login_required: builderPath.auth.qr_login_required,
+    missing_token_action: builderPath.auth.missing_token_action,
+  };
+  if (builderPath.auth.runtime_auth_provisioned === true) {
+    auth.runtime_auth_provisioned = true;
+  }
 
   return {
     schema_version: builderPath.schema_version,
     preflight: builderPath.preflight,
-    auth: Object.fromEntries(Object.entries({
-      mode: builderPath.auth.mode,
-      source: builderPath.auth.source,
-      can_auto_use: builderPath.auth.can_auto_use,
-      host_injected_token_mode: builderPath.auth.host_injected_token_mode,
-      host_token_env_detected: builderPath.auth.host_token_env_detected,
-      env_token_present: builderPath.auth.env_token_present,
-      runtime_auth_provisioned: builderPath.auth.runtime_auth_provisioned,
-      interactive_login_allowed: builderPath.auth.interactive_login_allowed,
-      browser_session_auth_allowed: builderPath.auth.browser_session_auth_allowed,
-      auth_runtime: builderPath.auth.auth_runtime,
-      cookie_auth_supported: builderPath.auth.cookie_auth_supported,
-      cookie_check_required: builderPath.auth.cookie_check_required,
-      playwright_cookie_check_required: builderPath.auth.playwright_cookie_check_required,
-      qr_login_required: builderPath.auth.qr_login_required,
-      missing_token_action: builderPath.auth.missing_token_action,
-    }).filter(([, value]) => value !== undefined)),
+    auth,
     environment_check_simplification: {
       minimal_probe_commands: environment.minimal_probe_commands,
       can_skip_default_exploration_when_summary_ok: environment.can_skip_default_exploration_when_summary_ok,

--- a/tests/agent-capabilities.test.js
+++ b/tests/agent-capabilities.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('agent-capabilities summary', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.dontMock('../lib/core/env');
+    jest.dontMock('../lib/core/utils');
+  });
+
+  test('runtime access token fast path skips environment snapshot and auth status checks', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-agent-cap-fast-'));
+    const buildEnvironmentSnapshot = jest.fn(() => {
+      throw new Error('slow environment precheck should be skipped');
+    });
+    const getAuthStatus = jest.fn(() => {
+      throw new Error('auth status check should be skipped');
+    });
+    const findProjectRoot = jest.fn(() => projectRoot);
+
+    jest.doMock('../lib/core/env', () => ({ buildEnvironmentSnapshot }));
+    jest.doMock('../lib/core/utils', () => ({ findProjectRoot, getAuthStatus }));
+
+    process.env.YIDA_AUTH_ENABLED = 'true';
+    process.env.OPENYIDA_ACCESS_TOKEN = 'runtime-access-token';
+    process.env.OPENYIDA_TOKEN_CORP_ID = 'corpRuntime';
+    process.env.OPENYIDA_TOKEN_USER_ID = 'userRuntime';
+
+    try {
+      const { buildAgentCapabilitiesSummary } = require('../lib/core/agent-capabilities');
+      const summary = buildAgentCapabilitiesSummary();
+
+      expect(buildEnvironmentSnapshot).not.toHaveBeenCalled();
+      expect(getAuthStatus).not.toHaveBeenCalled();
+      expect(findProjectRoot).toHaveBeenCalledTimes(1);
+      expect(() => JSON.parse(JSON.stringify(summary))).not.toThrow();
+      expect(summary).toMatchObject({
+        schema_version: 1,
+        name: 'openyida-agent-capabilities-summary',
+        login: {
+          status: 'ok',
+          auth_mode: 'token',
+          auth_source: 'env',
+          can_auto_use: true,
+        },
+        precheck: {
+          skipped: true,
+          reason: 'runtime_auth_provisioned',
+        },
+        workdir: projectRoot,
+        workdir_exists: true,
+        builder_path: {
+          auth: {
+            source: 'env',
+            can_auto_use: true,
+            host_injected_token_mode: true,
+            env_token_present: true,
+            runtime_auth_provisioned: true,
+            interactive_login_allowed: false,
+            browser_session_auth_allowed: false,
+          },
+        },
+      });
+      expect(summary.command_manifest_digest).toMatch(/^[a-f0-9]{64}$/);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('non-runtime access token path still uses existing summary checks', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-agent-cap-slow-'));
+    const buildEnvironmentSnapshot = jest.fn(() => ({
+      active: {
+        projectRoot,
+        projectRootExists: true,
+      },
+    }));
+    const getAuthStatus = jest.fn(() => ({
+      ok: false,
+      auth_mode: 'token',
+      status: 'not_logged_in',
+      can_auto_use: false,
+    }));
+    const findProjectRoot = jest.fn(() => {
+      throw new Error('findProjectRoot is only needed by the runtime fast path');
+    });
+
+    jest.doMock('../lib/core/env', () => ({ buildEnvironmentSnapshot }));
+    jest.doMock('../lib/core/utils', () => ({ findProjectRoot, getAuthStatus }));
+
+    delete process.env.YIDA_AUTH_ENABLED;
+    delete process.env.OPENYIDA_ACCESS_TOKEN;
+
+    try {
+      const { buildAgentCapabilitiesSummary } = require('../lib/core/agent-capabilities');
+      const summary = buildAgentCapabilitiesSummary();
+
+      expect(buildEnvironmentSnapshot).toHaveBeenCalledTimes(1);
+      expect(getAuthStatus).toHaveBeenCalledWith({ projectRoot, includeSecrets: false });
+      expect(findProjectRoot).not.toHaveBeenCalled();
+      expect(summary).not.toHaveProperty('precheck');
+      expect(summary.login).toMatchObject({
+        status: 'not_logged_in',
+        auth_mode: 'token',
+        can_auto_use: false,
+      });
+      expect(summary.builder_path.auth).not.toHaveProperty('runtime_auth_provisioned');
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -1666,6 +1666,10 @@ describe('CLI offline smoke', () => {
         status: 'ok',
         can_auto_use: true,
       });
+      expect(summary.precheck).toMatchObject({
+        skipped: true,
+        reason: 'runtime_auth_provisioned',
+      });
       expect(summary.builder_path.auth).toMatchObject({
         mode: 'token',
         source: 'env',
@@ -1673,6 +1677,7 @@ describe('CLI offline smoke', () => {
         host_injected_token_mode: true,
         host_token_env_detected: true,
         env_token_present: true,
+        runtime_auth_provisioned: true,
         interactive_login_allowed: false,
         browser_session_auth_allowed: false,
         missing_token_action: 'STOP_AND_REQUEST_HOST_TOKEN',
@@ -1745,6 +1750,7 @@ describe('CLI offline smoke', () => {
         status: 'not_logged_in',
         can_auto_use: false,
       });
+      expect(summary).not.toHaveProperty('precheck');
       expect(summary.builder_path.auth).toMatchObject({
         host_injected_token_mode: true,
         host_token_env_detected: true,
@@ -1752,6 +1758,7 @@ describe('CLI offline smoke', () => {
         interactive_login_allowed: false,
         missing_token_action: 'STOP_AND_REQUEST_HOST_TOKEN',
       });
+      expect(summary.builder_path.auth).not.toHaveProperty('runtime_auth_provisioned');
       expect(summary.builder_path.environment_check_simplification).toMatchObject({
         can_skip_default_exploration_when_summary_ok: true,
         skip_login_check_only_default: true,


### PR DESCRIPTION
## Summary
- add a summary-json fast path when runtime env auth is provisioned via YIDA_AUTH_ENABLED=true and OPENYIDA_ACCESS_TOKEN
- keep local/non-runtime agent summary behavior unchanged
- add unit and CLI smoke coverage for fast path and non-fast path behavior

## Tests
- npx jest tests/agent-capabilities.test.js tests/cli-smoke.test.js --runInBand
