### PR TITLE
fix: add builder AI source params to register app

### DIFF
--- a/lib/app/create-app.js
+++ b/lib/app/create-app.js
@@ -269,6 +269,8 @@ function buildCreateAppPayload(params, auth, contentLocale, openExclusive, openP
     openIsolationDatabase: 'n',
     openExclusiveUnit: 'n',
     group: 'ALL',
+    fromBuilderAi: 'y',
+    builderAiSource: 'local',
   };
   if (navTheme) {
     payload.navTheme = navTheme;

--- a/lib/app/import-app.js
+++ b/lib/app/import-app.js
@@ -40,6 +40,8 @@ async function createApp(appName, authRef) {
       openIsolationDatabase: 'n',
       openExclusiveUnit: 'n',
       group: 'ALL',
+      fromBuilderAi: 'y',
+      builderAiSource: 'local',
     });
     return httpPost(auth.baseUrl, '/query/app/registerApp.json', postData, auth.cookies);
   }, authRef);

--- a/tests/create-app.test.js
+++ b/tests/create-app.test.js
@@ -126,6 +126,8 @@ describe('create-app argument parsing', () => {
       group: 'ALL',
       openExclusive: 'n',
       openPhysicColumn: 'n',
+      fromBuilderAi: 'y',
+      builderAiSource: 'local',
     });
     expect(payload).not.toHaveProperty('navTheme');
     expect(payload).not.toHaveProperty('layoutDirection');


### PR DESCRIPTION
## Summary
- add fromBuilderAi=y and builderAiSource=local to create-app registerApp payload
- add the same params to import-app registerApp payload
- cover create-app payload with existing unit test assertions

## Tests
- node --check lib/app/create-app.js
- node --check lib/app/import-app.js
- npx jest tests/create-app.test.js tests/import-app.test.js
- npx eslint lib/app/create-app.js lib/app/import-app.js tests/create-app.test.js tests/import-app.test.js
- git diff --check