### PR TITLE
fix: guide QwenWork login through agent browser

### DIFF
--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -288,7 +288,10 @@ function buildInteractiveLogin(auth, runtime) {
       browser_default: 'caller_open_url',
       browser_owner: 'agent_browser',
       recommended_command: 'openyida login --no-browser',
-      agent_action: 'open_cli_printed_url_once',
+      agent_action: 'open_cli_printed_url_once_with_agent_browser',
+      url_source: 'login_command_stderr',
+      manual_user_open_fallback: 'only_when_agent_browser_tool_unavailable_or_failed',
+      must_not_only_print_url_when_agent_browser_available: true,
       reason: 'web_sandbox_agent_browser_available',
       ...base,
     };

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -1235,7 +1235,10 @@ describe('CLI offline smoke', () => {
         browser_default: 'caller_open_url',
         browser_owner: 'agent_browser',
         recommended_command: 'openyida login --no-browser',
-        agent_action: 'open_cli_printed_url_once',
+        agent_action: 'open_cli_printed_url_once_with_agent_browser',
+        url_source: 'login_command_stderr',
+        manual_user_open_fallback: 'only_when_agent_browser_tool_unavailable_or_failed',
+        must_not_only_print_url_when_agent_browser_available: true,
         reason: 'web_sandbox_agent_browser_available',
         playwright_required: false,
       });

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -97,6 +97,9 @@ describe('OpenYida skill contracts', () => {
     expect(skill).toContain('`openyida agent-capabilities --json` 是完整能力信息');
     expect(skill).toContain('不要把完整能力信息放进常规完整搭建链路');
     expect(skill).toContain('`workdir` 对应完整能力信息里的 `active.projectRoot`');
+    expect(skill).toContain('builder_path.interactive_login.mode=caller_open_url');
+    expect(skill).toContain('沙箱浏览器 / 内置 Browser');
+    expect(skill).toContain('只有没有浏览器工具或工具调用失败时');
     expect(skill).not.toContain('优先跑一次 `openyida agent-capabilities --json`');
   });
 
@@ -109,6 +112,8 @@ describe('OpenYida skill contracts', () => {
     expect(skill).toContain('不要把固定 `sleep`');
     expect(skill).toContain('`ok=true` 与 `can_auto_use=true`');
     expect(skill).toContain('用户未授权就关闭浏览器时');
+    expect(skill).toContain('不要只把 URL 贴给用户然后等待');
+    expect(skill).toContain('沙箱浏览器 / 内置 Browser');
   });
 
   test('QwenWork install guidance aligns with QoderWork user-level skills layout', () => {

--- a/yida-skills/SKILL.md
+++ b/yida-skills/SKILL.md
@@ -16,6 +16,8 @@ description: >
 
 先执行 `openyida agent-capabilities --summary-json`，确认 OpenYida、Node/npm、登录态和工作目录可用。`openyida agent-capabilities --json` 是完整能力信息，只在命令契约排障、manifest 差异诊断或深度调试时使用；不要把完整能力信息放进常规完整搭建链路。`workdir` 对应完整能力信息里的 `active.projectRoot`。
 
+如果快照显示 `builder_path.interactive_login.mode=caller_open_url`，说明 CLI 已把浏览器归属交给 Agent。执行 `openyida login --no-browser` 后，Agent 必须优先调用当前宿主的沙箱浏览器 / 内置 Browser 打开 CLI 输出的授权 URL 一次；只有没有浏览器工具或工具调用失败时，才让用户手动打开链接。
+
 未完成环境与登录态确认前，不创建应用、页面、表单，不发布页面。环境异常、登录失败、env token 注入和 `openyida copy` 初始化见 [环境准备与登录检测](references/setup-and-env.md)。
 
 核心判断：

--- a/yida-skills/references/setup-and-env.md
+++ b/yida-skills/references/setup-and-env.md
@@ -21,7 +21,7 @@ openyida login --check-only --json
 - snapshot 返回 `login.auth_source=env` 或 `failure_reason=env_token_missing` 时，进入运行环境注入 token 模式。凭证只来自运行环境注入的 `OPENYIDA_ACCESS_TOKEN`、`OPENYIDA_REFRESH_TOKEN` 等环境变量。
 - 其他 `login.auth_mode=token` 场景使用默认 OAuth token session。
 - 不要从 `.cache/cookies*.json` 推断登录态。
-- OAuth 浏览器归属以 `builder_path.interactive_login.mode` 为准：`not_required` 不触发 OAuth；`cli_auto_open` 执行 `openyida login`；`caller_open_url` 执行 `openyida login --no-browser`，由 Agent 只打开一次输出 URL；`unsupported` 停止说明环境没有可用浏览器能力，不要默认安装 Playwright。
+- OAuth 浏览器归属以 `builder_path.interactive_login.mode` 为准：`not_required` 不触发 OAuth；`cli_auto_open` 执行 `openyida login`；`caller_open_url` 执行 `openyida login --no-browser`，由 Agent 优先调用沙箱浏览器 / 内置 Browser 打开输出 URL 一次；`unsupported` 停止说明环境没有可用浏览器能力，不要默认安装 Playwright。
 
 ## 判断表
 
@@ -32,7 +32,7 @@ openyida login --check-only --json
 | `auth_mode=token` 且 `status=ok` 或 `can_auto_use=true` | 继续执行 |
 | snapshot 返回 `auth_source=env` / `failure_reason=env_token_missing` | 进入运行环境注入 token 模式；缺 token 时停止，让 Codex、yida-agent 等宿主注入 `OPENYIDA_ACCESS_TOKEN` 或 `OPENYIDA_REFRESH_TOKEN`；不要执行 OAuth |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=cli_auto_open` | 只执行一次 `openyida login`，等待该命令结束，并使用其最终 JSON 判断结果 |
-| `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 打开输出 URL 一次，并等待原命令结束 |
+| `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 优先调用沙箱浏览器 / 内置 Browser 打开输出 URL 一次，并等待原命令结束；无浏览器工具或调用失败时才让用户手动打开 |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=unsupported` | 停止并说明当前运行环境没有桌面浏览器或 Agent 浏览器能力 |
 | `auth_mode=token`，access token 过期 | 执行 `openyida auth refresh`；仍失败且 snapshot 未返回 env 注入时，再执行 `openyida login` |
 
@@ -51,6 +51,7 @@ openyida auth logout
 ## Agent OAuth 登录编排
 
 - `openyida login` 默认自动打开系统浏览器。等待原登录命令结束，不要提取授权 URL 后再次打开。
+- `interactive_login.mode=caller_open_url` 时，先执行 `openyida login --no-browser`，再用宿主沙箱浏览器 / 内置 Browser 打开 CLI 输出 URL；不要只把 URL 贴给用户然后等待。只有无浏览器工具或工具调用失败时，才退回手动打开。
 - 用户授权可能持续到 OAuth 超时（默认约 5 分钟）。原命令仍运行时，不要固定 `sleep`，也不要重复执行 `login --check-only`。
 - 只有原命令成功退出，且最终 JSON 包含 `ok=true` 与 `can_auto_use=true`，才能判定登录成功。
 - 用户未授权就关闭浏览器时，CLI 无法可靠感知窗口关闭。继续等待原命令，直到用户停止或命令超时；不要自动发起第二次登录。

--- a/yida-skills/skills/yida-login/SKILL.md
+++ b/yida-skills/skills/yida-login/SKILL.md
@@ -13,7 +13,8 @@ description: 宜搭登录态管理。以 OpenYida auth snapshot 为准；默认 
 - snapshot 返回 `login.auth_source=env` 或 `failure_reason=env_token_missing` 时，进入运行环境注入 token 模式。凭证只来自运行环境注入的 `OPENYIDA_ACCESS_TOKEN`、`OPENYIDA_REFRESH_TOKEN` 等环境变量。
 - 其他 `auth_mode=token` 场景使用默认 OAuth token session。
 - 不要从 `.cache/cookies*.json` 推断登录态。
-- 浏览器归属以 `builder_path.interactive_login.mode` 为准：`not_required` 不触发 OAuth；`cli_auto_open` 执行 `openyida login` 并等待；`caller_open_url` 执行 `openyida login --no-browser`，由 Agent 只打开一次 CLI 输出的授权 URL；`unsupported` 停止并说明没有可用浏览器能力，不要默认安装 Playwright。
+- 浏览器归属以 `builder_path.interactive_login.mode` 为准：`not_required` 不触发 OAuth；`cli_auto_open` 执行 `openyida login` 并等待；`caller_open_url` 执行 `openyida login --no-browser`，由 Agent 优先调用沙箱浏览器 / 内置 Browser 打开 CLI 输出的授权 URL 一次；`unsupported` 停止并说明没有可用浏览器能力，不要默认安装 Playwright。
+- `caller_open_url` 模式下，Agent 不要只把 URL 贴给用户然后等待。只有当前宿主没有浏览器工具，或浏览器工具调用失败时，才退回让用户手动打开 URL。
 
 ## 前置检查
 
@@ -37,7 +38,7 @@ openyida login --check-only --json
 | `auth_mode=token` 且 `status=ok` 或 `can_auto_use=true` | 继续执行业务命令 |
 | `auth_source=env` / `failure_reason=env_token_missing` | 进入运行环境注入 token 模式；缺 token 时停止，让 Codex、yida-agent 等宿主注入 `OPENYIDA_ACCESS_TOKEN` 或 `OPENYIDA_REFRESH_TOKEN`；不要执行 OAuth |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=cli_auto_open` | 只执行一次 `openyida login`，等待该命令结束，并使用其最终 JSON 判断结果 |
-| `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 打开输出的授权 URL 一次，并等待原命令结束 |
+| `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 优先调用沙箱浏览器 / 内置 Browser 打开输出 URL 一次，并等待原命令结束；无浏览器工具或调用失败时才让用户手动打开 |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=unsupported` | 停止并向用户说明当前运行环境没有桌面浏览器或 Agent 浏览器能力 |
 
 ## Token 模式命令
@@ -70,7 +71,7 @@ openyida login --no-browser
 OPENYIDA_NO_BROWSER=1 openyida login
 ```
 
-只有这种模式下，Agent 才能打开输出的授权 URL，并且只能打开一次。`--quiet` 只控制文本输出，不决定浏览器归属。
+只有这种模式下，Agent 才能打开输出的授权 URL，并且只能打开一次。若当前宿主提供沙箱浏览器 / 内置 Browser，必须优先调用该工具打开 URL，不要把 URL 只作为聊天文本交给用户；无浏览器工具或工具失败时才提示用户手动打开。`--quiet` 只控制文本输出，不决定浏览器归属。
 
 `openyida login --check-only --json` 仅用于恢复或防御性验证。不要把固定 `sleep` 或重复执行 `check-only` 当作默认完成机制。
 


### PR DESCRIPTION
## Summary
- Clarify QwenWork caller-open-url login capabilities so Agent browser opens the CLI authorization URL.
- Update OpenYida skill login guidance to avoid handing the URL to the user when an agent browser is available.
- Add smoke and skill contract assertions for the new login guidance.

## Tests
- npm test -- tests/cli-smoke.test.js tests/skill-contracts.test.js --runInBand
- npm run check:skills
- npm run check:release-risks
- node --check lib/core/agent-capabilities.js