### PR TITLE
feat: improve auth profile management UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ openyida login --check-only --json
 openyida auth status
 ```
 
+To reuse an existing shared login profile for the current project, switch first instead of starting a new OAuth login:
+
+```bash
+openyida auth profiles
+openyida auth profile switch <auth_profile>
+```
+
+If the target profile is not listed, run `openyida login` to add it, then switch to the new profile.
+
 OpenYida does not install Playwright by default.
 
 ### 4. Build With an AI Agent
@@ -356,9 +365,9 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | Command | Description |
 |---------|-------------|
 | `openyida login [target-url] [--env <name>\|--intl\|--overseas\|--global\|--yidaapps\|--alibaba] [--client-id <clientId>] [--endpoint <url>] [--no-browser]` | Login with OAuth token mode |
-| `openyida logout` | Logout / clear token |
-| `openyida auth <status\|login\|refresh\|logout>` | Token login state management |
-| `openyida org <list\|switch> [--json] [--corp-id <corpId>]` | Organization management (list / switch by OAuth re-login) |
+| `openyida logout` | Logout / unbind current project auth |
+| `openyida auth <status\|login\|refresh\|logout\|profiles\|profile switch>` | Token login state and profile management |
+| `openyida org <list\|switch> [--json] [--corp-id <corpId>]` | Organization management (list / switch existing profiles first) |
 | `openyida env [--json\|setup\|list\|show\|switch\|add\|remove] [options]` | Detect AI tool environment & token login state |
 
 ### App Management

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -55,10 +55,10 @@ OpenYida 要求 Node.js 18 或更高版本。安装后会提供 `openyida` 和 `
 在 AI 编程工作区中运行：
 
 ```bash
-openyida agent-capabilities --json
+openyida agent-capabilities --summary-json
 ```
 
-该命令会一次性返回 OpenYida 版本、当前工作区、AI 工具环境、登录态、组织上下文、命令清单和副作用提示。旧版本或轻量检查也可以使用：
+该命令会返回紧凑的 OpenYida 版本、登录态、工作区和命令清单摘要。需要完整诊断时再使用 `openyida agent-capabilities --json`；旧版本也可以降级使用：
 
 ```bash
 openyida env --json
@@ -79,6 +79,15 @@ AI 工具中建议登录后用下面任一命令确认 token session 可用：
 openyida login --check-only --json
 openyida auth status
 ```
+
+如果当前项目要复用已有共享登录 profile，先切换已有 profile，不要直接发起新的 OAuth 登录：
+
+```bash
+openyida auth profiles
+openyida auth profile switch <auth_profile>
+```
+
+目标 profile 不在列表中时，再执行 `openyida login` 新增登录态，随后切到新增 profile。
 
 如果用户给出明确的宜搭入口 URL，需要把 URL 传给登录命令：
 
@@ -246,9 +255,9 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 | 命令 | 说明 |
 |------|------|
 | `openyida login [target-url] [--env <name>\|--intl\|--overseas\|--global\|--yidaapps\|--alibaba] [--client-id <clientId>] [--endpoint <url>] [--no-browser]` | 登录（OAuth token 模式） |
-| `openyida logout` | 退出登录 / 清空 token |
-| `openyida auth <status\|login\|refresh\|logout>` | token 登录态管理 |
-| `openyida org <list\|switch> [--json] [--corp-id <corpId>]` | 组织管理（列表 / 重新登录切换） |
+| `openyida logout` | 退出登录 / 解绑当前项目登录态 |
+| `openyida auth <status\|login\|refresh\|logout\|profiles\|profile switch>` | token 登录态与 profile 管理 |
+| `openyida org <list\|switch> [--json] [--corp-id <corpId>]` | 组织管理（列表 / 优先按已有 profile 切换） |
 | `openyida env [--json\|setup\|list\|show\|switch\|add\|remove] [options]` | 检测 AI 工具环境和 token 登录态 |
 
 ### 应用管理

--- a/bin/yida.js
+++ b/bin/yida.js
@@ -336,6 +336,29 @@ function getArgValue(cliArgs, name) {
   return cliArgs[index + 1];
 }
 
+function getFirstPositionalArg(cliArgs, startIndex = 0) {
+  const valueFlags = new Set([
+    '--client-id',
+    '--corp-id',
+    '--endpoint',
+    '--base-url',
+    '--login-url',
+    '--profile',
+    '--user-id',
+  ]);
+  for (let index = startIndex; index < cliArgs.length; index++) {
+    const arg = cliArgs[index];
+    if (valueFlags.has(arg)) {
+      index++;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      return arg;
+    }
+  }
+  return null;
+}
+
 const UNSUPPORTED_LEGACY_LOGIN_FLAGS = new Set([
   '--qr',
   '--qr-code',
@@ -548,6 +571,13 @@ function buildTokenLoginOptions(loginArgs) {
   };
 }
 
+function buildLogoutOptions(logoutArgs) {
+  return {
+    authProfile: getArgValue(logoutArgs, '--profile'),
+    allProfiles: logoutArgs.includes('--all'),
+  };
+}
+
 function printAuthHelp() {
   printCommandUsage(t('cli.auth_usage'), t('cli.auth_example'));
 }
@@ -660,7 +690,7 @@ async function main() {
 
     case 'logout': {
       const { tokenLogout } = require('../lib/auth/token-auth');
-      console.log(JSON.stringify(await tokenLogout(), null, 2));
+      console.log(JSON.stringify(await tokenLogout(buildLogoutOptions(args)), null, 2));
       break;
     }
 
@@ -673,6 +703,18 @@ async function main() {
         printAuthHelp();
       } else if (subCommand === 'status') {
         console.log(JSON.stringify(getAuthStatus(buildTokenLoginOptions(authArgs)), null, 2));
+      } else if (subCommand === 'profiles') {
+        const { listAuthProfiles } = require('../lib/auth/profile');
+        console.log(JSON.stringify(listAuthProfiles(buildTokenLoginOptions(authArgs)), null, 2));
+      } else if (subCommand === 'profile') {
+        const profileSubCommand = authArgs[0];
+        if (profileSubCommand === 'switch') {
+          const target = getFirstPositionalArg(authArgs, 1);
+          const { switchAuthProfile } = require('../lib/auth/profile');
+          console.log(JSON.stringify(switchAuthProfile(target, buildTokenLoginOptions(authArgs)), null, 2));
+        } else {
+          throwCliUsage(t('cli.auth_usage'), t('cli.auth_example'));
+        }
       } else if (subCommand === 'login') {
         if (hasHelpFlag(authArgs)) {
           printLoginHelp();
@@ -686,7 +728,7 @@ async function main() {
       } else if (subCommand === 'refresh') {
         console.log(JSON.stringify(maskSensitiveAuthOutput(await tokenRefresh()), null, 2));
       } else if (subCommand === 'logout') {
-        console.log(JSON.stringify(await tokenLogout(), null, 2));
+        console.log(JSON.stringify(await tokenLogout(buildLogoutOptions(authArgs)), null, 2));
       } else {
         throwCliUsage(t('cli.auth_usage'), t('cli.auth_example'));
       }

--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const { CliError } = require('../core/cli-error');
+const {
+  isHostInjectedTokenMode,
+  listUserAuthProfiles,
+  loadAuthProfilePointer,
+  loadTokenSession,
+  saveAuthProfilePointer,
+} = require('./token-store');
+
+function cleanObject(value) {
+  const result = { ...value };
+  Object.keys(result).forEach((key) => {
+    if (result[key] === undefined || result[key] === null || result[key] === '') {
+      delete result[key];
+    }
+  });
+  return result;
+}
+
+function toProfileSummary(session = {}, currentAuthProfile) {
+  return cleanObject({
+    auth_profile: session.auth_profile,
+    corp_id: session.corp_id,
+    corp_name: session.corp_name,
+    user_id: session.user_id,
+    user_name: session.user_name,
+    auth_store: session.auth_store || 'user',
+    last_used_at: session.last_used_at,
+    is_current: !!currentAuthProfile && session.auth_profile === currentAuthProfile,
+  });
+}
+
+function getCurrentAuthProfile(options = {}) {
+  const pointer = loadAuthProfilePointer(options);
+  return pointer && pointer.auth_profile ? pointer.auth_profile : null;
+}
+
+function listAuthProfiles(options = {}) {
+  const currentAuthProfile = getCurrentAuthProfile(options);
+  const profiles = listUserAuthProfiles(options)
+    .map((profile) => toProfileSummary(profile, currentAuthProfile))
+    .sort((left, right) => String(right.last_used_at || '').localeCompare(String(left.last_used_at || '')));
+
+  return {
+    ok: true,
+    auth_mode: 'token',
+    status: 'ok',
+    auth_store: 'user',
+    current_auth_profile: currentAuthProfile,
+    count: profiles.length,
+    profiles,
+  };
+}
+
+function createProfileNotFoundError(target, options = {}) {
+  throw new CliError(
+    `auth profile not found: ${target}`,
+    {
+      code: 'AUTH_PROFILE_NOT_FOUND',
+      details: {
+        target,
+        nextStep: options.nextStep || 'Run openyida auth profiles to list existing profiles. If the target is missing, run openyida login to add it, then switch again.',
+      },
+    }
+  );
+}
+
+function createProfileRequiredError(target, candidates) {
+  throw new CliError(
+    `multiple auth profiles match target: ${target}; pass the exact auth_profile`,
+    {
+      code: 'AUTH_PROFILE_REQUIRED',
+      details: {
+        target,
+        candidate_count: candidates.length,
+        candidates,
+        nextStep: 'Run openyida auth profiles, then run openyida auth profile switch <auth_profile> with the exact profile id.',
+      },
+    }
+  );
+}
+
+function resolveSwitchTarget(target, options = {}) {
+  const normalizedTarget = String(target || '').trim();
+  if (!normalizedTarget) {
+    throw new CliError(
+      'target auth profile or corpId is required',
+      {
+        code: 'INVALID_ARGUMENTS',
+        usage: 'Usage: openyida auth profile switch <profile|corpId>',
+      }
+    );
+  }
+
+  const currentAuthProfile = getCurrentAuthProfile(options);
+  const profiles = listUserAuthProfiles(options);
+  const exactProfile = profiles.find((profile) => profile.auth_profile === normalizedTarget);
+  if (exactProfile) {
+    return {
+      session: exactProfile,
+      currentAuthProfile,
+      target_kind: 'auth_profile',
+    };
+  }
+
+  let candidates = profiles.filter((profile) => profile.corp_id === normalizedTarget);
+  if (options.userId) {
+    candidates = candidates.filter((profile) => profile.user_id === options.userId);
+  }
+  const candidateSummaries = candidates.map((profile) => toProfileSummary(profile, currentAuthProfile));
+  if (candidateSummaries.length > 1) {
+    createProfileRequiredError(normalizedTarget, candidateSummaries);
+  }
+  if (candidates.length === 1) {
+    return {
+      session: candidates[0],
+      currentAuthProfile,
+      target_kind: 'corp_id',
+    };
+  }
+
+  createProfileNotFoundError(normalizedTarget);
+}
+
+function switchAuthProfile(target, options = {}) {
+  if (isHostInjectedTokenMode(options.env || process.env)) {
+    throw new CliError(
+      'host-injected token mode cannot switch local auth profiles',
+      {
+        code: 'AUTH_PROFILE_SWITCH_HOST_INJECTED',
+        details: {
+          nextStep: 'Ask the host runtime to inject the target organization token instead of switching local profiles.',
+        },
+      }
+    );
+  }
+
+  const previousSession = loadTokenSession(options);
+  const { session, currentAuthProfile, target_kind: targetKind } = resolveSwitchTarget(target, options);
+  saveAuthProfilePointer(session, options);
+
+  return cleanObject({
+    ok: true,
+    auth_mode: 'token',
+    status: currentAuthProfile === session.auth_profile ? 'already_selected' : 'switched',
+    can_auto_use: true,
+    target_kind: targetKind,
+    previous_auth_profile: currentAuthProfile,
+    previous_corp_id: previousSession && previousSession.corp_id,
+    auth_profile: session.auth_profile,
+    auth_store: session.auth_store || 'user',
+    persistence_scope: session.persistence_scope || 'user',
+    corp_id: session.corp_id,
+    corp_name: session.corp_name,
+    user_id: session.user_id,
+    user_name: session.user_name,
+    base_url: session.base_url,
+    message: 'current project auth pointer switched to existing profile',
+  });
+}
+
+async function run(args = []) {
+  const subCommand = args[0];
+  const json = args.includes('--json');
+  const options = {
+    userId: getArgValue(args, '--user-id'),
+  };
+
+  if (!subCommand || subCommand === 'list' || subCommand === 'profiles') {
+    const result = listAuthProfiles(options);
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+
+  if (subCommand === 'switch') {
+    const target = getFirstPositionalArg(args, 1);
+    const result = switchAuthProfile(target, options);
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+
+  throw new CliError(
+    'Usage: openyida auth profile <switch>',
+    {
+      code: 'INVALID_ARGUMENTS',
+      usage: 'Usage: openyida auth profiles | openyida auth profile switch <profile|corpId>',
+      details: json ? { nextStep: 'Run openyida auth profiles to list existing profiles.' } : undefined,
+    }
+  );
+}
+
+function getArgValue(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || !args[index + 1] || args[index + 1].startsWith('--')) {
+    return null;
+  }
+  return args[index + 1];
+}
+
+function getFirstPositionalArg(args, startIndex = 0) {
+  const valueFlags = new Set(['--user-id']);
+  for (let index = startIndex; index < args.length; index++) {
+    const arg = args[index];
+    if (valueFlags.has(arg)) {
+      index++;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      return arg;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  listAuthProfiles,
+  run,
+  switchAuthProfile,
+};

--- a/lib/auth/profile.js
+++ b/lib/auth/profile.js
@@ -55,19 +55,22 @@ function listAuthProfiles(options = {}) {
 }
 
 function createProfileNotFoundError(target, options = {}) {
+  const nextStep = options.nextStep || 'Run openyida auth profiles to list existing profiles. If the target is missing, run openyida login to add it, then switch again.';
   throw new CliError(
     `auth profile not found: ${target}`,
     {
       code: 'AUTH_PROFILE_NOT_FOUND',
       details: {
         target,
-        nextStep: options.nextStep || 'Run openyida auth profiles to list existing profiles. If the target is missing, run openyida login to add it, then switch again.',
+        nextStep,
+        next_step: nextStep,
       },
     }
   );
 }
 
 function createProfileRequiredError(target, candidates) {
+  const nextStep = 'Run openyida auth profiles, then run openyida auth profile switch <auth_profile> with the exact profile id.';
   throw new CliError(
     `multiple auth profiles match target: ${target}; pass the exact auth_profile`,
     {
@@ -76,7 +79,8 @@ function createProfileRequiredError(target, candidates) {
         target,
         candidate_count: candidates.length,
         candidates,
-        nextStep: 'Run openyida auth profiles, then run openyida auth profile switch <auth_profile> with the exact profile id.',
+        nextStep,
+        next_step: nextStep,
       },
     }
   );
@@ -132,6 +136,7 @@ function switchAuthProfile(target, options = {}) {
         code: 'AUTH_PROFILE_SWITCH_HOST_INJECTED',
         details: {
           nextStep: 'Ask the host runtime to inject the target organization token instead of switching local profiles.',
+          next_step: 'Ask the host runtime to inject the target organization token instead of switching local profiles.',
         },
       }
     );

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -12,9 +12,14 @@ const {
 } = require('../core/env-manager');
 const { runDingtalkLoopback } = require('./oauth-loopback');
 const {
+  clearAllUserAuthProfiles,
   clearTokenSession,
+  deleteUserAuthProfile,
   isHostInjectedTokenMode,
+  listUserAuthProfiles,
+  loadLocalTokenSession,
   loadTokenSession,
+  loadUserProfileFile,
   maskToken,
   normalizeCorpName,
   normalizeTokenSession,
@@ -453,36 +458,108 @@ async function tokenRefresh(options = {}) {
   return saveTokenSession(normalized, options);
 }
 
+async function revokeTokenSession(session) {
+  if (!session || !session.refresh_token || !session.base_url) {
+    return;
+  }
+  try {
+    await requestJson('POST', appendPath(appendPath(session.base_url, DEFAULT_AUTH_PATH_PREFIX), '/logout'), {
+      refreshToken: session.refresh_token,
+    }, session.access_token ? {
+      authorization: `${session.token_type || 'Bearer'} ${session.access_token}`,
+    } : {});
+  } catch {
+    // Local logout should still clear the credential cache.
+  }
+}
+
+function toLogoutProfileSummary(session = {}) {
+  const summary = {
+    auth_profile: session.auth_profile,
+    corp_id: session.corp_id,
+    corp_name: session.corp_name,
+    user_id: session.user_id,
+    user_name: session.user_name,
+    auth_store: session.auth_store,
+    last_used_at: session.last_used_at,
+  };
+  Object.keys(summary).forEach((key) => {
+    if (summary[key] === undefined || summary[key] === null || summary[key] === '') {
+      delete summary[key];
+    }
+  });
+  return summary;
+}
+
 async function tokenLogout(options = {}) {
-  const session = loadTokenSession(options);
-  if (session && session.auth_source === 'env') {
+  const env = options.env || process.env;
+  if (isHostInjectedTokenMode(env)) {
+    return {
+      ok: true,
+      auth_mode: 'token',
+      status: 'host_injected_noop',
+      can_auto_use: false,
+      auth_source: 'env',
+      auth_store: 'host_injected',
+      persistence_scope: 'host',
+      message: 'host-injected token mode does not write or delete local auth profiles',
+    };
+  }
+
+  const authProfile = options.authProfile || options.profile;
+  const deleteAllProfiles = options.allProfiles === true || options.all === true;
+  if (deleteAllProfiles) {
+    const profiles = listUserAuthProfiles(options);
+    for (const profile of profiles) {
+      await revokeTokenSession(profile);
+    }
+    const deletedProfiles = clearAllUserAuthProfiles(options).map(toLogoutProfileSummary);
+    clearTokenSession(options);
     return {
       ok: true,
       auth_mode: 'token',
       status: 'logged_out',
       can_auto_use: false,
+      auth_store: 'user',
+      persistence_scope: 'user',
+      deleted_profile_count: deletedProfiles.length,
+      deleted_profiles: deletedProfiles,
+      project_unbound: true,
     };
   }
-  if (session && session.refresh_token && session.base_url) {
-    try {
-      await requestJson('POST', appendPath(appendPath(session.base_url, DEFAULT_AUTH_PATH_PREFIX), '/logout'), {
-        refreshToken: session.refresh_token,
-      }, session.access_token ? {
-        authorization: `${session.token_type || 'Bearer'} ${session.access_token}`,
-      } : {});
-    } catch {
-      // Local logout should still clear the credential cache.
-    }
+
+  if (authProfile) {
+    const profileSession = loadUserProfileFile(authProfile, options);
+    await revokeTokenSession(profileSession);
+    const deleted = deleteUserAuthProfile(authProfile, options);
+    clearTokenSession(options);
+    return {
+      ok: true,
+      auth_mode: 'token',
+      status: deleted ? 'logged_out' : 'profile_not_found',
+      can_auto_use: false,
+      auth_profile: authProfile,
+      auth_store: 'user',
+      persistence_scope: 'user',
+      deleted_profile_count: deleted ? 1 : 0,
+      project_unbound: true,
+      message: deleted
+        ? 'auth profile deleted'
+        : 'auth profile not found; run openyida auth profiles to list available profiles',
+    };
   }
-  clearTokenSession({
-    ...options,
-    authProfile: session && session.auth_profile,
-  });
+
+  const legacySession = loadLocalTokenSession(options);
+  await revokeTokenSession(legacySession);
+  clearTokenSession(options);
   return {
     ok: true,
     auth_mode: 'token',
-    status: 'logged_out',
+    status: 'project_unbound',
     can_auto_use: false,
+    deleted_profile_count: 0,
+    project_unbound: true,
+    message: 'current project auth pointer cleared; shared auth profiles were kept',
   };
 }
 

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -328,6 +328,10 @@ function tokenStatus(options = {}) {
       message: resolution.message || (hostInjected
         ? 'host-injected token is missing. Ask the host to inject OPENYIDA_ACCESS_TOKEN or OPENYIDA_REFRESH_TOKEN.'
         : undefined),
+      next_step: resolution.next_step || (hostInjected
+        ? 'Ask the host runtime to inject OPENYIDA_ACCESS_TOKEN or OPENYIDA_REFRESH_TOKEN; do not run OAuth login in host-injected token mode.'
+        : 'Run openyida login to add an auth profile.'),
+      next_step_commands: resolution.next_step_commands,
       candidate_count: resolution.candidate_count,
       candidates: resolution.candidates,
       user_auth_store_writable: resolution.user_auth_store_writable,

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -459,6 +459,39 @@ function clearAuthProfilePointer(options = {}) {
   }
 }
 
+function deleteUserAuthProfile(authProfile, options = {}) {
+  const normalizedAuthProfile = sanitizeProfileName(authProfile);
+  if (!normalizedAuthProfile) {
+    return false;
+  }
+
+  let deleted = false;
+  try {
+    const profileFile = getUserProfileFilePath(normalizedAuthProfile, options);
+    if (profileFile && fs.existsSync(profileFile)) {
+      fs.unlinkSync(profileFile);
+      deleted = true;
+    }
+  } catch {
+    // Logout should remain idempotent.
+  }
+
+  const pointer = loadAuthProfilePointer(options);
+  if (pointer && pointer.auth_profile === normalizedAuthProfile) {
+    clearAuthProfilePointer(options);
+  }
+  return deleted;
+}
+
+function clearAllUserAuthProfiles(options = {}) {
+  const profiles = listUserAuthProfiles(options);
+  profiles.forEach((profile) => {
+    deleteUserAuthProfile(profile.auth_profile, options);
+  });
+  clearAuthProfilePointer(options);
+  return profiles;
+}
+
 function clearProjectLegacyTokenSession(options = {}) {
   const tokenFile = getTokenFilePath(options);
   try {
@@ -857,19 +890,6 @@ function loadTokenSession(options = {}) {
 }
 
 function clearTokenSession(options = {}) {
-  const pointer = loadAuthProfilePointer(options);
-  const selector = getAuthProfileSelector(options);
-  const authProfile = selector.authProfile || (pointer && pointer.auth_profile);
-  try {
-    if (authProfile) {
-      const profileFile = getUserProfileFilePath(authProfile, options);
-      if (profileFile && fs.existsSync(profileFile)) {
-        fs.unlinkSync(profileFile);
-      }
-    }
-  } catch {
-    // Logout should remain idempotent.
-  }
   clearAuthProfilePointer(options);
   clearProjectLegacyTokenSession(options);
 }
@@ -911,10 +931,13 @@ module.exports = {
   loadAuthProfilePointer,
   saveAuthProfilePointer,
   clearAuthProfilePointer,
+  deleteUserAuthProfile,
+  clearAllUserAuthProfiles,
   clearTokenSession,
   clearProjectLegacyTokenSession,
   normalizeTokenSession,
   normalizeCorpName,
+  loadUserProfileFile,
   loadEnvTokenSession,
   loadLocalTokenSession,
   saveProjectLegacyTokenSession,

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -365,6 +365,33 @@ function toAuthProfileCandidate(session = {}) {
   return candidate;
 }
 
+function buildAuthProfileNextStep(status) {
+  if (status === 'profile_required') {
+    return {
+      next_step: 'Multiple auth profiles are available. Run openyida auth profiles, then run openyida auth profile switch <auth_profile> with the exact profile id. For one command, pass --profile <auth_profile>.',
+      next_step_commands: [
+        'openyida auth profiles',
+        'openyida auth profile switch <auth_profile>',
+      ],
+    };
+  }
+  if (status === 'profile_not_found') {
+    return {
+      next_step: 'No matching auth profile was found. Run openyida auth profiles to inspect existing profiles, or run openyida login to add a new profile.',
+      next_step_commands: [
+        'openyida auth profiles',
+        'openyida login',
+      ],
+    };
+  }
+  return {
+    next_step: 'Run openyida login to add an auth profile.',
+    next_step_commands: [
+      'openyida login',
+    ],
+  };
+}
+
 function getAuthProfileSelector(options = {}) {
   const env = options.env || process.env;
   return {
@@ -677,6 +704,7 @@ function selectUserProfileSession(options = {}, selection = {}) {
         session: null,
         status: 'profile_not_found',
         auth_profile: selector.authProfile,
+        ...buildAuthProfileNextStep('profile_not_found'),
       };
   }
 
@@ -705,6 +733,7 @@ function selectUserProfileSession(options = {}, selection = {}) {
     return {
       session: null,
       status: 'not_found',
+      ...buildAuthProfileNextStep('not_found'),
     };
   }
   if (candidates.length > 1) {
@@ -714,11 +743,14 @@ function selectUserProfileSession(options = {}, selection = {}) {
       candidate_count: candidates.length,
       candidates: candidates.map(toAuthProfileCandidate),
       message: 'multiple auth profiles found; pass --corp-id, --profile, or OPENYIDA_AUTH_PROFILE',
+      ...buildAuthProfileNextStep('profile_required'),
     };
   }
+  const status = selector.corpId || selector.userId ? 'profile_not_found' : 'not_found';
   return {
     session: null,
-    status: selector.corpId || selector.userId ? 'profile_not_found' : 'not_found',
+    status,
+    ...buildAuthProfileNextStep(status),
   };
 }
 
@@ -882,6 +914,8 @@ function resolveTokenSession(options = {}) {
     candidates: fallbackUserProfile.candidates || userProfile.candidates,
     message: fallbackUserProfile.message,
     auth_profile: fallbackUserProfile.auth_profile || userProfile.auth_profile,
+    next_step: fallbackUserProfile.next_step || userProfile.next_step,
+    next_step_commands: fallbackUserProfile.next_step_commands || userProfile.next_step_commands,
   };
 }
 

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -33,6 +33,8 @@ function compactLogin(login) {
     warning: login.warning,
     candidate_count: login.candidate_count,
     candidates: login.candidates,
+    next_step: login.next_step,
+    next_step_commands: login.next_step_commands,
     can_auto_use: login.can_auto_use === true,
   };
 }
@@ -222,6 +224,8 @@ function buildAuthPath(login, env = process.env) {
     user_auth_store_writable: login.user_auth_store_writable,
     persistence_scope: login.persistence_scope,
     warning: login.warning,
+    next_step: login.next_step,
+    next_step_commands: login.next_step_commands,
     can_auto_use: login.can_auto_use === true,
     host_injected_token_mode: hostInjectedTokenMode,
     host_token_env_detected: hostTokenEnvDetected,
@@ -427,6 +431,8 @@ function compactBuilderPath(builderPath) {
     user_auth_store_writable: builderPath.auth.user_auth_store_writable,
     persistence_scope: builderPath.auth.persistence_scope,
     warning: builderPath.auth.warning,
+    next_step: builderPath.auth.next_step,
+    next_step_commands: builderPath.auth.next_step_commands,
     can_auto_use: builderPath.auth.can_auto_use,
     host_injected_token_mode: builderPath.auth.host_injected_token_mode,
     host_token_env_detected: builderPath.auth.host_token_env_detected,

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -508,8 +508,8 @@ const COMMAND_SIDE_EFFECTS = new Map([
   ['auth', sideEffect('mixed', {
     mutates_yida: false,
     mutates_local: true,
-    read_actions: ['status'],
-    mutating_actions: ['login', 'refresh', 'logout'],
+    read_actions: ['status', 'profiles'],
+    mutating_actions: ['login', 'refresh', 'logout', 'profile switch'],
   })],
   ['batch', sideEffect('mixed', {
     mutates_yida: true,
@@ -785,7 +785,7 @@ const COMMAND_PERMISSIONS = new Map([
   ...permissionEntries([
     'auth',
   ], actionDependentPermission({
-    preauthorized_actions: ['login', 'refresh', 'logout'],
+    preauthorized_actions: ['login', 'refresh', 'logout', 'profile switch'],
   })),
 
   ...permissionEntries([
@@ -1020,7 +1020,7 @@ const COMMAND_GROUPS = [
         output: 'json',
       }),
       command('logout', ['logout'], 'logout', 'help.cmd_logout', { requiresLogin: false }),
-      command('auth', ['auth'], 'auth <status|login|refresh|logout>', 'help.cmd_auth', { requiresLogin: false }),
+      command('auth', ['auth'], 'auth <status|login|refresh|logout|profiles|profile switch>', 'help.cmd_auth', { requiresLogin: false }),
       command('org', ['org'], 'org <list|switch> [--json] [--corp-id <corpId>]', 'help.cmd_org'),
       command('env', ['env'], 'env [--json|setup|list|show|switch|add|remove] [options]', 'help.cmd_env', {
         requiresLogin: false,

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -13,9 +13,9 @@ module.exports = {
     alias: 'Alias:',
     group_auth: 'Auth & Environment',
     cmd_login: 'Login with OAuth token mode',
-    cmd_logout: 'Logout / clear token',
-    cmd_auth: 'Token login state management',
-    cmd_org: 'Organization management (list / switch by OAuth re-login)',
+    cmd_logout: 'Logout / unbind current project auth',
+    cmd_auth: 'Token login state and profile management',
+    cmd_org: 'Organization management (list / switch existing profiles first)',
     cmd_env: 'Detect AI tool environment & token login state',
     cmd_env_management: 'Manage public/private Yida environment profiles',
     group_app: 'App Management',
@@ -162,8 +162,10 @@ Commands:
   auth login                                                   Execute login
   auth refresh                                                 Refresh login credentials
   auth logout                                                  Logout
+  auth profiles                                                List existing login profiles
+  auth profile switch <profile|corpId>                         Switch current project to an existing profile
   org list                                                     List accessible organizations
-  org switch --corp-id <corpId>                                Switch organization (no re-login needed)
+  org switch --corp-id <corpId>                                Switch organization using existing profiles first
   export <appType> [output]                                    Export all form schemas (migration package)
   import <file> [name]                                         Import migration package, rebuild app
   get-permission <appType> <formUuid>                          Query form permission config
@@ -304,10 +306,10 @@ Examples:
     login_usage: 'Usage: openyida login [entryUrl|--public|--alibaba|--intl] [--no-browser] [--check-only] [--json] [--client-id <clientId>]',
     login_example: 'Examples:\n  openyida login                         # Automatically open the browser via OAuth loopback login\n  openyida login --no-browser            # Let the caller handle the authorization URL\n  openyida login --check-only --json     # Check token auth status only\n  openyida login --intl                  # Login against the international environment\n  OPENYIDA_NO_BROWSER=1 openyida login   # Suppress auto-opening the browser with an environment variable\n  openyida auth login                    # Login alias',
     login_unsupported_option: 'Removed legacy login option is no longer supported: {0}. Use token/OAuth login; runtime-environment injected mode only checks the injected token.',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n  openyida auth status         # View login status\n  openyida auth login          # Perform login\n  openyida auth refresh        # Refresh login session\n  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
-    org_example: 'Examples:\n  openyida org list --json                    # List accessible organizations\n  openyida org switch --corp-id dingXXX       # Switch by OAuth re-login',
+    org_example: 'Examples:\n  openyida org list --json                    # List accessible organizations\n  openyida org switch --corp-id dingXXX       # Switch existing profiles first; login to add one if missing',
     first_run_title: '  🤖 OpenYida - AI Conversation Mode Activated!               ',
     first_run_welcome: "  {0}Welcome to OpenYida!{1} Here's a quick start guide:",
     first_run_way1_title: '  📝 Option 1: Describe your needs directly',
@@ -500,9 +502,9 @@ Examples:
     title: '  openyida login - Yida Login Tool',
     logout_title: '  openyida logout - Yida Logout Tool',
     cookie_file_label: '\n  Token file: {0}',
-    logout_success: '  ✅ Token cleared, login session invalidated.',
-    logout_hint: '  Next time you run openyida login, OAuth login will be triggered.',
-    logout_no_file: '  ℹ️  Token file does not exist, nothing to clear.',
+    logout_success: '  ✅ Current project auth was unbound.',
+    logout_hint: '  Shared profiles are kept; pass --profile <auth_profile> or --all to delete them explicitly.',
+    logout_no_file: '  ℹ️  Current project has no token file or profile pointer to unbind.',
     using_cache: '🔍 Local token found, using it directly...',
     csrf_ok: '  ✅ csrf_token: {0}...',
     corp_id_ok: '  ✅ corpId: {0}',
@@ -853,10 +855,10 @@ Examples:
 
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n  openyida auth status         # View login status\n  openyida auth login          # Perform login\n  openyida auth refresh        # Refresh login session\n  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
-  org_example: 'Examples:\n  openyida org list --json                    # List accessible organizations\n  openyida org switch --corp-id dingXXX       # Switch by OAuth re-login to the specified organization',
+  org_example: 'Examples:\n  openyida org list --json                    # List accessible organizations\n  openyida org switch --corp-id dingXXX       # Switch existing profiles first; login to add one if missing',
   title: '  openyida import - Yida App Import Tool',
 
   // ── lib/import-app.js ──────────────────────────────

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -13,9 +13,9 @@ module.exports = {
     alias: '别名:',
     group_auth: '环境 & 认证',
     cmd_login: '登录（OAuth token 模式）',
-    cmd_logout: '退出登录 / 清空 token',
-    cmd_auth: 'token 登录态管理',
-    cmd_org: '组织管理（列表 / 重新登录切换）',
+    cmd_logout: '退出登录 / 解绑当前项目登录态',
+    cmd_auth: 'token 登录态与 profile 管理',
+    cmd_org: '组织管理（列表 / 优先按已有 profile 切换）',
     cmd_env: '检测 AI 工具环境和 token 登录态',
     cmd_env_management: '管理公有云 / 私有化环境',
     group_app: '应用管理',
@@ -162,8 +162,10 @@ openyida - 宜搭命令行工具
   auth login                                                   执行登录
   auth refresh                                                 刷新登录态
   auth logout                                                  退出登录
+  auth profiles                                                列出已有登录 profile
+  auth profile switch <profile|corpId>                         切换当前项目到已有 profile
   org list                                                     列出可访问的组织
-  org switch --corp-id <corpId>                                切换组织（无需重新登录）
+  org switch --corp-id <corpId>                                优先使用已有 profile 切换组织
   export <appType> [output]                                    导出应用所有表单 Schema（生成迁移包）
   import <file> [name]                                         导入迁移包，在目标环境重建应用
   get-permission <appType> <formUuid>                          查询表单权限配置
@@ -472,9 +474,9 @@ openyida - 宜搭命令行工具
     title: '  openyida login - 宜搭登录工具',
     logout_title: '  openyida logout - 宜搭退出登录工具',
     cookie_file_label: '\n  Token 文件: {0}',
-    logout_success: '  ✅ 已清空 token，登录态已失效。',
-    logout_hint: '  下次调用 openyida login 时将重新触发 OAuth 登录。',
-    logout_no_file: '  ℹ️  Token 文件不存在，无需清空。',
+    logout_success: '  ✅ 已解绑当前项目登录态。',
+    logout_hint: '  共享 profile 会保留；如需删除请显式传 --profile <auth_profile> 或 --all。',
+    logout_no_file: '  ℹ️  当前项目没有可解绑的 token 文件或 profile pointer。',
     using_cache: '🔍 检测到本地 token，直接使用...',
     csrf_ok: '  ✅ csrf_token: {0}...',
     corp_id_ok: '  ✅ corpId: {0}',
@@ -826,10 +828,10 @@ openyida - 宜搭命令行工具
   // ── lib/import-app.js ──────────────────────────────
   import_example2: '      openyida import ./yida-export.json "质量追溯系统（生产环境）"',
   exec_failed: '\n❌ 执行失败: {0}',
-  auth_usage: '用法: openyida auth <status|login|refresh|logout>',
-  auth_example: '示例:\n  openyida auth status         # 查看登录状态\n  openyida auth login          # 执行登录\n  openyida auth refresh        # 刷新登录态\n  openyida auth logout         # 退出登录',
+  auth_usage: '用法: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: '示例:\n  openyida auth status                         # 查看登录状态\n  openyida auth profiles                       # 列出已有登录 profile\n  openyida auth profile switch <auth_profile>  # 切换当前项目到已有 profile\n  openyida auth login                          # 目标 profile 不存在时登录新增\n  openyida auth refresh                        # 刷新登录态\n  openyida auth logout                         # 解绑当前项目登录态\n  openyida auth logout --profile <auth_profile> # 删除指定共享 profile',
   org_usage: '用法: openyida org <list|switch> [--json] [--corp-id <corpId>]',
-  org_example: '示例:\n  openyida org list --json                    # 列出可访问的组织\n  openyida org switch --corp-id dingXXX       # 重新 OAuth 登录并切换到指定组织',
+  org_example: '示例:\n  openyida org list --json                    # 列出可访问的组织\n  openyida org switch --corp-id dingXXX       # 优先切换已有 profile；不存在时登录新增',
   title: '  openyida import - 宜搭应用导入工具',
   // ── lib/get-page-config.js ─────────────────────────
   get_page_config: {

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -841,12 +837,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -841,12 +837,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -843,12 +839,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -843,12 +839,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -841,12 +837,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -309,12 +309,8 @@ module.exports = {
     first_run_footer1: '  対応 AI ツール：Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 ドキュメント：https://github.com/openyida/openyida',
     first_run_footer3: '  （このガイドは初回起動時のみ表示されます。openyida --help で全コマンドを確認できます）',
-    auth_usage: '使用方法: openyida auth <status|login|refresh|logout>',
-    auth_example: '例:\n' +
-      '  openyida auth status         # ログイン状態を確認\n' +
-      '  openyida auth login          # ログイン実行\n' +
-      '  openyida auth refresh        # ログイン状態を更新\n' +
-      '  openyida auth logout         # ログアウト',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: '使用方法: openyida org <list|switch>',
     org_example: '例:\n  openyida org list                       # アクセス可能な組織一覧\n  openyida org switch --corp-id dingXXX   # 指定組織に切り替え'
   },
@@ -800,12 +796,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -842,12 +838,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -843,12 +839,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -323,12 +323,8 @@ module.exports = {
     first_run_footer1: '  Supported AI tools: Codex / Claude Code / Aone Copilot / Cursor / OpenCode',
     first_run_footer2: '  📚 Docs: https://github.com/openyida/openyida',
     first_run_footer3: '  (This guide only shows on first run. Use openyida --help to see all commands)',
-    auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-    auth_example: 'Examples:\n' +
-      '  openyida auth status         # View login status\n' +
-      '  openyida auth login          # Perform login\n' +
-      '  openyida auth refresh        # Refresh login session\n' +
-      '  openyida auth logout         # Logout',
+    auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+    auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
     org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
     org_example: 'Examples:\n' +
       '  openyida org list --json                    # List accessible organizations\n' +
@@ -841,12 +837,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "Quality Traceability System (Production)"',
   exec_failed: '\n❌ Execution failed: {0}',
-  auth_usage: 'Usage: openyida auth <status|login|refresh|logout>',
-  auth_example: 'Examples:\n' +
-    '  openyida auth status         # View login status\n' +
-    '  openyida auth login          # Perform login\n' +
-    '  openyida auth refresh        # Refresh login session\n' +
-    '  openyida auth logout         # Logout',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: 'Usage: openyida org <list|switch> [--json] [--corp-id <corpId>]',
   org_example: 'Examples:\n' +
     '  openyida org list --json                    # List accessible organizations\n' +

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -788,12 +788,8 @@ module.exports = {
   },
   import_example2: '      openyida import ./yida-export.json "品質追溯系統（正式環境）"',
   exec_failed: '\n❌ 執行失敗：{0}',
-  auth_usage: '用法：openyida auth <status|login|refresh|logout>',
-  auth_example: '範例：\n' +
-    '  openyida auth status         # 查看登入狀態\n' +
-    '  openyida auth login          # 執行登入\n' +
-    '  openyida auth refresh        # 刷新登入態\n' +
-    '  openyida auth logout         # 登出',
+  auth_usage: 'Usage: openyida auth <status|login|refresh|logout|profiles|profile switch>',
+  auth_example: 'Examples:\n  openyida auth status                         # View login status\n  openyida auth profiles                       # List existing login profiles\n  openyida auth profile switch <auth_profile>  # Switch current project to an existing profile\n  openyida auth login                          # Add a profile when the target does not exist\n  openyida auth refresh                        # Refresh login session\n  openyida auth logout                         # Unbind current project auth\n  openyida auth logout --profile <auth_profile> # Delete a shared profile explicitly',
   org_usage: '用法：openyida org <list|switch>',
   org_example: '範例：\n  openyida org list                    # 列出可訪問的組織\n  openyida org switch --corp-id dingXXX  # 切換到指定組織',
   title: '  openyida import - 宜搭應用程式匯入工具',

--- a/tests/agent-capabilities.test.js
+++ b/tests/agent-capabilities.test.js
@@ -124,6 +124,11 @@ describe('agent-capabilities summary', () => {
           user_id: 'user-a',
         },
       ],
+      next_step: 'Run openyida auth profiles, then switch to an existing profile.',
+      next_step_commands: [
+        'openyida auth profiles',
+        'openyida auth profile switch <auth_profile>',
+      ],
     }));
     const findProjectRoot = jest.fn(() => {
       throw new Error('findProjectRoot is only needed by the runtime fast path');
@@ -159,6 +164,11 @@ describe('agent-capabilities summary', () => {
             corp_name: '组织 A',
           }),
         ],
+        next_step: 'Run openyida auth profiles, then switch to an existing profile.',
+        next_step_commands: [
+          'openyida auth profiles',
+          'openyida auth profile switch <auth_profile>',
+        ],
         can_auto_use: false,
       });
       expect(summary.builder_path.auth).toMatchObject({
@@ -168,6 +178,11 @@ describe('agent-capabilities summary', () => {
         corp_name: '组织 A',
         user_auth_store_writable: true,
         persistence_scope: 'project',
+        next_step: 'Run openyida auth profiles, then switch to an existing profile.',
+        next_step_commands: [
+          'openyida auth profiles',
+          'openyida auth profile switch <auth_profile>',
+        ],
       });
       expect(summary.builder_path.auth).not.toHaveProperty('runtime_auth_provisioned');
     } finally {

--- a/tests/auth-profile.test.js
+++ b/tests/auth-profile.test.js
@@ -135,7 +135,17 @@ describe('auth profile management', () => {
       authDir,
     });
 
-    expect(() => switchAuthProfile('corp-missing', { projectRoot, authDir })).toThrow(/auth profile not found/);
+    try {
+      switchAuthProfile('corp-missing', { projectRoot, authDir });
+      throw new Error('switchAuthProfile should throw');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'AUTH_PROFILE_NOT_FOUND',
+        details: {
+          next_step: expect.stringContaining('openyida auth profiles'),
+        },
+      });
+    }
     expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
       auth_profile: previous.auth_profile,
       corp_id: 'corp-a',
@@ -156,7 +166,18 @@ describe('auth profile management', () => {
       authDir,
     });
 
-    expect(() => switchAuthProfile('corp-b', { projectRoot, authDir })).toThrow(/multiple auth profiles/);
+    try {
+      switchAuthProfile('corp-b', { projectRoot, authDir });
+      throw new Error('switchAuthProfile should throw');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'AUTH_PROFILE_REQUIRED',
+        details: {
+          candidate_count: 2,
+          next_step: expect.stringContaining('openyida auth profile switch <auth_profile>'),
+        },
+      });
+    }
     expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
       auth_profile: previous.auth_profile,
       corp_id: 'corp-a',

--- a/tests/auth-profile.test.js
+++ b/tests/auth-profile.test.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  listAuthProfiles,
+  switchAuthProfile,
+} = require('../lib/auth/profile');
+const {
+  getUserProfileFilePath,
+  loadTokenSession,
+  saveTokenSession,
+} = require('../lib/auth/token-store');
+
+function makeSession(corpId, userId, accessToken, corpName) {
+  return {
+    access_token: accessToken,
+    refresh_token: `${accessToken}-refresh`,
+    base_url: 'https://www.aliwork.com',
+    client_id: 'openyida-cli',
+    corp_id: corpId,
+    corp_name: corpName || `组织 ${corpId}`,
+    user_id: userId,
+    user_name: `用户 ${userId}`,
+  };
+}
+
+describe('auth profile management', () => {
+  let rootDir;
+  let projectRoot;
+  let otherProjectRoot;
+  let authDir;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-auth-profile-'));
+    projectRoot = path.join(rootDir, 'project-a');
+    otherProjectRoot = path.join(rootDir, 'project-b');
+    authDir = path.join(rootDir, 'user-auth');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.mkdirSync(otherProjectRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  test('lists safe user auth profile metadata', () => {
+    const saved = saveTokenSession(makeSession('corp-a', 'user-a', 'access-a', '组织 A'), {
+      projectRoot,
+      authDir,
+    });
+
+    const result = listAuthProfiles({ projectRoot, authDir });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'ok',
+      auth_store: 'user',
+      current_auth_profile: saved.auth_profile,
+      count: 1,
+      profiles: [
+        expect.objectContaining({
+          auth_profile: saved.auth_profile,
+          corp_id: 'corp-a',
+          corp_name: '组织 A',
+          user_id: 'user-a',
+          user_name: '用户 user-a',
+          auth_store: 'user',
+          is_current: true,
+        }),
+      ],
+    });
+    expect(result.profiles[0].last_used_at).toBeTruthy();
+    expect(result.profiles[0]).not.toHaveProperty('access_token');
+    expect(result.profiles[0]).not.toHaveProperty('refresh_token');
+  });
+
+  test('switches current project pointer to an existing profile by profile id', () => {
+    const previous = saveTokenSession(makeSession('corp-a', 'user-a', 'access-a'), {
+      projectRoot,
+      authDir,
+    });
+    const target = saveTokenSession(makeSession('corp-b', 'user-b', 'access-b'), {
+      projectRoot: otherProjectRoot,
+      authDir,
+    });
+
+    const result = switchAuthProfile(target.auth_profile, { projectRoot, authDir });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'switched',
+      target_kind: 'auth_profile',
+      previous_auth_profile: previous.auth_profile,
+      previous_corp_id: 'corp-a',
+      auth_profile: target.auth_profile,
+      corp_id: 'corp-b',
+      user_id: 'user-b',
+    });
+    expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
+      auth_profile: target.auth_profile,
+      corp_id: 'corp-b',
+      user_id: 'user-b',
+    });
+    expect(fs.existsSync(getUserProfileFilePath(previous.auth_profile, { authDir }))).toBe(true);
+    expect(fs.existsSync(getUserProfileFilePath(target.auth_profile, { authDir }))).toBe(true);
+  });
+
+  test('switches current project pointer to an existing unique profile by corpId', () => {
+    saveTokenSession(makeSession('corp-a', 'user-a', 'access-a'), {
+      projectRoot,
+      authDir,
+    });
+    const target = saveTokenSession(makeSession('corp-b', 'user-b', 'access-b'), {
+      projectRoot: otherProjectRoot,
+      authDir,
+    });
+
+    const result = switchAuthProfile('corp-b', { projectRoot, authDir });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 'switched',
+      target_kind: 'corp_id',
+      auth_profile: target.auth_profile,
+      corp_id: 'corp-b',
+    });
+  });
+
+  test('does not mutate the current pointer when target profile is missing', () => {
+    const previous = saveTokenSession(makeSession('corp-a', 'user-a', 'access-a'), {
+      projectRoot,
+      authDir,
+    });
+
+    expect(() => switchAuthProfile('corp-missing', { projectRoot, authDir })).toThrow(/auth profile not found/);
+    expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
+      auth_profile: previous.auth_profile,
+      corp_id: 'corp-a',
+    });
+  });
+
+  test('requires exact profile when corpId matches multiple profiles', () => {
+    const previous = saveTokenSession(makeSession('corp-a', 'user-a', 'access-a'), {
+      projectRoot,
+      authDir,
+    });
+    saveTokenSession(makeSession('corp-b', 'user-b1', 'access-b1'), {
+      projectRoot: path.join(rootDir, 'project-b1'),
+      authDir,
+    });
+    saveTokenSession(makeSession('corp-b', 'user-b2', 'access-b2'), {
+      projectRoot: path.join(rootDir, 'project-b2'),
+      authDir,
+    });
+
+    expect(() => switchAuthProfile('corp-b', { projectRoot, authDir })).toThrow(/multiple auth profiles/);
+    expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
+      auth_profile: previous.auth_profile,
+      corp_id: 'corp-a',
+    });
+  });
+
+  test('host-injected token mode does not switch local profiles', () => {
+    const saved = saveTokenSession(makeSession('corp-a', 'user-a', 'access-a'), {
+      projectRoot,
+      authDir,
+    });
+
+    expect(() => switchAuthProfile(saved.auth_profile, {
+      projectRoot,
+      authDir,
+      env: { YIDA_AUTH_ENABLED: 'true' },
+    })).toThrow(/host-injected token mode/);
+    expect(loadTokenSession({ projectRoot, authDir })).toMatchObject({
+      auth_profile: saved.auth_profile,
+      corp_id: 'corp-a',
+    });
+  });
+});

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -573,6 +573,10 @@ describe('CLI offline smoke', () => {
       output: 'json',
       requires_login: false,
     });
+    expect(parsed.commands.find(entry => entry.id === 'auth')).toMatchObject({
+      usage: 'openyida auth <status|login|refresh|logout|profiles|profile switch>',
+      requires_login: false,
+    });
     expect(parsed.commands.find(entry => entry.id === 'dingtalk-link')).toMatchObject({
       usage: 'openyida dingtalk-link <url> [--target fullScreen] [--legacy-scheme] [--json]',
       output: 'text|json',
@@ -1603,8 +1607,8 @@ describe('CLI offline smoke', () => {
       kind: 'mixed',
       mutates_yida: false,
       mutates_local: true,
-      read_actions: ['status'],
-      mutating_actions: ['login', 'refresh', 'logout'],
+      read_actions: ['status', 'profiles'],
+      mutating_actions: ['login', 'refresh', 'logout', 'profile switch'],
     });
     expect(commandById.org.side_effect).toMatchObject({
       kind: 'mixed',

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -16,6 +16,7 @@ const {
   getBusinessContextFilePath,
   getUserProfileFilePath,
   getTokenFilePath,
+  listUserAuthProfiles,
   loadTokenSession,
   saveTokenSession,
 } = require('../lib/auth/token-store');
@@ -208,11 +209,52 @@ describe('token-auth', () => {
     expect(status).not.toHaveProperty('token_file');
   });
 
-  test('logout clears a user profile selected without a project pointer', async () => {
+  test('default logout only unbinds the current project and keeps shared user profiles', async () => {
+    const loginProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-login-project-'));
+    const secondProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-second-project-'));
+    const newProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-new-project-'));
+    try {
+      const saved = saveTokenSession({
+        access_token: 'profile-access-token',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'openyida-cli',
+        corp_id: 'corp-profile',
+        user_id: 'user-profile',
+      }, { projectRoot: loginProject, authDir });
+      const second = saveTokenSession({
+        access_token: 'second-profile-access-token',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'openyida-cli',
+        corp_id: 'corp-second',
+        user_id: 'user-second',
+      }, { projectRoot: secondProject, authDir });
+
+      const result = await tokenLogout({ projectRoot: newProject, authDir });
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'project_unbound',
+        deleted_profile_count: 0,
+        project_unbound: true,
+      });
+      expect(loadTokenSession({ projectRoot: newProject, authDir })).toBe(null);
+      expect(fs.existsSync(getUserProfileFilePath(saved.auth_profile, { authDir }))).toBe(true);
+      expect(loadTokenSession({ projectRoot: loginProject, authDir })).toMatchObject({
+        auth_profile: saved.auth_profile,
+        corp_id: 'corp-profile',
+      });
+      expect(fs.existsSync(getUserProfileFilePath(second.auth_profile, { authDir }))).toBe(true);
+    } finally {
+      fs.rmSync(loginProject, { recursive: true, force: true });
+      fs.rmSync(secondProject, { recursive: true, force: true });
+      fs.rmSync(newProject, { recursive: true, force: true });
+    }
+  });
+
+  test('logout deletes a shared user profile only when --profile is explicit', async () => {
     const loginProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-login-project-'));
     const newProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-new-project-'));
     try {
-      saveTokenSession({
+      const saved = saveTokenSession({
         access_token: 'profile-access-token',
         base_url: 'https://www.aliwork.com',
         client_id: 'openyida-cli',
@@ -220,15 +262,95 @@ describe('token-auth', () => {
         user_id: 'user-profile',
       }, { projectRoot: loginProject, authDir });
 
-      expect(loadTokenSession({ projectRoot: newProject, authDir })).toMatchObject({
-        auth_source: 'user_profile',
-        auth_store: 'user',
+      const result = await tokenLogout({
+        projectRoot: newProject,
+        authDir,
+        authProfile: saved.auth_profile,
       });
-      await tokenLogout({ projectRoot: newProject, authDir });
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'logged_out',
+        auth_profile: saved.auth_profile,
+        deleted_profile_count: 1,
+        project_unbound: true,
+      });
+      expect(fs.existsSync(getUserProfileFilePath(saved.auth_profile, { authDir }))).toBe(false);
       expect(loadTokenSession({ projectRoot: newProject, authDir })).toBe(null);
     } finally {
       fs.rmSync(loginProject, { recursive: true, force: true });
       fs.rmSync(newProject, { recursive: true, force: true });
+    }
+  });
+
+  test('logout --all deletes shared user profiles outside host-injected token mode', async () => {
+    const firstProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-login-a-'));
+    const secondProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-login-b-'));
+    try {
+      saveTokenSession({
+        access_token: 'profile-access-a',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'openyida-cli',
+        corp_id: 'corp-a',
+        user_id: 'user-a',
+      }, { projectRoot: firstProject, authDir });
+      saveTokenSession({
+        access_token: 'profile-access-b',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'openyida-cli',
+        corp_id: 'corp-b',
+        user_id: 'user-b',
+      }, { projectRoot: secondProject, authDir });
+
+      const result = await tokenLogout({
+        projectRoot: tmpDir,
+        authDir,
+        allProfiles: true,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'logged_out',
+        deleted_profile_count: 2,
+        project_unbound: true,
+      });
+      expect(listUserAuthProfiles({ authDir })).toHaveLength(0);
+      expect(loadTokenSession({ projectRoot: tmpDir, authDir })).toBe(null);
+    } finally {
+      fs.rmSync(firstProject, { recursive: true, force: true });
+      fs.rmSync(secondProject, { recursive: true, force: true });
+    }
+  });
+
+  test('host-injected token logout never deletes local user profiles', async () => {
+    const loginProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-login-project-'));
+    try {
+      const saved = saveTokenSession({
+        access_token: 'profile-access-token',
+        base_url: 'https://www.aliwork.com',
+        client_id: 'openyida-cli',
+        corp_id: 'corp-profile',
+        user_id: 'user-profile',
+      }, { projectRoot: loginProject, authDir });
+
+      const result = await tokenLogout({
+        projectRoot: tmpDir,
+        authDir,
+        authProfile: saved.auth_profile,
+        allProfiles: true,
+        env: {
+          YIDA_AUTH_ENABLED: 'true',
+        },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'host_injected_noop',
+        auth_store: 'host_injected',
+      });
+      expect(fs.existsSync(getUserProfileFilePath(saved.auth_profile, { authDir }))).toBe(true);
+    } finally {
+      fs.rmSync(loginProject, { recursive: true, force: true });
     }
   });
 

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -167,6 +167,11 @@ describe('token-auth', () => {
         ok: false,
         status: 'profile_required',
         candidate_count: 2,
+        next_step: expect.stringContaining('openyida auth profiles'),
+        next_step_commands: [
+          'openyida auth profiles',
+          'openyida auth profile switch <auth_profile>',
+        ],
       });
       expect(status.candidates).toEqual(expect.arrayContaining([
         expect.objectContaining({ corp_id: 'corp-a', corp_name: '组织 A', user_id: 'user-a' }),
@@ -205,6 +210,7 @@ describe('token-auth', () => {
       status: 'not_logged_in',
       can_auto_use: false,
       failure_reason: 'env_token_missing',
+      next_step: expect.stringContaining('Ask the host runtime to inject'),
     });
     expect(status).not.toHaveProperty('token_file');
   });

--- a/yida-skills/references/setup-and-env.md
+++ b/yida-skills/references/setup-and-env.md
@@ -30,6 +30,7 @@ openyida login --check-only --json
 | command not found | 安装或更新 `openyida`；不要创建资源 |
 | `workdir_exists=false` 或 `active.projectRootExists=false` | 先执行 `openyida copy`；工作目录存在前不要创建资源 |
 | `auth_mode=token` 且 `status=ok` 或 `can_auto_use=true` | 继续执行 |
+| `auth_mode=token` 且 `status=profile_required` | 不猜组织；执行 `openyida auth profiles`，再用 `openyida auth profile switch <auth_profile>` 切换已有 profile |
 | snapshot 返回 `auth_source=env` / `failure_reason=env_token_missing` | 进入运行环境注入 token 模式；缺 token 时停止，让 Codex、yida-agent 等宿主注入 `OPENYIDA_ACCESS_TOKEN` 或 `OPENYIDA_REFRESH_TOKEN`；不要执行 OAuth |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=cli_auto_open` | 只执行一次 `openyida login`，等待该命令结束，并使用其最终 JSON 判断结果 |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 打开输出 URL 一次，并等待原命令结束 |
@@ -44,9 +45,13 @@ openyida login --check-only --json
 openyida login
 openyida login --check-only --json
 openyida auth status
+openyida auth profiles
+openyida auth profile switch <auth_profile>
 openyida auth refresh
 openyida auth logout
 ```
+
+多 profile 场景下优先切换已有 profile；目标 profile 不存在时，才执行 `openyida login` 新增登录态，随后重新 `openyida auth profiles` 并切换到新增 profile。
 
 ## Agent OAuth 登录编排
 

--- a/yida-skills/skills-index.json
+++ b/yida-skills/skills-index.json
@@ -889,7 +889,7 @@
       "name": "yida-logout",
       "path": "skills/yida-logout/SKILL.md",
       "display_name": "退出宜搭登录",
-      "description": "退出宜搭登录，清空本地 token session。适用于切换账号或组织。",
+      "description": "退出宜搭登录或解绑当前项目登录态。默认保留共享 profile，显式 --profile/--all 才删除。",
       "category": "yida-skills/context",
       "tags": [
         "退出登录",

--- a/yida-skills/skills/yida-login/SKILL.md
+++ b/yida-skills/skills/yida-login/SKILL.md
@@ -35,6 +35,7 @@ openyida login --check-only --json
 | 状态 | 动作 |
 |---|---|
 | `auth_mode=token` 且 `status=ok` 或 `can_auto_use=true` | 继续执行业务命令 |
+| `status=profile_required` 且返回 `candidates` / `next_step` | 不猜组织；先执行 `openyida auth profiles`，再用 `openyida auth profile switch <auth_profile>` 切到用户确认或目标匹配的已有 profile |
 | `auth_source=env` / `failure_reason=env_token_missing` | 进入运行环境注入 token 模式；缺 token 时停止，让 Codex、yida-agent 等宿主注入 `OPENYIDA_ACCESS_TOKEN` 或 `OPENYIDA_REFRESH_TOKEN`；不要执行 OAuth |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=cli_auto_open` | 只执行一次 `openyida login`，等待该命令结束，并使用其最终 JSON 判断结果 |
 | `auth_mode=token`，未登录，且 `interactive_login.mode=caller_open_url` | 只执行一次 `openyida login --no-browser`，由 Agent 打开输出的授权 URL 一次，并等待原命令结束 |
@@ -48,9 +49,19 @@ openyida login --check-only --json
 openyida login
 openyida login --check-only --json
 openyida auth status
+openyida auth profiles
+openyida auth profile switch <auth_profile>
 openyida auth refresh
 openyida auth logout
 ```
+
+## Profile 选择原则
+
+- 当前已有多个 profile 且 snapshot 返回 `profile_required` 时，不要根据目录、组织名片段或最近操作猜测组织。
+- 先执行 `openyida auth profiles` 查看 `corp_name`、`corp_id`、`user_id`、`auth_profile`、`last_used_at` 和 `auth_store`。
+- 目标 profile 已存在时，执行 `openyida auth profile switch <auth_profile>`；这是非破坏性切换，只更新当前项目 pointer。
+- 目标 profile 不存在时，再执行 `openyida login` 新增登录态；登录完成后重新执行 `openyida auth profiles` 并切到新增 profile。
+- 运行环境注入 token 模式下，不要切换或删除本地 profile，让宿主注入目标组织的 token。
 
 ## Agent OAuth 登录编排
 

--- a/yida-skills/skills/yida-logout/SKILL.md
+++ b/yida-skills/skills/yida-logout/SKILL.md
@@ -1,27 +1,33 @@
 ---
 name: yida-logout
-description: 退出宜搭登录，清空本地 token session。适用于需要切换账号、切换组织或重置 refresh token 时。
+description: 退出宜搭登录或解绑当前项目登录态。默认只解绑当前项目 profile pointer；显式传 --profile 或 --all 才删除共享登录 profile。
 ---
 
 # 退出登录
 
 ## 严格禁止 (NEVER DO)
 
-- 不要在退出登录后立即执行需要登录态的命令，必须先重新登录
-- 不要手动删除或编辑 `.cache/auth-token-<env>.json`，必须通过 `openyida logout` / `openyida auth logout` 清空
+- 不要把默认 `openyida logout` 当成删除共享登录态；它只解绑当前项目 profile pointer，并清当前项目 legacy token
+- 不要在目标 profile 已存在时要求用户重新 OAuth 登录；应先执行 `openyida auth profile switch <auth_profile>`
+- 不要手动删除或编辑 `.cache/auth-token-<env>.json`、`.cache/openyida/auth-profile-<env>.json` 或用户 auth profile 文件
+- 运行环境注入 token 模式下，不要尝试写入或删除本地 user profile
 
 ## 严格要求 (MUST DO)
 
-- 退出后如需继续使用，必须重新执行 `openyida login` 获取新的登录态
+- 默认退出后如需继续使用，先执行 `openyida auth status` / `openyida auth profiles`，优先切换已有 profile
+- 只有目标 profile 不存在时，才执行 `openyida login` 新增登录态
+- 删除共享 profile 必须显式使用 `openyida auth logout --profile <auth_profile>` 或 `openyida auth logout --all`
 - **本技能不读写 memory**：退出操作仅清空当前环境的 token session，不依赖跨会话的 memory 状态
 
 ## 适用场景
 
 | 用户意图 | 触发条件 |
 |---------|---------|
-| 切换账号 | "切换账号"、"换个账号登录" |
-| 切换组织 | "切换组织"、当前 token 绑定了错误组织 |
+| 解绑当前项目 | "退出登录"、当前项目绑定了错误 profile |
+| 切换账号 | "切换账号"、"换个账号登录"，且已有目标 profile 可切换 |
+| 切换组织 | "切换组织"、当前 token 绑定了错误组织，且已有目标 profile 可切换 |
 | 重置登录态 | refresh token 缺失、过期或服务端拒绝刷新 |
+| 删除共享 profile | 用户明确要求删除某个 profile 或清空全部本地共享登录态 |
 
 ## 触发条件
 
@@ -41,19 +47,24 @@ description: 退出宜搭登录，清空本地 token session。适用于需要�
 
 ```bash
 openyida logout
+openyida auth profiles
+openyida auth profile switch <auth_profile>
+openyida auth logout --profile <auth_profile>
+openyida auth logout --all
 ```
 
-清空当前环境的 `.cache/auth-token-<env>.json` token session。下次调用需要鉴权的命令前，需要重新执行 `openyida login`。
+`openyida logout` / `openyida auth logout` 默认只解绑当前项目的 profile pointer，并清当前项目 legacy token；不会删除用户级共享 profile。
 
-**适用场景**：切换账号、切换组织、refresh token 失效无法自动刷新。
+**适用场景**：解绑当前项目、切换到已有 profile、显式删除共享 profile、refresh token 失效无法自动刷新。
 
 ## 异常处理
 
 | 异常场景 | 处理方式 |
 |---------|----------|
-| logout 后忘记重新登录 | 执行 `openyida login` 获取新的 token session |
-| 手动删除了 auth-token 文件 | 效果等同于 logout，下次需要重新登录 |
-| logout 后立即执行需要登录的命令 | 先完成 token 登录后再继续 |
+| logout 后仍需继续操作 | 执行 `openyida auth profiles`，优先 `openyida auth profile switch <auth_profile>` |
+| 目标 profile 不存在 | 执行 `openyida login` 新增登录态，再切到新增 profile |
+| 手动删除了 auth-token 文件 | 执行 `openyida auth status` 检查状态，不要继续手动删 profile |
+| logout 后立即执行需要登录的命令 | 先确认 `openyida auth status` 返回可用登录态 |
 
 ## Agent 错误处理策略
 
@@ -62,7 +73,7 @@ openyida logout
 | 错误类型 | 默认处理策略 |
 |---------|-------------|
 | 命令执行失败 | 停止执行，向用户展示错误信息，询问是否重试 |
-| auth-token 文件不存在 | 无需处理，说明已处于未登录状态 |
+| auth-token 文件不存在 | 无需处理；默认 logout 仍会尝试解绑 project pointer |
 | 文件权限不足 | 提示用户检查 `.cache/` 目录权限 |
-| logout 后需要继续操作 | 提示用户执行 `openyida login` 重新登录 |
+| logout 后需要继续操作 | 提示用户先 `openyida auth profiles` 并切换已有 profile；目标不存在时再 `openyida login` |
 | 未知错误 | 停止执行，完整展示错误信息，建议用户反馈问题 |


### PR DESCRIPTION
## Summary
- P1: split logout semantics so default logout only unbinds the current project pointer / legacy token, while --profile and --all explicitly delete shared user profiles.
- P1: add auth profiles and auth profile switch <profile|corpId> for non-destructive profile listing and selection.
- P2: add profile_required candidates / next_step hints to auth status and agent-capabilities, and align README, help, i18n, and yida-login/yida-logout skill docs.

## Tests
- node --check bin/yida.js lib/auth/token-store.js lib/auth/token-auth.js lib/auth/profile.js lib/core/agent-capabilities.js lib/core/command-manifest.js
- npx eslint bin/yida.js lib/auth/token-store.js lib/auth/token-auth.js lib/auth/profile.js lib/core/agent-capabilities.js lib/core/command-manifest.js tests/token-auth.test.js tests/auth-profile.test.js tests/agent-capabilities.test.js tests/cli-smoke.test.js --quiet
- npx jest tests/token-store.test.js tests/token-auth.test.js tests/org-switch.test.js tests/cli-smoke.test.js tests/agent-capabilities.test.js tests/skill-contracts.test.js tests/auth-profile.test.js --runInBand
- npm run check:i18n
- npm run check:skills
- npm run check:commands
- npm run check:docs
- git diff --check

## Notes
- check:skills reports the existing dist/skills/openyida warning but exits successfully.
- No cookie cleanup changes included. No #492 org switch behavior changes beyond using existing auth profile storage APIs.