### PR TITLE
refactor: remove cookie authRef compatibility

### DIFF
--- a/lib/app/app-lifecycle.js
+++ b/lib/app/app-lifecycle.js
@@ -66,8 +66,7 @@ async function changeAppLifecycle(action, params, authRef = createAuthRef()) {
   const response = await requestWithAutoLogin((auth) => httpPost(
     auth.baseUrl,
     buildRequestPath(action, params.appType),
-    buildPostData(params, auth),
-    auth.cookies
+    buildPostData(params, auth)
   ), authRef);
 
   if (!response || response.success !== true || response.content !== true) {

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -4528,7 +4528,7 @@ function sendPostRequest(baseUrl, requestPath, extraParams, formUuid, authRef) {
   const referer = formUuid
     ? `${baseUrl}/alibaba/web/${extraParams.appType || ''}/design/pageDesigner?formUuid=${formUuid}`
     : baseUrl + '/';
-  return httpPost(baseUrl, requestPath, postData, authRef && authRef.cookies, { referer });
+  return httpPost(baseUrl, requestPath, postData, { referer });
 }
 
 // ── 发送 updateFormConfig 请求 ───────────────────────
@@ -4544,8 +4544,7 @@ function sendUpdateConfigRequest(baseUrl, appType, formUuid, version, value, aut
   return httpPost(
     baseUrl,
     `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`,
-    postData,
-    authRef && authRef.cookies
+    postData
   );
 }
 
@@ -5057,7 +5056,7 @@ async function createFormForLegacyProcessQuiet(context, input) {
     );
   }, authRef);
   const serverRevision = extractSchemaServerRevision(shellSchemaResult);
-  const corpId = resolveCorpId(authRef.authData || authRef.cookieData || authRef);
+  const corpId = resolveCorpId(authRef.authData || authRef);
   const schema = buildFormSchema(formTitle, fields, formUuid, corpId, appType, layout, theme, labelAlign);
   const createValidationRules = collectSmartValidationRulesFromFields(fields).concat(validations || []);
   if (createValidationRules.length > 0) {

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -130,8 +130,7 @@ async function configureNavigationVisibility(authRef, appType, pageId, pageName,
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/updateFormSchemaInfo.json`,
-      buildPageInfoPostData(pageId, pageName, isRenderNav, auth.csrfToken),
-      auth.cookies
+      buildPageInfoPostData(pageId, pageName, isRenderNav, auth.csrfToken)
     );
   }, authRef);
 }
@@ -193,8 +192,7 @@ async function run(args) {
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
-      postData,
-      auth.cookies
+      postData
     );
   }, authRef);
 

--- a/lib/app/form-detail-style.js
+++ b/lib/app/form-detail-style.js
@@ -294,30 +294,22 @@ function extractSchema(schemaResult) {
   return schema;
 }
 
-function authRequestOptions(authRef, options = {}) {
-  if (authRef && Array.isArray(authRef.cookies) && authRef.cookies.length > 0) {
-    return [authRef.cookies, options];
-  }
-  return [options];
-}
-
 async function fetchFormSchema(authRef, appType, formUuid) {
   return requestWithAutoLogin((auth) => {
-    const args = authRequestOptions(auth);
     return httpGet(
       auth.baseUrl,
       buildApiPath(appType, 'getFormSchema', { prefix: '_view', namespace: 'alibaba' }),
       { formUuid, schemaVersion: 'V5' },
-      ...args
+      {}
     );
   }, authRef);
 }
 
 async function saveFormSchema(authRef, appType, formUuid, schema, version) {
   return requestWithAutoLogin((auth) => {
-    const optionsArgs = authRequestOptions(auth, {
+    const requestOptions = {
       referer: `${auth.baseUrl}/alibaba/web/${appType}/design/pageDesigner?formUuid=${formUuid}`,
-    });
+    };
     const body = {
       appType,
       formUuid,
@@ -336,7 +328,7 @@ async function saveFormSchema(authRef, appType, formUuid, schema, version) {
       auth.baseUrl,
       buildApiPath(appType, 'saveFormSchema', { prefix: '_view' }),
       querystring.stringify(body),
-      ...optionsArgs
+      requestOptions
     );
   }, authRef);
 }
@@ -352,12 +344,10 @@ async function refreshFormConfig(authRef, appType, formUuid, version) {
     if (auth.csrfToken) {
       body._csrf_token = auth.csrfToken;
     }
-    const args = authRequestOptions(auth);
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`,
-      querystring.stringify(body),
-      ...args
+      querystring.stringify(body)
     );
   }, authRef);
 }

--- a/lib/app/import-app.js
+++ b/lib/app/import-app.js
@@ -43,7 +43,7 @@ async function createApp(appName, authRef) {
       fromBuilderAi: 'y',
       builderAiSource: 'local',
     });
-    return httpPost(auth.baseUrl, '/query/app/registerApp.json', postData, auth.cookies);
+    return httpPost(auth.baseUrl, '/query/app/registerApp.json', postData);
   }, authRef);
 
   if (!result || !result.success || !result.content) {
@@ -83,8 +83,7 @@ async function createBlankForm(appType, formTitle, authRef, formType = 'receipt'
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
-      postData,
-      auth.cookies
+      postData
     );
   }, authRef);
 
@@ -100,13 +99,7 @@ async function createBlankForm(appType, formTitle, authRef, formType = 'receipt'
 
 async function saveFormSchema(appType, formUuid, schema, authRef, formType = 'receipt', serverRevision) {
   const tokenReady = isTokenAuthRef(authRef);
-  const cookieReady = !!(
-    authRef &&
-    typeof authRef.csrfToken === 'string' &&
-    authRef.csrfToken &&
-    Array.isArray(authRef.cookies)
-  );
-  if (!authRef || !authRef.baseUrl || (!tokenReady && !cookieReady)) {
+  if (!authRef || !authRef.baseUrl || !tokenReady) {
     const err = new Error('Import schema save requires an authenticated request context.');
     err.code = 'IMPORT_SCHEMA_WRITE_PRECHECK_FAILED';
     throw err;
@@ -143,8 +136,7 @@ async function saveFormSchema(appType, formUuid, schema, authRef, formType = 're
     authRef.baseUrl,
     `/alibaba/web/${appType}/_view/query/formdesign/saveFormSchema.json`,
     postData,
-    Array.isArray(authRef.cookies) ? authRef.cookies : authOptions,
-    Array.isArray(authRef.cookies) ? authOptions : undefined
+    authOptions
   );
 }
 
@@ -162,8 +154,7 @@ async function updateFormConfig(appType, formUuid, authRef) {
     return httpPost(
       auth.baseUrl,
       `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`,
-      postData,
-      auth.cookies
+      postData
     );
   }, authRef);
 

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -17,13 +17,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const https = require('https');
-const http = require('http');
 const querystring = require('querystring');
 const {
   findProjectRoot,
-  isLoginExpired,
-  isCsrfTokenExpired,
   httpPost,
   httpGet,
   requestWithAutoLogin,
@@ -216,8 +212,7 @@ async function fetchExistingSchemaContent(appType, formUuid, authRef) {
     return httpGet(
       auth.baseUrl,
       `/alibaba/web/${appType}/${PREFIX}/query/formdesign/getFormSchema.json`,
-      { formUuid, schemaVersion: SCHEMA_VERSION },
-      auth.cookies
+      { formUuid, schemaVersion: SCHEMA_VERSION }
     );
   }, authRef);
 
@@ -293,107 +288,16 @@ function buildCanvasSchemaContent(sourceCode, runtimeCode, importedModules, form
 
 // ── 4. 发送 saveFormSchema 请求 ──────────────────────
 
-function sendSaveRequestOnce(csrfToken, cookies, schemaContent, baseUrl, appType, formUuid, serverRevision) {
+function sendSaveRequestWithAuth(authRef, schemaContent, appType, formUuid, serverRevision) {
   if (
-    typeof csrfToken !== 'string' ||
-    csrfToken.length === 0 ||
-    !Array.isArray(cookies) ||
-    typeof baseUrl !== 'string' ||
-    baseUrl.length === 0
+    !authRef ||
+    typeof authRef.baseUrl !== 'string' ||
+    authRef.baseUrl.length === 0 ||
+    !isTokenAuthRef(authRef)
   ) {
     const authError = new Error('Publish Schema write authentication is not ready.');
     authError.code = 'PUBLISH_SCHEMA_WRITE_PRECHECK_FAILED';
     return Promise.reject(authError);
-  }
-  const gmtModified = requireSchemaServerRevision({ gmtModified: serverRevision });
-  return new Promise((resolve, reject) => {
-    const saveSchemaPath = `/alibaba/web/${appType}/${PREFIX}/query/formdesign/saveFormSchema.json?_stamp=${Date.now()}`;
-
-    const postData = querystring.stringify({
-      _csrf_token: csrfToken,
-      prefix: PREFIX,
-      content: schemaContent,
-      formUuid: formUuid,
-      gmtModified,
-      schemaVersion: SCHEMA_VERSION,
-      domainCode: DOMAIN_CODE,
-      importSchema: true,
-    });
-
-    const cookieHeader = cookies
-      .map((cookie) => `${cookie.name}=${cookie.value}`)
-      .join('; ');
-
-    const parsedUrl = new URL(baseUrl);
-    const isHttps = parsedUrl.protocol === 'https:';
-    const requestModule = isHttps ? https : http;
-
-    const requestOptions = {
-      hostname: parsedUrl.hostname,
-      port: parsedUrl.port || (isHttps ? 443 : 80),
-      path: saveSchemaPath,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': Buffer.byteLength(postData),
-        Origin: baseUrl,
-        Referer: `${baseUrl}/`,
-        Cookie: cookieHeader,
-      },
-    };
-
-    const request = requestModule.request(requestOptions, (response) => {
-      let responseData = '';
-      response.on('data', (chunk) => { responseData += chunk; });
-      response.on('end', () => {
-        info(t('common.http_status', response.statusCode));
-        let parsed;
-        try {
-          parsed = JSON.parse(responseData);
-        } catch (parseError) {
-          warn(t('common.response_body', responseData.substring(0, 500)));
-          resolve({ success: false, errorMsg: 'HTTP ' + response.statusCode + ': ' + t('common.response_not_json') });
-          return;
-        }
-        // 检测登录过期（errorCode: "307"）
-        if (isLoginExpired(parsed)) {
-          warn(t('common.login_expired', parsed.errorMsg));
-          resolve({ __needLogin: true });
-          return;
-        }
-        // 检测 csrf_token 过期（errorCode: "TIANSHU_000030"）
-        if (isCsrfTokenExpired(parsed)) {
-          warn(t('common.csrf_expired', parsed.errorMsg));
-          resolve({ __csrfExpired: true });
-          return;
-        }
-        resolve(parsed);
-      });
-    });
-
-    request.on('error', (requestError) => { reject(requestError); });
-
-    request.write(postData);
-    request.end();
-  });
-}
-
-function sendSaveRequestWithAuth(authRef, schemaContent, appType, formUuid, serverRevision) {
-  if (!authRef || typeof authRef.baseUrl !== 'string' || authRef.baseUrl.length === 0) {
-    const authError = new Error('Publish Schema write authentication is not ready.');
-    authError.code = 'PUBLISH_SCHEMA_WRITE_PRECHECK_FAILED';
-    return Promise.reject(authError);
-  }
-  if (!isTokenAuthRef(authRef)) {
-    return sendSaveRequestOnce(
-      authRef.csrfToken,
-      authRef.cookies,
-      schemaContent,
-      authRef.baseUrl,
-      appType,
-      formUuid,
-      serverRevision
-    );
   }
   const gmtModified = requireSchemaServerRevision({ gmtModified: serverRevision });
   const saveSchemaPath = `/alibaba/web/${appType}/${PREFIX}/query/formdesign/saveFormSchema.json?_stamp=${Date.now()}`;
@@ -407,12 +311,12 @@ function sendSaveRequestWithAuth(authRef, schemaContent, appType, formUuid, serv
     domainCode: DOMAIN_CODE,
     importSchema: true,
   });
-  return httpPost(authRef.baseUrl, saveSchemaPath, postData, authRef.cookies, { silentStatus: true });
+  return httpPost(authRef.baseUrl, saveSchemaPath, postData, { silentStatus: true });
 }
 
 // ── 5. 发送 updateFormConfig 请求 ────────────────────
 
-function sendUpdateConfigRequest(csrfToken, cookies, baseUrl, appType, formUuid, version, value) {
+function sendUpdateConfigRequest(csrfToken, baseUrl, appType, formUuid, version, value) {
   const updateConfigPath = `/dingtalk/web/${appType}/query/formdesign/updateFormConfig.json`;
   const postData = querystring.stringify({
     _csrf_token: csrfToken,
@@ -421,67 +325,7 @@ function sendUpdateConfigRequest(csrfToken, cookies, baseUrl, appType, formUuid,
     configType: 'MINI_RESOURCE',
     value: value,
   });
-  if (!Array.isArray(cookies) || cookies.length === 0) {
-    return httpPost(baseUrl, updateConfigPath, postData);
-  }
-
-  return new Promise((resolve, reject) => {
-    const cookieHeader = cookies
-      .map((cookie) => `${cookie.name}=${cookie.value}`)
-      .join('; ');
-
-    const parsedUrl = new URL(baseUrl);
-    const isHttps = parsedUrl.protocol === 'https:';
-    const requestModule = isHttps ? https : http;
-
-    const requestOptions = {
-      hostname: parsedUrl.hostname,
-      port: parsedUrl.port || (isHttps ? 443 : 80),
-      path: updateConfigPath,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': Buffer.byteLength(postData),
-        Origin: baseUrl,
-        Referer: `${baseUrl}/`,
-        Cookie: cookieHeader,
-      },
-    };
-
-    const request = requestModule.request(requestOptions, (response) => {
-      let responseData = '';
-      response.on('data', (chunk) => { responseData += chunk; });
-      response.on('end', () => {
-        info(t('common.http_status', response.statusCode));
-        let parsed;
-        try {
-          parsed = JSON.parse(responseData);
-        } catch (parseError) {
-          warn(t('common.response_body', responseData.substring(0, 500)));
-          resolve({ success: false, errorMsg: 'HTTP ' + response.statusCode + ': ' + t('common.response_not_json') });
-          return;
-        }
-        // 检测登录过期（errorCode: "307"）
-        if (isLoginExpired(parsed)) {
-          warn(t('common.login_expired', parsed.errorMsg));
-          resolve({ __needLogin: true });
-          return;
-        }
-        // 检测 csrf_token 过期（errorCode: "TIANSHU_000030"）
-        if (isCsrfTokenExpired(parsed)) {
-          warn(t('common.csrf_expired', parsed.errorMsg));
-          resolve({ __csrfExpired: true });
-          return;
-        }
-        resolve(parsed);
-      });
-    });
-
-    request.on('error', (requestError) => { reject(requestError); });
-
-    request.write(postData);
-    request.end();
-  });
+  return httpPost(baseUrl, updateConfigPath, postData);
 }
 
 async function sendUpdateConfigRequestWithAuth(authRef, appType, formUuid, version, value) {
@@ -489,7 +333,6 @@ async function sendUpdateConfigRequestWithAuth(authRef, appType, formUuid, versi
     const requestAuthRef = currentAuthRef || {};
     const response = await sendUpdateConfigRequest(
       requestAuthRef.csrfToken,
-      requestAuthRef.cookies,
       requestAuthRef.baseUrl || DEFAULT_BASE_URL,
       appType,
       formUuid,
@@ -958,6 +801,6 @@ if (require.main === module) {
   module.exports.countCustomPageDataSources = countCustomPageDataSources;
   module.exports.buildSchemaContent = buildSchemaContent;
   module.exports.buildCanvasSchemaContent = buildCanvasSchemaContent;
-  module.exports.sendSaveRequestOnce = sendSaveRequestOnce;
+  module.exports.sendSaveRequestWithAuth = sendSaveRequestWithAuth;
   module.exports.sendUpdateConfigRequestWithAuth = sendUpdateConfigRequestWithAuth;
 }

--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -271,8 +271,7 @@ async function run(args) {
     return httpPost(
       auth.baseUrl,
       requestPath,
-      postData,
-      auth.cookies
+      postData
     );
   }, authRef);
 

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -3,12 +3,10 @@
  *
  * 导出函数：
  *   findProjectRoot()         - 查找项目根目录（兼容悟空环境）
- *   extractInfoFromCookies()  - 从 Cookie 列表中提取 csrf_token / corp_id / user_id
  *   loadCookieData()          - 已废弃：默认登录态不再读取 Cookie 缓存
  *   getAuthStatus()           - 读取当前鉴权模式的安全状态摘要
  *   triggerLogin()            - 触发登录
- *   refreshCsrfToken()        - 刷新 csrf_token
- *   resolveBaseUrl()          - 从 cookieData 中解析 base_url
+ *   resolveBaseUrl()          - 从 authData 中解析 base_url
  *   isLoginExpired()          - 检测响应体是否表示登录过期
  *   isCsrfTokenExpired()      - 检测响应体是否表示 csrf_token 过期
  */
@@ -927,102 +925,11 @@ async function resolveBearerAuthHeaders(options = {}) {
   };
 }
 
-// ── Cookie 解析 ───────────────────────────────────────
-
-const CSRF_COOKIE_NAMES = new Set([
-  'tianshu_csrf_token',
-  'china_csrf_token',
-  'csrf_token',
-  '_csrf_token',
-]);
-
-/**
- * 从 Cookie 列表中提取 csrf_token、corp_id、user_id。
- *
- * 国内宜搭（aliwork.com）：corpId/userId 合并写在 `tianshu_corp_user` 里，
- * 形如 `${corpId}_${userId}`，按最后一个下划线切分。
- *
- * 海外 YiDA（yidaapps.com）：不写 `tianshu_corp_user`，而是单独写 `corp_id` cookie
- * 存放 corpId 明文；userId 加密在 `pub_uid` 里客户端无法解密，留 null 接受。
- *
- * @param {Array} cookies
- * @returns {{ csrfToken: string|null, corpId: string|null, userId: string|null }}
- */
-function extractInfoFromCookies(cookies) {
-  let csrfToken = null;
-  let corpId = null;
-  let userId = null;
-  const cookieList = Array.isArray(cookies) ? cookies : [];
-
-  for (const cookie of cookieList) {
-    if (cookie && CSRF_COOKIE_NAMES.has(cookie.name) && cookie.value && !csrfToken) {
-      csrfToken = cookie.value;
-    } else if (cookie && cookie.name === 'tianshu_corp_user') {
-      const lastUnderscore = cookie.value.lastIndexOf('_');
-      if (lastUnderscore > 0) {
-        corpId = cookie.value.slice(0, lastUnderscore);
-        userId = cookie.value.slice(lastUnderscore + 1);
-      }
-    }
-  }
-
-  if (!corpId) {
-    const corpCookie = cookieList.find((c) => c && ['corp_id', 'corpId'].includes(c.name) && c.value);
-    if (corpCookie) {
-      corpId = corpCookie.value;
-    }
-  }
-
-  if (!userId) {
-    const userCookie = cookieList.find((c) => c && ['user_id', 'userId', 'staffId'].includes(c.name) && c.value);
-    if (userCookie) {
-      userId = userCookie.value;
-    }
-  }
-
-  return { csrfToken, corpId, userId };
-}
-
-function parseCookieHeader(rawCookieHeader, options = {}) {
-  const raw = String(rawCookieHeader || '').trim();
-  if (!raw) {
-    return [];
-  }
-  let domain = '';
-  if (options.baseUrl) {
-    try {
-      domain = new URL(options.baseUrl).hostname;
-    } catch {
-      domain = '';
-    }
-  }
-  return raw
-    .split(';')
-    .map((part) => {
-      const trimmed = part.trim();
-      const equalsIndex = trimmed.indexOf('=');
-      if (equalsIndex <= 0) {
-        return null;
-      }
-      const name = trimmed.slice(0, equalsIndex).trim();
-      const value = trimmed.slice(equalsIndex + 1).trim();
-      if (!name) {
-        return null;
-      }
-      const cookie = { name, value };
-      if (domain) {
-        cookie.domain = domain;
-      }
-      return cookie;
-    })
-    .filter(Boolean);
-}
-
 // ── 登录态缓存读取 ────────────────────────────────────
 
 /**
  * 已废弃：默认登录态不再读取 Cookie。
- * 保留函数名用于旧测试/显式 mock 兼容；实际登录态只从 token session 读取。
+ * 保留函数名用于断言 legacy 缓存不生效；实际登录态只从 token session 读取。
  * @param {string} [projectRoot]
  * @param {string} [defaultBaseUrl]
  * @returns {object|null}
@@ -1097,15 +1004,6 @@ function triggerLogin(options = {}) {
   );
 }
 
-/**
- * 已废弃：默认 token 登录态不再刷新 CSRF。
- * @returns {object} loginResult
- */
-function refreshCsrfToken() {
-  warn(t('login.csrf_refresh'));
-  return null;
-}
-
 // ── 响应检测 ──────────────────────────────────────────
 
 /**
@@ -1173,30 +1071,30 @@ function isHttpAuthStatus(statusCode) {
 // ── base_url 解析 ─────────────────────────────────────
 
 /**
- * 从 cookieData 中解析 base_url，支持多环境配置优先级。
+ * 从 authData 中解析 base_url，支持多环境配置优先级。
  *
  * 优先级（高 → 低）：
- *   1. cookieData.base_url（鉴权服务返回的企业业务域名）
+ *   1. authData.base_url（鉴权服务返回的企业业务域名）
  *   2. OPENYIDA_ENDPOINT 环境变量（鉴权端点兼业务兜底）
  *   3. 当前激活的私有化环境配置
  *   4. 当前激活的环境配置（公有云默认）
  *   5. defaultBaseUrl 参数 / 公有云兜底
  *
- * @param {object} cookieData
+ * @param {object} authData
  * @param {string} [defaultBaseUrl]
  * @returns {string}
  */
-function resolveBaseUrl(cookieData, defaultBaseUrl) {
+function resolveBaseUrl(authData, defaultBaseUrl) {
   const { normalizeBaseUrl, resolveEndpoint } = require('./env-manager');
   const businessBaseUrl = normalizeBaseUrl(
-    cookieData && cookieData.base_url,
+    authData && authData.base_url,
     null
   );
   if (businessBaseUrl) {
     return businessBaseUrl;
   }
   const resolved = resolveEndpoint(null, undefined);
-  if (defaultBaseUrl && resolved === 'https://www.aliwork.com' && (!cookieData || !cookieData.base_url)) {
+  if (defaultBaseUrl && resolved === 'https://www.aliwork.com' && (!authData || !authData.base_url)) {
     return defaultBaseUrl.replace(/\/+$/, '');
   }
   return resolved;
@@ -1214,51 +1112,17 @@ function collectResponseText(res, onEnd) {
   });
 }
 
-function splitRequestAuthArgs(cookiesOrOptions, maybeOptions) {
-  if (Array.isArray(cookiesOrOptions)) {
-    return {
-      cookies: cookiesOrOptions,
-      options: maybeOptions || {},
-    };
+function resolveRequestOptions(optionsOrLegacyCookies, maybeOptions) {
+  if (maybeOptions !== undefined) {
+    return maybeOptions || {};
   }
-  return {
-    cookies: [],
-    options: cookiesOrOptions || {},
-  };
+  if (Array.isArray(optionsOrLegacyCookies)) {
+    return {};
+  }
+  return optionsOrLegacyCookies || {};
 }
 
-function resolveCookieAuthCookies(cookies) {
-  if (Array.isArray(cookies) && cookies.length > 0) {
-    return cookies;
-  }
-  return [];
-}
-
-function buildCookieAuthHeaders(baseUrl, cookies, optionsOverride = {}) {
-  const parsedUrl = new URL(baseUrl);
-  const requestHost = parsedUrl.hostname;
-  const cookieList = resolveCookieAuthCookies(cookies);
-  const filteredCookies = cookieList.filter(c => {
-    const cookieDomain = (c.domain || '').replace(/^\./, '');
-    return !cookieDomain || requestHost === cookieDomain || requestHost.endsWith('.' + cookieDomain);
-  });
-  const effectiveCookies = filteredCookies.length > 0 ? filteredCookies : cookieList;
-  const cookieHeader = effectiveCookies.map((c) => `${c.name}=${c.value}`).join('; ');
-  const { csrfToken } = extractInfoFromCookies(effectiveCookies);
-  const headers = {};
-  if (cookieHeader) {
-    headers.Cookie = cookieHeader;
-  }
-  if (optionsOverride.csrfToken || csrfToken) {
-    headers.global_csrf_token = optionsOverride.csrfToken || csrfToken;
-  }
-  return headers;
-}
-
-async function resolveRequestAuthHeaders(baseUrl, cookies, optionsOverride = {}) {
-  if (Array.isArray(cookies) && cookies.length > 0) {
-    return buildCookieAuthHeaders(baseUrl, cookies, optionsOverride);
-  }
+async function resolveRequestAuthHeaders(optionsOverride = {}) {
   const auth = await resolveBearerAuthHeaders(optionsOverride);
   return auth.headers;
 }
@@ -1279,14 +1143,14 @@ function createNonJsonResponseResult(statusCode, data) {
  * @param {string} baseUrl
  * @param {string} requestPath
  * @param {string} postData - querystring 格式
- * @param {Array} cookies
+ * @param {object} [options]
  * @returns {Promise<object>}
  */
-async function httpPost(baseUrl, requestPath, postData, cookiesOrOptions, maybeOptions) {
+async function httpPost(baseUrl, requestPath, postData, optionsOrLegacyCookies, maybeOptions) {
   const https = require('https');
   const http = require('http');
-  const { cookies, options: optionsOverride } = splitRequestAuthArgs(cookiesOrOptions, maybeOptions);
-  const authHeaders = await resolveRequestAuthHeaders(baseUrl, cookies, optionsOverride);
+  const optionsOverride = resolveRequestOptions(optionsOrLegacyCookies, maybeOptions);
+  const authHeaders = await resolveRequestAuthHeaders(optionsOverride);
   const bodyData = postData === null || postData === undefined ? '' : String(postData);
 
   return new Promise((resolve, reject) => {
@@ -1357,11 +1221,11 @@ async function httpPost(baseUrl, requestPath, postData, cookiesOrOptions, maybeO
   });
 }
 
-async function httpPostJson(baseUrl, requestPath, payload, cookiesOrOptions, maybeOptions) {
+async function httpPostJson(baseUrl, requestPath, payload, optionsOrLegacyCookies, maybeOptions) {
   const https = require('https');
   const http = require('http');
-  const { cookies, options: optionsOverride } = splitRequestAuthArgs(cookiesOrOptions, maybeOptions);
-  const authHeaders = await resolveRequestAuthHeaders(baseUrl, cookies, optionsOverride);
+  const optionsOverride = resolveRequestOptions(optionsOrLegacyCookies, maybeOptions);
+  const authHeaders = await resolveRequestAuthHeaders(optionsOverride);
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
@@ -1436,15 +1300,15 @@ async function httpPostJson(baseUrl, requestPath, payload, cookiesOrOptions, may
  * @param {string} baseUrl
  * @param {string} requestPath
  * @param {object} queryParams
- * @param {Array} cookies
+ * @param {object} [options]
  * @returns {Promise<object>}
  */
-async function httpGet(baseUrl, requestPath, queryParams, cookiesOrOptions, maybeOptions) {
+async function httpGet(baseUrl, requestPath, queryParams, optionsOrLegacyCookies, maybeOptions) {
   const https = require('https');
   const http = require('http');
   const querystring = require('querystring');
-  const { cookies, options: optionsOverride } = splitRequestAuthArgs(cookiesOrOptions, maybeOptions);
-  const authHeaders = await resolveRequestAuthHeaders(baseUrl, cookies, optionsOverride);
+  const optionsOverride = resolveRequestOptions(optionsOrLegacyCookies, maybeOptions);
+  const authHeaders = await resolveRequestAuthHeaders(optionsOverride);
 
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(baseUrl);
@@ -1527,15 +1391,11 @@ async function httpGet(baseUrl, requestPath, queryParams, cookiesOrOptions, mayb
 /**
  * 带自动重登录的请求封装。
  * @param {Function} requestFn - 接受 authRef 返回 Promise 的工厂函数
- * @param {object} authRef - { csrfToken, cookies, baseUrl, cookieData }
+ * @param {object} authRef - { baseUrl, authData }
  * @returns {Promise<object>}
  */
 async function requestWithAutoLogin(requestFn, authRef) {
   const result = await requestFn(authRef);
-
-  if (isExplicitCookieAuthRef(authRef)) {
-    return result;
-  }
 
   if (result && result.__needLogin) {
     const { tokenRefresh, isRefreshAuthRequired } = require('../auth/token-auth');
@@ -1579,16 +1439,6 @@ async function requestWithAutoLogin(requestFn, authRef) {
   }
 
   return result;
-}
-
-function isExplicitCookieAuthRef(authRef) {
-  if (!authRef || !Array.isArray(authRef.cookies) || authRef.cookies.length === 0) {
-    return false;
-  }
-  const authData = authRef.authData || authRef.cookieData || {};
-  const authMode = authRef.authMode || authRef.auth_mode || authData.auth_mode || authData.authMode;
-  const authSource = authRef.authSource || authRef.auth_source || authData.auth_source || authData.authSource;
-  return authMode !== 'token' && authSource !== 'token';
 }
 
 function normalizeRefreshedTokenAuthData(refreshResult, fallbackBaseUrl) {
@@ -1637,13 +1487,10 @@ module.exports = {
   findProjectRoot,
   resolveProjectRoot,
   buildSkillsDiagnostics,
-  extractInfoFromCookies,
-  parseCookieHeader,
   getAuthStatus,
   loadAuthData,
   loadCookieData,
   triggerLogin,
-  refreshCsrfToken,
   resolveBaseUrl,
   isLoginExpired,
   isCsrfTokenExpired,

--- a/lib/core/yida-client.js
+++ b/lib/core/yida-client.js
@@ -40,12 +40,10 @@ function isUsableAuthData(authData) {
   if (!authData) {
     return false;
   }
-  if (authData.auth_mode === 'token' || authData.authMode === 'token') {
-    return true;
-  }
-  const cookies = Array.isArray(authData.cookies) ? authData.cookies : [];
-  const csrfToken = authData.csrf_token || authData.csrfToken || authData._csrf_token;
-  return cookies.length > 0 && typeof csrfToken === 'string' && csrfToken.length > 0;
+  return authData.auth_mode === 'token' ||
+    authData.authMode === 'token' ||
+    authData.auth_source === 'token' ||
+    authData.authSource === 'token';
 }
 
 function createAuthRef(authData) {
@@ -68,11 +66,6 @@ function createAuthRef(authData) {
     corpName: safeAuthData.corp_name || '',
     userId: safeAuthData.user_id || '',
   };
-  if (Array.isArray(safeAuthData.cookies)) {
-    authRef.cookieData = safeAuthData;
-    authRef.cookies = safeAuthData.cookies;
-    authRef.csrfToken = safeAuthData.csrf_token || safeAuthData.csrfToken || safeAuthData._csrf_token || '';
-  }
   return authRef;
 }
 
@@ -93,37 +86,13 @@ function isTokenAuthRef(authRef) {
   return authMode === 'token' || authSource === 'token';
 }
 
-function isCookieAuthRef(authRef) {
-  if (!authRef) {
-    return false;
-  }
-  const authData = authRef.authData || authRef.cookieData || {};
-  const authMode = authRef.authMode || authRef.auth_mode || authData.auth_mode || authData.authMode;
-  const authSource = authRef.authSource || authRef.auth_source || authData.auth_source || authData.authSource;
-  return (
-    authMode === 'env' ||
-    authMode === 'cookie' ||
-    authSource === 'env' ||
-    authSource === 'cookie' ||
-    Array.isArray(authRef.cookies)
-  );
-}
-
 function isAuthRefReady(authRef) {
   if (!authRef) {
     return false;
   }
-  if (isTokenAuthRef(authRef)) {
-    return true;
-  }
-  return (
-    isCookieAuthRef(authRef) &&
+  return isTokenAuthRef(authRef) &&
     typeof authRef.baseUrl === 'string' &&
-    authRef.baseUrl.length > 0 &&
-    typeof authRef.csrfToken === 'string' &&
-    authRef.csrfToken.length > 0 &&
-    Array.isArray(authRef.cookies)
-  );
+    authRef.baseUrl.length > 0;
 }
 
 class YidaClient {
@@ -162,9 +131,9 @@ class YidaClient {
       ? queryParams(ref)
       : queryParams;
     if (options === undefined) {
-      return httpGet(ref.baseUrl, resolvedRequestPath, resolvedQueryParams || null, ref.cookies);
+      return httpGet(ref.baseUrl, resolvedRequestPath, resolvedQueryParams || null);
     }
-    return httpGet(ref.baseUrl, resolvedRequestPath, resolvedQueryParams || null, ref.cookies, options);
+    return httpGet(ref.baseUrl, resolvedRequestPath, resolvedQueryParams || null, options);
   }
 
   async postForm(requestPath, bodyParams, options) {
@@ -200,9 +169,9 @@ class YidaClient {
       ? resolvedBodyParams
       : querystring.stringify(resolvedBodyParams || {});
     if (options === undefined) {
-      return httpPost(ref.baseUrl, resolvedRequestPath, postData, ref.cookies);
+      return httpPost(ref.baseUrl, resolvedRequestPath, postData);
     }
-    return httpPost(ref.baseUrl, resolvedRequestPath, postData, ref.cookies, options);
+    return httpPost(ref.baseUrl, resolvedRequestPath, postData, options);
   }
 
   async postJson(requestPath, bodyParams, options) {
@@ -254,16 +223,9 @@ function requireOneShotAuth(authRef) {
   if (isTokenAuthRef(authRef)) {
     return authRef;
   }
-  if (
-    typeof authRef.csrfToken !== 'string' ||
-    authRef.csrfToken.length === 0 ||
-    !Array.isArray(authRef.cookies)
-  ) {
-    const error = new Error('Schema write authentication is not ready.');
-    error.code = 'YIDA_WRITE_AUTH_NOT_READY';
-    throw error;
-  }
-  return authRef;
+  const error = new Error('Schema write authentication is not ready.');
+  error.code = 'YIDA_WRITE_AUTH_NOT_READY';
+  throw error;
 }
 
 function requireReadAuth(authRef) {
@@ -275,12 +237,9 @@ function requireReadAuth(authRef) {
   if (isTokenAuthRef(authRef)) {
     return authRef;
   }
-  if (!Array.isArray(authRef.cookies)) {
-    const error = new Error('Yida read authentication is not ready.');
-    error.code = 'YIDA_READ_AUTH_NOT_READY';
-    throw error;
-  }
-  return authRef;
+  const error = new Error('Yida read authentication is not ready.');
+  error.code = 'YIDA_READ_AUTH_NOT_READY';
+  throw error;
 }
 
 function createYidaClient(options = {}) {
@@ -293,7 +252,6 @@ module.exports = {
   createAuthRef,
   createYidaClient,
   isAuthRefReady,
-  isCookieAuthRef,
   isTokenAuthRef,
   unwrapYidaResponse,
 };

--- a/lib/report/append.js
+++ b/lib/report/append.js
@@ -169,7 +169,7 @@ async function main(args) {
   // Step 1: 读取登录态
   warn('\n[Step 1] 读取登录态...');
   const authRef = ensureSession();
-  const corpId = authRef.corpId || authRef.cookieData.corp_id || '';
+  const corpId = authRef.corpId || (authRef.authData && authRef.authData.corp_id) || '';
   warn('登录态就绪，域名:', authRef.baseUrl);
 
   // Step 2: 读取图表定义

--- a/tests/app-lifecycle.test.js
+++ b/tests/app-lifecycle.test.js
@@ -23,7 +23,8 @@ const {
 const AUTH_REF = {
   baseUrl: 'https://www.aliwork.com',
   csrfToken: 'csrf-value',
-  cookies: [{ name: 'session', value: 'redacted' }],
+  authMode: 'token',
+  authSource: 'token',
 };
 
 beforeEach(() => {
@@ -36,7 +37,7 @@ describe('app lifecycle requests', () => {
     utils.httpPost.mockResolvedValue({ success: true, content: true });
 
     const output = await changeAppLifecycle('online', parseArgs(['APP_1']));
-    const [baseUrl, requestPath, rawBody, cookies] = utils.httpPost.mock.calls[0];
+    const [baseUrl, requestPath, rawBody] = utils.httpPost.mock.calls[0];
 
     expect(baseUrl).toBe('https://www.aliwork.com');
     expect(requestPath).toMatch(/^\/dingtalk\/web\/APP_1\/query\/app\/onlineApp\.json\?_api=App\.goOnline&_mock=false&_stamp=\d+$/);
@@ -46,7 +47,7 @@ describe('app lifecycle requests', () => {
       isToDingAppCenter: 'n',
       showAppCenter: 'n',
     });
-    expect(cookies).toBe(AUTH_REF.cookies);
+    expect(utils.httpPost.mock.calls[0][3]).toBeUndefined();
     expect(output).toMatchObject({ success: true, action: 'online', appType: 'APP_1' });
   });
 

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -57,8 +57,8 @@ describe('create-form.js imports', () => {
     expect(getBody).toContain('httpGet(baseUrl, requestPath, queryParams)');
     expect(postBody).toContain('httpPost(baseUrl, requestPath, postData');
     expect(updateBody).toMatch(/httpPost\(\s*baseUrl,/);
-    expect(postBody).toContain('authRef && authRef.cookies');
-    expect(updateBody).toContain('authRef && authRef.cookies');
+    expect(postBody).not.toContain('authRef && authRef.cookies');
+    expect(updateBody).not.toContain('authRef && authRef.cookies');
     expect(postBody).not.toContain('Cookie:');
     expect(updateBody).not.toContain('Cookie:');
   });
@@ -78,12 +78,10 @@ describe('legacy process form bridge', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const mockUtils = {
       loadAuthData: jest.fn(() => ({
-        csrf_token: 'csrf',
-        cookies: [{ name: 'session', value: 'private' }],
         corp_id: 'corp',
         base_url: 'https://example.test',
-        auth_mode: 'cookie',
-        auth_source: 'cookie',
+        auth_mode: 'token',
+        auth_source: 'token',
       })),
       httpPost: jest.fn((baseUrl, requestPath) => {
         if (requestPath.includes('saveFormSchemaInfo')) {
@@ -98,7 +96,6 @@ describe('legacy process form bridge', () => {
         return Promise.resolve({ success: true });
       }),
       requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
-      loadCookieData: jest.fn(),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
       httpGet: jest.fn(() => Promise.resolve({ success: true, content: { gmtModified: 100 } })),
@@ -108,8 +105,8 @@ describe('legacy process form bridge', () => {
     const isolatedCreateForm = require('../lib/app/create-form');
     const result = await isolatedCreateForm.createFormForLegacyProcess({
       baseUrl: 'https://example.test',
-      cookies: [{ name: 'session', value: 'private' }],
-      csrfToken: 'csrf',
+      authMode: 'token',
+      authSource: 'token',
       corpId: 'corp',
     }, {
       appType: 'APP_TEST',
@@ -784,17 +781,10 @@ function loadIsolatedLegacyForm(schema) {
   const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   const mockUtils = {
     loadAuthData: jest.fn(() => ({
-      csrf_token: 'csrf',
-      cookies: [{ name: 'session', value: 'private' }],
       corp_id: 'corp',
       base_url: 'https://example.test',
-      auth_mode: 'cookie',
-      auth_source: 'cookie',
-    })),
-    loadCookieData: jest.fn(() => ({
-      csrf_token: 'csrf',
-      cookies: [{ name: 'session', value: 'private' }],
-      corp_id: 'corp',
+      auth_mode: 'token',
+      auth_source: 'token',
     })),
     triggerLogin: jest.fn(),
     resolveBaseUrl: jest.fn(() => 'https://example.test'),
@@ -2377,14 +2367,11 @@ function loadIsolatedCreateFormCommand(overrides = {}) {
   const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   const mockUtils = Object.assign({
     loadAuthData: jest.fn(() => ({
-      csrf_token: 'csrf',
-      cookies: [{ name: 'session', value: 'private' }],
       corp_id: 'corp',
       base_url: 'https://example.test',
-      auth_mode: 'cookie',
-      auth_source: 'cookie',
+      auth_mode: 'token',
+      auth_source: 'token',
     })),
-    loadCookieData: jest.fn(),
     triggerLogin: jest.fn(),
     resolveBaseUrl: jest.fn(() => 'https://example.test'),
     httpGet: jest.fn(() => Promise.resolve({ success: true, content: { gmtModified: 100 } })),
@@ -3068,17 +3055,10 @@ describe('legacy create-form compatibility', () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     const mockUtils = {
       loadAuthData: jest.fn(() => ({
-        csrf_token: 'csrf',
-        cookies: [{ name: 'tianshu_corp_user', value: 'corp_user' }],
         corp_id: 'corp',
         base_url: 'https://example.test',
-        auth_mode: 'cookie',
-        auth_source: 'cookie',
-      })),
-      loadCookieData: jest.fn(() => ({
-        csrf_token: 'csrf',
-        cookies: [{ name: 'tianshu_corp_user', value: 'corp_user' }],
-        corp_id: 'corp',
+        auth_mode: 'token',
+        auth_source: 'token',
       })),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),

--- a/tests/form-mode-service.test.js
+++ b/tests/form-mode-service.test.js
@@ -179,7 +179,8 @@ describe('shared form mode service', () => {
       authRef: {
         baseUrl: 'https://example.test',
         csrfToken: 'csrf',
-        cookies: [],
+        authMode: 'token',
+        authSource: 'token',
       },
       assertRemoteDispatchBoundary() {},
     }, {

--- a/tests/import-app.test.js
+++ b/tests/import-app.test.js
@@ -34,7 +34,6 @@ describe('import-app helpers', () => {
     const httpPost = jest.fn().mockResolvedValue(response);
     const requestWithAutoLogin = jest.fn((requestFn, authRef) => requestFn(authRef));
     jest.doMock('../lib/core/utils', () => ({
-      loadCookieData: jest.fn(),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
       httpGet: jest.fn(),
@@ -47,7 +46,7 @@ describe('import-app helpers', () => {
       'APP_XXX',
       'FORM_XXX',
       { pages: [] },
-      { baseUrl: 'https://example.test', csrfToken: 'csrf', cookies: [] },
+      { baseUrl: 'https://example.test', csrfToken: 'csrf', authMode: 'token', authSource: 'token' },
       'receipt',
       100
     )).resolves.toEqual(response);
@@ -63,7 +62,6 @@ describe('import-app helpers', () => {
     jest.resetModules();
     const httpPost = jest.fn();
     jest.doMock('../lib/core/utils', () => ({
-      loadCookieData: jest.fn(),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
       httpGet: jest.fn(),
@@ -76,7 +74,7 @@ describe('import-app helpers', () => {
       'APP_XXX',
       'FORM_XXX',
       { pages: [] },
-      { baseUrl: 'https://example.test', cookies: [] },
+      { baseUrl: 'https://example.test', authMode: 'cookie', authSource: 'cookie' },
       'receipt',
       100
     )).rejects.toMatchObject({ code: 'IMPORT_SCHEMA_WRITE_PRECHECK_FAILED' });
@@ -84,7 +82,7 @@ describe('import-app helpers', () => {
       'APP_XXX',
       'FORM_XXX',
       { pages: [] },
-      { baseUrl: 'https://example.test', csrfToken: 'csrf', cookies: [] },
+      { baseUrl: 'https://example.test', csrfToken: 'csrf', authMode: 'token', authSource: 'token' },
       'receipt'
     )).rejects.toMatchObject({ code: 'SCHEMA_REMOTE_READ_FAILED' });
 

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -24,7 +24,6 @@ const {
   findDuplicateSourceMismatches,
   loadPublishSource,
   mergePageDataSource,
-  sendSaveRequestOnce,
   verifyPublishTarget,
 } = require('../lib/app/publish');
 const {
@@ -572,67 +571,65 @@ describe('publish prechecks', () => {
   test.each([
     ['login expiry', { success: false, errorCode: '307' }],
     ['CSRF expiry', { success: false, errorCode: 'TIANSHU_000030' }],
-    ['redirect response', { success: false, errorCode: '302' }],
+    ['redirect response', { __needLogin: true, __httpStatus: 302 }],
     ['ordinary failure', { success: false, errorCode: 'FAILED' }],
-  ])('legacy publish Schema transport sends once on %s', async (label, responseBody) => {
-    const previousQuiet = process.env.YIDA_QUIET;
-    process.env.YIDA_QUIET = '1';
-    const requestSpy = jest.spyOn(https, 'request').mockImplementation((options, callback) => {
-      const response = new EventEmitter();
-      response.statusCode = label === 'redirect response' ? 302 : 200;
-      const request = new EventEmitter();
-      request.write = jest.fn();
-      request.end = jest.fn(() => {
-        callback(response);
-        response.emit('data', JSON.stringify(responseBody));
-        response.emit('end');
-      });
-      return request;
+  ])('token publish Schema transport delegates once on %s', async (label, responseBody) => {
+    jest.resetModules();
+    const httpPost = jest.fn().mockResolvedValue(responseBody);
+    jest.doMock('../lib/core/utils', () => {
+      const actual = jest.requireActual('../lib/core/utils');
+      return {
+        ...actual,
+        httpPost,
+      };
     });
+    const isolatedPublish = require('../lib/app/publish');
 
     try {
-      await sendSaveRequestOnce(
-        'csrf',
-        [{ name: 'session', value: 'private' }],
+      await isolatedPublish.sendSaveRequestWithAuth(
+        { baseUrl: 'https://example.test', authMode: 'token', authSource: 'token' },
         JSON.stringify({ pages: [] }),
-        'https://example.test',
         'APP_XXX',
         'FORM_XXX',
         100
       );
-      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(httpPost).toHaveBeenCalledTimes(1);
+      expect(httpPost.mock.calls[0][3]).toEqual({ silentStatus: true });
+      expect(label).toBeTruthy();
     } finally {
-      requestSpy.mockRestore();
-      if (previousQuiet === undefined) {
-        delete process.env.YIDA_QUIET;
-      } else {
-        process.env.YIDA_QUIET = previousQuiet;
-      }
+      jest.dontMock('../lib/core/utils');
+      jest.resetModules();
     }
   });
 
-  test('legacy publish Schema transport rejects missing auth or revision before request', async () => {
-    const requestSpy = jest.spyOn(https, 'request');
+  test('token publish Schema transport rejects missing token auth or revision before request', async () => {
+    jest.resetModules();
+    const httpPost = jest.fn();
+    jest.doMock('../lib/core/utils', () => {
+      const actual = jest.requireActual('../lib/core/utils');
+      return {
+        ...actual,
+        httpPost,
+      };
+    });
+    const isolatedPublish = require('../lib/app/publish');
 
-    await expect(sendSaveRequestOnce(
-      '',
-      [],
+    await expect(isolatedPublish.sendSaveRequestWithAuth(
+      { baseUrl: 'https://example.test', authMode: 'cookie', authSource: 'cookie' },
       JSON.stringify({ pages: [] }),
-      'https://example.test',
       'APP_XXX',
       'FORM_XXX',
       100
     )).rejects.toMatchObject({ code: 'PUBLISH_SCHEMA_WRITE_PRECHECK_FAILED' });
-    await expect(Promise.resolve().then(() => sendSaveRequestOnce(
-      'csrf',
-      [],
+    await expect(Promise.resolve().then(() => isolatedPublish.sendSaveRequestWithAuth(
+      { baseUrl: 'https://example.test', authMode: 'token', authSource: 'token' },
       JSON.stringify({ pages: [] }),
-      'https://example.test',
       'APP_XXX',
       'FORM_XXX'
     ))).rejects.toMatchObject({ code: 'SCHEMA_REMOTE_READ_FAILED' });
 
-    expect(requestSpy).not.toHaveBeenCalled();
-    requestSpy.mockRestore();
+    expect(httpPost).not.toHaveBeenCalled();
+    jest.dontMock('../lib/core/utils');
+    jest.resetModules();
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -236,6 +236,33 @@ describe('http redirect login detection', () => {
     }
   });
 
+  test('httpPost ignores legacy cookie arrays and sends bearer auth only', async () => {
+    let capturedHeaders = null;
+    const server = http.createServer((req, res) => {
+      capturedHeaders = req.headers;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ success: true }));
+    });
+    const port = await listen(server);
+
+    try {
+      const result = await httpPost(
+        `http://127.0.0.1:${port}`,
+        '/legacy-cookie-arg',
+        'a=1',
+        [{ name: 'session', value: 'private' }],
+        { silentStatus: true, csrfToken: 'legacy-csrf' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(capturedHeaders.authorization).toBe('Bearer test-access-token');
+      expect(capturedHeaders.cookie).toBeUndefined();
+      expect(capturedHeaders.global_csrf_token).toBeUndefined();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   test('httpGet 将 307 跳转识别为需要重新登录', async () => {
     const server = http.createServer((req, res) => {
       res.statusCode = 307;

--- a/tests/yida-client.test.js
+++ b/tests/yida-client.test.js
@@ -58,6 +58,32 @@ describe('yida-client', () => {
     expect(utils.triggerLogin).toHaveBeenCalledTimes(1);
   });
 
+  test('does not expose legacy cookie auth data as an auth ref', () => {
+    utils.loadAuthData.mockReturnValue({
+      base_url: 'https://legacy.example.test',
+      auth_mode: 'cookie',
+      auth_source: 'cookie',
+      cookies: [{ name: 'session', value: 'private' }],
+      csrf_token: 'csrf',
+    });
+    utils.triggerLogin.mockReturnValue({
+      base_url: 'https://example.yida.test',
+      auth_mode: 'token',
+      auth_source: 'token',
+    });
+
+    const authRef = createAuthRef();
+
+    expect(authRef).toMatchObject({
+      baseUrl: 'https://example.yida.test',
+      authMode: 'token',
+      authSource: 'token',
+    });
+    expect(authRef).not.toHaveProperty('cookies');
+    expect(authRef).not.toHaveProperty('cookieData');
+    expect(utils.triggerLogin).toHaveBeenCalledTimes(1);
+  });
+
   test('wraps GET requests with auto-login handling', async () => {
     const client = createYidaClient();
     const result = await client.get('/query/path.json', { page: 1 });
@@ -121,7 +147,8 @@ describe('yida-client', () => {
   test('postFormOnce rejects missing write auth before transport', async () => {
     const client = createYidaClient({ authRef: {
       baseUrl: 'https://example.yida.test',
-      cookies: [],
+      authMode: 'cookie',
+      authSource: 'cookie',
     } });
 
     await expect(client.postFormOnce('/save/path.json', {})).rejects.toMatchObject({


### PR DESCRIPTION
## 改动概述

移除已废弃的 cookie authRef 兼容分支，使实现与 `agent-capabilities` 中 `cookie_auth_supported:false`、`cookie_check_required:false`、`playwright_cookie_check_required:false` 保持一致。

本 PR 只做 cookie 登录兼容清理：不改 OAuth token 协议，不改 org switch，不触碰 PRD 检查。

## 改动类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级
- [ ] 🌐 国际化（i18n）
- [ ] 🎨 UI / 终端输出优化
- [ ] 📦 发布 / 打包流程调整

## 关联 Issue / 需求

Internal cleanup: #83584385

## 主要变更

- `lib/core/yida-client.js`：`createAuthRef` 只接受 token 登录态，不再暴露 `cookies` / `cookieData`；auth readiness 收敛为 token authRef。
- `lib/core/utils.js`：HTTP helper 不再构造 `Cookie` / `global_csrf_token` header；legacy cookie 数组参数会被忽略并继续走 Bearer token。
- `lib/app/publish.js`、`create-form.js`、`import-app.js`、`create-page.js`、`form-detail-style.js` 等：删除 `auth.cookies` 传递和 publish raw cookie transport。
- `tests/*`：更新 auth mock 和断言，覆盖 legacy cookies 不生效、token-only authRef、agent capabilities cookie flags 为 false。

## 兼容性与风险

- [x] 无破坏性变更
- [ ] 涉及 CLI 参数或输出格式变更，已说明兼容策略
- [x] 涉及登录态、Cookie、组织上下文或私有化环境，已确认无敏感信息泄露
- [ ] 涉及宜搭真实数据写入，已说明影响范围和回滚方式

风险说明：该 PR 删除的是已声明不支持的 cookie 登录兼容路径；正常 OAuth token / host-injected token 路径已通过相关单测覆盖。`_csrf_token` 仍可能作为平台 API body/query 参数出现，不代表 cookie 登录回退。

## 测试与验证

- [ ] `npm test`
- [x] `npx eslint lib/core/utils.js lib/core/yida-client.js lib/app/publish.js lib/app/create-form.js lib/app/import-app.js lib/app/create-page.js lib/app/form-detail-style.js lib/app/app-lifecycle.js lib/app/update-app.js lib/report/append.js tests/app-lifecycle.test.js tests/create-form.test.js tests/form-mode-service.test.js tests/import-app.test.js tests/publish-precheck.test.js tests/utils.test.js tests/yida-client.test.js --quiet`
- [x] `node --check` modified JS files
- [ ] `npm run check:syntax`
- [ ] `npm run check:skills`（如涉及 `yida-skills/`）
- [ ] `npm run build:skills`（如涉及 Wukong 技能包）
- [ ] `npm run check:package`（如涉及发布包内容）
- [ ] 已在真实宜搭环境验证相关功能（如适用）
- [ ] 私有化部署场景已验证或确认不受影响（如适用）

Additional validation:

- [x] `npx jest tests/utils.test.js tests/yida-client.test.js tests/publish-precheck.test.js tests/create-form.test.js tests/cli-smoke.test.js tests/agent-capabilities.test.js --runInBand`（240 tests passed）
- [x] `npm run check:i18n`（ratchet passed; existing optional-language warnings only）
- [x] `git diff --check`

## 文档与 Agent 技能

- [ ] 新增或调整 CLI 命令时，已更新 `README.md` 命令一览表
- [ ] 新增用户可见文案时，已同步 `lib/core/locales/` 下所有语言包
- [ ] 涉及 Agent 工作流变化时，已更新 `yida-skills/` 相关技能说明
- [ ] 涉及 GitHub Release / npm 发布行为时，已更新 `CHANGELOG.md`

## 截图 / 录屏

不适用。

## Reviewer 关注点

- 请重点确认删除范围只覆盖 cookie authRef / cookie transport 兼容分支。
- 请确认 token authRef + Bearer HTTP helper 路径未被误伤。
