### PR TITLE
fix: respect cloud host token auth mode

### DIFF
--- a/bin/yida.js
+++ b/bin/yida.js
@@ -289,6 +289,9 @@ function printLoginResult(result) {
     corp_id: result.corp_id,
     user_id: result.user_id,
     user_name: result.user_name,
+    already_logged_in: result.already_logged_in,
+    login_action: result.login_action,
+    previous_status: result.previous_status,
     failure_reason: result.failure_reason,
     message: result.message,
     warning: result.warning,
@@ -670,15 +673,13 @@ async function main() {
 
     case 'login': {
       const loginArgs = applyLoginEnvironmentFlags(args, { inferTargetUrl: true });
-      const { getAuthStatus, isEnvAuthMode } = require('../lib/core/utils');
+      const { getAuthStatus } = require('../lib/core/utils');
       if (hasHelpFlag(loginArgs)) {
         printLoginHelp();
       } else {
         assertNoUnsupportedLegacyLoginFlags(rawArgs, loginArgs);
         if (loginArgs.includes('--check-only')) {
           console.log(JSON.stringify(getAuthStatus(buildTokenLoginOptions(loginArgs)), null, 2));
-        } else if (isEnvAuthMode()) {
-          printLoginResult(getAuthStatus(buildTokenLoginOptions(loginArgs)));
         } else {
           const { tokenLogin } = require('../lib/auth/token-auth');
           const result = await tokenLogin(buildTokenLoginOptions(loginArgs));
@@ -697,7 +698,7 @@ async function main() {
     case 'auth': {
       const subCommand = args[0];
       const authArgs = applyLoginEnvironmentFlags(args.slice(1), { inferTargetUrl: true });
-      const { getAuthStatus, isEnvAuthMode } = require('../lib/core/utils');
+      const { getAuthStatus } = require('../lib/core/utils');
       const { tokenLogin, tokenLogout, tokenRefresh } = require('../lib/auth/token-auth');
       if (!subCommand || subCommand === '--help' || subCommand === '-h') {
         printAuthHelp();
@@ -720,9 +721,7 @@ async function main() {
           printLoginHelp();
         } else {
           assertNoUnsupportedLegacyLoginFlags(rawArgs.slice(1), authArgs);
-          const result = isEnvAuthMode()
-            ? getAuthStatus(buildTokenLoginOptions(authArgs))
-            : await tokenLogin(buildTokenLoginOptions(authArgs));
+          const result = await tokenLogin(buildTokenLoginOptions(authArgs));
           printLoginResult(result);
         }
       } else if (subCommand === 'refresh') {

--- a/lib/auth/token-auth.js
+++ b/lib/auth/token-auth.js
@@ -274,6 +274,38 @@ function isRefreshAuthRequired(value) {
 }
 
 async function tokenLogin(options = {}) {
+  const env = options.env || process.env;
+  if (isHostInjectedTokenMode(env)) {
+    const status = tokenStatus(options);
+    if (status && status.can_auto_use) {
+      return {
+        ...status,
+        ok: true,
+        status: 'ok',
+        can_auto_use: true,
+        already_logged_in: true,
+        login_action: 'noop',
+        previous_status: status.status,
+        message: 'host-injected OpenYida credentials are already available; OAuth login was skipped',
+      };
+    }
+    return {
+      ...status,
+      ok: false,
+      auth_mode: 'token',
+      auth_source: status && status.auth_source ? status.auth_source : 'env',
+      auth_store: status && status.auth_store ? status.auth_store : 'host_injected',
+      persistence_scope: status && status.persistence_scope ? status.persistence_scope : 'host',
+      status: status && status.status ? status.status : 'not_logged_in',
+      can_auto_use: false,
+      already_logged_in: false,
+      login_action: 'noop',
+      message: status && status.message
+        ? status.message
+        : 'host-injected token is missing. Ask the host to inject OPENYIDA_ACCESS_TOKEN or OPENYIDA_REFRESH_TOKEN.',
+    };
+  }
+
   const baseUrl = resolveTokenBaseUrl(options);
   const authBaseUrl = appendPath(baseUrl, DEFAULT_AUTH_PATH_PREFIX);
   const clientId = options.clientId || process.env.OPENYIDA_DINGTALK_CLIENT_ID || DINGTALK_OAUTH_CLIENT_ID;

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -618,7 +618,17 @@ function saveTokenSession(session, options = {}) {
 
 function isHostInjectedTokenMode(env = process.env) {
   const authEnabled = String(env.YIDA_AUTH_ENABLED || '').trim().toLowerCase();
-  return ['1', 'true', 'yes', 'on'].includes(authEnabled);
+  if (['1', 'true', 'yes', 'on'].includes(authEnabled)) {
+    return true;
+  }
+  const authMode = String(env.OPENYIDA_AUTH_MODE || '').trim().toLowerCase();
+  if (authMode !== 'token') {
+    return false;
+  }
+  return !!(
+    String(env.OPENYIDA_ACCESS_TOKEN || '').trim() ||
+    String(env.OPENYIDA_REFRESH_TOKEN || '').trim()
+  );
 }
 
 function loadEnvTokenSession(env = process.env) {

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -9,6 +9,7 @@ const { buildCommandManifest } = require('./command-manifest');
 const { buildEnvironmentSnapshot } = require('./env');
 const coreUtils = require('./utils');
 const { findProjectRoot, getAuthStatus } = coreUtils;
+const { isHostInjectedTokenMode } = require('../auth/token-store');
 
 function redactLogin(login) {
   const redacted = { ...login };
@@ -204,7 +205,7 @@ function forbiddenAliasBriefs(manifest) {
 }
 
 function buildAuthPath(login, env = process.env) {
-  const hostInjectedTokenMode = isTruthyEnv(env.YIDA_AUTH_ENABLED);
+  const hostInjectedTokenMode = isHostInjectedTokenMode(env);
   const envTokenPresent = hasEnvTokenCredential(env);
   const authSource = login.auth_source || (hostInjectedTokenMode || envTokenPresent ? 'env' : 'token_session');
   const hostTokenEnvDetected = hostInjectedTokenMode || envTokenPresent || authSource === 'env';
@@ -645,7 +646,7 @@ function buildAgentCapabilities() {
     recommended: {
       preflight_command: 'openyida agent-capabilities --summary-json',
       full_capabilities_command: 'openyida agent-capabilities --json',
-      mutation_guard: 'Run mutating commands only when login.status is ok or after a successful openyida login.',
+      mutation_guard: 'Run mutating commands only when login.status is ok, login.can_auto_use is true, or after a successful openyida login.',
       workdir: projectRoot,
       workdir_source: projectResolution.source,
       workdir_reason: projectResolution.reason,

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -455,8 +455,8 @@ function getNodeExecutable() {
 }
 
 function isInjectedAuthMode(env = process.env) {
-  const authEnabled = String(env.YIDA_AUTH_ENABLED || '').trim().toLowerCase();
-  return ['1', 'true', 'yes', 'on'].includes(authEnabled);
+  const { isHostInjectedTokenMode } = require('../auth/token-store');
+  return isHostInjectedTokenMode(env);
 }
 
 function isEnvAuthMode(env = process.env) {
@@ -942,7 +942,7 @@ function loadCookieData(projectRoot, defaultBaseUrl) {
 
 /**
  * 读取当前默认登录态。
- * 默认使用 OAuth token session；YIDA_AUTH_ENABLED=true 时仅使用运行环境注入 token。
+ * 默认使用 OAuth token session；host-injected token mode 时仅使用运行环境注入 token。
  * @param {string} [projectRoot]
  * @param {string} [defaultBaseUrl]
  * @returns {object|null}
@@ -961,7 +961,7 @@ function getAuthStatus(options = {}) {
 // ── 登录触发 ──────────────────────────────────────────
 
 /**
- * 校验默认登录态；host mode 下不会触发 OAuth，本地模式提示用户执行 openyida login。
+ * 校验默认登录态；host-injected token mode 下不会触发 OAuth，本地模式提示用户执行 openyida login。
  * @param {object} [options]
  * @param {boolean} [options.force=false] - 是否跳过本地缓存，强制重新登录
  * @returns {object} loginResult

--- a/tests/agent-capabilities.test.js
+++ b/tests/agent-capabilities.test.js
@@ -96,6 +96,95 @@ describe('agent-capabilities summary', () => {
     }
   });
 
+  test('OPENYIDA_AUTH_MODE=token refresh token is treated as host-injected auth', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-agent-cap-cloud-'));
+    const buildEnvironmentSnapshot = jest.fn(() => ({
+      active: {
+        projectRoot,
+        projectRootExists: true,
+      },
+    }));
+    const getAuthStatus = jest.fn(() => ({
+      ok: true,
+      auth_mode: 'token',
+      auth_source: 'env',
+      auth_store: 'host_injected',
+      corp_id: 'corpCloud',
+      corp_name: '云端组织',
+      user_id: 'userCloud',
+      user_auth_store_writable: null,
+      persistence_scope: 'host',
+      status: 'refresh_required',
+      can_auto_use: true,
+    }));
+    const findProjectRoot = jest.fn(() => {
+      throw new Error('findProjectRoot is only needed by the runtime fast path');
+    });
+
+    jest.doMock('../lib/core/env', () => ({ buildEnvironmentSnapshot }));
+    jest.doMock('../lib/core/utils', () => ({ findProjectRoot, getAuthStatus }));
+
+    delete process.env.YIDA_AUTH_ENABLED;
+    process.env.OPENYIDA_AUTH_MODE = 'token';
+    process.env.OPENYIDA_REFRESH_TOKEN = 'runtime-refresh-token';
+    process.env.OPENYIDA_TOKEN_CORP_ID = 'corpCloud';
+    process.env.OPENYIDA_TOKEN_CORP_NAME = '云端组织';
+    process.env.OPENYIDA_TOKEN_USER_ID = 'userCloud';
+
+    try {
+      const { buildAgentCapabilitiesSummary } = require('../lib/core/agent-capabilities');
+      const summary = buildAgentCapabilitiesSummary();
+
+      expect(buildEnvironmentSnapshot).toHaveBeenCalledTimes(1);
+      expect(getAuthStatus).toHaveBeenCalledWith({ projectRoot, includeSecrets: false });
+      expect(findProjectRoot).not.toHaveBeenCalled();
+      expect(summary).not.toHaveProperty('precheck');
+      expect(summary.login).toMatchObject({
+        status: 'refresh_required',
+        auth_mode: 'token',
+        auth_source: 'env',
+        auth_store: 'host_injected',
+        corp_id: 'corpCloud',
+        corp_name: '云端组织',
+        user_id: 'userCloud',
+        user_auth_store_writable: null,
+        persistence_scope: 'host',
+        can_auto_use: true,
+      });
+      expect(summary.builder_path.auth).toMatchObject({
+        source: 'env',
+        store: 'host_injected',
+        corp_id: 'corpCloud',
+        corp_name: '云端组织',
+        user_id: 'userCloud',
+        user_auth_store_writable: null,
+        persistence_scope: 'host',
+        can_auto_use: true,
+        host_injected_token_mode: true,
+        host_token_env_detected: true,
+        env_token_present: true,
+        interactive_login_allowed: false,
+        browser_session_auth_allowed: false,
+        missing_token_action: 'STOP_AND_REQUEST_HOST_TOKEN',
+      });
+      expect(summary.builder_path.auth).not.toHaveProperty('runtime_auth_provisioned');
+      expect(summary.builder_path.interactive_login).toMatchObject({
+        mode: 'not_required',
+        browser_owner: 'none',
+        recommended_command: null,
+        reason: 'host_token_env_detected',
+      });
+      expect(summary.builder_path.environment_check_simplification).toMatchObject({
+        can_skip_default_exploration_when_summary_ok: true,
+        skip_login_check_only_default: true,
+        skip_browser_login_default: true,
+        stop_when_host_token_missing: false,
+      });
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test('non-runtime access token path still uses existing summary checks', () => {
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-agent-cap-slow-'));
     const buildEnvironmentSnapshot = jest.fn(() => ({

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -52,6 +52,7 @@ function cliEnv() {
     MULE_SANDBOX_ID: '',
     OPENYIDA_AGENT_MODE: '',
     OPENYIDA_ASSUME_DESKTOP: '',
+    OPENYIDA_AUTH_MODE: '',
     QWENWORK: '',
     QWENWORK_INTEGRATION_MODE: '',
     QWENWORKCN_INTEGRATION_MODE: '',
@@ -66,6 +67,7 @@ function cliEnv() {
     OPENYIDA_REFRESH_TOKEN: '',
     OPENYIDA_TOKEN_CLIENT_ID: '',
     OPENYIDA_TOKEN_CORP_ID: '',
+    OPENYIDA_TOKEN_CORP_NAME: '',
     OPENYIDA_TOKEN_USER_ID: '',
     OPENYIDA_ENDPOINT: '',
     OPENYIDA_NO_BROWSER: '',
@@ -1835,6 +1837,9 @@ describe('CLI offline smoke', () => {
         auth_source: 'env',
         status: 'ok',
         can_auto_use: true,
+        already_logged_in: true,
+        login_action: 'noop',
+        previous_status: 'ok',
       });
 
       const authStatus = JSON.parse(runOkWithEnv(['auth', 'status', '--json'], env, workspace));
@@ -1940,6 +1945,122 @@ describe('CLI offline smoke', () => {
       expect(JSON.stringify(summary)).not.toContain('cookies.json');
       expect(summary.login).not.toHaveProperty('cookies');
       expect(summary.login).not.toHaveProperty('csrf_token');
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('YIDA_AUTH_ENABLED=true treats refresh-only host token as logged-in login noop', () => {
+    const workspace = createCodexWorkspace();
+    try {
+      const loginOutput = runOkWithEnv(['login', '--no-browser', '--json'], {
+        CODEX_SHELL: '1',
+        OPENYIDA_ENV: 'public',
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_TOKEN_CLIENT_ID: 'openyida-cli',
+        OPENYIDA_TOKEN_CORP_ID: 'corpEnv',
+        OPENYIDA_TOKEN_USER_ID: 'userEnv',
+        OPENYIDA_ENDPOINT: 'https://env-token.example.com',
+      }, workspace);
+
+      expect(loginOutput).not.toContain('login.dingtalk.com/oauth2/auth');
+      expect(JSON.parse(loginOutput)).toMatchObject({
+        ok: true,
+        auth_mode: 'token',
+        auth_source: 'env',
+        auth_store: 'host_injected',
+        persistence_scope: 'host',
+        status: 'ok',
+        can_auto_use: true,
+        already_logged_in: true,
+        login_action: 'noop',
+        previous_status: 'refresh_required',
+        corp_id: 'corpEnv',
+        user_id: 'userEnv',
+      });
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('OPENYIDA_AUTH_MODE=token treats refresh-only host token as logged-in without OAuth', () => {
+    const workspace = createCodexWorkspace();
+    const env = {
+      CODEX_SHELL: '1',
+      OPENYIDA_ENV: 'public',
+      OPENYIDA_AUTH_MODE: 'token',
+      OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      OPENYIDA_TOKEN_CLIENT_ID: 'openyida-cli',
+      OPENYIDA_TOKEN_CORP_ID: 'corpEnv',
+      OPENYIDA_TOKEN_CORP_NAME: '环境组织',
+      OPENYIDA_TOKEN_USER_ID: 'userEnv',
+      OPENYIDA_ENDPOINT: 'https://env-token.example.com',
+      OPENYIDA_NO_BROWSER: '1',
+      OPENYIDA_OAUTH_TIMEOUT_MS: '80',
+    };
+    try {
+      const loginResult = runAnyWithEnv(['login', '--no-browser', '--json', '--quiet'], env, workspace);
+      expect(loginResult.status).toBe(0);
+      expect(loginResult.stderr).not.toContain('login.dingtalk.com/oauth2/auth');
+      expect(loginResult.stdout).not.toContain('login.dingtalk.com/oauth2/auth');
+      expect(JSON.parse(loginResult.stdout)).toMatchObject({
+        ok: true,
+        auth_mode: 'token',
+        auth_source: 'env',
+        auth_store: 'host_injected',
+        persistence_scope: 'host',
+        status: 'ok',
+        can_auto_use: true,
+        already_logged_in: true,
+        login_action: 'noop',
+        previous_status: 'refresh_required',
+        corp_id: 'corpEnv',
+        user_id: 'userEnv',
+      });
+
+      const summary = JSON.parse(runOkWithEnv(['agent-capabilities', '--summary-json'], env, workspace));
+      expect(summary.login).toMatchObject({
+        auth_mode: 'token',
+        auth_source: 'env',
+        auth_store: 'host_injected',
+        persistence_scope: 'host',
+        status: 'refresh_required',
+        can_auto_use: true,
+        corp_id: 'corpEnv',
+        corp_name: '环境组织',
+        user_id: 'userEnv',
+      });
+      expect(summary).not.toHaveProperty('precheck');
+      expect(summary.builder_path.auth).toMatchObject({
+        mode: 'token',
+        source: 'env',
+        store: 'host_injected',
+        can_auto_use: true,
+        host_injected_token_mode: true,
+        host_token_env_detected: true,
+        env_token_present: true,
+        interactive_login_allowed: false,
+        browser_session_auth_allowed: false,
+        missing_token_action: 'STOP_AND_REQUEST_HOST_TOKEN',
+      });
+      expect(summary.builder_path.auth).not.toHaveProperty('runtime_auth_provisioned');
+      expect(summary.builder_path.interactive_login).toMatchObject({
+        mode: 'not_required',
+        browser_default: 'not_required',
+        browser_owner: 'none',
+        recommended_command: null,
+        agent_action: 'do_not_run_oauth_login',
+        reason: 'host_token_env_detected',
+      });
+      expect(summary.builder_path.environment_check_simplification).toMatchObject({
+        can_skip_default_exploration_when_summary_ok: true,
+        skip_login_check_only_default: true,
+        skip_browser_login_default: true,
+        skip_cookie_or_playwright_checks_default: true,
+        stop_when_host_token_missing: false,
+      });
+      expect(JSON.stringify(summary)).not.toContain('login.dingtalk.com/oauth2/auth');
     } finally {
       fs.rmSync(workspace, { recursive: true, force: true });
     }

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 const {
   getAccessToken,
   normalizeTokenResponse,
+  tokenLogin,
   tokenLogout,
   tokenRefresh,
   tokenStatus,
@@ -135,6 +136,74 @@ describe('token-auth', () => {
     });
     expect(status.access_token).toBe('env-...');
     expect(status).not.toHaveProperty('token_file');
+  });
+
+  test('host-injected token login returns already logged in without OAuth', async () => {
+    const result = await tokenLogin({
+      projectRoot: tmpDir,
+      authDir,
+      noBrowser: true,
+      quiet: true,
+      timeoutMs: 1,
+      env: {
+        YIDA_AUTH_ENABLED: 'true',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_TOKEN_CLIENT_ID: 'openyida-cli',
+        OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+        OPENYIDA_TOKEN_USER_ID: 'user-env',
+        OPENYIDA_ENDPOINT: 'https://env-token.example.com',
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      auth_mode: 'token',
+      auth_source: 'env',
+      auth_store: 'host_injected',
+      persistence_scope: 'host',
+      status: 'ok',
+      can_auto_use: true,
+      already_logged_in: true,
+      login_action: 'noop',
+      previous_status: 'refresh_required',
+      corp_id: 'corp-env',
+      user_id: 'user-env',
+    });
+    expect(fs.existsSync(getTokenFilePath({ projectRoot: tmpDir, authDir }))).toBe(false);
+  });
+
+  test('OPENYIDA_AUTH_MODE=token refresh token login skips OAuth without YIDA_AUTH_ENABLED', async () => {
+    const result = await tokenLogin({
+      projectRoot: tmpDir,
+      authDir,
+      noBrowser: true,
+      quiet: true,
+      timeoutMs: 1,
+      env: {
+        OPENYIDA_AUTH_MODE: 'token',
+        OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+        OPENYIDA_TOKEN_CLIENT_ID: 'openyida-cli',
+        OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+        OPENYIDA_TOKEN_USER_ID: 'user-env',
+        OPENYIDA_ENDPOINT: 'https://env-token.example.com',
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      auth_mode: 'token',
+      auth_source: 'env',
+      auth_store: 'host_injected',
+      persistence_scope: 'host',
+      status: 'ok',
+      can_auto_use: true,
+      already_logged_in: true,
+      login_action: 'noop',
+      previous_status: 'refresh_required',
+      corp_id: 'corp-env',
+      user_id: 'user-env',
+    });
+    expect(fs.existsSync(getTokenFilePath({ projectRoot: tmpDir, authDir }))).toBe(false);
   });
 
   test('status exposes safe candidates when multiple profiles require selection', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -11,6 +11,7 @@ const {
   isLoginExpired,
   loadAuthData,
   loadCookieData,
+  isEnvAuthMode,
   detectActiveTool,
   detectRuntimeCapabilities,
   hasDesktopEnvironment,
@@ -479,6 +480,7 @@ describe('loadCookieData', () => {
 describe('loadAuthData', () => {
   let tmpDir;
   let originalAuthEnabled;
+  let originalAuthMode;
   let originalLegacyCookieEnv;
   let originalAccessToken;
   let originalRefreshToken;
@@ -490,6 +492,7 @@ describe('loadAuthData', () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-token-utils-'));
     originalAuthEnabled = process.env.YIDA_AUTH_ENABLED;
+    originalAuthMode = process.env.OPENYIDA_AUTH_MODE;
     originalLegacyCookieEnv = process.env[LEGACY_COOKIE_ENV];
     originalAccessToken = process.env.OPENYIDA_ACCESS_TOKEN;
     originalRefreshToken = process.env.OPENYIDA_REFRESH_TOKEN;
@@ -498,6 +501,7 @@ describe('loadAuthData', () => {
     originalUserId = process.env.OPENYIDA_TOKEN_USER_ID;
     originalAuthDir = process.env.OPENYIDA_AUTH_DIR;
     delete process.env.YIDA_AUTH_ENABLED;
+    delete process.env.OPENYIDA_AUTH_MODE;
     delete process.env[LEGACY_COOKIE_ENV];
     delete process.env.OPENYIDA_ACCESS_TOKEN;
     delete process.env.OPENYIDA_REFRESH_TOKEN;
@@ -516,6 +520,7 @@ describe('loadAuthData', () => {
       }
     };
     restore('YIDA_AUTH_ENABLED', originalAuthEnabled);
+    restore('OPENYIDA_AUTH_MODE', originalAuthMode);
     restore(LEGACY_COOKIE_ENV, originalLegacyCookieEnv);
     restore('OPENYIDA_ACCESS_TOKEN', originalAccessToken);
     restore('OPENYIDA_REFRESH_TOKEN', originalRefreshToken);
@@ -575,6 +580,25 @@ describe('loadAuthData', () => {
     expect(loadAuthData(tmpDir)).toMatchObject({
       auth_mode: 'token',
       auth_source: 'env',
+      corp_id: 'corpEnv',
+      user_id: 'userEnv',
+      base_url: 'https://env-token.example.com',
+    });
+  });
+
+  test('OPENYIDA_AUTH_MODE=token 时读取运行环境注入 refresh token', () => {
+    process.env.OPENYIDA_AUTH_MODE = 'token';
+    process.env.OPENYIDA_REFRESH_TOKEN = 'env-refresh-token';
+    process.env.OPENYIDA_ENDPOINT = 'https://env-token.example.com';
+    process.env.OPENYIDA_TOKEN_CORP_ID = 'corpEnv';
+    process.env.OPENYIDA_TOKEN_USER_ID = 'userEnv';
+
+    expect(isEnvAuthMode()).toBe(true);
+    expect(loadAuthData(tmpDir)).toMatchObject({
+      auth_mode: 'token',
+      auth_source: 'env',
+      auth_store: 'host_injected',
+      persistence_scope: 'host',
       corp_id: 'corpEnv',
       user_id: 'userEnv',
       base_url: 'https://env-token.example.com',


### PR DESCRIPTION
## Summary
- Treat OPENYIDA_AUTH_MODE=token with OPENYIDA_ACCESS_TOKEN or OPENYIDA_REFRESH_TOKEN as host-injected OpenYida auth
- Keep cloud refresh-token sessions from falling back to OAuth login
- Align agent-capabilities and utils host auth detection with token-store
- Add regression coverage for the yida-agent cloud env contract without YIDA_AUTH_ENABLED

## Verification
- node --check lib/auth/token-store.js lib/core/agent-capabilities.js lib/core/utils.js lib/auth/token-auth.js bin/yida.js
- npx eslint lib/auth/token-store.js lib/core/agent-capabilities.js lib/core/utils.js lib/auth/token-auth.js bin/yida.js tests/token-auth.test.js tests/agent-capabilities.test.js tests/cli-smoke.test.js tests/utils.test.js --quiet
- git diff --check
- npx jest tests/token-store.test.js tests/token-auth.test.js tests/agent-capabilities.test.js tests/cli-smoke.test.js tests/utils.test.js --runInBand
- npm run check:release-risks
- Manual smoke: OPENYIDA_AUTH_MODE=token + OPENYIDA_REFRESH_TOKEN login --json --quiet exits 0 with no OAuth URL on stderr