### PR TITLE
fix: 流程表单提交改走 startInstance；支持全员权限、复杂 dataPermit 与权限矩阵

### DIFF
--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -18,6 +18,7 @@ const { CliError } = require('./cli-error');
 const { createAuthRef, createYidaClient, isAuthRefReady } = require('./yida-client');
 
 const { buildComponentAliasMaps } = require('../app/get-schema');
+const { getProcessCodeFromFormBinding } = require('../app/services/form-mode-service');
 
 const USAGE = `openyida data - Unified Yida data CLI
 
@@ -25,6 +26,7 @@ Usage:
   openyida data query form <appType> <formUuid> [--page N] [--size N] [--all] [--max-pages N] [--search-json JSON|--search-file .cache/openyida/search.json] [--resolve-aliases] [--inst-id ID] [--no-hydrate-subforms]
   openyida data get form <appType> --inst-id <formInstId> [--form-uuid <formUuid>] [--no-hydrate-subforms]
   openyida data create form <appType> <formUuid> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--dept-id ID] [--resolve-aliases]
+    说明：若目标表单为流程表单，会自动使用 /v1/process/startInstance.json 发起流程。
   openyida data update form <appType> --inst-id <formInstId> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--form-uuid <formUuid>] [--use-latest-version y] [--resolve-aliases]
   openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId|alias> [--page N] [--size N] [--resolve-aliases]
 
@@ -592,6 +594,15 @@ async function getForm(positionals, options, session) {
   }));
 }
 
+async function resolveProcessCode(session, appType, formUuid) {
+  try {
+    return await getProcessCodeFromFormBinding(session, appType, formUuid);
+  } catch (err) {
+    console.warn(`⚠️  无法判断表单 ${formUuid} 是否为流程表单，将使用 saveFormData 提交：${err.message}`);
+    return null;
+  }
+}
+
 async function createForm(positionals, options, session) {
   requirePositionals(positionals, 2, ['appType', 'formUuid']);
   const dataJson = requireJsonOption(options, 'data_json', 'data_file', '数据');
@@ -603,6 +614,16 @@ async function createForm(positionals, options, session) {
     formDataJson: translateJsonWithAliases(dataJson, aliasContext, translateFormDataObject),
   };
   if (options.dept_id) {params.deptId = options.dept_id;}
+
+  const processCode = await resolveProcessCode(session, appType, formUuid);
+  if (processCode) {
+    printResult(await sendPost(session, appType, `/dingtalk/web/${appType}/v1/process/startInstance.json`, {
+      ...params,
+      processCode,
+    }));
+    return;
+  }
+
   printResult(await sendPost(session, appType, `/dingtalk/web/${appType}/v1/form/saveFormData.json`, params));
 }
 

--- a/lib/permission/matrix-service.js
+++ b/lib/permission/matrix-service.js
@@ -1,0 +1,56 @@
+/**
+ * matrix-service.js - 宜搭权限矩阵查询服务
+ *
+ * 提供权限矩阵列表查询与单个矩阵详情查询，供 save-permission 等命令使用。
+ */
+'use strict';
+
+const { createAuthRef, createYidaClient } = require('../core/yida-client');
+
+/**
+ * 查询权限矩阵列表
+ *
+ * @param {object} authRef - 认证引用对象
+ * @param {object} options - 查询选项
+ * @param {string} [options.keyword] - 搜索关键词
+ * @param {number} [options.page=1] - 页码
+ * @param {number} [options.limit=10] - 每页条数
+ * @returns {Promise<Array>} 权限矩阵列表
+ */
+async function getMatrixList(authRef, options = {}) {
+  const ref = authRef || createAuthRef();
+  const { keyword = '', page = 1, limit = 10 } = options;
+  const client = createYidaClient({ authRef: ref });
+  const result = await client.getContent('/query/matrix/getMatrixList.json', {
+    keyword,
+    page,
+    limit,
+  }, {
+    action: 'getMatrixList',
+    failMessage: '获取权限矩阵列表失败',
+  });
+  return (result && result.data) || [];
+}
+
+/**
+ * 根据 ID 查询单个权限矩阵详情
+ *
+ * @param {object} authRef - 认证引用对象
+ * @param {string} matrixId - 权限矩阵 ID
+ * @returns {Promise<object>} 权限矩阵详情
+ */
+async function getMatrixById(authRef, matrixId) {
+  const ref = authRef || createAuthRef();
+  const client = createYidaClient({ authRef: ref });
+  return client.getContent('/query/matrix/getMatrixById.json', {
+    matrixId,
+  }, {
+    action: 'getMatrixById',
+    failMessage: `获取权限矩阵 ${matrixId} 详情失败`,
+  });
+}
+
+module.exports = {
+  getMatrixList,
+  getMatrixById,
+};

--- a/lib/permission/save-permission.js
+++ b/lib/permission/save-permission.js
@@ -139,7 +139,30 @@ function parseArgs(args) {
   return { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, createMode, groupName };
 }
 
+function buildDataPermit(dataPermission) {
+  if (dataPermission && Array.isArray(dataPermission.rule)) {
+    return JSON.stringify(dataPermission);
+  }
+  const dataRange = (dataPermission && dataPermission.dataRange) || 'ALL';
+  const permitType = DATA_RANGE_TO_PERMIT_TYPE[dataRange] || dataRange;
+  return JSON.stringify({ rule: [{ type: permitType, value: 'y' }] });
+}
+
 function validateDataPermission(dataPermission) {
+  if (dataPermission && Array.isArray(dataPermission.rule)) {
+    const validTypes = new Set([
+      ...Object.keys(DATA_RANGE_TO_PERMIT_TYPE),
+      ...Object.values(DATA_RANGE_TO_PERMIT_TYPE),
+    ]);
+    for (const item of dataPermission.rule) {
+      if (item.type && !validTypes.has(item.type)) {
+        throw new Error(
+          `无效的 rule type: ${item.type}，有效值: ${Array.from(validTypes).join(', ')}`
+        );
+      }
+    }
+    return;
+  }
   const validRanges = Object.keys(DATA_RANGE_TO_PERMIT_TYPE);
   if (dataPermission.dataRange && !validRanges.includes(dataPermission.dataRange)) {
     throw new Error(
@@ -340,6 +363,7 @@ async function run(args) {
     // 构建新权限组数据
     const dataRange = (dataPermission && dataPermission.dataRange) || 'ALL';
     const permitType = DATA_RANGE_TO_PERMIT_TYPE[dataRange] || dataRange;
+    const dataPermitStr = buildDataPermit(dataPermission);
 
     const newOperatePermit = {};
     if (actionPermission) {
@@ -369,7 +393,7 @@ async function run(args) {
       packageName: { zh_CN: groupName, en_US: groupName, type: 'i18n' },
       description: { zh_CN: groupName, en_US: groupName, type: 'i18n' },
       roleData: JSON.stringify({ include: roleInclude }),
-      dataPermit: JSON.stringify({ rule: [{ type: permitType, value: 'y' }] }),
+      dataPermit: dataPermitStr,
       operatePermit: JSON.stringify(newOperatePermit),
       customButtonPermit: '[]',
       fieldPermit: JSON.stringify(normalizedFieldPermission || { fieldRange: 'FORM' }),
@@ -378,7 +402,11 @@ async function run(args) {
     };
 
     warn(`  → 权限组名称: ${groupName}`);
-    warn(`  → 数据范围: ${dataRange} → ${permitType}`);
+    if (dataPermission && Array.isArray(dataPermission.rule)) {
+      warn(`  → 数据范围: 自定义规则（${dataPermission.rule.length} 条）`);
+    } else {
+      warn(`  → 数据范围: ${dataRange} → ${permitType}`);
+    }
     warn(`  → 操作权限: ${Object.keys(newOperatePermit).join(', ') || '（无）'}`);
     if (normalizedFieldPermission) {warn('  → 字段权限: 自定义 fieldPermit');}
     if (members) {warn(`  → 成员: ${members.join(', ')}`);}
@@ -390,15 +418,21 @@ async function run(args) {
       const newPackageUuid = createResult.content || '';
       warn('  ✅ 权限组新增成功！');
       warn(SEP);
+      const dataPermissionSummary = (dataPermission && Array.isArray(dataPermission.rule))
+        ? `数据范围: 自定义规则（${dataPermission.rule.length} 条）`
+        : `数据范围: ${dataRange}`;
+      const membersSummary = allMembers
+        ? '成员: 全员'
+        : (members ? `成员: ${members.join(', ')}` : '仅管理员');
       console.log(JSON.stringify({
         success: true,
         packageUuid: newPackageUuid,
         summary: {
           name: groupName,
-          dataPermission: `数据范围: ${dataRange}`,
+          dataPermission: dataPermissionSummary,
           actionPermission: `操作权限: ${Object.keys(newOperatePermit).join(', ') || '（无）'}`,
           fieldPermission: normalizedFieldPermission ? '自定义 fieldPermit' : '全部字段',
-          members: members ? `成员: ${members.join(', ')}` : '仅管理员',
+          members: membersSummary,
         },
         message: '权限组已新增',
       }, null, 2));
@@ -459,8 +493,12 @@ async function run(args) {
   let permitType = null;
   const stepParts = [];
   if (dataPermission) {
-    permitType = DATA_RANGE_TO_PERMIT_TYPE[dataPermission.dataRange] || dataPermission.dataRange;
-    stepParts.push(`数据权限: ${dataPermission.dataRange} → ${permitType}`);
+    if (Array.isArray(dataPermission.rule)) {
+      stepParts.push(`数据权限: 自定义规则（${dataPermission.rule.length} 条）`);
+    } else {
+      permitType = DATA_RANGE_TO_PERMIT_TYPE[dataPermission.dataRange] || dataPermission.dataRange;
+      stepParts.push(`数据权限: ${dataPermission.dataRange} → ${permitType}`);
+    }
   }
   if (actionPermission) {
     stepParts.push('操作权限: 同步更新');
@@ -481,7 +519,7 @@ async function run(args) {
     const updatedPkg = { ...pkg };
 
     if (dataPermission) {
-      updatedPkg.dataPermit = JSON.stringify({ rule: [{ type: permitType, value: 'y' }] });
+      updatedPkg.dataPermit = buildDataPermit(dataPermission);
     }
 
     if (actionPermission) {
@@ -542,6 +580,7 @@ module.exports = {
   validateDataPermission,
   validateActionPermission,
   normalizeFieldPermission,
+  buildDataPermit,
   fetchPermitPackages,
   buildRoleData,
   savePermitPackage,

--- a/lib/permission/save-permission.js
+++ b/lib/permission/save-permission.js
@@ -6,6 +6,7 @@
  *   openyida save-permission <appType> <formUuid> --action-permission <json>
  *   openyida save-permission <appType> <formUuid> --field-permission <json>
  *   openyida save-permission <appType> <formUuid> --members <userIds> --data-permission <json>
+ *   openyida save-permission <appType> <formUuid> --matrix <json> --data-permission <json>
  *
  * 用法（新增权限组）：
  *   openyida save-permission <appType> <formUuid> --create --name <权限组名称> [--members <userIds>] [--data-permission <json>] [--action-permission <json>] [--field-permission <json>]
@@ -14,6 +15,8 @@
  *   示例：--members "54255850977641,12345678901234"
  *   不传则保持原有成员配置不变（更新模式）或仅包含管理员（新增模式）
  * --all-members 参数：新增/更新权限组时设置为「全员可见」（roleType=DEFAULT, roleValue=ALL）
+ * --matrix 参数：使用权限矩阵作为权限成员，JSON 格式 {"matrixId":"MATRIX-XXX","columnId":"column_YYY"}
+ *   与 --members / --all-members 互斥
  *
  * 注意：--field-permission 透传宜搭 fieldPermit 原始 JSON，使用前建议先通过 get-permission 查看现有结构。
  */
@@ -40,6 +43,7 @@ const DATA_RANGE_TO_PERMIT_TYPE = {
   FREE_LOGIN: 'FREE_LOGIN',
   CUSTOM_DEPARTMENT: 'CUSTOM_DEPARTMENT',
   FORMULA: 'FORMULA',
+  MATRIX: 'MATRIX',
 };
 
 // 所有支持的操作权限 key
@@ -63,10 +67,11 @@ const VALID_OPERATE_KEYS = [
 function parseArgs(args) {
   if (args.length < 2) {
     throw new CliError([
-      '用法: openyida save-permission <appType> <formUuid> [--create --name <名称>] [--data-permission <json>] [--action-permission <json>] [--field-permission <json>] [--members <userIds>] [--all-members]',
+      '用法: openyida save-permission <appType> <formUuid> [--create --name <名称>] [--data-permission <json>] [--action-permission <json>] [--field-permission <json>] [--members <userIds>] [--all-members] [--matrix <json>]',
       '示例（更新）: openyida save-permission APP_XXX FORM-XXX --data-permission \'{"role":"DEFAULT","dataRange":"SELF"}\'',
       '示例（新增全员）: openyida save-permission APP_XXX FORM-XXX --create --name "全部人员看全部数据" --all-members --data-permission \'{"dataRange":"ALL"}\'',
       '示例（新增指定人员）: openyida save-permission APP_XXX FORM-XXX --create --name "只读权限组" --members "54255850977641"',
+      '示例（新增矩阵）: openyida save-permission APP_XXX FORM-XXX --create --name "矩阵权限组" --matrix \'{"matrixId":"MATRIX-XXX","columnId":"column_YYY"}\' --data-permission \'{"rule":[{"type":"ORIGINATOR","value":"y"},{"type":"MATRIX","value":"y"}]}\'',
     ].join('\n'), {
       code: 'SAVE_PERMISSION_INVALID_ARGUMENTS',
     });
@@ -79,6 +84,7 @@ function parseArgs(args) {
   let fieldPermission = null;
   let members = null;
   let allMembers = false;
+  let matrix = null;
   let createMode = false;
   let groupName = null;
 
@@ -121,6 +127,15 @@ function parseArgs(args) {
       index++;
     } else if (args[index] === '--all-members') {
       allMembers = true;
+    } else if (args[index] === '--matrix' && args[index + 1]) {
+      try {
+        matrix = JSON.parse(args[index + 1]);
+      } catch {
+        throw new CliError(`--matrix 参数 JSON 解析失败: ${args[index + 1]}，格式: {"matrixId":"MATRIX-XXX","columnId":"column_YYY"}`, {
+          code: 'SAVE_PERMISSION_INVALID_ARGUMENTS',
+        });
+      }
+      index++;
     }
   }
 
@@ -130,13 +145,13 @@ function parseArgs(args) {
     });
   }
 
-  if (!createMode && !dataPermission && !actionPermission && !fieldPermission && !members) {
-    throw new CliError('请至少提供 --data-permission、--action-permission、--field-permission 或 --members 参数之一', {
+  if (!createMode && !dataPermission && !actionPermission && !fieldPermission && !members && !matrix) {
+    throw new CliError('请至少提供 --data-permission、--action-permission、--field-permission、--members 或 --matrix 参数之一', {
       code: 'SAVE_PERMISSION_INVALID_ARGUMENTS',
     });
   }
 
-  return { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, createMode, groupName };
+  return { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, matrix, createMode, groupName };
 }
 
 function buildDataPermit(dataPermission) {
@@ -168,6 +183,18 @@ function validateDataPermission(dataPermission) {
     throw new Error(
       `无效的 dataRange: ${dataPermission.dataRange}，有效值: ${validRanges.join(', ')}`
     );
+  }
+}
+
+function validateMatrix(matrix) {
+  if (!matrix || typeof matrix !== 'object') {
+    throw new Error('--matrix 参数必须是 JSON 对象');
+  }
+  if (!matrix.matrixId || typeof matrix.matrixId !== 'string') {
+    throw new Error('--matrix 参数必须包含 matrixId 字符串');
+  }
+  if (!matrix.columnId || typeof matrix.columnId !== 'string') {
+    throw new Error('--matrix 参数必须包含 columnId 字符串');
   }
 }
 
@@ -308,7 +335,7 @@ function savePermitPackage(appType, formUuid, permitPackage, overrideMembers, au
 }
 
 async function run(args) {
-  const { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, createMode, groupName } = parseArgs(args);
+  const { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, matrix, createMode, groupName } = parseArgs(args);
 
   warn(SEP);
   warn('  save-permission - 宜搭表单权限配置保存');
@@ -324,9 +351,16 @@ async function run(args) {
   // Step 0: 参数校验
   warn('\n📋 Step 0: 验证参数');
   try {
+    if (matrix && (members || allMembers)) {
+      throw new Error('--matrix 与 --members / --all-members 互斥，请勿同时指定');
+    }
     if (dataPermission) {
       validateDataPermission(dataPermission);
       warn(`  ✅ 数据权限验证通过（dataRange: ${dataPermission.dataRange || 'ALL'}）`);
+    }
+    if (matrix) {
+      validateMatrix(matrix);
+      warn(`  ✅ 权限矩阵验证通过（matrixId: ${matrix.matrixId}, columnId: ${matrix.columnId}）`);
     }
     if (actionPermission) {
       validateActionPermission(actionPermission);
@@ -375,9 +409,11 @@ async function run(args) {
       newOperatePermit['OPERATE_VIEW'] = 'y';
     }
 
-    // 构建 roleData：--all-members 时为全员（DEFAULT/ALL），指定成员时为管理员+指定人员，否则仅管理员
+    // 构建 roleData：--matrix / --all-members / --members / 默认管理员 四选一
     let roleInclude;
-    if (allMembers) {
+    if (matrix) {
+      roleInclude = [{ roleType: 'MATRIX', roleValue: [{ matrixId: matrix.matrixId, columnId: matrix.columnId }] }];
+    } else if (allMembers) {
       roleInclude = [{ roleType: 'DEFAULT', roleValue: 'ALL' }];
     } else if (members && members.length > 0) {
       roleInclude = [
@@ -409,7 +445,11 @@ async function run(args) {
     }
     warn(`  → 操作权限: ${Object.keys(newOperatePermit).join(', ') || '（无）'}`);
     if (normalizedFieldPermission) {warn('  → 字段权限: 自定义 fieldPermit');}
-    if (members) {warn(`  → 成员: ${members.join(', ')}`);}
+    if (matrix) {
+      warn(`  → 权限矩阵: ${matrix.matrixId} / ${matrix.columnId}`);
+    } else if (members) {
+      warn(`  → 成员: ${members.join(', ')}`);
+    }
 
     const createResult = await savePermitPackage(appType, formUuid, newPkg, null, authRef);
 
@@ -421,9 +461,16 @@ async function run(args) {
       const dataPermissionSummary = (dataPermission && Array.isArray(dataPermission.rule))
         ? `数据范围: 自定义规则（${dataPermission.rule.length} 条）`
         : `数据范围: ${dataRange}`;
-      const membersSummary = allMembers
-        ? '成员: 全员'
-        : (members ? `成员: ${members.join(', ')}` : '仅管理员');
+      let membersSummary;
+      if (matrix) {
+        membersSummary = `权限矩阵: ${matrix.matrixId} / ${matrix.columnId}`;
+      } else if (allMembers) {
+        membersSummary = '成员: 全员';
+      } else if (members) {
+        membersSummary = `成员: ${members.join(', ')}`;
+      } else {
+        membersSummary = '仅管理员';
+      }
       console.log(JSON.stringify({
         success: true,
         packageUuid: newPackageUuid,
@@ -470,13 +517,19 @@ async function run(args) {
   warn(`  ✅ 获取到 ${packages.length} 个权限组`);
 
   // 根据 role 筛选要更新的权限组
-  const targetRole = (dataPermission || actionPermission || fieldPermission || {}).role || 'DEFAULT';
+  let targetRole = (dataPermission || actionPermission || fieldPermission || {}).role || 'DEFAULT';
+  if (matrix) {
+    targetRole = 'MATRIX';
+  }
   const packagesToUpdate = packages.filter((pkg) => {
     if (targetRole === 'DEFAULT') {
       return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === 'DEFAULT');
     }
     if (targetRole === 'MANAGER') {
       return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === 'MANAGER');
+    }
+    if (targetRole === 'MATRIX') {
+      return pkg.roleMembers && pkg.roleMembers.some((rm) => rm.roleType === 'MATRIX');
     }
     return true;
   });
@@ -505,6 +558,9 @@ async function run(args) {
   }
   if (normalizedFieldPermission) {
     stepParts.push('字段权限: 同步更新');
+  }
+  if (matrix) {
+    stepParts.push(`权限矩阵: ${matrix.matrixId} / ${matrix.columnId}`);
   }
   if (members) {
     stepParts.push(`成员: ${members.join(', ')}`);
@@ -540,6 +596,13 @@ async function run(args) {
     // --all-members 时强制将权限组改为全员可见
     if (allMembers) {
       updatedPkg.roleData = JSON.stringify({ include: [{ roleType: 'DEFAULT', roleValue: 'ALL' }] });
+    }
+
+    // --matrix 时强制将权限组改为权限矩阵
+    if (matrix) {
+      updatedPkg.roleData = JSON.stringify({
+        include: [{ roleType: 'MATRIX', roleValue: [{ matrixId: matrix.matrixId, columnId: matrix.columnId }] }],
+      });
     }
 
     // members 参数传给 savePermitPackage，null 表示不修改成员
@@ -579,6 +642,7 @@ module.exports = {
   parseArgs,
   validateDataPermission,
   validateActionPermission,
+  validateMatrix,
   normalizeFieldPermission,
   buildDataPermit,
   fetchPermitPackages,

--- a/lib/permission/save-permission.js
+++ b/lib/permission/save-permission.js
@@ -13,6 +13,7 @@
  * --members 参数：指定权限组成员，多个钉钉 userId 用逗号分隔
  *   示例：--members "54255850977641,12345678901234"
  *   不传则保持原有成员配置不变（更新模式）或仅包含管理员（新增模式）
+ * --all-members 参数：新增/更新权限组时设置为「全员可见」（roleType=DEFAULT, roleValue=ALL）
  *
  * 注意：--field-permission 透传宜搭 fieldPermit 原始 JSON，使用前建议先通过 get-permission 查看现有结构。
  */
@@ -62,9 +63,10 @@ const VALID_OPERATE_KEYS = [
 function parseArgs(args) {
   if (args.length < 2) {
     throw new CliError([
-      '用法: openyida save-permission <appType> <formUuid> [--create --name <名称>] [--data-permission <json>] [--action-permission <json>] [--field-permission <json>] [--members <userIds>]',
+      '用法: openyida save-permission <appType> <formUuid> [--create --name <名称>] [--data-permission <json>] [--action-permission <json>] [--field-permission <json>] [--members <userIds>] [--all-members]',
       '示例（更新）: openyida save-permission APP_XXX FORM-XXX --data-permission \'{"role":"DEFAULT","dataRange":"SELF"}\'',
-      '示例（新增）: openyida save-permission APP_XXX FORM-XXX --create --name "只读权限组" --members "54255850977641"',
+      '示例（新增全员）: openyida save-permission APP_XXX FORM-XXX --create --name "全部人员看全部数据" --all-members --data-permission \'{"dataRange":"ALL"}\'',
+      '示例（新增指定人员）: openyida save-permission APP_XXX FORM-XXX --create --name "只读权限组" --members "54255850977641"',
     ].join('\n'), {
       code: 'SAVE_PERMISSION_INVALID_ARGUMENTS',
     });
@@ -76,6 +78,7 @@ function parseArgs(args) {
   let actionPermission = null;
   let fieldPermission = null;
   let members = null;
+  let allMembers = false;
   let createMode = false;
   let groupName = null;
 
@@ -116,6 +119,8 @@ function parseArgs(args) {
       // 多个钉钉 userId 用逗号分隔，如 "54255850977641,12345678901234"
       members = args[index + 1].split(',').map((id) => id.trim()).filter(Boolean);
       index++;
+    } else if (args[index] === '--all-members') {
+      allMembers = true;
     }
   }
 
@@ -131,7 +136,7 @@ function parseArgs(args) {
     });
   }
 
-  return { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, createMode, groupName };
+  return { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, createMode, groupName };
 }
 
 function validateDataPermission(dataPermission) {
@@ -280,7 +285,7 @@ function savePermitPackage(appType, formUuid, permitPackage, overrideMembers, au
 }
 
 async function run(args) {
-  const { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, createMode, groupName } = parseArgs(args);
+  const { appType, formUuid, dataPermission, actionPermission, fieldPermission, members, allMembers, createMode, groupName } = parseArgs(args);
 
   warn(SEP);
   warn('  save-permission - 宜搭表单权限配置保存');
@@ -346,10 +351,17 @@ async function run(args) {
       newOperatePermit['OPERATE_VIEW'] = 'y';
     }
 
-    // 构建 roleData：默认包含管理员，如果指定了 members 则追加 PERSONS 条目
-    const roleInclude = [{ roleType: 'MANAGER', roleValue: 'appMainAdminRole,corpAdminRole' }];
-    if (members && members.length > 0) {
-      roleInclude.push({ roleType: 'PERSONS', roleValue: members.join(',') });
+    // 构建 roleData：--all-members 时为全员（DEFAULT/ALL），指定成员时为管理员+指定人员，否则仅管理员
+    let roleInclude;
+    if (allMembers) {
+      roleInclude = [{ roleType: 'DEFAULT', roleValue: 'ALL' }];
+    } else if (members && members.length > 0) {
+      roleInclude = [
+        { roleType: 'MANAGER', roleValue: 'appMainAdminRole,corpAdminRole' },
+        { roleType: 'PERSONS', roleValue: members.join(',') },
+      ];
+    } else {
+      roleInclude = [{ roleType: 'MANAGER', roleValue: 'appMainAdminRole,corpAdminRole' }];
     }
 
     const newPkg = {
@@ -485,6 +497,11 @@ async function run(args) {
 
     if (normalizedFieldPermission) {
       updatedPkg.fieldPermit = JSON.stringify(normalizedFieldPermission);
+    }
+
+    // --all-members 时强制将权限组改为全员可见
+    if (allMembers) {
+      updatedPkg.roleData = JSON.stringify({ include: [{ roleType: 'DEFAULT', roleValue: 'ALL' }] });
     }
 
     // members 参数传给 savePermitPackage，null 表示不修改成员

--- a/tests/matrix-service.test.js
+++ b/tests/matrix-service.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+jest.mock('../lib/core/utils', () => ({
+  loadAuthData: jest.fn(),
+  triggerLogin: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://www.aliwork.com'),
+  httpGet: jest.fn(),
+  httpPost: jest.fn(),
+  requestWithAutoLogin: jest.fn(),
+}));
+
+const utils = require('../lib/core/utils');
+const { getMatrixList, getMatrixById } = require('../lib/permission/matrix-service');
+
+const mockAuthData = {
+  base_url: 'https://www.aliwork.com',
+  auth_mode: 'token',
+  auth_source: 'token',
+  corp_id: 'corp-1',
+  user_id: 'user-1',
+};
+
+describe('matrix-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    utils.loadAuthData.mockReturnValue(mockAuthData);
+    utils.requestWithAutoLogin.mockImplementation((requestFn, authRef) => requestFn(authRef));
+  });
+
+  test('getMatrixList returns data array from response', async () => {
+    utils.httpGet.mockResolvedValueOnce({
+      success: true,
+      content: {
+        currentPage: 1,
+        data: [
+          { matrixId: 'MATRIX-1', name: { zh_CN: '测试矩阵' } },
+        ],
+      },
+    });
+
+    const list = await getMatrixList(null, { keyword: '测试', page: 1, limit: 10 });
+
+    expect(list).toEqual([{ matrixId: 'MATRIX-1', name: { zh_CN: '测试矩阵' } }]);
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+    const [baseUrl, path, params] = utils.httpGet.mock.calls[0];
+    expect(baseUrl).toBe('https://www.aliwork.com');
+    expect(path).toBe('/query/matrix/getMatrixList.json');
+    expect(params).toMatchObject({
+      keyword: '测试',
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  test('getMatrixList returns empty array when response has no data', async () => {
+    utils.httpGet.mockResolvedValueOnce({ success: true, content: {} });
+
+    const list = await getMatrixList(null);
+
+    expect(list).toEqual([]);
+  });
+
+  test('getMatrixById returns matrix detail', async () => {
+    utils.httpGet.mockResolvedValueOnce({
+      success: true,
+      content: {
+        matrixId: 'MATRIX-1',
+        name: { zh_CN: '测试矩阵' },
+      },
+    });
+
+    const detail = await getMatrixById(null, 'MATRIX-1');
+
+    expect(detail).toEqual({
+      matrixId: 'MATRIX-1',
+      name: { zh_CN: '测试矩阵' },
+    });
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+    const [baseUrl, path, params] = utils.httpGet.mock.calls[0];
+    expect(path).toBe('/query/matrix/getMatrixById.json');
+    expect(params).toMatchObject({ matrixId: 'MATRIX-1' });
+  });
+});

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -16,7 +16,12 @@ jest.mock('../lib/core/utils', () => ({
   requestWithAutoLogin: jest.fn(),
 }));
 
+jest.mock('../lib/app/services/form-mode-service', () => ({
+  getProcessCodeFromFormBinding: jest.fn(),
+}));
+
 const utils = require('../lib/core/utils');
+const formModeService = require('../lib/app/services/form-mode-service');
 
 const mockAuthData = {
   base_url: 'https://www.aliwork.com',
@@ -90,6 +95,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   // 默认已登录
   utils.loadAuthData.mockReturnValue(mockAuthData);
+  // 默认按普通表单处理（非流程表单）
+  formModeService.getProcessCodeFromFormBinding.mockResolvedValue(null);
 });
 
 // ── 参数校验 ──────────────────────────────────────────────────────────
@@ -502,6 +509,57 @@ describe('run() create form', () => {
 
     mockLog.mockRestore();
     mockError.mockRestore();
+  });
+
+  test('目标表单是流程表单时自动使用 startInstance.json 发起流程', async () => {
+    formModeService.getProcessCodeFromFormBinding.mockResolvedValue('PROC-XXX');
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { processInstanceId: 'PROC-INST-NEW' },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await run(['create', 'form', 'APP_XXX', 'FORM-XXX', '--data-json', '{"textField_1":"hello"}']);
+
+    expect(formModeService.getProcessCodeFromFormBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ corpId: 'corp-1' }),
+      'APP_XXX',
+      'FORM-XXX'
+    );
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/v1/process/startInstance.json');
+    const postBody = decodeURIComponent(utils.httpPost.mock.calls[0][2]);
+    expect(postBody).toContain('processCode=PROC-XXX');
+    expect(postBody).toContain('formDataJson={"textField_1":"hello"}');
+    expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"success": true'));
+
+    mockLog.mockRestore();
+    mockWarn.mockRestore();
+  });
+
+  test('流程表单绑定查询失败时回退到 saveFormData.json 并告警', async () => {
+    formModeService.getProcessCodeFromFormBinding.mockRejectedValue(new Error('binding timeout'));
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { formInstId: 'INST-FALLBACK' },
+    });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await run(['create', 'form', 'APP_XXX', 'FORM-XXX', '--data-json', '{"textField_1":"hello"}']);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost.mock.calls[0][1]).toBe('/dingtalk/web/APP_XXX/v1/form/saveFormData.json');
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('无法判断表单 FORM-XXX 是否为流程表单'));
+    expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('"success": true'));
+
+    mockLog.mockRestore();
+    mockWarn.mockRestore();
   });
 
   test('缺少 --data-json 时打印错误并退出', async () => {

--- a/tests/save-permission.test.js
+++ b/tests/save-permission.test.js
@@ -16,7 +16,7 @@ jest.mock('../lib/core/i18n', () => ({
 }));
 
 const utils = require('../lib/core/utils');
-const { run, buildDataPermit } = require('../lib/permission/save-permission');
+const { run, buildDataPermit, validateMatrix } = require('../lib/permission/save-permission');
 
 const mockAuthData = {
   base_url: 'https://www.aliwork.com',
@@ -301,6 +301,124 @@ describe('save-permission command', () => {
     });
   });
 
+  test('creates a permission group with matrix member', async () => {
+    utils.httpPost.mockResolvedValueOnce({
+      success: true,
+      content: 'pkg-matrix',
+    });
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--create',
+      '--name',
+      '使用权限矩阵的权限组',
+      '--matrix',
+      '{"matrixId":"MATRIX-XNCVJYB60YW7L0HPY9HE","columnId":"column_1767839664612"}',
+      '--data-permission',
+      '{"rule":[{"type":"ORIGINATOR","value":"y"},{"type":"MATRIX","value":"y"}]}',
+      '--action-permission',
+      '{"operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":true}}',
+    ]);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(body.packageUuid).toBeUndefined();
+    expect(JSON.parse(body.dataPermit)).toEqual({
+      rule: [
+        { type: 'ORIGINATOR', value: 'y' },
+        { type: 'MATRIX', value: 'y' },
+      ],
+    });
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [{
+        roleType: 'MATRIX',
+        roleValue: [{ matrixId: 'MATRIX-XNCVJYB60YW7L0HPY9HE', columnId: 'column_1767839664612' }],
+      }],
+    });
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      packageUuid: 'pkg-matrix',
+      summary: {
+        name: '使用权限矩阵的权限组',
+        members: '权限矩阵: MATRIX-XNCVJYB60YW7L0HPY9HE / column_1767839664612',
+      },
+      message: '权限组已新增',
+    });
+  });
+
+  test('updates existing matrix package when --matrix is provided', async () => {
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          formPermit: [
+            {
+              packageUuid: 'pkg-matrix-old',
+              packageName: { zh_CN: '旧矩阵组' },
+              roleMembers: [{ roleType: 'MATRIX' }],
+              roleData: JSON.stringify({
+                include: [{ roleType: 'MATRIX', roleValue: [{ matrixId: 'OLD', columnId: 'OLD' }] }],
+              }),
+            },
+          ],
+        },
+      });
+    utils.httpPost.mockResolvedValueOnce({ success: true });
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--matrix',
+      '{"matrixId":"MATRIX-XNCVJYB60YW7L0HPY9HE","columnId":"column_1767839664612"}',
+      '--data-permission',
+      '{"rule":[{"type":"ORIGINATOR","value":"y"},{"type":"MATRIX","value":"y"}]}',
+    ]);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(body.packageUuid).toBe('pkg-matrix-old');
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [{
+        roleType: 'MATRIX',
+        roleValue: [{ matrixId: 'MATRIX-XNCVJYB60YW7L0HPY9HE', columnId: 'column_1767839664612' }],
+      }],
+    });
+    expect(JSON.parse(body.dataPermit)).toEqual({
+      rule: [
+        { type: 'ORIGINATOR', value: 'y' },
+        { type: 'MATRIX', value: 'y' },
+      ],
+    });
+  });
+
+  test('rejects mixing --matrix with --members or --all-members', async () => {
+    let error;
+    try {
+      await run([
+        'APP-1',
+        'FORM-1',
+        '--create',
+        '--name',
+        '冲突组',
+        '--matrix',
+        '{"matrixId":"MATRIX-1","columnId":"col-1"}',
+        '--members',
+        'user1',
+      ]);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeTruthy();
+    expect(error.isCliError).toBe(true);
+    expect(error.code).toBe('SAVE_PERMISSION_INVALID_ARGUMENTS');
+    expect(utils.httpGet).not.toHaveBeenCalled();
+    expect(utils.httpPost).not.toHaveBeenCalled();
+  });
+
   test('invalid JSON rejects with CliError instead of exiting', async () => {
     let error;
     try {
@@ -349,5 +467,19 @@ describe('buildDataPermit', () => {
       },
     };
     expect(JSON.parse(buildDataPermit(complex))).toEqual(complex);
+  });
+});
+
+describe('validateMatrix', () => {
+  test('accepts valid matrix object', () => {
+    expect(() => validateMatrix({ matrixId: 'MATRIX-1', columnId: 'col-1' })).not.toThrow();
+  });
+
+  test('rejects missing matrixId', () => {
+    expect(() => validateMatrix({ columnId: 'col-1' })).toThrow('matrixId');
+  });
+
+  test('rejects missing columnId', () => {
+    expect(() => validateMatrix({ matrixId: 'MATRIX-1' })).toThrow('columnId');
   });
 });

--- a/tests/save-permission.test.js
+++ b/tests/save-permission.test.js
@@ -125,6 +125,132 @@ describe('save-permission command', () => {
     });
   });
 
+  test('creates an all-members group when --all-members is provided', async () => {
+    utils.httpPost.mockResolvedValueOnce({
+      success: true,
+      content: 'pkg-all',
+    });
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--create',
+      '--name',
+      '全部人员看全部数据',
+      '--all-members',
+      '--data-permission',
+      '{"dataRange":"ALL"}',
+    ]);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(body.packageUuid).toBeUndefined();
+    expect(body).toMatchObject({
+      formUuid: 'FORM-1',
+      dataPermit: '{"rule":[{"type":"ALL","value":"y"}]}',
+      operatePermit: '{"OPERATE_VIEW":"y"}',
+      fieldPermit: '{"fieldRange":"FORM"}',
+    });
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [{ roleType: 'DEFAULT', roleValue: 'ALL' }],
+    });
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      packageUuid: 'pkg-all',
+      summary: {
+        name: '全部人员看全部数据',
+        dataPermission: '数据范围: ALL',
+      },
+      message: '权限组已新增',
+    });
+  });
+
+  test('updates existing package to all-members when --all-members is provided', async () => {
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          formPermit: [
+            {
+              packageUuid: 'pkg-1',
+              packageName: { zh_CN: '默认组' },
+              roleMembers: [{ roleType: 'DEFAULT' }],
+              roleData: '{"include":[{"roleType":"DEFAULT","roleValue":"ALL"}]}',
+              dataPermit: '{"rule":[{"type":"SELF","value":"y"}]}',
+              operatePermit: '{"OPERATE_VIEW":"y"}',
+              fieldPermit: '{"fieldRange":"FORM"}',
+            },
+          ],
+        },
+      });
+    utils.httpPost.mockResolvedValueOnce({ success: true });
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--all-members',
+      '--data-permission',
+      '{"dataRange":"ALL"}',
+    ]);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(body).toMatchObject({
+      formUuid: 'FORM-1',
+      packageUuid: 'pkg-1',
+      dataPermit: '{"rule":[{"type":"ALL","value":"y"}]}',
+    });
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [{ roleType: 'DEFAULT', roleValue: 'ALL' }],
+    });
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      summary: {
+        dataPermission: '数据范围: ALL',
+      },
+      message: '权限配置已保存',
+    });
+  });
+
+  test('creates a manager+persons group when --members is provided', async () => {
+    utils.httpPost.mockResolvedValueOnce({
+      success: true,
+      content: 'pkg-persons',
+    });
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--create',
+      '--name',
+      '指定人员组',
+      '--members',
+      'user1,user2',
+    ]);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [
+        { roleType: 'MANAGER', roleValue: 'appMainAdminRole,corpAdminRole' },
+        { roleType: 'PERSONS', roleValue: 'user1,user2' },
+      ],
+    });
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      packageUuid: 'pkg-persons',
+      summary: {
+        name: '指定人员组',
+        members: '成员: user1, user2',
+      },
+      message: '权限组已新增',
+    });
+  });
+
   test('invalid JSON rejects with CliError instead of exiting', async () => {
     let error;
     try {

--- a/tests/save-permission.test.js
+++ b/tests/save-permission.test.js
@@ -16,7 +16,7 @@ jest.mock('../lib/core/i18n', () => ({
 }));
 
 const utils = require('../lib/core/utils');
-const { run } = require('../lib/permission/save-permission');
+const { run, buildDataPermit } = require('../lib/permission/save-permission');
 
 const mockAuthData = {
   base_url: 'https://www.aliwork.com',
@@ -251,6 +251,56 @@ describe('save-permission command', () => {
     });
   });
 
+  test('creates a permission group with complex data-permit rules', async () => {
+    utils.httpPost.mockResolvedValueOnce({
+      success: true,
+      content: 'pkg-complex',
+    });
+
+    const complexDataPermission = {
+      rule: [
+        { type: 'ORIGINATOR', value: 'y' },
+        { type: 'ORIGINATOR_DEPARTMENT', value: 'y' },
+        { type: 'CUSTOM_DEPARTMENT', value: 'y' },
+      ],
+      customDepartmentData: {
+        departmentIds: ['637215248'],
+        drillDown: 'n',
+      },
+    };
+
+    await run([
+      'APP-1',
+      'FORM-1',
+      '--create',
+      '--name',
+      '复杂数据权限组',
+      '--all-members',
+      '--data-permission',
+      JSON.stringify(complexDataPermission),
+      '--action-permission',
+      '{"operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":true}}',
+    ]);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    const body = querystring.parse(utils.httpPost.mock.calls[0][2]);
+    expect(body.packageUuid).toBeUndefined();
+    expect(JSON.parse(body.dataPermit)).toEqual(complexDataPermission);
+    expect(JSON.parse(body.roleData)).toEqual({
+      include: [{ roleType: 'DEFAULT', roleValue: 'ALL' }],
+    });
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      packageUuid: 'pkg-complex',
+      summary: {
+        name: '复杂数据权限组',
+        dataPermission: '数据范围: 自定义规则（3 条）',
+      },
+      message: '权限组已新增',
+    });
+  });
+
   test('invalid JSON rejects with CliError instead of exiting', async () => {
     let error;
     try {
@@ -264,5 +314,40 @@ describe('save-permission command', () => {
     expect(error.code).toBe('SAVE_PERMISSION_INVALID_ARGUMENTS');
     expect(utils.httpGet).not.toHaveBeenCalled();
     expect(utils.httpPost).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildDataPermit', () => {
+  test('maps simple dataRange to single rule', () => {
+    expect(JSON.parse(buildDataPermit({ dataRange: 'ALL' }))).toEqual({
+      rule: [{ type: 'ALL', value: 'y' }],
+    });
+    expect(JSON.parse(buildDataPermit({ dataRange: 'SELF' }))).toEqual({
+      rule: [{ type: 'ORIGINATOR', value: 'y' }],
+    });
+  });
+
+  test('defaults to ALL when dataPermission is empty', () => {
+    expect(JSON.parse(buildDataPermit(null))).toEqual({
+      rule: [{ type: 'ALL', value: 'y' }],
+    });
+  });
+
+  test('passes through complex permission payload with rule array', () => {
+    const complex = {
+      rule: [
+        { type: 'ORIGINATOR', value: 'y' },
+        { type: 'ORIGINATOR_DEPARTMENT', value: 'y' },
+      ],
+      customDepartmentData: {
+        departmentIds: ['637215248'],
+        drillDown: 'n',
+      },
+      formulaData: {
+        condition: 'OR',
+        rules: [],
+      },
+    };
+    expect(JSON.parse(buildDataPermit(complex))).toEqual(complex);
   });
 });

--- a/yida-skills/skills/yida-data-management/SKILL.md
+++ b/yida-skills/skills/yida-data-management/SKILL.md
@@ -110,6 +110,7 @@ openyida data query form <appType> <formUuid> [--page 1 --size 20] [--search-jso
 openyida data get form <appType> --inst-id <formInstId>
 openyida data create form <appType> <formUuid> --data-json '<json>' [--resolve-aliases]
 openyida data create form <appType> <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/record.json [--resolve-aliases]
+> `create form` 会自动探测表单类型；当目标表单为流程表单时，会改用 `/v1/process/startInstance.json` 发起流程。若已知 `processCode`，仍推荐显式使用 `create process`。
 openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-json '<json>' [--resolve-aliases]
 openyida data update form <appType> --inst-id <formInstId> --form-uuid <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/patch.json [--resolve-aliases]
 openyida data query subform <appType> <formUuid> --inst-id <formInstId> --table-field-id <fieldId|alias> [--page 1 --size 100] [--resolve-aliases]

--- a/yida-skills/skills/yida-form-permission/SKILL.md
+++ b/yida-skills/skills/yida-form-permission/SKILL.md
@@ -55,6 +55,7 @@ openyida save-permission <appType> <formUuid> [选项]
 | `--action-permission <json>` | 修改操作权限（完全替换，只保留 true 的项） |
 | `--field-permission <json>` | 修改字段权限，传入宜搭 `fieldPermit` 对象或 `{ "role": "DEFAULT", "fieldPermit": {...} }` |
 | `--members <userIds>` | 修改成员，多个 userId 逗号分隔 |
+| `--all-members` | 设置权限组为「全员可见」（`roleData.include` 为 `DEFAULT/ALL`） |
 
 ### 数据权限 `dataRange` 可选值
 
@@ -79,13 +80,25 @@ openyida save-permission <appType> <formUuid> --create --name <名称> [选项]
 示例：
 
 ```bash
-openyida save-permission APP_XXX FORM-XXX \
+openyida save-permission APP_XXX FORM_XXX \
   --create --name "部门数据查看组" \
   --members "54255850977641" \
   --data-permission '{"dataRange":"ORIGINATOR_DEPARTMENT"}' \
   --action-permission '{"operations":{"OPERATE_VIEW":true}}' \
   --field-permission '{"fieldRange":"FORM"}'
 ```
+
+> 设置「全部人员看全部数据」时，必须加上 `--all-members`，确保 `roleData.include` 为 `DEFAULT/ALL`：
+>
+> ```bash
+> openyida save-permission APP_XXX FORM_XXX \
+>   --create --name "全部人员看全部数据" \
+>   --all-members \
+>   --data-permission '{"dataRange":"ALL"}' \
+>   --action-permission '{"operations":{"OPERATE_VIEW":true}}'
+> ```
+>
+> 若目标表单已存在 DEFAULT 权限组，也可直接用 `--all-members --data-permission '{"dataRange":"ALL"}'` 更新该组。
 
 ## 字段权限
 

--- a/yida-skills/skills/yida-form-permission/SKILL.md
+++ b/yida-skills/skills/yida-form-permission/SKILL.md
@@ -67,6 +67,41 @@ openyida save-permission <appType> <formUuid> [选项]
 | `SAME_LEVEL_DEPARTMENT` | 同级部门 |
 | `SUBORDINATE_DEPARTMENT` | 下级部门 |
 
+> 如需同时设置多个数据范围、自定义部门或自定义过滤条件，可直接传入宜搭完整的 `dataPermit` JSON（必须包含 `rule` 数组）。例如截图中的「本人提交 + 本部门 + 同级部门 + 下级部门 + 免登 + 自定义部门 + 自定义过滤条件」可表示为：
+>
+> ```json
+> {
+>   "rule": [
+>     { "type": "ORIGINATOR", "value": "y" },
+>     { "type": "ORIGINATOR_DEPARTMENT", "value": "y" },
+>     { "type": "SAME_LEVEL_DEPARTMENT", "value": "y" },
+>     { "type": "SUBORDINATE_DEPARTMENT", "value": "y" },
+>     { "type": "FREE_LOGIN", "value": "y" },
+>     { "type": "CUSTOM_DEPARTMENT", "value": "y" },
+>     { "type": "FORMULA", "value": "y" }
+>   ],
+>   "customDepartmentData": {
+>     "departmentIds": ["637215248"],
+>     "drillDown": "n"
+>   },
+>   "formulaData": {
+>     "condition": "OR",
+>     "ruleId": "group-xxx",
+>     "rules": []
+>   }
+> }
+> ```
+>
+> 命令示例：
+>
+> ```bash
+> openyida save-permission APP_XXX FORM_XXX \
+>   --create --name "全部成员可查看本人提交数据" \
+>   --all-members \
+>   --data-permission '{"rule":[{"type":"ORIGINATOR","value":"y"},{"type":"ORIGINATOR_DEPARTMENT","value":"y"},{"type":"SAME_LEVEL_DEPARTMENT","value":"y"},{"type":"SUBORDINATE_DEPARTMENT","value":"y"},{"type":"FREE_LOGIN","value":"y"},{"type":"CUSTOM_DEPARTMENT","value":"y"},{"type":"FORMULA","value":"y"}],"customDepartmentData":{"departmentIds":["637215248"],"drillDown":"n"},"formulaData":{"condition":"OR","ruleId":"group-xxx","rules":[]}}' \
+>   --action-permission '{"operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":true,"OPERATE_DELETE":true,"OPERATE_HISTORY":true,"OPERATE_COMMENT":true,"OPERATE_PRINT":true}}'
+> ```
+
 ### 操作权限 key
 
 `OPERATE_VIEW`、`OPERATE_EDIT`、`OPERATE_DELETE`、`OPERATE_HISTORY`、`OPERATE_COMMENT`、`OPERATE_PRINT`、`OPERATE_CREATE`、`OPERATE_BATCH_EDIT`、`OPERATE_BATCH_EXPORT`、`OPERATE_BATCH_IMPORT`、`OPERATE_BATCH_DELETE`、`OPERATE_BATCH_PRINT`、`OPERATE_BATCH_DOWNLOAD`、`OPERATE_BATCH_DOWNLOAD_QRCODE`

--- a/yida-skills/skills/yida-form-permission/SKILL.md
+++ b/yida-skills/skills/yida-form-permission/SKILL.md
@@ -56,6 +56,7 @@ openyida save-permission <appType> <formUuid> [选项]
 | `--field-permission <json>` | 修改字段权限，传入宜搭 `fieldPermit` 对象或 `{ "role": "DEFAULT", "fieldPermit": {...} }` |
 | `--members <userIds>` | 修改成员，多个 userId 逗号分隔 |
 | `--all-members` | 设置权限组为「全员可见」（`roleData.include` 为 `DEFAULT/ALL`） |
+| `--matrix <json>` | 使用权限矩阵作为权限成员，JSON 格式 `{"matrixId":"MATRIX-XXX","columnId":"column_YYY"}`，与 `--members` / `--all-members` 互斥 |
 
 ### 数据权限 `dataRange` 可选值
 
@@ -66,6 +67,7 @@ openyida save-permission <appType> <formUuid> [选项]
 | `DEPARTMENT` / `ORIGINATOR_DEPARTMENT` | 本部门提交 |
 | `SAME_LEVEL_DEPARTMENT` | 同级部门 |
 | `SUBORDINATE_DEPARTMENT` | 下级部门 |
+| `MATRIX` | 权限矩阵条件 |
 
 > 如需同时设置多个数据范围、自定义部门或自定义过滤条件，可直接传入宜搭完整的 `dataPermit` JSON（必须包含 `rule` 数组）。例如截图中的「本人提交 + 本部门 + 同级部门 + 下级部门 + 免登 + 自定义部门 + 自定义过滤条件」可表示为：
 >
@@ -134,6 +136,18 @@ openyida save-permission APP_XXX FORM_XXX \
 > ```
 >
 > 若目标表单已存在 DEFAULT 权限组，也可直接用 `--all-members --data-permission '{"dataRange":"ALL"}'` 更新该组。
+>
+> ### 使用权限矩阵
+> 1. 先在宜搭后台「权限矩阵」中获取目标矩阵 ID 与结果列 columnId；或调用底层服务 `/query/matrix/getMatrixList.json` / `/query/matrix/getMatrixById.json` 查询。
+> 2. 创建/更新权限组时指定 `--matrix '{"matrixId":"MATRIX-XXX","columnId":"column_YYY"}'`，并配合 `--data-permission` 设置包含 `MATRIX` 的数据范围。
+>
+> ```bash
+> openyida save-permission APP_XXX FORM_XXX \
+>   --create --name "使用权限矩阵的权限组" \
+>   --matrix '{"matrixId":"MATRIX-XNCVJYB60YW7L0HPY9HE","columnId":"column_1767839664612"}' \
+>   --data-permission '{"rule":[{"type":"ORIGINATOR","value":"y"},{"type":"MATRIX","value":"y"}]}' \
+>   --action-permission '{"operations":{"OPERATE_VIEW":true,"OPERATE_EDIT":true,"OPERATE_DELETE":true,"OPERATE_HISTORY":true,"OPERATE_COMMENT":true,"OPERATE_PRINT":true}}'
+> ```
 
 ## 字段权限
 


### PR DESCRIPTION
## 改动摘要

1. **流程表单提交修复**
   - lib/core/query-data.js 的 createForm 在提交前自动检测表单是否为流程表单
   - 流程表单改走 /v1/process/startInstance.json，普通表单仍使用 /v1/form/saveFormData.json

2. **全员可见全部数据权限**
   - lib/permission/save-permission.js 新增 --all-members 参数
   - 显式生成 roleData=DEFAULT/ALL，保留原有默认逻辑不变

3. **复杂 dataPermit 规则透传**
   - --data-permission 支持包含 rule 数组的完整宜搭 dataPermit JSON
   - 支持 customDepartmentData、formulaData 等复杂数据范围

4. **权限矩阵成员支持**
   - 新增 lib/permission/matrix-service.js 封装矩阵查询接口
   - save-permission 新增 --matrix 参数
   - 支持 roleData=MATRIX 与 dataPermit 中 MATRIX rule

## 测试

- 新增/更新 tests/query-data.test.js
- 新增/更新 tests/save-permission.test.js
- 新增 tests/matrix-service.test.js