### PR TITLE
chore: 发布 2026.8.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
+## [2026.8.20] - 2026-08-20
+
+### Added
+
+- `openyida save-permission` 支持复杂 `dataPermit` 规则透传与权限矩阵成员配置，可在保留原始权限表达能力的同时批量生成成员维度的数据权限。
+- `save-permission --all-members` 新增全员可见全部数据快捷配置，并同步表单权限技能文档中的权限矩阵与全员数据可见说明。
+
+### Fixed
+
+- 流程表单数据提交改用 `startInstance` 链路，避免通过通用数据更新路径发起流程实例时出现提交语义不一致。
+
 ## [2026.8.19-2] - 2026-08-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.8.19-2",
+  "version": "2026.8.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.8.19-2",
+      "version": "2026.8.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.8.19-2",
+  "version": "2026.8.20",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",


### PR DESCRIPTION
## 变更

- 将 package.json / package-lock.json 版本同步到 2026.8.20。
- 补充 2026.8.20 更新日志，覆盖 #499 中流程表单 startInstance、save-permission 全员权限、复杂 dataPermit 与权限矩阵能力。

## 验证

- node scripts/validate-structure.js
- npm run check:release-risks（error=0；2 个既有浏览器/URL 拉起人工验证提醒）
- git diff --check
- npm pack --dry-run
- npm run check:quick（通过；仅既有 lint warning）
- npm run check:package-size
- npm run build:skills && npm run check:skills

备注：npm run check:ci 在 Step 1 的 npm ci 被本机 npm 配置拦截：EALLOWSCRIPTS（--allow-scripts is not allowed in project-scoped installs），尚未进入代码检查阶段。