### PR TITLE
feat: harden aggregate table, report, and connector E2E contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida connector list` | List HTTP connectors |
 | `openyida connector create "name" "domain" ...` | Create a connector |
 | `openyida connector detail <id>` | View connector details |
-| `openyida connector delete <id>` | Delete a connector |
+| `openyida connector delete <id> [--force]` | Show manual deletion guidance (CLI does not delete) |
 | `openyida connector add-action --operations <file> --connector-id <id>` | Add an action |
 | `openyida connector list-actions <id>` | List actions |
 | `openyida connector delete-action <id> <operation-id>` | Delete an action |

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -351,7 +351,7 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 | `openyida connector list` | 列出 HTTP 连接器 |
 | `openyida connector create "name" "domain" ...` | 创建连接器 |
 | `openyida connector detail <id>` | 查看连接器详情 |
-| `openyida connector delete <id>` | 删除连接器 |
+| `openyida connector delete <id> [--force]` | 显示平台手工删除指引（CLI 不执行删除） |
 | `openyida connector add-action --operations <file> --connector-id <id>` | 添加执行动作 |
 | `openyida connector list-actions <id>` | 列出执行动作 |
 | `openyida connector delete-action <id> <operation-id>` | 删除执行动作 |

--- a/lib/aggregate-table/aggregate-table.js
+++ b/lib/aggregate-table/aggregate-table.js
@@ -8,16 +8,13 @@ const { t } = require('../core/i18n');
 const { buildYidaTitleI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 const { fetchFormPageList, resolveLocalizedText } = require('../app/form-navigation');
+const {
+  DESIGN_KEYS,
+  assertAggregateDesignConfig,
+  assertAggregateDesignReadback,
+} = require('./contract');
 
 const FORM_TYPE_VIRTUAL_VIEW = 'virtualView';
-const DESIGN_KEYS = [
-  'relationForms',
-  'relationships',
-  'aggregatedFields',
-  'auxFields',
-  'formulaFields',
-  'validators',
-];
 
 function hasHelpFlag(args) {
   return (args || []).includes('--help') || (args || []).includes('-h');
@@ -133,7 +130,7 @@ async function checkVirtualViewFeature(authRef, appType) {
 }
 
 async function createEmptyVirtualView(authRef, appType, title) {
-  return createYidaClient({ authRef }).postForm(
+  return createYidaClient({ authRef }).postFormOnce(
     `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
     buildCreateEmptyPostData(title)
   );
@@ -157,7 +154,11 @@ async function postVirtualViewDesign(authRef, appType, formUuid, designInfo, act
     throw new Error(`Unknown aggregate table action: ${action}`);
   }
 
-  return createYidaClient({ authRef }).postForm(
+  const client = createYidaClient({ authRef });
+  const post = action === 'save' || action === 'publish'
+    ? client.postFormOnce.bind(client)
+    : client.postForm.bind(client);
+  return post(
     `/alibaba/web/${appType}/query/virtualview/${endpoint}`,
     buildDesignPostData(formUuid, designInfo, gmtModified)
   );
@@ -318,6 +319,11 @@ async function runCreateEmpty(args) {
   const createResult = await createEmptyVirtualView(authRef, appType, name);
   const created = assertSuccess(createResult, t('aggregate_table.create_empty'));
   const formUuid = (created && created.formUuid) || created;
+  if ((typeof formUuid !== 'string' && typeof formUuid !== 'number') || String(formUuid).length === 0) {
+    const error = new Error('Aggregate table creation returned no recoverable identity.');
+    error.code = 'AGGREGATE_CREATE_IDENTITY_MISSING';
+    throw error;
+  }
   const designUrl = buildDesignUrl(authRef.baseUrl, appType, formUuid, { fromNew: true });
   const workbenchUrl = buildWorkbenchUrl(authRef.baseUrl, appType, formUuid);
 
@@ -401,6 +407,7 @@ async function runPreview(args) {
 
   const authRef = await createAuthRef();
   const designInfo = normalizeDesignConfig(readJsonInput(input), formUuid);
+  assertAggregateDesignConfig(designInfo, { mode: 'draft' });
   const result = await postVirtualViewDesign(authRef, appType, formUuid, designInfo, 'preview');
   const rows = assertSuccess(result, t('aggregate_table.preview'));
   const rowCount = Array.isArray(rows) ? rows.length : 0;
@@ -439,13 +446,28 @@ async function runSaveOrPublish(args, action) {
   }
 
   const authRef = await createAuthRef();
-  const { designInfo, gmtModified } = await loadDesignForMutation(authRef, appType, formUuid, input, action);
-  if (isPublish && designInfo.relationForms.length === 0) {
-    throw new Error(t('aggregate_table.publish_requires_source'));
-  }
+  const { designInfo, currentConfig, gmtModified } = await loadDesignForMutation(authRef, appType, formUuid, input, action);
+  assertAggregateDesignConfig(designInfo, { mode: isPublish ? 'publish' : 'draft' });
 
   const result = await postVirtualViewDesign(authRef, appType, formUuid, designInfo, action, gmtModified);
   const content = assertSuccess(result, isPublish ? t('aggregate_table.publish') : t('aggregate_table.save'));
+  const readbackResult = await getVirtualViewConfig(authRef, appType, formUuid);
+  const readback = assertSuccess(readbackResult, t('aggregate_table.inspect'));
+  assertAggregateDesignReadback(designInfo, readback);
+  const responseRevision = content && content.gmtModified;
+  const readbackRevision = readback && readback.gmtModified;
+  if ((responseRevision === undefined || responseRevision === null) &&
+      (readbackRevision === undefined || readbackRevision === null)) {
+    const error = new Error('AGGREGATE_WRITE_REVISION_MISSING');
+    error.code = 'AGGREGATE_WRITE_REVISION_MISSING';
+    throw error;
+  }
+  if ((responseRevision === undefined || responseRevision === null) &&
+      currentConfig && String(readbackRevision) === String(currentConfig.gmtModified)) {
+    const error = new Error('AGGREGATE_WRITE_REVISION_UNCHANGED');
+    error.code = 'AGGREGATE_WRITE_REVISION_UNCHANGED';
+    throw error;
+  }
   const designUrl = buildDesignUrl(authRef.baseUrl, appType, formUuid);
   const workbenchUrl = buildWorkbenchUrl(authRef.baseUrl, appType, formUuid);
 
@@ -465,6 +487,7 @@ async function runSaveOrPublish(args, action) {
     formUuid,
     gmtModified: content && content.gmtModified,
     response: content,
+    readbackVerified: true,
     designUrl,
     workbenchUrl,
   }, designUrl, { stage: `aggregate_table_${action}_success`, title: formUuid }, flags.openMode), null, 2));

--- a/lib/aggregate-table/contract.js
+++ b/lib/aggregate-table/contract.js
@@ -1,0 +1,234 @@
+'use strict';
+
+const { isDeepStrictEqual } = require('util');
+
+const DESIGN_KEYS = [
+  'relationForms',
+  'relationships',
+  'aggregatedFields',
+  'auxFields',
+  'formulaFields',
+  'validators',
+];
+
+// Mirrors the designer defaults read from configLimit. Only limits that map to
+// persisted design arrays are enforced here.
+const DEFAULT_LIMITS = Object.freeze({
+  relationForms: 10,
+  relationships: 10,
+  formulaFields: 10,
+  auxFields: 10,
+});
+
+function addError(errors, code, path) {
+  errors.push({ code, path });
+}
+
+function isNonEmptyValue(value) {
+  return value !== null && value !== undefined && String(value).length > 0;
+}
+
+function validateArrayShapes(config, errors) {
+  for (const key of DESIGN_KEYS) {
+    if (!Array.isArray(config && config[key])) {
+      addError(errors, 'AGGREGATE_DESIGN_ARRAY_REQUIRED', key);
+    }
+  }
+}
+
+function validateLimits(config, limits, errors) {
+  const limitCodes = {
+    relationForms: 'AGGREGATE_RELATION_FORMS_LIMIT',
+    relationships: 'AGGREGATE_RELATIONSHIPS_LIMIT',
+    formulaFields: 'AGGREGATE_FORMULA_FIELDS_LIMIT',
+    auxFields: 'AGGREGATE_AUX_FIELDS_LIMIT',
+  };
+
+  for (const [key, limit] of Object.entries(limits)) {
+    if (Array.isArray(config[key]) && config[key].length > limit) {
+      addError(errors, limitCodes[key] || 'AGGREGATE_DESIGN_LIMIT', key);
+    }
+  }
+}
+
+function validateEntries(config, errors) {
+  if (Array.isArray(config.relationForms)) {
+    config.relationForms.forEach((item, index) => {
+      if (!item || !isNonEmptyValue(item.formUuid)) {
+        addError(errors, 'AGGREGATE_RELATION_FORM_INVALID', `relationForms[${index}]`);
+      }
+    });
+  }
+
+  if (Array.isArray(config.relationships)) {
+    config.relationships.forEach((item, index) => {
+      const relationshipInfos = item && item.relationshipInfos;
+      if (!Array.isArray(relationshipInfos) || relationshipInfos.length === 0 ||
+          relationshipInfos.some((entry) => entry === null || entry === undefined)) {
+        addError(errors, 'AGGREGATE_RELATIONSHIP_INVALID', `relationships[${index}]`);
+      }
+    });
+  }
+
+  if (Array.isArray(config.aggregatedFields)) {
+    config.aggregatedFields.forEach((item, index) => {
+      if (!item || !isNonEmptyValue(item.name)) {
+        addError(errors, 'AGGREGATE_COLUMN_INVALID', `aggregatedFields[${index}]`);
+      }
+    });
+  }
+
+  if (Array.isArray(config.formulaFields)) {
+    config.formulaFields.forEach((item, index) => {
+      if (!item || !isNonEmptyValue(item.formula)) {
+        addError(errors, 'AGGREGATE_FORMULA_FIELD_INVALID', `formulaFields[${index}]`);
+      }
+    });
+  }
+
+  if (Array.isArray(config.validators)) {
+    config.validators.forEach((item, index) => {
+      if (!item || !isNonEmptyValue(item.formula)) {
+        addError(errors, 'AGGREGATE_VALIDATOR_INVALID', `validators[${index}]`);
+      }
+    });
+  }
+}
+
+function validatePublishCompleteness(config, errors) {
+  const required = [
+    ['relationForms', 'AGGREGATE_RELATION_FORMS_REQUIRED'],
+    ['relationships', 'AGGREGATE_RELATIONSHIPS_REQUIRED'],
+    ['aggregatedFields', 'AGGREGATE_COLUMNS_REQUIRED'],
+    ['formulaFields', 'AGGREGATE_FORMULA_FIELDS_REQUIRED'],
+  ];
+
+  for (const [key, code] of required) {
+    if (!Array.isArray(config[key]) || config[key].length === 0) {
+      addError(errors, code, key);
+    }
+  }
+}
+
+function validateAggregateDesignConfig(config, options = {}) {
+  const mode = options.mode || 'draft';
+  if (mode !== 'draft' && mode !== 'publish') {
+    throw new Error(`Unsupported aggregate contract mode: ${mode}`);
+  }
+
+  const safeConfig = config && typeof config === 'object' && !Array.isArray(config)
+    ? config
+    : {};
+  const limits = { ...DEFAULT_LIMITS, ...(options.limits || {}) };
+  const errors = [];
+
+  validateArrayShapes(safeConfig, errors);
+  validateLimits(safeConfig, limits, errors);
+  validateEntries(safeConfig, errors);
+  if (mode === 'publish') {
+    validatePublishCompleteness(safeConfig, errors);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function assertAggregateDesignConfig(config, options = {}) {
+  const result = validateAggregateDesignConfig(config, options);
+  if (result.valid) {
+    return config;
+  }
+
+  const error = new Error(result.errors.map((item) => item.code).join(', '));
+  error.name = 'AggregateDesignContractError';
+  error.code = 'AGGREGATE_DESIGN_CONTRACT_INVALID';
+  error.details = result.errors;
+  throw error;
+}
+
+function projectAggregateDesignConfig(config) {
+  const safeConfig = config && typeof config === 'object' ? config : {};
+  const projected = {};
+  for (const key of DESIGN_KEYS) {
+    projected[key] = Array.isArray(safeConfig[key]) ? safeConfig[key] : [];
+  }
+  return projected;
+}
+
+function isI18nValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) && (
+    value.type === 'i18n' ||
+    Object.prototype.hasOwnProperty.call(value, 'zh_CN') ||
+    Object.prototype.hasOwnProperty.call(value, 'en_US') ||
+    Object.prototype.hasOwnProperty.call(value, 'pureEn_US')
+  );
+}
+
+function canonicalizeI18nValue(value) {
+  const zhCN = value.zh_CN || value.value || '';
+  const enUS = value.en_US || value.pureEn_US || zhCN;
+  return {
+    type: value.type || 'i18n',
+    zh_CN: String(zhCN),
+    en_US: String(enUS),
+  };
+}
+
+function isEmptyFilter(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const rules = value.rules;
+  return (rules === undefined || rules === null || (Array.isArray(rules) && rules.length === 0)) &&
+    !value.logicOperator;
+}
+
+function canonicalizeAggregateValue(value, key = '') {
+  if (isI18nValue(value)) {
+    return canonicalizeI18nValue(value);
+  }
+  if (key === 'filter' && isEmptyFilter(value)) {
+    return {};
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeAggregateValue(item));
+  }
+  if (!value || typeof value !== 'object') {
+    if (key === 'precision' && value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+    return value;
+  }
+
+  const result = {};
+  for (const childKey of Object.keys(value)) {
+    const childValue = value[childKey];
+    if ((childKey === 'filterState' && (childValue === null || childValue === undefined)) ||
+        (childKey === 'parentId' && (childValue === '' || childValue === null || childValue === undefined))) {
+      continue;
+    }
+    result[childKey] = canonicalizeAggregateValue(childValue, childKey);
+  }
+  return result;
+}
+
+function assertAggregateDesignReadback(expected, actual) {
+  const expectedProjection = canonicalizeAggregateValue(projectAggregateDesignConfig(expected));
+  const actualProjection = canonicalizeAggregateValue(projectAggregateDesignConfig(actual));
+  if (isDeepStrictEqual(expectedProjection, actualProjection)) {
+    return actualProjection;
+  }
+
+  const error = new Error('AGGREGATE_DESIGN_READBACK_MISMATCH');
+  error.name = 'AggregateDesignReadbackError';
+  error.code = 'AGGREGATE_DESIGN_READBACK_MISMATCH';
+  throw error;
+}
+
+module.exports = {
+  DEFAULT_LIMITS,
+  DESIGN_KEYS,
+  assertAggregateDesignConfig,
+  assertAggregateDesignReadback,
+  projectAggregateDesignConfig,
+  validateAggregateDesignConfig,
+};

--- a/lib/connector/api.js
+++ b/lib/connector/api.js
@@ -8,6 +8,10 @@
 'use strict';
 
 const { createAuthRef, createYidaClient } = require('../core/yida-client');
+const {
+  assertConnectorReadback,
+  buildConnectorTestPayload,
+} = require('./contract');
 
 // ── 登录态获取 ────────────────────────────────────────
 
@@ -85,29 +89,22 @@ function buildOperationsSummary(operations) {
  * @returns {string}
  */
 function buildConnectorDesc(userDesc, originalDesc, authRef, operations) {
+  void authRef;
   const now = new Date();
   const updateTime = now.toLocaleString('zh-CN');
-  const currentUserId = authRef.userId || (authRef.authData && authRef.authData.user_id)
-    ? authRef.userId || authRef.authData.user_id
-    : '';
 
   let createTime = updateTime;
-  let createUserId = currentUserId;
 
   if (originalDesc) {
     const createTimeMatch = originalDesc.match(/📅 创建时间: (.+)/);
-    const createUserMatch = originalDesc.match(/👤 创建人: (.+)/);
     if (createTimeMatch) {createTime = createTimeMatch[1].trim();}
-    if (createUserMatch) {createUserId = createUserMatch[1].trim();}
   }
 
   const metaInfo = [
     '',
     '---',
     '🤖 created by openyida',
-    `👤 创建人: ${createUserId}`,
     `📅 创建时间: ${createTime}`,
-    `✏️ 最近修改人: ${currentUserId}`,
     `🔄 最近保存: ${updateTime}`,
   ].join('\n');
 
@@ -145,6 +142,14 @@ async function connectorPost(apiPath, bodyParams, authRef) {
   return createYidaClient({ authRef }).postForm(apiPath, bodyParams);
 }
 
+async function connectorPostOnce(apiPath, bodyParams, authRef) {
+  return createYidaClient({ authRef }).postFormOnce(apiPath, bodyParams);
+}
+
+async function connectorPostJsonOnce(apiPath, bodyParams, authRef) {
+  return createYidaClient({ authRef }).postJsonOnce(apiPath, bodyParams);
+}
+
 // ── 连接器列表 ────────────────────────────────────────
 
 /**
@@ -160,7 +165,8 @@ async function connectorPost(apiPath, bodyParams, authRef) {
  */
 async function listConnectors(options, authRef) {
   const pageSize = options.pageSize || 100;
-  let apiPath = `/query/newconnector/listConnector.json?_api=ConnectorFactory.getConnectorList&pageSize=${pageSize}&currentPage=1&connectorMode=5`;
+  const currentPage = options.currentPage || 1;
+  let apiPath = `/query/newconnector/listConnector.json?_api=ConnectorFactory.getConnectorList&pageSize=${pageSize}&currentPage=${currentPage}&connectorMode=5`;
 
   if (options.keyword) {
     apiPath += `&displayName=${encodeURIComponent(options.keyword)}`;
@@ -183,8 +189,23 @@ async function listConnectors(options, authRef) {
 
   return {
     connectors: result.content?.data || result.data || [],
-    total: result.content?.totalElements || 0,
+    total: result.content?.totalElements || result.content?.totalCount || result.totalCount || 0,
   };
+}
+
+async function listAllConnectors(options, authRef) {
+  const pageSize = options.pageSize || 100;
+  const connectors = [];
+  for (let currentPage = 1; currentPage <= 100; currentPage++) {
+    const page = await listConnectors({ ...options, pageSize, currentPage }, authRef);
+    connectors.push(...page.connectors);
+    if (page.connectors.length < pageSize || (page.total > 0 && connectors.length >= page.total)) {
+      return connectors;
+    }
+  }
+  const error = new Error('Connector list exceeded the safe pagination limit.');
+  error.code = 'CONNECTOR_LIST_PAGINATION_LIMIT';
+  throw error;
 }
 
 /**
@@ -194,8 +215,13 @@ async function listConnectors(options, authRef) {
  * @returns {Promise<object|null>}
  */
 async function findConnectorById(connectorId, authRef) {
-  const { connectors } = await listConnectors({ pageSize: 100 }, authRef);
+  const connectors = await listAllConnectors({ pageSize: 100 }, authRef);
   return connectors.find(c => String(c.id) === String(connectorId)) || null;
+}
+
+async function findConnectorByName(connectorName, authRef) {
+  const connectors = await listAllConnectors({ pageSize: 100 }, authRef);
+  return connectors.find(c => c.connectorName === connectorName) || null;
 }
 
 // ── 连接器详情 ────────────────────────────────────────
@@ -206,8 +232,17 @@ async function findConnectorById(connectorId, authRef) {
  * @param {object} authRef
  * @returns {Promise<object>}
  */
-async function getConnectorDetail(connectorName, authRef) {
-  const apiPath = `/query/newconnector/getConnectorDetail.json?_api=ConnectorFactory.getConnectorDetail&connectorName=${connectorName}`;
+async function getConnectorDetail(identity, authRef) {
+  const params = typeof identity === 'object' && identity !== null
+    ? identity
+    : { connectorName: identity };
+  const query = [
+    '_api=ConnectorFactory.getConnectorDetail',
+    params.id ? `id=${encodeURIComponent(params.id)}` : '',
+    params.connectorName ? `connectorName=${encodeURIComponent(params.connectorName)}` : '',
+    params.connectorMode ? `connectorMode=${encodeURIComponent(params.connectorMode)}` : '',
+  ].filter(Boolean).join('&');
+  const apiPath = `/query/newconnector/getConnectorDetail.json?${query}`;
   const result = await connectorGet(apiPath, authRef);
 
   if (result.hasError || !result.content) {
@@ -248,7 +283,7 @@ async function saveConnector(params, authRef) {
     bodyParams.id = params.id;
   }
 
-  const result = await connectorPost(
+  const result = await connectorPostOnce(
     '/query/newconnector/createOrUpdateConnector.json?_api=ConnectorFactory.createOrUpdateConnector',
     bodyParams,
     authRef
@@ -258,9 +293,46 @@ async function saveConnector(params, authRef) {
     throw new Error(result.errorMsg || result.message || '保存连接器失败');
   }
 
-  // 返回连接器 ID（新建时服务端在 content 中返回）
-  const connectorId = result.content?.id || result.content || null;
-  return { ...result, connectorId };
+  const content = result.content;
+  const connectorId = content && typeof content === 'object'
+    ? content.id
+    : (typeof content === 'string' || typeof content === 'number' ? content : null);
+  const responseConnectorName = content && typeof content === 'object'
+    ? content.connectorName
+    : null;
+  if (!connectorId && !responseConnectorName) {
+    const error = new Error('Connector write succeeded without a recoverable identity.');
+    error.code = 'CONNECTOR_WRITE_IDENTITY_MISSING';
+    throw error;
+  }
+
+  const connectorName = responseConnectorName || params.connectorName;
+  const detail = await getConnectorDetail({
+    id: connectorId,
+    connectorName,
+    connectorMode: params.connectorMode || '5',
+  }, authRef);
+  assertConnectorReadback(params, detail);
+
+  return {
+    ...result,
+    connectorId,
+    connectorName,
+    detail,
+    readbackVerified: true,
+  };
+}
+
+async function deleteConnector(connectorName, connectorMode, authRef) {
+  const result = await connectorPostOnce(
+    '/query/newconnector/deleteConnector.json?_api=ConnectorFactory.deleteConnector',
+    { connectorName, connectorMode: connectorMode || '5' },
+    authRef
+  );
+  if (!result || result.hasError || result.success === false || result.content === false) {
+    throw new Error(result?.errorMsg || result?.message || '删除连接器失败');
+  }
+  return { success: true, connectorName };
 }
 
 // ── 鉴权账号 ──────────────────────────────────────────
@@ -271,15 +343,42 @@ async function saveConnector(params, authRef) {
  * @param {object} authRef
  * @returns {Promise<Array>}
  */
-async function listConnections(connectorName, authRef) {
-  const apiPath = `/query/connection/listConnection.json?_api=ConnectorFactory.listConnection&connectorName=${connectorName}`;
-  const result = await connectorGet(apiPath, authRef);
+async function listConnectionsPage(connectorName, pageNumber, authRef) {
+  const result = await connectorPost(
+    '/query/connection/listConnection.json?_api=ConnectorFactory.listConnection',
+    { pageSize: 100, pageNumber, connectorName },
+    authRef
+  );
 
   if (result.hasError) {
     throw new Error(result.errorMsg || '获取鉴权账号列表失败');
   }
 
-  return result.content?.data || result.content || [];
+  const connections = result.content?.data || result.data ||
+    (Array.isArray(result.content) ? result.content : []);
+  return {
+    connections,
+    total: result.content?.totalCount || result.content?.totalElements || result.totalCount || 0,
+  };
+}
+
+async function listConnections(connectorName, authRef) {
+  const page = await listConnectionsPage(connectorName, 1, authRef);
+  return page.connections;
+}
+
+async function listAllConnections(connectorName, authRef) {
+  const connections = [];
+  for (let pageNumber = 1; pageNumber <= 100; pageNumber++) {
+    const page = await listConnectionsPage(connectorName, pageNumber, authRef);
+    connections.push(...page.connections);
+    if (page.connections.length < 100 || (page.total > 0 && connections.length >= page.total)) {
+      return connections;
+    }
+  }
+  const error = new Error('Connection list exceeded the safe pagination limit.');
+  error.code = 'CONNECTOR_CONNECTION_PAGINATION_LIMIT';
+  throw error;
 }
 
 /**
@@ -289,6 +388,13 @@ async function listConnections(connectorName, authRef) {
  * @returns {Promise<object>}
  */
 async function createConnection(params, authRef) {
+  const before = await listAllConnections(params.connectorName, authRef);
+  if (before.some(connection => connection.connectionName === params.connectionName)) {
+    const error = new Error('A connection with the requested owned name already exists.');
+    error.code = 'CONNECTOR_CONNECTION_NAME_EXISTS';
+    throw error;
+  }
+
   const bodyParams = {
     _locale_time_zone_offset: '28800000',
     connectionName: params.connectionName,
@@ -298,7 +404,7 @@ async function createConnection(params, authRef) {
     authType: params.authType,
   };
 
-  const result = await connectorPost(
+  const result = await connectorPostOnce(
     '/query/newconnector/createConnection.json?_api=ConnectorFactory.createConnection',
     bodyParams,
     authRef
@@ -308,7 +414,26 @@ async function createConnection(params, authRef) {
     throw new Error(result.errorMsg || result.message || '创建鉴权账号失败');
   }
 
-  return result.content || result;
+  const content = result.content;
+  const connectionId = content && typeof content === 'object'
+    ? (content.id || content.connectionId)
+    : (typeof content === 'string' || typeof content === 'number' ? content : null);
+  const beforeIds = new Set(before.map(connection => String(connection.id || connection.connectionId)));
+  const after = await listAllConnections(params.connectorName, authRef);
+  const matches = after.filter(connection => {
+    const id = connection.id || connection.connectionId;
+    if (connectionId) {
+      return String(id) === String(connectionId) && connection.connectionName === params.connectionName;
+    }
+    return connection.connectionName === params.connectionName && !beforeIds.has(String(id));
+  });
+  if (matches.length !== 1) {
+    const error = new Error('Connection creation could not be recovered by an exact owned readback.');
+    error.code = 'CONNECTOR_CONNECTION_READBACK_MISMATCH';
+    throw error;
+  }
+
+  return { ...matches[0], readbackVerified: true };
 }
 
 // ── 连接器测试 ────────────────────────────────────────
@@ -320,19 +445,9 @@ async function createConnection(params, authRef) {
  * @returns {Promise<object>}
  */
 async function testConnector(params, authRef) {
-  const bodyParams = {
-    _locale_time_zone_offset: '28800000',
-    connectorId: params.connectorId,
-    operationId: params.operationId,
-    header: JSON.stringify(params.header || {}),
-    query: JSON.stringify(params.query || {}),
-    body: JSON.stringify(params.body || {}),
-    authId: params.authId || '',
-  };
-
-  const result = await connectorPost(
-    '/query/newconnector/testConnector.json?_api=ConnectorFactory.testConnector',
-    bodyParams,
+  const result = await connectorPostJsonOnce(
+    '/query/newconnector/testOperation.json',
+    buildConnectorTestPayload(params),
     authRef
   );
 
@@ -346,11 +461,17 @@ module.exports = {
   buildOperationsSummary,
   connectorGet,
   connectorPost,
+  connectorPostOnce,
+  connectorPostJsonOnce,
   listConnectors,
+  listAllConnectors,
   findConnectorById,
+  findConnectorByName,
   getConnectorDetail,
   saveConnector,
+  deleteConnector,
   listConnections,
+  listAllConnections,
   createConnection,
   testConnector,
 };

--- a/lib/connector/api.js
+++ b/lib/connector/api.js
@@ -323,18 +323,6 @@ async function saveConnector(params, authRef) {
   };
 }
 
-async function deleteConnector(connectorName, connectorMode, authRef) {
-  const result = await connectorPostOnce(
-    '/query/newconnector/deleteConnector.json?_api=ConnectorFactory.deleteConnector',
-    { connectorName, connectorMode: connectorMode || '5' },
-    authRef
-  );
-  if (!result || result.hasError || result.success === false || result.content === false) {
-    throw new Error(result?.errorMsg || result?.message || '删除连接器失败');
-  }
-  return { success: true, connectorName };
-}
-
 // ── 鉴权账号 ──────────────────────────────────────────
 
 /**
@@ -469,7 +457,6 @@ module.exports = {
   findConnectorByName,
   getConnectorDetail,
   saveConnector,
-  deleteConnector,
   listConnections,
   listAllConnections,
   createConnection,

--- a/lib/connector/connector-create.js
+++ b/lib/connector/connector-create.js
@@ -158,8 +158,8 @@ function buildSecuritySchemes(options) {
     case 'BASIC':
       return JSON.stringify({
         BasicAuth: {
-          username: options.username || '用户名',
-          password: options.password || '密码',
+          username: '用户名',
+          password: '密码',
           type: 'http',
           scheme: 'basic',
         },
@@ -194,7 +194,7 @@ function parseBaseUrl(url) {
     return {
       scheme: parsed.protocol.replace(':', ''),
       host: parsed.hostname,
-      basePath: '/',
+      basePath: parsed.pathname || '/',
     };
   } catch (e) {
     return {
@@ -327,4 +327,4 @@ async function run(args) {
   }
 }
 
-module.exports = { run };
+module.exports = { buildSecuritySchemes, parseBaseUrl, run };

--- a/lib/connector/connector-delete.js
+++ b/lib/connector/connector-delete.js
@@ -7,7 +7,12 @@
 'use strict';
 const { fail } = require('../core/chalk');
 
-const { getAuthRef, findConnectorById } = require('./api');
+const {
+  deleteConnector,
+  findConnectorById,
+  findConnectorByName,
+  getAuthRef,
+} = require('./api');
 
 function showUsage() {
   console.log(`
@@ -49,13 +54,15 @@ async function run(args) {
     process.exit(1);
   }
 
-  // 宜搭没有独立的删除连接器 API，通过 createOrUpdateConnector 无法删除
-  // 实际删除需要通过宜搭平台管理后台操作
-  // 这里提示用户前往平台操作
   console.log(`\n连接器: ${connector.displayName}`);
-  console.log('\n⚠️  注意: 宜搭 API 暂不支持通过接口直接删除连接器。');
-  console.log('请前往宜搭平台管理后台手动删除:');
-  console.log('   https://www.aliwork.com/platformManage/customConnectorFactory');
+  await deleteConnector(connector.connectorName, connector.connectorMode || '5', authRef);
+  const residual = await findConnectorByName(connector.connectorName, authRef);
+  if (residual) {
+    const error = new Error('连接器删除后的列表回读仍存在目标资源');
+    error.code = 'CONNECTOR_DELETE_READBACK_MISMATCH';
+    throw error;
+  }
+  console.log('\n✅ 连接器删除成功');
 }
 
 module.exports = { run };

--- a/lib/connector/connector-delete.js
+++ b/lib/connector/connector-delete.js
@@ -1,5 +1,5 @@
 /**
- * connector delete - 删除连接器
+ * connector delete - 连接器删除指引（只读）
  *
  * 用法：openyida connector delete <connector-id> [--force]
  */
@@ -7,19 +7,14 @@
 'use strict';
 const { fail } = require('../core/chalk');
 
-const {
-  deleteConnector,
-  findConnectorById,
-  findConnectorByName,
-  getAuthRef,
-} = require('./api');
+const { findConnectorById, getAuthRef } = require('./api');
 
 function showUsage() {
   console.log(`
 用法: openyida connector delete <connector-id> [--force]
 
 选项:
-  --force    跳过确认提示
+  --force    跳过首次警告，仅展示目标和手工删除指引（不会自动删除）
 
 示例:
   openyida connector delete 910244
@@ -40,8 +35,8 @@ async function run(args) {
   console.log(`连接器 ID: ${connectorId}`);
 
   if (!force) {
-    console.log('\n⚠️  警告: 此操作不可恢复，关联的执行动作也将被删除！');
-    console.log('如果需要跳过确认，请使用 --force 参数:');
+    console.log('\n⚠️  警告: 在平台删除连接器不可恢复，关联的执行动作也将被删除！');
+    console.log('如需查询目标并查看手工删除指引，请使用 --force 参数（CLI 不会执行删除）:');
     console.log(`   openyida connector delete ${connectorId} --force`);
     return;
   }
@@ -55,14 +50,9 @@ async function run(args) {
   }
 
   console.log(`\n连接器: ${connector.displayName}`);
-  await deleteConnector(connector.connectorName, connector.connectorMode || '5', authRef);
-  const residual = await findConnectorByName(connector.connectorName, authRef);
-  if (residual) {
-    const error = new Error('连接器删除后的列表回读仍存在目标资源');
-    error.code = 'CONNECTOR_DELETE_READBACK_MISMATCH';
-    throw error;
-  }
-  console.log('\n✅ 连接器删除成功');
+  console.log('\n⚠️  CLI 未执行删除操作：当前无法确定性证明该连接器未被表单、页面、流程或集成自动化引用。');
+  console.log('请先确认并解除全部依赖，再前往宜搭平台管理后台手工删除:');
+  console.log('   https://www.aliwork.com/platformManage/customConnectorFactory');
 }
 
 module.exports = { run };

--- a/lib/connector/connector-test.js
+++ b/lib/connector/connector-test.js
@@ -174,10 +174,11 @@ async function run(args) {
   console.log('🚀 正在发送测试请求...\n');
 
   const result = await testConnector({
-    connectorId: options.connectorId,
-    operationId: options.actionId,
+    connector: detail,
+    operation,
     header: testParams.header,
     query: testParams.query,
+    path: {},
     body: testParams.body,
     authId: options.accountId || '',
   }, authRef);

--- a/lib/connector/contract.js
+++ b/lib/connector/contract.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { isDeepStrictEqual } = require('util');
+
+function createContractError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function parseJsonValue(value, fallback) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  if (typeof value !== 'string') {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw createContractError(
+      'CONNECTOR_CONTRACT_JSON_INVALID',
+      'Connector definition contains invalid JSON.'
+    );
+  }
+}
+
+function projectConnectorDefinition(value = {}) {
+  return {
+    operations: parseJsonValue(value.operations, []),
+    displayName: value.displayName || '',
+    iconUrl: value.iconUrl || '',
+    connectorDesc: value.connectorDesc || '',
+    host: value.host || '',
+    baseUrl: value.baseUrl || '/',
+    scheme: value.scheme || 'https',
+    tongxunluTemplateId: String(value.tongxunluTemplateId || ''),
+    // The frontend submits "0" for a non-FAAS HTTP connector, while the
+    // platform readback normalizes the same sentinel to an empty string.
+    faasTemplateId: String(value.faasTemplateId || value.templateId || '0'),
+    securitySchemes: parseJsonValue(value.securitySchemes, {}),
+    connectorMode: String(value.connectorMode || '5'),
+    connectorName: value.connectorName || '',
+    category: value.category || 'http',
+  };
+}
+
+function assertConnectorReadback(expected, actual) {
+  const expectedProjection = projectConnectorDefinition(expected);
+  const actualProjection = projectConnectorDefinition(actual);
+  if (!isDeepStrictEqual(actualProjection, expectedProjection)) {
+    throw createContractError(
+      'CONNECTOR_READBACK_MISMATCH',
+      'Connector readback does not match the submitted definition.'
+    );
+  }
+  return actualProjection;
+}
+
+function joinConnectorUrl(connector, operation) {
+  const scheme = String(connector.scheme || 'https').replace(/:\/\/$/, '');
+  const host = String(connector.host || '').replace(/^\/+|\/+$/g, '');
+  const baseUrl = String(connector.baseUrl || '/').replace(/^\/+|\/+$/g, '');
+  const operationUrl = String(operation.url || operation.path || '').replace(/^\/+/, '');
+  const path = [baseUrl, operationUrl].filter(Boolean).join('/');
+  return `${scheme}://${host}${path ? `/${path}` : ''}`;
+}
+
+function buildConnectorTestPayload(params) {
+  const connector = params.connector || {};
+  const operation = params.operation || {};
+  const method = String(operation.method || 'get').toLowerCase();
+  const payload = {
+    url: joinConnectorUrl(connector, operation),
+    method,
+    path: params.path || {},
+    query: params.query || {},
+    header: params.header || {},
+    connectorMode: Number(connector.connectorMode || 5),
+  };
+  const connection = params.authId || params.connection;
+  // The frontend leaves `connection` undefined for NONE auth. Sending an
+  // empty string makes the platform try to cast it to an integer.
+  if (connection !== undefined && connection !== null && connection !== '') {
+    payload.connection = connection;
+  }
+  if (method !== 'get' && method !== 'delete') {
+    payload.body = params.body || {};
+  }
+  return payload;
+}
+
+module.exports = {
+  assertConnectorReadback,
+  buildConnectorTestPayload,
+  parseJsonValue,
+  projectConnectorDefinition,
+};

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -1222,7 +1222,7 @@ const COMMAND_GROUPS = [
       command('connector.list', ['connector', 'list'], 'connector list', 'help.cmd_connector_list'),
       command('connector.create', ['connector', 'create'], 'connector create "name" "domain" ...', 'help.cmd_connector_create'),
       command('connector.detail', ['connector', 'detail'], 'connector detail <id>', 'help.cmd_connector_detail'),
-      command('connector.delete', ['connector', 'delete'], 'connector delete <id>', 'help.cmd_connector_delete'),
+      command('connector.delete', ['connector', 'delete'], 'connector delete <id> [--force]', 'help.cmd_connector_delete'),
       command('connector.add-action', ['connector', 'add-action'], 'connector add-action --operations <file> --connector-id <id>', 'help.cmd_connector_add_action'),
       command('connector.list-actions', ['connector', 'list-actions'], 'connector list-actions <id>', 'help.cmd_connector_list_actions'),
       command('connector.delete-action', ['connector', 'delete-action'], 'connector delete-action <id> <operation-id>', 'help.cmd_connector_delete_action'),

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -74,7 +74,7 @@ module.exports = {
     cmd_connector_list: 'List HTTP connectors',
     cmd_connector_create: 'Create a connector',
     cmd_connector_detail: 'View connector details',
-    cmd_connector_delete: 'Delete a connector',
+    cmd_connector_delete: 'Show manual deletion guidance (CLI does not delete)',
     cmd_connector_add_action: 'Add an action',
     cmd_connector_list_actions: 'List actions',
     cmd_connector_delete_action: 'Delete an action',
@@ -177,7 +177,7 @@ Commands:
   connector list [options]                                     List HTTP connectors
   connector create "<name>" "<domain>" --operations <file> [options]  Create connector
   connector detail <connector-id>                              View connector details
-  connector delete <connector-id> [--force]                    Delete connector
+  connector delete <connector-id> [--force]                    Show manual deletion guidance (CLI does not delete)
   connector add-action --operations <file> --connector-id <id> Add action to connector
   connector list-actions <connector-id>                        List actions
   connector delete-action <connector-id> <operation-id>        Delete action

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -74,7 +74,7 @@ module.exports = {
     cmd_connector_list: '列出 HTTP 连接器',
     cmd_connector_create: '创建连接器',
     cmd_connector_detail: '查看连接器详情',
-    cmd_connector_delete: '删除连接器',
+    cmd_connector_delete: '显示平台手工删除指引（CLI 不执行删除）',
     cmd_connector_add_action: '添加执行动作',
     cmd_connector_list_actions: '列出执行动作',
     cmd_connector_delete_action: '删除执行动作',
@@ -177,7 +177,7 @@ openyida - 宜搭命令行工具
   connector list [选项]                                        列出 HTTP 连接器
   connector create "名称" "域名" --operations <file> [选项]    创建连接器
   connector detail <connector-id>                              查看连接器详情
-  connector delete <connector-id> [--force]                    删除连接器
+  connector delete <connector-id> [--force]                    显示平台手工删除指引（CLI 不执行删除）
   connector add-action --operations <file> --connector-id <id> 添加执行动作到连接器
   connector list-actions <connector-id>                        列出执行动作
   connector delete-action <connector-id> <operation-id>        删除执行动作

--- a/lib/core/yida-client.js
+++ b/lib/core/yida-client.js
@@ -197,6 +197,25 @@ class YidaClient {
     );
   }
 
+  async postJsonOnce(requestPath, bodyParams, options) {
+    const ref = requireOneShotAuth(this.authRef);
+    const resolvedRequestPath = typeof requestPath === 'function'
+      ? requestPath(ref)
+      : requestPath;
+    const resolvedBodyParams = typeof bodyParams === 'function'
+      ? bodyParams(ref)
+      : bodyParams;
+    const resolvedOptions = typeof options === 'function'
+      ? options(ref)
+      : options;
+    return httpPostJson(
+      ref.baseUrl,
+      resolvedRequestPath,
+      resolvedBodyParams || {},
+      resolvedOptions || {}
+    );
+  }
+
   async getContent(requestPath, params = {}, options = {}) {
     const response = await this.get(
       requestPath,

--- a/lib/report/append.js
+++ b/lib/report/append.js
@@ -34,6 +34,11 @@ const { warn } = require('../core/chalk');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 const { getReportSchema, saveReportSchema } = require('./http');
 const { requireSchemaServerRevision } = require('../core/server-revision');
+const {
+  assertReportSchemaReadback,
+  normalizeReportSchemaContent,
+  prepareReportSchemaForSave,
+} = require('./contract');
 
 // ── HTTP：获取已有报表 Schema ─────────────────────────
 // GET 用 /alibaba/web/ 路径
@@ -286,7 +291,8 @@ async function main(args) {
 
   // Step 6: 保存 Schema
   warn('\n[Step 5] 保存 Schema...');
-  const saveResult = await saveReportSchema(authRef, appType, reportId, schema, serverRevision);
+  const expectedSchema = prepareReportSchemaForSave(schema, { serverRevision });
+  const saveResult = await saveReportSchema(authRef, appType, reportId, expectedSchema, serverRevision);
 
   if (!saveResult || !saveResult.success) {
     const errorMsg = saveResult ? saveResult.errorMsg || '未知错误' : '请求失败';
@@ -296,6 +302,16 @@ async function main(args) {
       details: saveResult || { success: false, reportId, errorMsg },
     });
   }
+
+  const readbackResult = await getReportSchema(authRef, appType, reportId);
+  if (!readbackResult || readbackResult.success === false) {
+    const errorMsg = readbackResult ? readbackResult.errorMsg || '未知错误' : '请求失败';
+    throw new CliError(errorMsg, {
+      code: 'APPEND_CHART_READBACK_FAILED',
+      details: readbackResult || { success: false, reportId, errorMsg },
+    });
+  }
+  assertReportSchemaReadback(expectedSchema, normalizeReportSchemaContent(readbackResult));
 
   const reportUrl = `${authRef.baseUrl}/${appType}/workbench/${reportId}`;
   warn('\n' + SEP);
@@ -311,6 +327,7 @@ async function main(args) {
       reportId,
       appType,
       appendedChartCount: charts.length,
+      readbackVerified: true,
       url: reportUrl,
     },
     reportUrl,

--- a/lib/report/contract.js
+++ b/lib/report/contract.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const { isDeepStrictEqual } = require('util');
+
+const REPORT_DOMAIN_CODE = 'tEXDRG';
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeReportConfig(config) {
+  if (typeof config !== 'string') {
+    return config && typeof config === 'object' && !Array.isArray(config) ? config : {};
+  }
+  try {
+    const parsed = JSON.parse(config);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (cause) {
+    const error = new Error('REPORT_SCHEMA_CONFIG_INVALID');
+    error.code = 'REPORT_SCHEMA_CONFIG_INVALID';
+    error.cause = cause;
+    throw error;
+  }
+}
+
+function normalizeReportSchemaContent(value) {
+  let schema = value && Object.prototype.hasOwnProperty.call(value, 'content')
+    ? value.content
+    : value;
+  if (typeof schema === 'string') {
+    try {
+      schema = JSON.parse(schema);
+    } catch (cause) {
+      const error = new Error('REPORT_SCHEMA_CONTENT_INVALID');
+      error.code = 'REPORT_SCHEMA_CONTENT_INVALID';
+      error.cause = cause;
+      throw error;
+    }
+  }
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    const error = new Error('REPORT_SCHEMA_CONTENT_INVALID');
+    error.code = 'REPORT_SCHEMA_CONTENT_INVALID';
+    throw error;
+  }
+  return schema;
+}
+
+function visitComponentNodes(node, callback) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  callback(node);
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child) => visitComponentNodes(child, callback));
+  }
+}
+
+function collectReportI18nKeys(schema) {
+  const keys = [];
+  const seen = new Set();
+  const pages = schema && Array.isArray(schema.pages) ? schema.pages : [];
+
+  pages.forEach((page) => {
+    const trees = page && Array.isArray(page.componentsTree) ? page.componentsTree : [];
+    trees.forEach((tree) => visitComponentNodes(tree, (node) => {
+      const key = node && node.data && node.data.key;
+      if (typeof key !== 'string' || key.length === 0 || key.startsWith('i18n') || seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      keys.push(key);
+    }));
+  });
+
+  return keys;
+}
+
+function prepareReportSchemaForSave(schema, options = {}) {
+  const prepared = cloneJson(normalizeReportSchemaContent(schema));
+  delete prepared.i18nData;
+  prepared.config = normalizeReportConfig(prepared.config);
+
+  const i18nKeys = collectReportI18nKeys(prepared);
+  if (i18nKeys.length > 0) {
+    prepared.config.i18nKeyList = i18nKeys;
+  } else {
+    delete prepared.config.i18nKeyList;
+  }
+
+  if (options.serverRevision !== undefined) {
+    prepared.gmtModified = options.serverRevision;
+  }
+  return prepared;
+}
+
+const OMITTED = Symbol('REPORT_SCHEMA_OMITTED');
+const DESIGNER_ONLY_KEYS = new Set(['lifeCycles', 'css', 'utils']);
+
+function canonicalizeReportValue(value) {
+  if (value === null || value === undefined) {
+    return OMITTED;
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => canonicalizeReportValue(item))
+      .filter((item) => item !== OMITTED);
+    return items.length > 0 ? items : OMITTED;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const result = {};
+  Object.keys(value).sort().forEach((key) => {
+    if (DESIGNER_ONLY_KEYS.has(key)) {
+      return;
+    }
+    const canonical = canonicalizeReportValue(value[key]);
+    if (canonical !== OMITTED) {
+      result[key] = canonical;
+    }
+  });
+  return Object.keys(result).length > 0 ? result : OMITTED;
+}
+
+function projectReportSchema(schema) {
+  const projected = cloneJson(normalizeReportSchemaContent(schema));
+  projected.config = normalizeReportConfig(projected.config);
+  delete projected.gmtModified;
+  delete projected.id;
+  delete projected.i18nData;
+  delete projected.status;
+  const canonical = canonicalizeReportValue(projected);
+  return canonical === OMITTED ? {} : canonical;
+}
+
+function assertReportSchemaReadback(expected, actual) {
+  const expectedProjection = projectReportSchema(expected);
+  const actualProjection = projectReportSchema(actual);
+  if (isDeepStrictEqual(expectedProjection, actualProjection)) {
+    return actualProjection;
+  }
+
+  const error = new Error('REPORT_SCHEMA_READBACK_MISMATCH');
+  error.name = 'ReportSchemaReadbackError';
+  error.code = 'REPORT_SCHEMA_READBACK_MISMATCH';
+  throw error;
+}
+
+module.exports = {
+  REPORT_DOMAIN_CODE,
+  assertReportSchemaReadback,
+  collectReportI18nKeys,
+  normalizeReportSchemaContent,
+  normalizeReportConfig,
+  prepareReportSchemaForSave,
+  projectReportSchema,
+};

--- a/lib/report/http.js
+++ b/lib/report/http.js
@@ -3,12 +3,17 @@
 const { createYidaClient } = require('../core/yida-client');
 const { buildYidaI18n } = require('../core/yida-i18n');
 const { requireSchemaServerRevision } = require('../core/server-revision');
+const {
+  REPORT_DOMAIN_CODE,
+  collectReportI18nKeys,
+  prepareReportSchemaForSave,
+} = require('./contract');
 
 /**
  * 调用 saveFormSchemaInfo 创建空白报表
  */
 async function createBlankReport(authRef, appType, reportTitle) {
-  return createYidaClient({ authRef }).postForm(`/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`, auth => ({
+  return createYidaClient({ authRef }).postFormOnce(`/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`, auth => ({
     _csrf_token: auth.csrfToken,
     formType: 'report',
     title: JSON.stringify(buildYidaI18n(reportTitle, { en_US: reportTitle, ja_JP: reportTitle })),
@@ -18,7 +23,7 @@ async function createBlankReport(authRef, appType, reportTitle) {
 async function getReportSchema(authRef, appType, reportId) {
   const result = await createYidaClient({ authRef }).get(
     `/alibaba/web/${appType}/_view/query/formdesign/getFormSchema.json`,
-    { formUuid: reportId, schemaVersion: 'V5' }
+    { formUuid: reportId, schemaVersion: 'V5', domainCode: REPORT_DOMAIN_CODE }
   );
   if (result && result.success !== false) {
     requireSchemaServerRevision(result, createRevisionError);
@@ -34,12 +39,30 @@ async function saveReportSchema(authRef, appType, reportId, schema, serverRevisi
     { gmtModified: serverRevision },
     createRevisionError
   );
-  return createYidaClient({ authRef }).postFormOnce(`/dingtalk/web/${appType}/_view/query/formdesign/saveFormSchema.json`, auth => ({
+  const preparedSchema = prepareReportSchemaForSave(schema, { serverRevision: gmtModified });
+  const i18nKeys = collectReportI18nKeys(preparedSchema);
+  const client = createYidaClient({ authRef });
+
+  if (i18nKeys.length > 0) {
+    const bindingResult = await client.postFormOnce(`/${appType}/query/appI18n/updateI18nBinding.json`, auth => ({
+      _csrf_token: auth.csrfToken,
+      targetType: 'page',
+      catalog1: reportId,
+      i18nKeyList: i18nKeys.join(','),
+    }));
+    if (!bindingResult || bindingResult.success === false || bindingResult.__needLogin) {
+      const error = new Error('REPORT_I18N_BINDING_FAILED');
+      error.code = 'REPORT_I18N_BINDING_FAILED';
+      throw error;
+    }
+  }
+
+  return client.postFormOnce(`/alibaba/web/${appType}/_view/query/formdesign/saveFormSchema.json`, auth => ({
     _csrf_token: auth.csrfToken,
     formUuid: reportId,
-    content: JSON.stringify(schema),
+    content: JSON.stringify(preparedSchema),
     schemaVersion: 'V5',
-    importSchema: 'true',
+    domainCode: REPORT_DOMAIN_CODE,
     gmtModified,
   }));
 }

--- a/lib/report/index.js
+++ b/lib/report/index.js
@@ -19,6 +19,11 @@ const { warn } = require('../core/chalk');
 const { createBlankReport, getReportSchema, saveReportSchema } = require('./http');
 const { requireSchemaServerRevision } = require('../core/server-revision');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
+const {
+  assertReportSchemaReadback,
+  normalizeReportSchemaContent,
+  prepareReportSchemaForSave,
+} = require('./contract');
 
 // ── 参数解析 ──────────────────────────────────────────
 
@@ -283,6 +288,11 @@ async function main(args) {
   }
 
   const reportId = createResult.content.formUuid || createResult.content;
+  if ((typeof reportId !== 'string' && typeof reportId !== 'number') || String(reportId).length === 0) {
+    throw new CliError('报表创建响应缺少可回读的资源标识', {
+      code: 'CREATE_REPORT_IDENTITY_MISSING',
+    });
+  }
   warn('报表创建成功，ID:', reportId);
 
   const shellResult = await getReportSchema(authRef, appType, reportId);
@@ -424,7 +434,8 @@ async function main(args) {
 
   // Step 5: 保存报表 Schema
   warn('\n[Step 5] 保存报表 Schema...');
-  const saveResult = await saveReportSchema(authRef, appType, reportId, schema, serverRevision);
+  const expectedSchema = prepareReportSchemaForSave(schema, { serverRevision });
+  const saveResult = await saveReportSchema(authRef, appType, reportId, expectedSchema, serverRevision);
 
   if (!saveResult || !saveResult.success) {
     const errorMsg = saveResult
@@ -441,6 +452,16 @@ async function main(args) {
       details: saveResult || { success: false, reportId, errorMsg },
     });
   }
+
+  const readbackResult = await getReportSchema(authRef, appType, reportId);
+  if (!readbackResult || readbackResult.success === false) {
+    const errorMsg = readbackResult ? readbackResult.errorMsg || '未知错误' : '请求失败';
+    throw new CliError(errorMsg, {
+      code: 'CREATE_REPORT_READBACK_FAILED',
+      details: readbackResult || { success: false, reportId, errorMsg },
+    });
+  }
+  assertReportSchemaReadback(expectedSchema, normalizeReportSchemaContent(readbackResult));
 
   warn('Schema 保存成功！');
 
@@ -460,6 +481,7 @@ async function main(args) {
       reportTitle: reportTitle,
       appType: appType,
       chartCount: charts.length,
+      readbackVerified: true,
       url: reportUrl,
     },
     reportUrl,

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -1766,3 +1766,72 @@ module.exports = {
     error: '\n❌ خطأ في الاستيراد: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'فشل حفظ التحقق من صلاحية مدير التطبيق',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'فشل حفظ تحقق دفتر عناوين: المتوقع={0}, الفعلي={1}',
+  admin_verify_failed: 'فشل حفظ صلاحيات المدير: {0} غير موجود في قائمة {1}',
+  sub_admin_scope_verify_failed: 'فشل نطاق حفظ صلاحية نائب المدير: المتوقع={0}, الفعلي={1}',
+  admin_remove_verify_failed: 'فشل التحقق من إزالة المدير: لا يزال {0} موجودًا في قائمة {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'استبدال الأعضاء المركبين يتطلب أيضًا --confirm-member-replace',
+  data_object_required: 'يجب أن تكون صلاحية البيانات كائن JSON',
+  data_rule_required: 'لا يجب أن تكون قاعدة صلاحيات البيانات فارغة',
+  data_rule_type_required: 'يجب أن تتضمن كل عنصر في قاعدة صلاحيات البيانات نوعًا (type)',
+  data_rule_value_invalid: 'قيمة قاعدة صلاحية البيانات {0} يجب أن تكون y/n أو قيمة منطقية',
+  data_enabled_required: 'يجب تفعيل صلاحية البيانات على الأقل نطاق بيانات واحد',
+  custom_department_ids_required: 'يتطلب CUSTOM_DEPARTMENT قائمة departmentIds غير فارغة في customDepartmentData',
+  formula_data_required: 'يتطلب FORMULA قاعدة formulaData غير فارغة',
+  data_range_required: 'تتطلب صلاحية البيانات نطاق بيانات dataRange أو قاعدة غير فارغين',
+  action_enabled_required: 'يجب أن تحتوي صلاحيات الإجراءات على مجموعة عمليات واحدة الأقل least set to true',
+  action_value_boolean: 'يجب أن تكون صلاحيات الإجراء {0} قيمة منطقية (boolean)',
+  field_range_invalid: 'يدعم صلاحية الحقول fieldRange فقط FORM أو CUSTOM',
+  field_status_required: 'تتطلب صلاحية حقول مخصصة قائمة fieldStatus غير فارغة',
+  field_status_item_required: 'يجب أن يتضمن كل عنصر في fieldStatus التسمية (label)، واسم الحقل (fieldName)، ومكون المكون (componentName)، والقيمة (value)',
+  field_status_value_invalid: 'قيمة صلاحية الحقول غير صالحة: {0}; القيم الصالحة هي: {1}',
+  json_object_required: '{0} يجب أن يكون كائن JSON',
+  parse_failed: 'فشل تحليل {0}: {1}',
+  role_conflict: 'تحديد صلاحية صلاحيات غير متسقة: {0}',
+  matrix_role_only: '--matrix يمكنه تحديث مجموعة الصلاحيات فقط role=MATRIX',
+  all_members_role_only: '--all-members يمكنه تحديث مجموعة الصلاحيات فقط role=DEFAULT',
+  target_role_invalid: 'صلاحية غير صالحة: {0}; القيم المتاحة هي: {1}',
+  unnamed_package: 'غير مسمّى',
+  missing_package_uuid: 'ليس هناك UUID',
+  target_no_match: 'لم تطابق أي مجموعة صلاحية role={0}؛ تم التوقف عن الكتابة الصفرية لمنع تحديث غير مقصود. مجموعات الصلاحيات الحالية:\n{2}',
+  target_ambiguous: 'تم مطابقة {1} مجموعة صلاحيات لـ role={0}؛ تم التوقف عن الكتابة الصفرية لمنع تحديث غير مقصود.\n{2}',
+  unknown_operate_keys: 'تحتوي المجموعة الحالية للصلاحية على مفاتيح عمليات مجهولة بالنسبة إلى CLI، لذا لا يمكن تغيير action-permission: {0}. قد يتم تغيير أبعاد أخرى وسيتم حفظ المفاتيح المجهولة حرفيًا.',
+  matrix_role_value_required: 'يجب أن تكون roleData.roleValue في MATRIX قائمة غير فارغة',
+  matrix_data_required: 'عندما يستخدم الأعضاء MATRIX، يجب أن تتضمن قاعدة صلاحية البيانات MATRIX',
+  data_matrix_member_required: 'عندما تحتوي صلاحيات البيانات على MATRIX، يجب على الأعضاء اختيار مصفوفة صلاحية صحيحة',
+  members_all_conflict: '--members و --all-members متناقضان بشكل متبادل',
+  invalid_arguments: 'فشلت تحقق الحجة: {0}',
+  query_limit: 'وصل استعلام مجموعة الصلاحيات إلى حد الـ 20 العنصر الحالي، لذا لا يمكن إثبات فريدة الدور العالمية. تم التوقف عن الكتابة بالصفر.\n{0}',
+  unique_target: '  ✅ هدف فريد: {0}',
+  member_before: '  الأعضاء قبل: {0}',
+  member_after: '  الأعضاء بعد:  {0}',
+  member_removed: '  أدوار العضو لإزالتها: {0}',
+  member_replace_confirm: 'ستؤدي استبدال الأعضاء إلى إزالة الأدوار المركبة الموجودة. راجع قبل/بعد وأضف --confirm-member-replace. المدخلات التي سيتم فقدانها: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'يجب أن يبدأ openUrl بـ /o/ أو /s/, القيمة الحالية هي: {0}',
+  verify_failed: 'فشلت التحقق من حفظ ما بعد الحفظ: {0}',
+  current_state_incomplete: 'تم التوقف عن الحفظ: لا تحتوي حالة الوصول العام الحالية على openPageAuthConfig، لذا لا يمكن إثبات الحفاظ الآمن',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'لا يمكن كتابة JSX النسخ كـ {{0}}؛ يتم معالجتها كمتغير وتسبب في {0} غير معرف. استخدم نصًا عاديً {0} أو سلسلة مقترنة {\'{0}\'} بدلاً من ذلك.',
+  lint_form_open_container: 'يجب استخدام FormOpenContainer عند فتح صفحات تقديم/تفاصيل نموذج Yida من صفحة مخصصة: إطار iframe سحب على العرض (50vw)، وصفحة كاملة فقط في الجوال. يجب أن تستدعي معالجة الأزرار openForm({ type: "submission" | "detail", ... }).',
+  lint_form_detail_link: 'يجب استخدام نموذج Yida تفاصيل صفحات حقيقية formInstId: اقرأ أولاً row.formInstId، وقم بتعطيل أو تنبيه عند عدم وجود معرف المصفوفة بدلاً من فتح رابط formDetail مع formInstId فارغ.',
+  lint_searchformdata_http_path: 'يجب أن تستخدم استدعاء مباشر searchFormDatas.json /dingtalk/web/<appType>/v1/form/searchFormDatas.json؛ ليس /query/form/searchFormDatas.json نقطة بيانات صالحة للبيانات النموذجية',
+  lint_searchformdata_http_query_params: 'يفتقر استعلام URL البحث المباشر عن searchFormDatas.json إلى المعلمات المطلوبة: {0}. استخدم URLSearchParams مع appType، formUuid، currentPage، pageSize، وsearchFieldJson',
+  lint_searchformdata_http_csrf: 'يجب أن يضع استدعاء مباشر searchFormDatas.json رمز CSRF التشغيلي في كل من _csrf_token استعلام URL و global_csrf_token رأس طلب الطلبات',
+  lint_searchformdata_http_credentials: 'يجب تعيين استدعاء مباشر searchFormDatas.json credentials: "include" حتى يرسل المتصفح ملفات تعريف الارتباط تسجيل الدخول ذات الأصل نفسه',
+  lint_canvas_yida_api_bridge_missing: 'يجب أن تستهلك بيانات نموذج YidaCodeCanvas window.__OPENYIDA_YIDA_API__ أولاً (يحقق طبقة النشر الجسر this.utils.yida من didMount الخارجي); لا تعتمد على البحث الداخلي يدوي fetch searchFormDatas',
+});

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'عرض موصلات HTTP',
     cmd_connector_create: 'إنشاء موصل',
     cmd_connector_detail: 'عرض تفاصيل الموصل',
-    cmd_connector_delete: 'حذف موصل',
+    cmd_connector_delete: 'عرض إرشادات الحذف اليدوي (واجهة CLI لا تحذف)',
     cmd_connector_add_action: 'Add an action',
     cmd_connector_list_actions: 'List actions',
     cmd_connector_delete_action: 'Delete an action',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    عرض إرشادات الحذف اليدوي (واجهة CLI لا تحذف)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'HTTP-Konnektoren auflisten',
     cmd_connector_create: 'Konnektor erstellen',
     cmd_connector_detail: 'Konnektor-Details anzeigen',
-    cmd_connector_delete: 'Konnektor löschen',
+    cmd_connector_delete: 'Anleitung zum manuellen Löschen anzeigen (CLI löscht nicht)',
     cmd_connector_add_action: 'Aktion hinzufügen',
     cmd_connector_list_actions: 'Aktionen auflisten',
     cmd_connector_delete_action: 'Aktion löschen',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    Anleitung zum manuellen Löschen anzeigen (CLI löscht nicht)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -1766,3 +1766,72 @@ module.exports = {
     error: '\n❌ Importfehler: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'App-Administrator-Save-Verifizierung fehlgeschlagen',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'Adressbuch-Berechtigungs-Save-Verifizierung fehlgeschlagen: erwartet={0}, tatsächlich={1}',
+  admin_verify_failed: 'Administrator-Save-Verifizierung fehlgeschlagen: {0} wurde in der Liste {1} nicht gefunden',
+  sub_admin_scope_verify_failed: 'Subadministrator-Bereichs-Save-Verifizierung fehlgeschlagen: erwartet={0}, tatsächlich={1}',
+  admin_remove_verify_failed: 'Administrator-Rücknahme-Verifizierung fehlgeschlagen: {0} befindet sich noch in der Liste {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'Das Ersetzen zusammengesetzter Mitglieder erfordert auch --confirm-member-replace',
+  data_object_required: 'Datenberechtigung muss ein JSON-Objekt sein',
+  data_rule_required: 'Datenberechtigungsregel darf nicht leer sein',
+  data_rule_type_required: 'Jeder Datenberechtigungsregeln-Eintrag muss einen Typ enthalten',
+  data_rule_value_invalid: 'Der Wert der Datenberechtigungsregel {0} muss y/n oder ein Boolean sein',
+  data_enabled_required: 'Datenberechtigung muss mindestens eine Datenskala aktivieren',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT erfordert nicht-leere customDepartmentData.departmentIds',
+  formula_data_required: 'FORMULA erfordert nicht-leere formulaData',
+  data_range_required: 'Datenberechtigung erfordert eine nicht-leere dataRange oder Regel',
+  action_enabled_required: 'Handlungsberechtigung muss mindestens einen Operationssatz auf true setzen',
+  action_value_boolean: 'Handlungsberechtigung {0} muss ein Boolean sein',
+  field_range_invalid: 'Feldberechtigungs fieldRange unterstützt nur FORM oder CUSTOM',
+  field_status_required: 'CUSTOM Feldberechtigung erfordert eine nicht-leere fieldStatus-Array',
+  field_status_item_required: 'Jedes fieldStatus-Eintrag muss label, fieldName, componentName und value enthalten',
+  field_status_value_invalid: 'Ungültiger Feldberechtigungs-Wert: {0}; gültige Werte: {1}',
+  json_object_required: '{0} muss ein JSON-Objekt sein',
+  parse_failed: 'Parse von {0} fehlgeschlagen: {1}',
+  role_conflict: 'Berechtigungsargumente spezifizieren inkonsistente Rollen: {0}',
+  matrix_role_only: '--matrix kann nur eine role=MATRIX Berechtigungsgruppe aktualisieren',
+  all_members_role_only: '--all-members kann nur eine role=DEFAULT Berechtigungsgruppe aktualisieren',
+  target_role_invalid: 'Ungültige Rolle: {0}; gültige Werte: {1}',
+  unnamed_package: 'Unbenannt',
+  missing_package_uuid: 'Kein UUID vorhanden',
+  target_no_match: 'Keine Berechtigungsgruppe passte zu role={0}; mit Nullschreiben abgebrochen, um eine unbeabsichtigte Aktualisierung zu verhindern. Aktuelle Berechtigungsgruppen:\n{2}',
+  target_ambiguous: 'role={0} passte {1} Berechtigungsguppen; mit Nullschreiben abgebrochen, um eine unbeabsichtigte Aktualisierung zu verhindern.\n{2}',
+  unknown_operate_keys: 'Die aktuelle Berechtigungsgruppe enthält Operationsschlüssel, die dem CLI unbekannt sind, daher kann action-permission nicht geändert werden: {0}. Andere Dimensionen können noch geändert werden und unbekannte Schlüssel werden wortwörtlich erhalten.',
+  matrix_role_value_required: 'MATRIX roleData.roleValue muss ein nicht-leeres Array sein',
+  matrix_data_required: 'Wenn Mitglieder MATRIX verwenden, muss die Datenberechtigungsregel MATRIX enthalten',
+  data_matrix_member_required: 'Wenn Datenberechtigung MATRIX enthält, müssen Mitglieder eine gültige Berechtigungsmatrix auswählen',
+  members_all_conflict: '--members und --all-members sind sich gegenseitig ausschließend',
+  invalid_arguments: 'Argumentvalidierung fehlgeschlagen: {0}',
+  query_limit: 'Die Berechtigungsguppen-Abfrage erreichte den aktuellen Limit von 20-Einträgen, sodass globale Rollen-Eindeutigkeit nicht bewiesen werden kann. Mit Nullschreiben abgebrochen.\n{0}',
+  unique_target: '  ✅ Einzigartiges Ziel: {0}',
+  member_before: '  Mitglieder vorher: {0}',
+  member_after: '  Mitglieder nach:  {0}',
+  member_removed: '  Mitgliedsrollen zum Entfernen: {0}',
+  member_replace_confirm: 'Mitgliedsersetzung entfernt bestehende zusammengesetzte Rollen. Prüfen Sie vor/nach und fügen Sie --confirm-member-replace hinzu. Einträge, die verloren gehen werden: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl muss mit /o/ oder /s/ beginnen, aktueller Wert: {0}',
+  verify_failed: 'Post-Save-Verifizierung fehlgeschlagen: {0}',
+  current_state_incomplete: 'Save abgebrochen: aktuelle public-access-Konfiguration fehlt openPageAuthConfig, sodass sichere Bewahrung nicht bewiesen werden kann',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX-Copy kann als {{0}} geschrieben werden; es wird als Variable behandelt und verursacht {0} ist nicht definiert. Verwenden Sie stattdessen rohen Text {0} oder einen zitierten String {\'{0}\'}.',
+  lint_form_open_container: 'Öffnung von Yida-Form-Einreichung/Detail-Seiten aus einer benutzerdefinierten Seite muss FormOpenContainer verwenden: ein 50vw-Ziehkasten-Iframe auf Desktop und nur volle/neue Seiten auf Mobilgeräten. Button-Handler sollten openForm({ type: "submission" | "detail", ... }) aufrufen.',
+  lint_form_detail_link: 'Yida-Form-Detail-Seiten müssen eine echte formInstId verwenden: lesen Sie zuerst row.formInstId und deaktivieren oder warnen, wenn die Instanz-ID fehlt, anstatt ein leeres formInstId mit einem formDetail-Link zu öffnen.',
+  lint_searchformdata_http_path: 'Eine direkte searchFormDatas.json-Aufruf muss /dingtalk/web/<appType>/v1/form/searchFormDatas.json verwenden; /query/form/searchFormDatas.json ist kein gültiger Form-Daten-Endpunkt',
+  lint_searchformdata_http_query_params: 'Der direkte searchFormDatas.json URL-Abfrage fehlt erforderliche Parameter: {0}. Verwenden Sie URLSearchParams mit appType, formUuid, currentPage, pageSize und searchFieldJson',
+  lint_searchformdata_http_csrf: 'Eine direkte searchFormDatas.json-Aufruf muss den Laufzeit-CSRF-Token sowohl in der _csrf_token URL-Abfrage als auch im global_csrf_token Request-Header setzen',
+  lint_searchformdata_http_credentials: 'Eine direkte searchFormDatas.json-Aufruf muss credentials: "include" festlegen, damit der Browser Same-Origin-Anmelde-Cookies sendet',
+  lint_canvas_yida_api_bridge_missing: 'YidaCodeCanvas Form-Daten-Lesevorgänge müssen zuerst window.__OPENYIDA_YIDA_API__ verbrauchen (die Publish-Schicht injiziert den this.utils.yida Brücke von außen didMount); verwenden Sie nicht standardmäßig eine handgeschriebene interne searchFormDatas-Abfrage',
+});

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -1768,3 +1768,72 @@ module.exports = {
     error: '\n❌ Error de importación: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'La verificación de guardado del administrador falló',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'El guardado de la permisión de libreta de direcciones falló: esperado={0}, real={1}',
+  admin_verify_failed: 'El guardado como administrador falló: {0} no se encontró en la lista {1}',
+  sub_admin_scope_verify_failed: 'El guardado del alcance de subadministrador falló: esperado={0}, real={1}',
+  admin_remove_verify_failed: 'La verificación de eliminación como administrador falló: {0} sigue estando en la lista {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'Reemplazar miembros compuestos también requiere --confirm-member-replace',
+  data_object_required: 'El permiso de datos debe ser un objeto JSON',
+  data_rule_required: 'La regla del permiso de datos no puede estar vacía',
+  data_rule_type_required: 'Cada elemento de la regla del permiso de datos debe incluir el tipo',
+  data_rule_value_invalid: 'El valor de la regla del permiso de datos {0} debe ser y/n o booleano',
+  data_enabled_required: 'El permiso de datos debe habilitar al menos un rango de datos',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT requiere departmentIds no vacío en customDepartmentData',
+  formula_data_required: 'FORMULA requiere formulaData no vacío',
+  data_range_required: 'El permiso de datos requiere dataRange o rule no vacíos',
+  action_enabled_required: 'El permiso de acción debe contener al menos una operación establecida en true',
+  action_value_boolean: 'La permisión de acción {0} debe ser booleana',
+  field_range_invalid: 'fieldRange del permiso de campo solo soporta FORM o CUSTOM',
+  field_status_required: 'El permiso de campo CUSTOM requiere un array fieldStatus no vacío',
+  field_status_item_required: 'Cada elemento de fieldStatus debe incluir label, fieldName, componentName y value',
+  field_status_value_invalid: 'Valor del permiso de campo inválido: {0}; valores válidos: {1}',
+  json_object_required: '{0} debe ser un objeto JSON',
+  parse_failed: 'Error al analizar {0}: {1}',
+  role_conflict: 'Los argumentos del permiso especifican roles inconsistentes: {0}',
+  matrix_role_only: '--matrix solo puede actualizar el grupo de permisos role=MATRIX',
+  all_members_role_only: '--all-members solo puede actualizar el grupo de permisos role=DEFAULT',
+  target_role_invalid: 'Rol inválido: {0}; valores válidos: {1}',
+  unnamed_package: 'Sin nombre',
+  missing_package_uuid: 'No hay UUID',
+  target_no_match: 'No se encontró grupo de permisos que coincida con role={0}; abortado con cero escrituras para prevenir una actualización no intencionada. Grupos de permisos actuales:\n{2}',
+  target_ambiguous: 'role={0} coincide con {1} grupos de permisos; abortado con cero escrituras para prevenir una actualización no intencionada.\n{2}',
+  unknown_operate_keys: 'El grupo actual de permisos contiene claves de operación desconocidas por la CLI, así que action-permission no puede cambiar: {0}. Otras dimensiones aún pueden cambiarse y las claves desconocidas se preservarán tal cual.',
+  matrix_role_value_required: 'roleData.roleValue del rol MATRIX debe ser un array no vacío',
+  matrix_data_required: 'Cuando los miembros usan MATRIX, la regla de permiso de datos debe incluir MATRIX',
+  data_matrix_member_required: 'Cuando el permiso de datos incluye MATRIX, los miembros deben seleccionar una matriz de permisos válida',
+  members_all_conflict: '--members y --all-members son mutuamente excluyentes',
+  invalid_arguments: 'La validación de argumentos falló: {0}',
+  query_limit: 'La consulta del grupo de permisos alcanzó el límite actual de 20 elementos, por lo que no se puede probar la unicidad global de los roles. Abortado con cero escrituras.\n{0}',
+  unique_target: '  ✅ Objetivo único: {0}',
+  member_before: '  Miembros antes: {0}',
+  member_after: '  Miembros después:  {0}',
+  member_removed: '  Roles de miembros a eliminar: {0}',
+  member_replace_confirm: 'El reemplazo de miembro eliminará los roles compuestos existentes. Revise antes/después y agregue --confirm-member-replace. Entradas que se perderán: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl debe comenzar con /o/ o /s/, valor actual: {0}',
+  verify_failed: 'La verificación post-guardado falló: {0}',
+  current_state_incomplete: 'Guardado abortado: la configuración de acceso público actual carece de openPageAuthConfig, por lo que no se puede probar una preservación segura',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'La copia JSX no se puede escribir como {{0}}; se trata como variable y causa {0} is not defined. Use plain text {0} o una cadena con comillas {\'{0}\'} en su lugar.',
+  lint_form_open_container: 'Abrir páginas de envío/detalles del formulario Yida desde una página personalizada debe usar FormOpenContainer: un iframe drawer de 50vw para escritorio, y solo nueva/página completa para móvil. Los manejadores de botón deben llamar openForm({ type: "submission" | "detail", ... }).',
+  lint_form_detail_link: 'Las páginas de detalle del formulario Yida deben usar una formInstId real: lea row.formInstId primero, y deshabilite o advierta cuando el id de instancia esté ausente en lugar de abrir un enlace formDetail con un formInstId vacío.',
+  lint_searchformdata_http_path: 'Una llamada directa a searchFormDatas.json debe usar /dingtalk/web/<appType>/v1/form/searchFormDatas.json; /query/form/searchFormDatas.json no es un endpoint válido de datos del formulario',
+  lint_searchformdata_http_query_params: 'La consulta URL directa de searchFormDatas.json falta los parámetros requeridos: {0}. Use URLSearchParams con appType, formUuid, currentPage, pageSize y searchFieldJson',
+  lint_searchformdata_http_csrf: 'Una llamada directa a searchFormDatas.json debe poner el token CSRF en tiempo de ejecución tanto en _csrf_token como en global_csrf_token header',
+  lint_searchformdata_http_credentials: 'Una llamada directa a searchFormDatas.json debe establecer credentials: "include" para que el navegador envíe cookies de inicio de sesión del mismo origen',
+  lint_canvas_yida_api_bridge_missing: 'Las lecturas de datos del formulario YidaCodeCanvas deben consumir window.__OPENYIDA_YIDA_API__ primero (la capa publish inyecta this.utils.yida desde didMount externo); no use por defecto la búsqueda interna manual fetch searchFormDatas',
+});

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'Listar conectores HTTP',
     cmd_connector_create: 'Crear conector',
     cmd_connector_detail: 'Ver detalles del conector',
-    cmd_connector_delete: 'Eliminar conector',
+    cmd_connector_delete: 'Mostrar instrucciones de eliminación manual (la CLI no elimina)',
     cmd_connector_add_action: 'Agregar acción',
     cmd_connector_list_actions: 'Listar acciones',
     cmd_connector_delete_action: 'Eliminar acción',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    Mostrar instrucciones de eliminación manual (la CLI no elimina)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'Lister les connecteurs HTTP',
     cmd_connector_create: 'Créer un connecteur',
     cmd_connector_detail: 'Voir les détails du connecteur',
-    cmd_connector_delete: 'Supprimer un connecteur',
+    cmd_connector_delete: 'Afficher le guide de suppression manuelle (la CLI ne supprime rien)',
     cmd_connector_add_action: 'Ajouter une action',
     cmd_connector_list_actions: 'Lister les actions',
     cmd_connector_delete_action: 'Supprimer une action',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    Afficher le guide de suppression manuelle (la CLI ne supprime rien)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -1768,3 +1768,72 @@ module.exports = {
     error: "\n❌ Erreur d'importation : {0}"
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'Échec de la vérification d\'enregistrement par l\'administrateur',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'Échec du sauvegarde des permissions pour le carnet d\'adresses : attendu={0}, réel={1}',
+  admin_verify_failed: 'Échec du sauvegarde des permissions administrateur : {0} n\'a pas été trouvé dans la liste de {1}',
+  sub_admin_scope_verify_failed: 'Échec du sauvegarde des périmètres sous-administrateur : attendu={0}, réel={1}',
+  admin_remove_verify_failed: 'Échec de vérification de suppression d\'administrateur : {0} est toujours dans la liste de {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'Le remplacement des membres composites nécessite également --confirm-member-replace',
+  data_object_required: 'La permission sur les données doit être un objet JSON',
+  data_rule_required: 'La règle de permission sur les données ne peut pas être vide',
+  data_rule_type_required: 'Chaque élément de la règle de permission sur les données doit inclure le type',
+  data_rule_value_invalid: 'La valeur de l\'élément {0} de la règle de permission sur les données doit être y/n ou booléen',
+  data_enabled_required: 'La permission sur les données doit activer au moins une plage de données',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT nécessite des departmentIds personnalisés non vides dans customDepartmentData',
+  formula_data_required: 'FORMULA nécessite des formulaData non vides',
+  data_range_required: 'La permission sur les données nécessite une plage de données ou une règle non vide',
+  action_enabled_required: 'La permission d\'action doit contenir au moins un ensemble d\'opérations défini à true',
+  action_value_boolean: 'L\'autorisation {0} d\'action doit être booléenne',
+  field_range_invalid: 'Le champRange de la permission sur les champs ne supporte que FORM ou CUSTOM',
+  field_status_required: 'La permission sur les champs personnalisés nécessite un tableau fieldStatus non vide',
+  field_status_item_required: 'Chaque élément de fieldStatus doit inclure label, fieldName, componentName et value',
+  field_status_value_invalid: 'Valeur invalide pour la permission sur le champ : {0} ; valeurs valides : {1}',
+  json_object_required: '{0} doit être un objet JSON',
+  parse_failed: 'Échec de l\'analyse de {0} : {1}',
+  role_conflict: 'Les arguments de permission spécifient des rôles incohérents : {0}',
+  matrix_role_only: '--matrix ne peut mettre à jour qu\'un groupe de permissions rôle=MATRIX',
+  all_members_role_only: '--all-members ne peut mettre à jour qu\'un groupe de permissions rôle=DEFAULT',
+  target_role_invalid: 'Rôle invalide : {0} ; valeurs valides : {1}',
+  unnamed_package: 'Sans nom',
+  missing_package_uuid: 'Pas d\'identifiant unique (UUID)',
+  target_no_match: 'Aucun groupe de permission n\'a correspondu au rôle={0} ; annulation avec zéro écriture pour éviter une mise à jour non intentionnelle. Groupes de permissions actuels :\n{2}',
+  target_ambiguous: 'rôle={0} correspond aux groupes de permissions {1} ; annulation avec zéro écriture pour éviter une mise à jour non intentionnelle.\n{2}',
+  unknown_operate_keys: 'Le groupe de permission actuel contient des clés d\'opération inconnues au CLI, donc action-permission ne peut pas être modifié : {0}. D\'autres dimensions peuvent toujours être modifiées et les clés inconnues seront conservées telles quelles.',
+  matrix_role_value_required: 'La valeur rôleData.roleValue de MATRIX doit être un tableau non vide',
+  matrix_data_required: 'Lorsque des membres utilisent MATRIX, la règle de permission sur les données doit inclure MATRIX',
+  data_matrix_member_required: 'Lorsque la permission sur les données contient MATRIX, les membres doivent sélectionner une matrice de permissions valide',
+  members_all_conflict: '--members et --all-members sont mutuellement exclusifs',
+  invalid_arguments: 'Échec de validation des arguments : {0}',
+  query_limit: 'La requête du groupe de permission a atteint la limite actuelle de 20 éléments, donc l\'unicité globale du rôle ne peut pas être prouvée. Annulé avec zéro écriture.\n{0}',
+  unique_target: '  ✅ Cible unique : {0}',
+  member_before: '  Membres avant : {0}',
+  member_after: '  Membres après :  {0}',
+  member_removed: '  Rôles de membre à supprimer : {0}',
+  member_replace_confirm: 'Le remplacement des membres supprimera les rôles composites existants. Veuillez vérifier avant/après et ajouter --confirm-member-replace. Entrées qui seront perdues : {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl doit commencer par /o/ ou /s/, valeur actuelle : {0}',
+  verify_failed: 'Échec de vérification après sauvegarde : {0}',
+  current_state_incomplete: 'Sauvegarde annulée : la configuration d\'accès public actuel manque openPageAuthConfig, donc une préservation sécurisée ne peut pas être prouvée',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'La copie JSX ne peut pas s\'écrire comme {{0}} ; elle est traitée comme une variable et provoque {0} n\'est pas défini. Utilisez du texte brut {0} ou une chaîne citée {\'{0}\'} à la place.',
+  lint_form_open_container: 'L\'ouverture des pages de soumission/détail Yida depuis une page personnalisée doit utiliser FormOpenContainer : un cadre iframe de 50vw sur bureau, et uniquement pleine/nouvelle page sur mobile. Les gestionnaires de bouton doivent appeler openForm({ type: "submission" | "detail", ... }).',
+  lint_form_detail_link: 'Les pages de détail Yida doivent utiliser une vraie formInstId : lisez d\'abord row.formInstId, et désactivez ou mettez en garde lorsque l\'identifiant est manquant au lieu d\'ouvrir un lien formDetail avec un formInstId vide.',
+  lint_searchformdata_http_path: 'Une appel direct searchFormDatas.json doit utiliser /dingtalk/web/<appType>/v1/form/searchFormDatas.json ; /query/form/searchFormDatas.json n\'est pas une fin de point valide pour les données de formulaire',
+  lint_searchformdata_http_query_params: 'La requête URL directe searchFormDatas.json manque des paramètres requis : {0}. Utilisez URLSearchParams avec appType, formUuid, currentPage, pageSize et searchFieldJson',
+  lint_searchformdata_http_csrf: 'Une appel direct searchFormDatas.json doit placer le jeton CSRF temps d\'exécution dans à la fois _csrf_token query URL et global_csrf_token en-tête de demande',
+  lint_searchformdata_http_credentials: 'Une appel direct searchFormDatas.json doit définir credentials : "include" pour que le navigateur envoie les cookies de connexion same-origin',
+  lint_canvas_yida_api_bridge_missing: 'Les lectures des données YidaCodeCanvas doivent consommer window.__OPENYIDA_YIDA_API__ d\'abord (la couche publish injecte ce pont this.utils.yida depuis didMount externe) ; ne passez pas par défaut à une recherche interne manuelle searchFormDatas fetch',
+});

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -1766,3 +1766,72 @@ module.exports = {
     error: '\n❌ आयात त्रुटि: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'प्रशासक सहेजित जांच विफल हुई',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'पता पुस्तिका अनुमति सेव विफल: अपेक्षित={0}, वास्तविक={1}',
+  admin_verify_failed: 'प्रशासक सेव विफल: {0} को {1} सूची में नहीं मिला',
+  sub_admin_scope_verify_failed: 'उप-प्रशासक दायरा सेव विफल: अपेक्षित={0}, वास्तविक={1}',
+  admin_remove_verify_failed: 'प्रशासक हटाया जांच विफल: {0} अभी भी {1} सूची में है',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'युग्मित सदस्यों को बदलने के लिए --confirm-member-replace की आवश्यकता होती है',
+  data_object_required: 'डेटा अनुमति एक JSON वस्तु होनी चाहिए',
+  data_rule_required: 'डेटा अनुमति नियत नहीं खाली हो सकता',
+  data_rule_type_required: 'हर डेटा अनुमति नियत पद में प्रकार शामिल करना होगा',
+  data_rule_value_invalid: 'डेटा अनुमति नियत {0} का मान y/n या बूल्न होना चाहिए',
+  data_enabled_required: 'डेटा अनुमति कम से कम एक डेटा श्रेणी सक्षम करनी होगी',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT के लिए खाली नहीं होने वाले कस्टमDepartmentData.departmentIds की आवश्यकता है',
+  formula_data_required: 'FORMULA के लिए खाली नहीं होने वाला formulaData की आवश्यकता है',
+  data_range_required: 'डेटा अनुमति में एक खाली डेटाRange या नियत होना चाहिए',
+  action_enabled_required: 'कार्य अनुमति में कम से कम एक ऑपरेशन सत्य करके शामिल करना होगा',
+  action_value_boolean: 'कार्य अनुमति {0} बूल्न होनी चाहिए',
+  field_range_invalid: 'क्षेत्र अनुमति क्षेत्रRange केवल FORM या CUSTOM को समर्थन करता है',
+  field_status_required: 'CUSTOM क्षेत्र अनुमति में एक खाली fieldStatus अरे की आवश्यकता है',
+  field_status_item_required: 'हर fieldStatus पद में लेबल, fieldName, componentName और मान शामिल करना होगा',
+  field_status_value_invalid: 'अमान्य क्षेत्र अनुमति मान: {0}; वैध मान: {1}',
+  json_object_required: '{0} एक JSON वस्तु होना चाहिए',
+  parse_failed: '{0} को पारित करने में विफलता: {1}',
+  role_conflict: 'अनुमति तर्ग असंगत भूमिकाएं निर्दिष्ट करते हैं: {0}',
+  matrix_role_only: '--matrix केवल एक role=MATRIX अनुमति समूह को अपडेट कर सकता है',
+  all_members_role_only: '--all-members केवल एक role=DEFAULT अनुमति समूह को अपडेट कर सकता है',
+  target_role_invalid: 'अमान्य भूमिका: {0}; वैध मान: {1}',
+  unnamed_package: 'नामहीन',
+  missing_package_uuid: 'कोई UUID नहीं',
+  target_no_match: 'role={0} के लिए कोई अनुमति समूह मेल नहीं खाता; अनपेक्षित अपडेट को रोकने के साथ शून्य लिखतों से विरुद्ध किया गया है। वर्तमान अनुमति समूह:\n{2}',
+  target_ambiguous: 'role={0} ने {1} अनुमति समूहों का मेल खाया; अनपेक्षित अपडेट को रोकने के साथ शून्य लिखतों से विरुद्ध किया गया है。\n{2}',
+  unknown_operate_keys: 'वर्तमान अनुमति समूह में CLI द्वारा अज्ञात ऑपरेशन चाबीएं शामिल हैं, इसलिए action-permutation बदला नहीं जा सकता: {0}। अन्य आयाम अभी भी बदले जा सकते हैं और अज्ञात चाबियां बिना परिवर्तन रखी जाएंगी।',
+  matrix_role_value_required: 'MATRIX roleData.roleValue एक खाली अरे होनी चाहिए',
+  matrix_data_required: 'जब सदस्य MATRIX का उपयोग करते हैं, तो डेटा अनुमति नियत में MATRIX शामिल करना होगा',
+  data_matrix_member_required: 'डेटा अनुमति में MATRIX होने पर, सदस्यों को एक वैध अनुमति मैट्रिक्स चुनना होगा',
+  members_all_conflict: '--members और --all-members आपसी रूप से विरोधी हैं',
+  invalid_arguments: 'तर्ग जांच विफल: {0}',
+  query_limit: 'अनुमति समूह प्रश्न वर्तमान 20-पद सीमा को पहुंच गया, इसलिए वैश्विक भूमिका एकता का सिद्ध नहीं किया जा सकता। शून्य लिखतों के साथ विरुद्ध किया गया है。\n{0}',
+  unique_target: '  ✅ अकेला लक्ष्य: {0}',
+  member_before: '  सदस्यों से पहले: {0}',
+  member_after: '  सदस्यों के बाद:  {0}',
+  member_removed: '  हटाने वाले सदस्य भूमिकाएं: {0}',
+  member_replace_confirm: 'सदस्य प्रतिस्थापन मौजूदा युग्मित भूमिकाओं को हटाएगा। पहले/बाद और --confirm-member-replace जोड़ने से पहले समीक्षा करें। खो जाने वाले प्रविष्टियां: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl /o/ या /s/ के साथ शुरू होना चाहिए, वर्तमान मान: {0}',
+  verify_failed: 'सेव-बाद जांच विफल हुई: {0}',
+  current_state_incomplete: 'सेव रद्द किया गया है: वर्तमान सार्वजनिक पहुंच कॉन्फ़िगरेशन openPageAuthConfig की कमी रखता है, इसलिए सुरक्षित संरक्षण का सिद्ध नहीं किया जा सकता',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX कॉपी {{0}} के रूप में लिखा नहीं जा सकता; इसे एक चर के रूप में माना जाता है और {0} परिभाषित नहीं है। साधारण टेक्स्ट {0} या उद्धृत शब्द {\'{0}\'} का उपयोग करें इसके बजाय।',
+  lint_form_open_container: 'कस्टम पेज से Yida फॉर्म सबमिशन/विस्तार पृष्ठ खोलने के लिए FormOpenContainer का उपयोग करना चाहिए: डेस्कटॉप पर एक 50vw ड्रायर iframe, और मोबाइल पर केवल पूरा/नया पृष्ठ। बटन हैंडल openForm({ type: "submission" | "detail", ... }) को कॉल करनी चाहिए।',
+  lint_form_detail_link: 'Yida फॉर्म विस्तार पृष्ठ एक वास्तविक formInstId का उपयोग करना चाहिए: पहले row.formInstId पढ़ें, और instance id की कमी होने पर बंद या चेतावन दें, खाली formInstId के साथ एक formDetail लिंक खोलने के बजाय।',
+  lint_searchformdata_http_path: 'एक सीधा searchFormDatas.json कॉल /dingtalk/web/<appType>/v1/form/searchFormDatas.json का उपयोग करना चाहिए; /query/form/searchFormDatas.json एक वैध फॉर्म डेटा एंडपॉइंट नहीं है',
+  lint_searchformdata_http_query_params: 'सीधा searchFormDatas.json URL प्रश्न आवश्यक पैरामीटर्स की कमी रखता है: {0}। appType, formUuid, currentPage, pageSize और searchFieldJson के साथ URLSearchParams का उपयोग करें',
+  lint_searchformdata_http_csrf: 'एक सीधा searchFormDatas.json कॉल runtime CSRF टोकन को दोनों _csrf_token URL प्रश्न और global_csrf_token अनुरोध हेडर में रखना चाहिए',
+  lint_searchformdata_http_credentials: 'एक सीधा searchFormDatas.json कॉल credentials: "include" सेट करना होगा ताकि ब्राउज़र सम-मूल्य लॉगिन कोकीज भेजे',
+  lint_canvas_yida_api_bridge_missing: 'YidaCodeCanvas फॉर्म डेटा पढ़ें window.__OPENYIDA_YIDA_API__ पहले उपभोग करना चाहिए (पब्लिश स्तर बाहरी didMount से this.utils.yida ब्रिज इंजेक्ट करता है); हाथ से लिखी गई आंतरिक searchFormDatas fetch पर डिफ़ॉल्ट न करें',
+});

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'HTTP कनेक्टर सूचीबद्ध करें',
     cmd_connector_create: 'कनेक्टर बनाएं',
     cmd_connector_detail: 'कनेक्टर विवरण देखें',
-    cmd_connector_delete: 'कनेक्टर हटाएं',
+    cmd_connector_delete: 'मैन्युअल हटाने के निर्देश दिखाएँ (CLI नहीं हटाता)',
     cmd_connector_add_action: 'Add an action',
     cmd_connector_list_actions: 'List actions',
     cmd_connector_delete_action: 'Delete an action',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    मैन्युअल हटाने के निर्देश दिखाएँ (CLI नहीं हटाता)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'HTTP コネクタ一覧',
     cmd_connector_create: 'コネクタを作成',
     cmd_connector_detail: 'コネクタ詳細を表示',
-    cmd_connector_delete: 'コネクタを削除',
+    cmd_connector_delete: '手動削除の案内を表示（CLI は削除しません）',
     cmd_connector_add_action: 'アクションを追加',
     cmd_connector_list_actions: 'アクション一覧を表示',
     cmd_connector_delete_action: 'アクションを削除',
@@ -168,7 +168,7 @@ module.exports = {
       '  connector list [オプション]                                  HTTP コネクター一覧\n' +
       '  connector create "名前" "ドメイン" --operations <file> [オプション]  コネクター作成\n' +
       '  connector detail <connector-id>                              コネクター詳細を表示\n' +
-      '  connector delete <connector-id> [--force]                    コネクターを削除\n' +
+      '  connector delete <connector-id> [--force]                    手動削除の案内を表示（CLI は削除しません）\n' +
       '  connector add-action --operations <file> --connector-id <id> アクションを追加\n' +
       '  connector list-actions <connector-id>                        アクション一覧\n' +
       '  connector delete-action <connector-id> <operation-id>        アクションを削除\n' +

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -1693,3 +1693,72 @@ module.exports = {
     create_form_error: 'フォームの作成に失敗しました'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'アプリ管理者の保存検証に失敗しました',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'アドレス帳権限の保存検証に失敗しました：期待値={0}, 実際値={1}',
+  admin_verify_failed: '管理者の保存検証に失敗しました：{0} が {1} リストに見つかりませんでした',
+  sub_admin_scope_verify_failed: 'サブ管理者スコープの保存検証に失敗しました：期待値={0}, 実際値={1}',
+  admin_remove_verify_failed: '管理者削除の検証に失敗しました：{0} はまだ {1} リストに含まれています',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: '複合メンバーを置換する場合も --confirm-member-replace を指定する必要があります',
+  data_object_required: 'データ権限は JSON オブジェクトである必要があります',
+  data_rule_required: 'データ権限ルールが空でないこと',
+  data_rule_type_required: 'すべてのデータ権限ルールの項目に type が含まれている必要があります',
+  data_rule_value_invalid: 'データ権限ルールの {0} の値は y/n または boolean でなければなりません',
+  data_enabled_required: 'データ権限で少なくとも 1 つのデータ範囲を有効にする必要があります',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT では customDepartmentData.departmentIds が空でないこと',
+  formula_data_required: 'FORMULA では formulaData が空でないこと',
+  data_range_required: 'データ権限では dataRange または rule のいずれかが空でないこと',
+  action_enabled_required: 'アクション権限に true に設定された少なくとも 1 つの操作セットを含める必要があります',
+  action_value_boolean: 'アクション権限 {0} は boolean でなければなりません',
+  field_range_invalid: 'フィールド権限の fieldRange は FORM または CUSTOM のみサポートしています',
+  field_status_required: 'CUSTOM フィールド権限では非空の fieldStatus 配列が必要です',
+  field_status_item_required: 'すべての fieldStatus 項目に label, fieldName, componentName, value が含まれている必要があります',
+  field_status_value_invalid: '無効なフィールド権限値：{0}; 有効な値：{1}',
+  json_object_required: '{0} は JSON オブジェクトである必要があります',
+  parse_failed: '{0} の解析に失敗しました: {1}',
+  role_conflict: '権限引数は不一致のロールを指定しています：{0}',
+  matrix_role_only: '--matrix は role=MATRIX 許可グループのみ更新できます',
+  all_members_role_only: '--all-members は role=DEFAULT 許可グループのみ更新できます',
+  target_role_invalid: '無効なロール：{0}; 有効な値：{1}',
+  unnamed_package: '名前なし',
+  missing_package_uuid: 'UUID なし',
+  target_no_match: 'role={0} に一致する許可グループがありません。意図しない更新を防ぐためにゼロの書き込みで中止しました。現在の許可グループ:\n{2}',
+  target_ambiguous: 'role={0} は {1} 個の許可グループに一致しています。意図しない更新を防ぐためにゼロの書き込みで中止しました。\n{2}',
+  unknown_operate_keys: '現在の許可グループには CLI が認識していない操作キーが含まれているため、action-permission を変更できません：{0}. 他の次元は引き続き変更でき、無効なキーはそのまま保持されます。',
+  matrix_role_value_required: 'MATRIX roleData.roleValue は空でない配列である必要があります',
+  matrix_data_required: 'メンバーが MATRIX を使用する場合、データ権限ルールには MATRIX を含める必要があります',
+  data_matrix_member_required: 'データ権限に MATRIX が含まれている場合、メンバーは有効な許可マトリックスを選択する必要があります',
+  members_all_conflict: '--members と --all-members は互いに排他的です',
+  invalid_arguments: '引数検証に失敗しました：{0}',
+  query_limit: '許可グループのクエリが現在の 20 アイテム制限に達し、グローバルなロール一意性が証明できません。ゼロの書き込みで中止。\n{0}',
+  unique_target: '  ✅ ユニークターゲット: {0}',
+  member_before: '  メンバー前：{0}',
+  member_after: '  メンバー後：  {0}',
+  member_removed: '  削除するメンバーロール：{0}',
+  member_replace_confirm: 'メンバー置換は既存の複合ロールを削除します。前後を確認し、--confirm-member-replace を追加してください。失われるエントリ：{0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl は /o/ または /s/ で始まる必要があります。現在の値: {0}',
+  verify_failed: '保存後の検証に失敗しました：{0}',
+  current_state_incomplete: '保存中止：現在の公開アクセス設定が openPageAuthConfig を持たないため、安全な保持の証明できません',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX コピーは {{0}} として書けません。変数とみなされ {0} is not defined が発生します。代わりに平文 {0} またはクォートされた文字列 {\'{0}\'} を使用してください。',
+  lint_form_open_container: 'カスタムページから Yida フォーム送信/詳細ページを開く場合、FormOpenContainer（デスクトップでは 50vw ドローア iframe、モバイルではフル画面/新規ページのみ）を使用する必要があります。ボタンハンドラーは openForm({ type: "submission" | "detail", ... }) を呼び出すべきです。',
+  lint_form_detail_link: 'Yida フォーム詳細ページには実際の formInstId を使用する必要があります：row.formInstId を読み取り、formInstId が欠落している場合はフォーム詳細リンクで空の formInstId を開く代わりに無効化または警告を表示してください。',
+  lint_searchformdata_http_path: '直接 searchFormDatas.json の呼び出しは /dingtalk/web/<appType>/v1/form/searchFormDatas.json を使用する必要があります。/query/form/searchFormDatas.json は有効なフォームデータエンドポイントではありません',
+  lint_searchformdata_http_query_params: '直接的な searchFormDatas.json URL クエリには必須パラメータ {0} が不足しています。URLSearchParams で appType, formUuid, currentPage, pageSize, searchFieldJson を使用してください',
+  lint_searchformdata_http_csrf: '直接の searchFormDatas.json 呼び出しでは、_csrf_token URL クエリと global_csrf_token リクエストヘッダーに両方にランタイム CSRF トークンを設定する必要があります',
+  lint_searchformdata_http_credentials: '直接的な searchFormDatas.json 呼び出しでは credentials: "include" を設定し、ブラウザが同一オリジンのログインクッキーを送信する必要があるためです',
+  lint_canvas_yida_api_bridge_missing: 'YidaCodeCanvas フォームデータの読み取りにはまず window.__OPENYIDA_YIDA_API__ を消費する必要があります（publish レイヤーは outer didMount から this.utils.yida ブリッジを注入します）。手書きの内部 searchFormDatas 取得にデフォルトを使用しないでください',
+});

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'HTTP 커넥터 목록',
     cmd_connector_create: '커넥터 생성',
     cmd_connector_detail: '커넥터 상세 보기',
-    cmd_connector_delete: '커넥터 삭제',
+    cmd_connector_delete: '수동 삭제 안내 표시(CLI는 삭제하지 않음)',
     cmd_connector_add_action: 'Add an action',
     cmd_connector_list_actions: 'List actions',
     cmd_connector_delete_action: 'Delete an action',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    수동 삭제 안내 표시(CLI는 삭제하지 않음)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -1767,3 +1767,72 @@ module.exports = {
     error: '\n❌ 앱 가져오기 오류: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: '앱 관리자 저장 검증 실패',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: '주소록 권한 저장 검증 실패: 예상={0}, 실제={1}',
+  admin_verify_failed: '관리자 저장 검증 실패: {0}이/가 {1} 목록에 존재하지 않음',
+  sub_admin_scope_verify_failed: '부 관리자 범위 저장 검증 실패: 예상={0}, 실제={1}',
+  admin_remove_verify_failed: '관리자 제거 검증 실패: {0}은/는 여전히 {1} 목록에 존재함',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: '복합 멤버를 교체할 경우 --confirm-member-replace 플래그도 필요합니다.',
+  data_object_required: '데이터 권한은 JSON 객체여야 합니다.',
+  data_rule_required: '데이터 규칙이 비어있지 않아야 합니다.',
+  data_rule_type_required: '모든 데이터 규칙 항목에는 type 이 포함되어야 합니다.',
+  data_rule_value_invalid: '데이터 규칙 {0} 의 값은 y/n 또는 boolean 이어야 합니다.',
+  data_enabled_required: '데이터 권한에서 최소 하나의 데이터 범위를 활성화해야 합니다.',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT 는 비어있지 않은 customDepartmentData.departmentIds 를 요구합니다.',
+  formula_data_required: 'FORMULA 는 비어있지 않은 formulaData 를 요구합니다.',
+  data_range_required: '데이터 권한은 비어있지 않은 dataRange 또는 rule 을 포함해야 합니다.',
+  action_enabled_required: '행동 권한에서 true 로 설정된 최소 하나의 작업 집합을 포함해야 합니다.',
+  action_value_boolean: '행동 권한 {0} 은 boolean 이어야 합니다.',
+  field_range_invalid: '필드 권한의 fieldRange 는 FORM 또는 CUSTOM 만 지원합니다.',
+  field_status_required: 'CUSTOM 필드 권한은 비어있지 않은 fieldStatus 배열을 요구합니다.',
+  field_status_item_required: '모든 fieldStatus 항목에는 label, fieldName, componentName, value 가 포함되어야 합니다.',
+  field_status_value_invalid: '유효하지 않은 필드 권한 값: {0}; 유효한 값: {1}',
+  json_object_required: '{0} 은 JSON 객체여야 합니다.',
+  parse_failed: '{0} 파싱 실패: {1}',
+  role_conflict: '권한 인수에 모순된 역할이 지정되었습니다: {0}',
+  matrix_role_only: '--matrix 는 role=MATRIX 권한 그룹만 업데이트할 수 있습니다.',
+  all_members_role_only: '--all-members 은 role=DEFAULT 권한 그룹만 업데이트할 수 있습니다.',
+  target_role_invalid: '유효하지 않은 역할: {0}; 유효한 값: {1}',
+  unnamed_package: '이름 없음',
+  missing_package_uuid: 'UUID 없음',
+  target_no_match: '역할={0}에 맞는 권한 그룹을 찾지 못했습니다; 의도하지 않은 업데이트를 방지하기 위해 제로 쓰기로 중단. 현재 권한 그룹:\n{2}',
+  target_ambiguous: '역할={0}이/가 {1} 개의 권한 그룹과 일치합니다; 의도하지 않은 업데이트를 방지하기 위해 제로 쓰기로 중단.\n{2}',
+  unknown_operate_keys: '현재 권한 그룹에는 CLI 가 모르는 작업 키가 포함되어 있어 action-permission 을 변경할 수 없습니다: {0}. 다른 차원은 여전히 변경 가능하고, 알려지지 않은 키는 그대로 유지됩니다.',
+  matrix_role_value_required: 'MATRIX roleData.roleValue 는 비어있지 않은 배열이어야 합니다.',
+  matrix_data_required: '멤버가 MATRIX 를 사용할 경우 데이터 규칙에는 MATRIX 가 포함되어 있어야 합니다.',
+  data_matrix_member_required: '데이터 권한에 MATRIX 가 포함된 경우 멤버는 유효한 권한 행렬을 선택해야 합니다.',
+  members_all_conflict: '--members 와 --all-members 는 상호 배타적입니다.',
+  invalid_arguments: '인수 검증 실패: {0}',
+  query_limit: '권한 그룹 쿼리가 현재 20 개 항목 제한에 도달하여 전역 역할 고유성을 증명할 수 없습니다. 제로 쓰기로 중단.\n{0}',
+  unique_target: '  ✅ 고유 타겟: {0}',
+  member_before: '  멤버 이전: {0}',
+  member_after: '  멤버 이후:  {0}',
+  member_removed: '  제거할 멤버 역할: {0}',
+  member_replace_confirm: '멤버 교체는 기존 복합 역할을 제거합니다. 전후 상태를 검토하고 --confirm-member-replace 를 추가하세요. 손실될 항목: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl 은 /o/ 또는 /s/ 로 시작해야 합니다, 현재 값: {0}',
+  verify_failed: '저장 후 검증 실패: {0}',
+  current_state_incomplete: '저중단: 공개 액세스 구성이 openPageAuthConfig 를 누락하여 안전한 보존을 증명할 수 없습니다.',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX 복사 {{0}} 로 작성될 수 없으며, 변수로 간주되어 {0} is not defined 오류를 유발합니다. 평문 텍스트 {0} 또는 인용된 문자열 {\'{0}\'} 대신 사용하세요.',
+  lint_form_open_container: '커스텀 페이지에서 Yida 폼 제출/상세 페이지를 열려면 FormOpenContainer 를 사용해야 합니다: 데스크톱에서는 50vw 드래워 iframe, 모바일에서는 전체/새 페이지만 사용합니다. 버튼 핸들러는 openForm({ type: "submission" | "detail", ... }) 을 호출해야 합니다.',
+  lint_form_detail_link: 'Yida 폼 상세 페이지에는 실제 formInstId 를 사용해야 합니다: row.formInstId 를 먼저 읽으시고, 빈 formInstId 로 폼Detail 링크를 열지 않고 대신 비활성화 또는 경고하세요.',
+  lint_searchformdata_http_path: '직접적인 searchFormDatas.json 호출은 /dingtalk/web/<appType>/v1/form/searchFormDatas.json 을 사용해야 합니다; /query/form/searchFormDatas.json 은 유효하지 않은 폼 데이터 엔드포인트입니다.',
+  lint_searchformdata_http_query_params: '직접적인 searchFormDatas.json URL 쿼리는 필수 파라미터 {0} 를 누락했습니다. appType, formUuid, currentPage, pageSize, searchFieldJson 을 사용하여 URLSearchParams 로 사용하세요.',
+  lint_searchformdata_http_csrf: '직접적인 searchFormDatas.json 호출은 _csrf_token URL 쿼리와 global_csrf_token 요청 헤더 모두에 런타임 CSRF 토큰을 포함해야 합니다.',
+  lint_searchformdata_http_credentials: '직접적인 searchFormDatas.json 호출은 credentials: "include" 를 설정하여 브라우저가 같은 기원 로그인 쿠키를 전송하도록 해야 합니다.',
+  lint_canvas_yida_api_bridge_missing: 'YidaCodeCanvas 폼 데이터 읽기는 window.__OPENYIDA_YIDA_API__ 를 먼저 소비해야 합니다 (publish 레이어는 outer didMount 에서 this.utils.yida 브릿지를 주입합니다); 내부적인 searchFormDatas fetch 에 기본값을 사용하지 마세요.',
+});

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -1768,3 +1768,72 @@ module.exports = {
     error: '\n❌ Erro de importação: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'Falha na verificação de salvamento pelo administrador da aplicação',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'Falha no salvamento da permissão do livro-endereços: esperado={0}, real={1}',
+  admin_verify_failed: 'Falha no salvamento como administrador: {0} não foi encontrado na lista de {1}',
+  sub_admin_scope_verify_failed: 'Falha no salvamento do escopo de sub-administrador: esperado={0}, real={1}',
+  admin_remove_verify_failed: 'Falha na verificação de remoção como administrador: {0} ainda está presente na lista de {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'Substituir membros compostos também requer --confirm-member-replace',
+  data_object_required: 'A permissão de dados deve ser um objeto JSON',
+  data_rule_required: 'A regra de permissão de dados não pode estar vazia',
+  data_rule_type_required: 'Cada item da regra de permissão de dados deve incluir o tipo',
+  data_rule_value_invalid: 'O valor da regra de permissão de dados {0} deve ser y/n ou booleano',
+  data_enabled_required: 'A permissão de dados deve habilitar pelo menos uma faixa de dados',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT requer departmentIds não vazio em customDepartmentData',
+  formula_data_required: 'FORMULA requer formulaData não vazio',
+  data_range_required: 'A permissão de dados deve conter uma dataRange ou regra não vazia',
+  action_enabled_required: 'A permissão de ação deve conter pelo menos um conjunto de operações definido como true',
+  action_value_boolean: 'A permissão de ação {0} deve ser booleana',
+  field_range_invalid: 'O campoRange da permissão de campo só suporta FORM ou CUSTOM',
+  field_status_required: 'A permissão de campo CUSTOM requer um array fieldStatus não vazio',
+  field_status_item_required: 'Cada item de fieldStatus deve incluir label, fieldName, componentName e value',
+  field_status_value_invalid: 'Valor inválido da permissão de campo: {0}; valores válidos: {1}',
+  json_object_required: '{0} deve ser um objeto JSON',
+  parse_failed: 'Falha ao analisar {0}: {1}',
+  role_conflict: 'Os argumentos da permissão especificam papéis inconsistentes: {0}',
+  matrix_role_only: '--matrix pode atualizar apenas o grupo de permissão role=MATRIX',
+  all_members_role_only: '--all-members pode atualizar apenas o grupo de permissão role=DEFAULT',
+  target_role_invalid: 'Papel inválido: {0}; valores válidos: {1}',
+  unnamed_package: 'Sem nome',
+  missing_package_uuid: 'Sem UUID',
+  target_no_match: 'Nenhum grupo de permissão correspondente ao papel={0}; abortado com zero escritas para evitar atualizações não intencionais. Grupos de permissão atuais:\n{2}',
+  target_ambiguous: 'role={0} corresponde a {1} grupos de permissão; abortado com zero escritas para evitar atualizações não intencionais.\n{2}',
+  unknown_operate_keys: 'O grupo de permissão atual contém chaves de operação desconhecidas pelo CLI, então action-permission não pode ser alterada: {0}. Outras dimensões ainda podem ser alteradas e as chaves desconhecidas serão preservadas literalmente.',
+  matrix_role_value_required: 'A roleData.roleValue do papel MATRIX deve ser um array não vazio',
+  matrix_data_required: 'Quando os membros usam MATRIX, a regra de permissão de dados deve incluir MATRIX',
+  data_matrix_member_required: 'Quando a permissão de dados inclui MATRIX, os membros devem selecionar uma matriz de permissão válida',
+  members_all_conflict: '--members e --all-members são mutuamente exclusivos',
+  invalid_arguments: 'Falha na validação do argumento: {0}',
+  query_limit: 'A consulta ao grupo de permissão atingiu o limite atual de 20 itens, então a unicidade global dos papéis não pode ser provada. Abortado com zero escritas.\n{0}',
+  unique_target: '  ✅ Alvo único: {0}',
+  member_before: '  Membros antes: {0}',
+  member_after: '  Membros depois:  {0}',
+  member_removed: '  Papéis de membros a remover: {0}',
+  member_replace_confirm: 'A substituição de membro removerá papéis compostos existentes. Revise antes/depois e adicione --confirm-member-replace. Entradas que serão perdidas: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl deve começar com /o/ ou /s/, valor atual: {0}',
+  verify_failed: 'Falha na verificação pós-salvamento: {0}',
+  current_state_incomplete: 'Salvamento abortado: a configuração de acesso público atual carece de openPageAuthConfig, então não pode ser provada uma preservação segura',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'A cópia JSX não pode ser escrita como {{0}}; é tratada como variável e causa {0} is not defined. Use texto plano {0} ou string citada {\'{0}\'} em vez disso.',
+  lint_form_open_container: 'Abrir páginas de envio/de detalhe do formulário Yida a partir de uma página personalizada deve usar FormOpenContainer: um iframe de gaveta de 50vw no desktop, e apenas nova/página completa no mobile. Os manipuladores de botão devem chamar openForm({ type: "submission" | "detail", ... }).',
+  lint_form_detail_link: 'As páginas de detalhe do formulário Yida devem usar um formInstId real: leia row.formInstId primeiro, e desabilite ou avise quando o ID da instância estiver ausente em vez de abrir uma link de formDetail com um formInstId vazio.',
+  lint_searchformdata_http_path: 'Uma chamada direta a searchFormDatas.json deve usar /dingtalk/web/<appType>/v1/form/searchFormDatas.json; /query/form/searchFormDatas.json não é um endpoint válido de dados do formulário',
+  lint_searchformdata_http_query_params: 'A consulta URL direta para searchFormDatas.json está faltando parâmetros obrigatórios: {0}. Use URLSearchParams com appType, formUuid, currentPage, pageSize e searchFieldJson',
+  lint_searchformdata_http_csrf: 'Uma chamada direta a searchFormDatas.json deve colocar o token CSRF de tempo de execução tanto na consulta _csrf_token quanto no cabeçalho global_csrf_token do pedido',
+  lint_searchformdata_http_credentials: 'Uma chamada direta a searchFormDatas.json deve definir credentials: "include" para que o navegador envie cookies de login da mesma origem',
+  lint_canvas_yida_api_bridge_missing: 'As leituras de dados do formulário YidaCodeCanvas devem consumir window.__OPENYIDA_YIDA_API__ primeiro (a camada publish injeta a ponte this.utils.yida desde didMount externo); não use por padrão uma busca interna manual fetch searchFormDatas',
+});

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'Listar conectores HTTP',
     cmd_connector_create: 'Criar conector',
     cmd_connector_detail: 'Ver detalhes do conector',
-    cmd_connector_delete: 'Excluir conector',
+    cmd_connector_delete: 'Mostrar instruções de exclusão manual (a CLI não exclui)',
     cmd_connector_add_action: 'Adicionar ação',
     cmd_connector_list_actions: 'Listar ações',
     cmd_connector_delete_action: 'Excluir ação',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    Mostrar instruções de exclusão manual (a CLI não exclui)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: 'Liệt kê trình kết nối HTTP',
     cmd_connector_create: 'Tạo trình kết nối',
     cmd_connector_detail: 'Xem chi tiết trình kết nối',
-    cmd_connector_delete: 'Xóa trình kết nối',
+    cmd_connector_delete: 'Hiển thị hướng dẫn xóa thủ công (CLI không thực hiện xóa)',
     cmd_connector_add_action: 'Add an action',
     cmd_connector_list_actions: 'List actions',
     cmd_connector_delete_action: 'Delete an action',
@@ -170,7 +170,7 @@ module.exports = {
       '  connector list [options]                                     List HTTP connectors\n' +
       '  connector create "<name>" "<domain>" --operations <file> [options]  Create connector\n' +
       '  connector detail <connector-id>                              View connector details\n' +
-      '  connector delete <connector-id> [--force]                    Delete connector\n' +
+      '  connector delete <connector-id> [--force]                    Hiển thị hướng dẫn xóa thủ công (CLI không thực hiện xóa)\n' +
       '  connector add-action --operations <file> --connector-id <id> Add action to connector\n' +
       '  connector list-actions <connector-id>                        List actions\n' +
       '  connector delete-action <connector-id> <operation-id>        Delete action\n' +

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -1766,3 +1766,72 @@ module.exports = {
     error: '\n❌ Lỗi nhập ứng dụng: {0}'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: 'Lỗi xác minh lưu của quản trị viên ứng dụng',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: 'Xác minh lưu thư mục địa chỉ thất bại: mong đợi={0}, thực tế={1}',
+  admin_verify_failed: 'Xác minh lưu quản trị viên thất bại: {0} không có trong danh sách {1}',
+  sub_admin_scope_verify_failed: 'Xác minh phạm vi phụ quản trị viên thất bại: mong đợi={0}, thực tế={1}',
+  admin_remove_verify_failed: 'Xác minh xóa quản trị viên thất bại: {0} vẫn còn trong danh sách {1}',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: 'Thay thế thành viên hợp nhất cũng yêu cầu --confirm-member-replace',
+  data_object_required: 'Quyền dữ liệu phải là một đối tượng JSON',
+  data_rule_required: 'Quy tắc quyền dữ liệu không được để trống',
+  data_rule_type_required: 'Mỗi mục quy tắc quyền dữ liệu phải bao gồm trường type',
+  data_rule_value_invalid: 'Giá trị của quy tắc quyền dữ liệu {0} phải là y/n hoặc boolean',
+  data_enabled_required: 'Quyền dữ liệu phải bật ít nhất một khoảng dữ liệu',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT yêu cầu customDepartmentData.departmentIds không rỗng',
+  formula_data_required: 'FORMULA yêu cầu formulaData không rỗng',
+  data_range_required: 'Quyền dữ liệu phải có dataRange hoặc rule không rỗng',
+  action_enabled_required: 'Quyền hành động phải chứa ít nhất một bộ thao tác được đặt thành true',
+  action_value_boolean: 'Quyền hành động {0} phải là boolean',
+  field_range_invalid: 'Trường quyền dữ liệu fieldRange chỉ hỗ trợ FORM hoặc CUSTOM',
+  field_status_required: 'Quyền trường tùy chỉnh yêu cầu mảng fieldStatus không rỗng',
+  field_status_item_required: 'Mỗi mục fieldStatus phải bao gồm label, fieldName, componentName và value',
+  field_status_value_invalid: 'Giá trị quyền trường không hợp lệ: {0}; các giá trị hợp lệ: {1}',
+  json_object_required: '{0} phải là một đối tượng JSON',
+  parse_failed: 'Không thể giải mã {0}: {1}',
+  role_conflict: 'Các tham số quyền xác định các vai trò không nhất quán: {0}',
+  matrix_role_only: '--matrix chỉ có thể cập nhật nhóm quyền role=MATRIX',
+  all_members_role_only: '--all-members chỉ có thể cập nhật nhóm quyền role=DEFAULT',
+  target_role_invalid: 'Vai trò không hợp lệ: {0}; giá trị hợp lệ: {1}',
+  unnamed_package: 'Không đặt tên',
+  missing_package_uuid: 'Không có UUID',
+  target_no_match: 'Không có nhóm quyền phù hợp với vai trò={0}; hủy bỏ để ngăn cập nhật không mong muốn (không ghi dữ liệu). Các nhóm quyền hiện tại:\n{2}',
+  target_ambiguous: 'Vai trò={0} khớp {1} nhóm quyền; hủy bỏ để ngăn cập nhật không mong muốn.\n{2}',
+  unknown_operate_keys: 'Nhóm quyền hiện tại chứa các khóa thao tác mà CLI chưa biết, do đó action-permission không thể thay đổi: {0}. Các chiều khác vẫn có thể được thay đổi và các khóa chưa biết sẽ được giữ nguyên.',
+  matrix_role_value_required: 'MATRIX roleData.roleValue phải là một mảng không rỗng',
+  matrix_data_required: 'Khi sử dụng MATRIX, quy tắc quyền dữ liệu phải bao gồm MATRIX',
+  data_matrix_member_required: 'Khi quyền dữ liệu bao gồm MATRIX, thành viên phải chọn ma trận quyền hợp lệ',
+  members_all_conflict: '--members và --all-members là loại trừ lẫn nhau',
+  invalid_arguments: 'Kiểm tra tham số thất bại: {0}',
+  query_limit: 'Lên đến giới hạn hiện tại của truy vấn nhóm quyền (20 mục), do đó không thể chứng minh tính duy nhất toàn cục. Hủy bỏ với không ghi dữ liệu.\n{0}',
+  unique_target: '  ✅ Mục tiêu độc nhất: {0}',
+  member_before: '  Thành viên trước: {0}',
+  member_after: '  Thành viên sau:  {0}',
+  member_removed: '  Vai trò thành viên cần xóa: {0}',
+  member_replace_confirm: 'Thay thế thành viên sẽ xóa các vai trò hợp chất hiện có. Hãy xem xét trước/sau và thêm --confirm-member-replace. Các mục sắp bị mất: {0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl phải bắt đầu bằng /o/ hoặc /s/, giá trị hiện tại: {0}',
+  verify_failed: 'Kiểm tra sau lưu thất bại: {0}',
+  current_state_incomplete: 'Lưu bị hủy: cấu hình truy cập công khai hiện tại thiếu openPageAuthConfig, do đó không thể chứng minh bảo tồn an toàn',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX copy không thể viết dưới dạng {{0}}; nó được xử lý như biến và gây ra lỗi {0} is not defined. Hãy sử dụng văn bản thường {0} hoặc chuỗi có dấu ngoặc đơn {\'{0}\'} thay vào đó.',
+  lint_form_open_container: 'Khi mở trang Yida form submission/detail từ một trang tùy chỉnh, hãy sử dụng FormOpenContainer: khung trượt iframe trên máy tính để bàn (50vw) và chỉ toàn bộ/trang mới trên di động. Xử lý nút nên gọi openForm({ type: "submission" | "detail", ... }).',
+  lint_form_detail_link: 'Trang chi tiết form Yida phải sử dụng một formInstId thực tế: hãy đọc row.formInstId trước, và tắt hoặc cảnh báo khi id instance bị thiếu thay vì mở liên kết formDetail với formInstId rỗng.',
+  lint_searchformdata_http_path: 'Một cuộc gọi trực tiếp searchFormDatas.json bắt buộc phải sử dụng /dingtalk/web/<appType>/v1/form/searchFormDatas.json; /query/form/searchFormDatas.json không phải là điểm cuối dữ liệu form hợp lệ',
+  lint_searchformdata_http_query_params: 'Cuộc gọi URL tham số truy vấn trực tiếp searchFormDatas.json thiếu các tham số bắt buộc: {0}. Hãy sử dụng URLSearchParams với appType, formUuid, currentPage, pageSize và searchFieldJson',
+  lint_searchformdata_http_csrf: 'Một cuộc gọi trực tiếp searchFormDatas.json phải đặt token CSRF thời gian chạy vào cả _csrf_token trong truy vấn URL và global_csrf_token trong tiêu đề yêu cầu',
+  lint_searchformdata_http_credentials: 'Một cuộc gọi trực tiếp searchFormDatas.json phải thiết lập credentials: "include" để trình duyệt gửi cookie đăng nhập cùng nguồn gốc',
+  lint_canvas_yida_api_bridge_missing: 'Đọc dữ liệu form YidaCodeCanvas bắt buộc phải tiêu thụ window.__OPENYIDA_YIDA_API__ trước (lớp publish tiêm cầu nối this.utils.yida từ didMount bên ngoài); không mặc định đến fetch searchFormDatas nội bộ viết tay',
+});

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -1639,3 +1639,72 @@ module.exports = {
     cache_available: '已存在可用的 CLI token session 緩存，無需重新開啟瀏覽器登入。'
   }
 };
+
+// Safety-critical verification and publish lint messages.
+Object.assign(module.exports.app_permission || (module.exports.app_permission = {}), {
+  verify_failed: '應用管理員保存後驗證失敗',
+});
+
+Object.assign(module.exports.corp_manager || (module.exports.corp_manager = {}), {
+  address_book_verify_failed: '保存通訊錄權限後驗證失敗：expected={0}, actual={1}',
+  admin_verify_failed: '管理員保存後驗證失敗：{0} 未出現在 {1} 列表中',
+  sub_admin_scope_verify_failed: '平台子管理員保存後範圍驗證失敗：expected={0}, actual={1}',
+  admin_remove_verify_failed: '管理員移除後驗證失敗：{0} 仍在 {1} 列表中',
+});
+
+Object.assign(module.exports.save_permission || (module.exports.save_permission = {}), {
+  confirm_member_replace_usage: '複合成員替換需要額外傳入 --confirm-member-replace',
+  data_object_required: '數據權限必須是 JSON 物件',
+  data_rule_required: '數據權限 rule 不能為空',
+  data_rule_type_required: '數據權限 rule 每一項都必須包含 type',
+  data_rule_value_invalid: '數據權限 rule {0} 的 value 只支援 y/n 或 boolean',
+  data_enabled_required: '數據權限至少需要一個啟用的數據範圍',
+  custom_department_ids_required: 'CUSTOM_DEPARTMENT 必須提供非空 customDepartmentData.departmentIds',
+  formula_data_required: 'FORMULA 必須提供非空 formulaData',
+  data_range_required: '數據權限必須提供非空 dataRange 或 rule',
+  action_enabled_required: '操作權限至少需要一個值為 true 的操作',
+  action_value_boolean: '操作權限 {0} 的值必須是 boolean',
+  field_range_invalid: '字段權限 fieldRange 只支援 FORM 或 CUSTOM',
+  field_status_required: 'CUSTOM 字段權限必須包含非空 fieldStatus 數組',
+  field_status_item_required: 'fieldStatus 每一項必須包含 label、fieldName、componentName 和 value',
+  field_status_value_invalid: '無效字段權限值：{0}，有效值：{1}',
+  json_object_required: '{0} 必須是 JSON 物件',
+  parse_failed: '{0} 解析失敗：{1}',
+  role_conflict: '權限參數中的 role 不一致：{0}',
+  matrix_role_only: '--matrix 只能更新 role=MATRIX 的權限組',
+  all_members_role_only: '--all-members 只能更新 role=DEFAULT 的權限組',
+  target_role_invalid: '無效 role: {0}，有效值：{1}',
+  unnamed_package: '未命名',
+  missing_package_uuid: '無 UUID',
+  target_no_match: 'role={0} 未匹配；為防止誤更新已中止（零寫入）。目前權限組：\n{2}',
+  target_ambiguous: 'role={0} 匹配 {1} 個權限組；為防止誤更新已中止（零寫入）。\n{2}',
+  unknown_operate_keys: '當前權限組包含 CLI 未識別的操作權限鍵，不能修改 action-permission: {0}。可只修改其他維度，未知鍵會原樣保留。',
+  matrix_role_value_required: 'MATRIX roleData.roleValue 必須是非空數組',
+  matrix_data_required: '成員選擇為 MATRIX 時，數據權限 rule 必須包含 MATRIX',
+  data_matrix_member_required: '數據權限包含 MATRIX 時，成員必須選擇有效權限矩陣',
+  members_all_conflict: '--members 與 --all-members 互斥，請勿同時指定',
+  invalid_arguments: '參數驗證失敗：{0}',
+  query_limit: '權限組查詢已達到當前 20 條上限，無法證明 role 目標全局唯一，已中止（零寫入）。\n{0}',
+  unique_target: '  ✅ 唯一目標：{0}',
+  member_before: '  成員 before: {0}',
+  member_after: '  成員 after： {0}',
+  member_removed: '  將移除成員角色：{0}',
+  member_replace_confirm: '成員替換會移除現有複合角色，請核對 before/after 後加入 --confirm-member-replace。將遺失：{0}',
+});
+
+Object.assign(module.exports.save_share_config || (module.exports.save_share_config = {}), {
+  err_page_url_prefix: 'openUrl 必須以 /o/ 或 /s/ 開頭，當前值：{0}',
+  verify_failed: '保存後驗證失敗：{0}',
+  current_state_incomplete: '保存已中止：當前公開訪問配置缺少 openPageAuthConfig，無法證明可安全保留',
+});
+
+Object.assign(module.exports.publish || (module.exports.publish = {}), {
+  lint_jsx_text_identifier: 'JSX 中文文案不能寫成 {{0}}，這會被當作變量並導致 {0} is not defined；請改成純文本 {0} 或字符串 {\'{0}\'}。',
+  lint_form_open_container: '自定義頁內打開表單提交/詳情只能使用 FormOpenContainer：PC 端用 50vw 抽屜 iframe，移動端才整頁或新頁打開。按鈕事件請調用 openForm({ type: "submission" | "detail", ... })。',
+  lint_form_detail_link: '表單詳情頁必須使用真實 formInstId：優先讀取 row.formInstId，缺少實例 ID 時禁用詳情入口或提示，不能打開空 formInstId 的 formDetail 鏈接。',
+  lint_searchformdata_http_path: '直連 searchFormDatas.json 必須使用 /dingtalk/web/<appType>/v1/form/searchFormDatas.json；/query/form/searchFormDatas.json 不是有效表單數據端點',
+  lint_searchformdata_http_query_params: '直連 searchFormDatas.json 的 URL query 缺少必要參數：{0}；請用 URLSearchParams 寫入 appType、formUuid、currentPage、pageSize 和 searchFieldJson',
+  lint_searchformdata_http_csrf: '直連 searchFormDatas.json 需要把運行態 CSRF 同時放入 URL query 的 _csrf_token 和請求頭 global_csrf_token',
+  lint_searchformdata_http_credentials: '直連 searchFormDatas.json 必須設置 credentials: "include"，讓瀏覽器攜帶同源登錄態',
+  lint_canvas_yida_api_bridge_missing: 'YidaCodeCanvas 表單數據讀取必須優先消費 window.__OPENYIDA_YIDA_API__（發布層由外層 didMount 注入 this.utils.yida 橋）；不要默認手寫內部 searchFormDatas fetch',
+});

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -73,7 +73,7 @@ module.exports = {
     cmd_connector_list: '列出 HTTP 連接器',
     cmd_connector_create: '建立連接器',
     cmd_connector_detail: '查看連接器詳情',
-    cmd_connector_delete: '刪除連接器',
+    cmd_connector_delete: '顯示平台手動刪除指引（CLI 不執行刪除）',
     cmd_connector_add_action: '新增執行動作',
     cmd_connector_list_actions: '列出執行動作',
     cmd_connector_delete_action: '刪除執行動作',
@@ -168,7 +168,7 @@ module.exports = {
       '  connector list [選項]                                        列出 HTTP 連接器\n' +
       '  connector create "名稱" "網域" --operations <file> [選項]    建立連接器\n' +
       '  connector detail <connector-id>                              查看連接器詳情\n' +
-      '  connector delete <connector-id> [--force]                    刪除連接器\n' +
+      '  connector delete <connector-id> [--force]                    顯示平台手動刪除指引（CLI 不執行刪除）\n' +
       '  connector add-action --operations <file> --connector-id <id> 新增執行動作到連接器\n' +
       '  connector list-actions <connector-id>                        列出執行動作\n' +
       '  connector delete-action <connector-id> <operation-id>        刪除執行動作\n' +

--- a/scripts/i18n-baseline.json
+++ b/scripts/i18n-baseline.json
@@ -1,50 +1,72 @@
 {
   "base": "zh",
-  "basePathCount": 1392,
+  "basePathCount": 1457,
   "locales": {
     "ar": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "de": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "en": {
-      "missing": 7,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "es": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "fr": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "hi": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "ja": {
-      "missing": 396,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "ko": {
-      "missing": 696,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "pt": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "vi": {
-      "missing": 697,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     },
     "zh-HK": {
-      "missing": 356,
-      "typeMismatch": 0
+      "missing": 0,
+      "missingKeys": [],
+      "typeMismatch": 0,
+      "typeMismatchKeys": []
     }
   }
 }

--- a/scripts/validate-i18n.js
+++ b/scripts/validate-i18n.js
@@ -25,7 +25,6 @@ const LOCALES_DIR = path.join(ROOT, 'lib', 'core', 'locales');
 const EXTRA_LOCALES_DIR = path.join(ROOT, 'locales-extra', 'core');
 const BASELINE_FILE = path.join(__dirname, 'i18n-baseline.json');
 const BASE_LOCALE = 'zh';
-const CORE_CHECK_LOCALES = new Set(['en']);
 
 function resolveLocaleFile(name) {
   const coreFile = path.join(LOCALES_DIR, `${name}.js`);
@@ -110,6 +109,38 @@ function readBaseline() {
   }
 }
 
+function findRegressions(report, baseline) {
+  const regressions = [];
+  Object.keys(report).forEach((name) => {
+    const current = report[name];
+    const saved = baseline.locales[name] || {
+      missing: 0,
+      missingKeys: [],
+      typeMismatch: 0,
+      typeMismatchKeys: [],
+    };
+    const checks = [
+      ['missing', 'missingKeys', '缺失'],
+      ['typeMismatch', 'typeMismatchKeys', '类型冲突'],
+    ];
+    checks.forEach(([field, keysField, label]) => {
+      if (Array.isArray(saved[keysField])) {
+        const known = new Set(saved[keysField]);
+        const added = current[field].filter((key) => !known.has(key));
+        if (added.length > 0) {
+          regressions.push(`${name} 新增${label} ${added.length} 个：${added.join(', ')}`);
+        }
+        return;
+      }
+      const savedCount = Number(saved[field]) || 0;
+      if (current[field].length > savedCount) {
+        regressions.push(`${name} ${label} ${savedCount} → ${current[field].length}`);
+      }
+    });
+  });
+  return regressions;
+}
+
 function main() {
   const asJson = process.argv.includes('--json');
   const isCheck = process.argv.includes('--check');
@@ -125,13 +156,15 @@ function main() {
     totalTypeMismatch += report[name].typeMismatch.length;
   });
 
-  // 生成/更新基线：记录每个语言当前缺失数与类型冲突数
+  // 生成/更新基线：同时记录精确路径，防止缺失 key 被等量替换后绕过计数棘轮。
   if (isUpdateBaseline) {
     const baseline = { base: BASE_LOCALE, basePathCount, locales: {} };
     Object.keys(report).forEach((name) => {
       baseline.locales[name] = {
         missing: report[name].missing.length,
+        missingKeys: report[name].missing,
         typeMismatch: report[name].typeMismatch.length,
+        typeMismatchKeys: report[name].typeMismatch,
       };
     });
     fs.writeFileSync(BASELINE_FILE, JSON.stringify(baseline, null, 2) + '\n');
@@ -165,23 +198,13 @@ function main() {
       console.error('\n[i18n] 未找到基线文件，请先运行 node scripts/validate-i18n.js --update-baseline');
       process.exit(1);
     }
-    const regressions = [];
-    Object.keys(report).forEach((name) => {
-      if (!CORE_CHECK_LOCALES.has(name)) { return; }
-      const base = baseline.locales[name] || { missing: 0, typeMismatch: 0 };
-      if (report[name].missing.length > base.missing) {
-        regressions.push(`${name} 缺失 ${base.missing} → ${report[name].missing.length}`);
-      }
-      if (report[name].typeMismatch.length > base.typeMismatch) {
-        regressions.push(`${name} 类型冲突 ${base.typeMismatch} → ${report[name].typeMismatch.length}`);
-      }
-    });
+    const regressions = findRegressions(report, baseline);
     if (regressions.length) {
       console.error('\n[i18n] 棘轮校验失败：以下语言漂移增大，请补齐新增 key 或修正后重试：\n  - ' + regressions.join('\n  - '));
       console.error('（存量缺失作为跟踪项，补齐后运行 --update-baseline 收紧基线）');
       process.exit(1);
     }
-    console.log('\n[i18n] 棘轮校验通过：核心语言无新增漂移 ✓（可选语言同步参与结构校验）');
+    console.log('\n[i18n] 棘轮校验通过：所有语言均无新增 key 漂移 ✓');
     return;
   }
 
@@ -194,4 +217,11 @@ function main() {
   console.log('\n[i18n] 全部语言包 key 对齐 ✓');
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  computeReport,
+  findRegressions,
+};

--- a/tests/aggregate-table-contract.test.js
+++ b/tests/aggregate-table-contract.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const {
+  DEFAULT_LIMITS,
+  assertAggregateDesignConfig,
+  projectAggregateDesignConfig,
+  validateAggregateDesignConfig,
+} = require('../lib/aggregate-table/contract');
+
+function buildValidConfig(overrides = {}) {
+  return {
+    formUuid: 'FORM-VIEW',
+    relationForms: [{ formUuid: 'FORM-SOURCE' }],
+    relationships: [{
+      relationId: 'REL-1',
+      relationshipInfos: [{ id: 'field_name', name: '名称' }],
+    }],
+    aggregatedFields: [{ id: 'REL-1', name: '名称' }],
+    auxFields: [],
+    formulaFields: [{ id: 'metric_count', formula: 'COUNT(field_name)' }],
+    validators: [],
+    ...overrides,
+  };
+}
+
+describe('aggregate-table frontend contract', () => {
+  test('accepts a publishable designer payload and keeps filters optional', () => {
+    const result = validateAggregateDesignConfig(buildValidConfig(), { mode: 'publish' });
+
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  test.each([
+    ['relationForms', [], 'AGGREGATE_RELATION_FORMS_REQUIRED'],
+    ['relationships', [], 'AGGREGATE_RELATIONSHIPS_REQUIRED'],
+    ['aggregatedFields', [], 'AGGREGATE_COLUMNS_REQUIRED'],
+    ['formulaFields', [], 'AGGREGATE_FORMULA_FIELDS_REQUIRED'],
+  ])('rejects incomplete publish config: %s', (key, value, code) => {
+    const result = validateAggregateDesignConfig(buildValidConfig({ [key]: value }), { mode: 'publish' });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code }),
+    ]));
+  });
+
+  test('rejects invalid relationship, column, formula, and validator entries', () => {
+    const result = validateAggregateDesignConfig(buildValidConfig({
+      relationships: [{ relationId: 'REL-1', relationshipInfos: [null] }],
+      aggregatedFields: [{ id: 'REL-1', name: '' }],
+      formulaFields: [{ id: 'metric_count', formula: '' }],
+      validators: [{ formula: '' }],
+    }), { mode: 'publish' });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map((error) => error.code)).toEqual(expect.arrayContaining([
+      'AGGREGATE_RELATIONSHIP_INVALID',
+      'AGGREGATE_COLUMN_INVALID',
+      'AGGREGATE_FORMULA_FIELD_INVALID',
+      'AGGREGATE_VALIDATOR_INVALID',
+    ]));
+  });
+
+  test('draft mode permits incomplete designer state but still enforces array shape and limits', () => {
+    expect(validateAggregateDesignConfig({
+      relationForms: [],
+      relationships: [],
+      aggregatedFields: [],
+      auxFields: [],
+      formulaFields: [],
+      validators: [],
+    }, { mode: 'draft' })).toEqual({ valid: true, errors: [] });
+
+    const tooManySources = Array.from(
+      { length: DEFAULT_LIMITS.relationForms + 1 },
+      (_, index) => ({ formUuid: `FORM-${index}` })
+    );
+    const invalid = validateAggregateDesignConfig(buildValidConfig({
+      relationForms: tooManySources,
+    }), { mode: 'draft' });
+
+    expect(invalid.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'AGGREGATE_RELATION_FORMS_LIMIT' }),
+    ]));
+  });
+
+  test('assert helper throws a stable contract error before a remote write', () => {
+    expect(() => assertAggregateDesignConfig(buildValidConfig({
+      formulaFields: [],
+    }), { mode: 'publish' })).toThrow(expect.objectContaining({
+      code: 'AGGREGATE_DESIGN_CONTRACT_INVALID',
+    }));
+  });
+
+  test('readback projection only compares the six designer-owned arrays', () => {
+    expect(projectAggregateDesignConfig({
+      ...buildValidConfig(),
+      gmtModified: 123,
+      stashGmtModified: 456,
+      isStashConfig: 'y',
+      unknownServerField: 'ignored',
+    })).toEqual({
+      relationForms: [{ formUuid: 'FORM-SOURCE' }],
+      relationships: [{
+        relationId: 'REL-1',
+        relationshipInfos: [{ id: 'field_name', name: '名称' }],
+      }],
+      aggregatedFields: [{ id: 'REL-1', name: '名称' }],
+      auxFields: [],
+      formulaFields: [{ id: 'metric_count', formula: 'COUNT(field_name)' }],
+      validators: [],
+    });
+  });
+
+  test('readback accepts deterministic platform normalization without weakening semantic equality', () => {
+    const expected = buildValidConfig({
+      relationForms: [{
+        formUuid: 'FORM-SOURCE',
+        title: { type: 'i18n', zh_CN: '订单', en_US: 'Orders' },
+        filter: {},
+      }],
+      relationships: [{
+        relationId: 'REL-1',
+        relationshipInfos: [{
+          id: 'field_name',
+          name: { type: 'i18n', zh_CN: '名称', en_US: 'Name' },
+        }],
+      }],
+      formulaFields: [{
+        id: 'metric_count',
+        formula: 'COUNT(field_name)',
+        name: { type: 'i18n', zh_CN: '数量', en_US: 'Count' },
+        props: { precision: 2 },
+      }],
+    });
+    const actual = buildValidConfig({
+      relationForms: [{
+        formUuid: 'FORM-SOURCE',
+        title: {
+          type: 'i18n', zh_CN: '订单', en_US: 'Orders', pureEn_US: 'Orders',
+          ja_JP: '', key: '', value: '',
+        },
+        filter: { logicOperator: '', rules: null },
+        filterState: null,
+      }],
+      relationships: [{
+        relationId: 'REL-1',
+        relationshipInfos: [{
+          id: 'field_name',
+          parentId: '',
+          name: {
+            type: 'i18n', zh_CN: '名称', en_US: 'Name', pureEn_US: 'Name',
+            ja_JP: '', key: '', value: '',
+          },
+        }],
+      }],
+      formulaFields: [{
+        id: 'metric_count',
+        formula: 'COUNT(field_name)',
+        name: {
+          type: 'i18n', zh_CN: '数量', en_US: 'Count', pureEn_US: 'Count',
+          ja_JP: '', key: '', value: '',
+        },
+        props: { precision: '2' },
+      }],
+    });
+
+    expect(() => require('../lib/aggregate-table/contract')
+      .assertAggregateDesignReadback(expected, actual)).not.toThrow();
+
+    actual.formulaFields[0].formula = 'COUNT(other_field)';
+    expect(() => require('../lib/aggregate-table/contract')
+      .assertAggregateDesignReadback(expected, actual)).toThrow(expect.objectContaining({
+      code: 'AGGREGATE_DESIGN_READBACK_MISMATCH',
+    }));
+  });
+});

--- a/tests/aggregate-table.test.js
+++ b/tests/aggregate-table.test.js
@@ -38,6 +38,22 @@ const mockAuthData = {
   user_id: 'user-1',
 };
 
+function buildPublishableDesign(overrides = {}) {
+  return {
+    formUuid: 'FORM-VIEW',
+    relationForms: [{ formUuid: 'FORM-SOURCE' }],
+    relationships: [{
+      relationId: 'REL-1',
+      relationshipInfos: [{ id: 'field_name', name: '名称' }],
+    }],
+    aggregatedFields: [{ id: 'REL-1', name: '名称' }],
+    auxFields: [],
+    formulaFields: [{ id: 'metric_count', formula: 'COUNT(field_name)' }],
+    validators: [],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   utils.loadAuthData.mockReturnValue(mockAuthData);
@@ -169,7 +185,162 @@ describe('aggregate-table run', () => {
       formType: 'virtualView',
       designUrl: 'https://www.aliwork.com/alibaba/web/APP_XXX/design/virtualViewDesigner.html?formUuid=FORM-VIEW&fromNew=true',
     });
+    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
 
     mockLog.mockRestore();
+  });
+
+  test('create-empty fails closed when the single write returns no form identity', async () => {
+    utils.httpPost
+      .mockResolvedValueOnce({ success: true, content: true })
+      .mockResolvedValueOnce({ success: true, content: {} });
+
+    await expect(run([
+      'create-empty',
+      'APP_XXX',
+      '客户聚合表',
+      '--no-open',
+    ])).rejects.toMatchObject({
+      code: 'AGGREGATE_CREATE_IDENTITY_MISSING',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(2);
+    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
+  });
+
+  test('publish rejects an incomplete frontend contract before the remote write', async () => {
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: { gmtModified: 1, stashGmtModified: 1 },
+    });
+
+    await expect(run([
+      'publish',
+      'APP_XXX',
+      'FORM-VIEW',
+      JSON.stringify(buildPublishableDesign({ formulaFields: [] })),
+      '--no-open',
+    ])).rejects.toMatchObject({
+      code: 'AGGREGATE_DESIGN_CONTRACT_INVALID',
+    });
+
+    expect(utils.httpPost).not.toHaveBeenCalled();
+  });
+
+  test('publish performs one write and requires exact designer-owned readback', async () => {
+    const design = buildPublishableDesign();
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...design, gmtModified: 1, stashGmtModified: 1 },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...design, gmtModified: 2, stashGmtModified: 1, serverOnly: true },
+      });
+    utils.httpPost.mockResolvedValue({ success: true, content: { gmtModified: 2 } });
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run([
+      'publish',
+      'APP_XXX',
+      'FORM-VIEW',
+      JSON.stringify(design),
+      '--no-open',
+    ]);
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost.mock.calls[0][1]).toBe(
+      '/alibaba/web/APP_XXX/query/virtualview/update.json'
+    );
+    const output = JSON.parse(mockLog.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      success: true,
+      action: 'publish',
+      readbackVerified: true,
+    });
+
+    mockLog.mockRestore();
+  });
+
+  test('publish fails closed when the platform readback differs', async () => {
+    const design = buildPublishableDesign();
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...design, gmtModified: 1, stashGmtModified: 1 },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: {
+          ...design,
+          aggregatedFields: [{ id: 'REL-1', name: '平台返回了不同列名' }],
+          gmtModified: 2,
+        },
+      });
+    utils.httpPost.mockResolvedValue({ success: true, content: { gmtModified: 2 } });
+
+    await expect(run([
+      'publish',
+      'APP_XXX',
+      'FORM-VIEW',
+      JSON.stringify(design),
+      '--no-open',
+    ])).rejects.toMatchObject({
+      code: 'AGGREGATE_DESIGN_READBACK_MISMATCH',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+  });
+
+  test('publish accepts a success response without a response revision when exact readback advances', async () => {
+    const design = buildPublishableDesign();
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...design, gmtModified: 1, stashGmtModified: 1 },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...design, gmtModified: 2, stashGmtModified: 1 },
+      });
+    utils.httpPost.mockResolvedValue({ success: true, content: {} });
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run([
+      'publish',
+      'APP_XXX',
+      'FORM-VIEW',
+      JSON.stringify(design),
+      '--no-open',
+    ]);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(mockLog.mock.calls[0][0])).toMatchObject({
+      success: true,
+      readbackVerified: true,
+    });
+    mockLog.mockRestore();
+  });
+
+  test('publish rejects a revision-less response when readback did not advance', async () => {
+    const design = buildPublishableDesign();
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: { ...design, gmtModified: 1, stashGmtModified: 1 },
+    });
+    utils.httpPost.mockResolvedValue({ success: true, content: {} });
+
+    await expect(run([
+      'publish',
+      'APP_XXX',
+      'FORM-VIEW',
+      JSON.stringify(design),
+      '--no-open',
+    ])).rejects.toMatchObject({
+      code: 'AGGREGATE_WRITE_REVISION_UNCHANGED',
+    });
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/connector-api.test.js
+++ b/tests/connector-api.test.js
@@ -12,7 +12,6 @@ jest.mock('../lib/core/utils', () => ({
 
 const utils = require('../lib/core/utils');
 const {
-  deleteConnector,
   createConnection,
   listConnections,
   saveConnector,
@@ -129,19 +128,6 @@ describe('connector frontend API contract', () => {
 
     expect(utils.httpPost).toHaveBeenCalledTimes(1);
     expect(utils.httpGet).not.toHaveBeenCalled();
-  });
-
-  test('delete uses the frontend endpoint once and returns confirmed deletion', async () => {
-    utils.httpPost.mockResolvedValue({ success: true, content: true });
-
-    await expect(deleteConnector('Http_owned', '5', authRef)).resolves.toMatchObject({
-      success: true,
-      connectorName: 'Http_owned',
-    });
-
-    expect(utils.httpPost).toHaveBeenCalledTimes(1);
-    expect(utils.httpPost.mock.calls[0][1]).toContain('/query/newconnector/deleteConnector.json');
-    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
   });
 
   test('listConnections follows the frontend POST pagination contract', async () => {

--- a/tests/connector-api.test.js
+++ b/tests/connector-api.test.js
@@ -1,0 +1,267 @@
+'use strict';
+
+jest.mock('../lib/core/utils', () => ({
+  loadAuthData: jest.fn(),
+  triggerLogin: jest.fn(),
+  resolveBaseUrl: jest.fn(() => 'https://www.aliwork.com'),
+  httpGet: jest.fn(),
+  httpPost: jest.fn(),
+  httpPostJson: jest.fn(),
+  requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+}));
+
+const utils = require('../lib/core/utils');
+const {
+  deleteConnector,
+  createConnection,
+  listConnections,
+  saveConnector,
+  testConnector,
+} = require('../lib/connector/api');
+const { buildConnectorDesc } = require('../lib/connector/api');
+const { buildSecuritySchemes, parseBaseUrl } = require('../lib/connector/connector-create');
+
+const authRef = {
+  baseUrl: 'https://www.aliwork.com',
+  authMode: 'token',
+  authSource: 'token',
+  userId: 'sensitive-user-id',
+  authData: {
+    auth_mode: 'token',
+    auth_source: 'token',
+    user_id: 'sensitive-user-id',
+  },
+};
+
+function buildConnectorParams(overrides = {}) {
+  return {
+    operations: JSON.stringify([{
+      id: 'operation-ping',
+      operationId: 'ping',
+      summary: 'Ping',
+      method: 'get',
+      url: 'v1/ping',
+    }]),
+    displayName: 'E2E Connector',
+    iconUrl: 'chaxun%%#FFA200',
+    connectorDesc: 'owned by test',
+    host: 'api.example.com',
+    baseUrl: '/',
+    scheme: 'https',
+    tongxunluTemplateId: '',
+    faasTemplateId: '0',
+    securitySchemes: '{}',
+    connectorMode: '5',
+    connectorName: 'Http_owned',
+    category: 'http',
+    ...overrides,
+  };
+}
+
+describe('connector frontend API contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    utils.loadAuthData.mockReturnValue(authRef.authData);
+  });
+
+  test('save sends once and verifies the exact connector detail readback', async () => {
+    const params = buildConnectorParams();
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { id: 101, connectorName: params.connectorName },
+    });
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: { content: { ...params, id: 101, templateId: '0' } },
+    });
+
+    const result = await saveConnector(params, authRef);
+
+    expect(result).toMatchObject({
+      connectorId: 101,
+      connectorName: params.connectorName,
+      readbackVerified: true,
+    });
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
+    expect(utils.httpGet.mock.calls[0][1]).toContain('getConnectorDetail.json');
+  });
+
+  test('save accepts the platform empty FAAS sentinel for a plain HTTP connector', async () => {
+    const params = buildConnectorParams();
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { id: 101, connectorName: params.connectorName },
+    });
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: { content: { ...params, faasTemplateId: '', id: 101 } },
+    });
+
+    await expect(saveConnector(params, authRef)).resolves.toMatchObject({
+      connectorId: 101,
+      readbackVerified: true,
+    });
+  });
+
+  test('save still fails closed when a semantic connector field changes', async () => {
+    const params = buildConnectorParams();
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { id: 101, connectorName: params.connectorName },
+    });
+    utils.httpGet.mockResolvedValue({
+      success: true,
+      content: { content: { ...params, host: 'different.example.com', id: 101 } },
+    });
+
+    await expect(saveConnector(params, authRef)).rejects.toMatchObject({
+      code: 'CONNECTOR_READBACK_MISMATCH',
+    });
+  });
+
+  test('save fails closed when success omits both id and connectorName', async () => {
+    utils.httpPost.mockResolvedValue({ success: true, content: {} });
+
+    await expect(saveConnector(buildConnectorParams(), authRef)).rejects.toMatchObject({
+      code: 'CONNECTOR_WRITE_IDENTITY_MISSING',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpGet).not.toHaveBeenCalled();
+  });
+
+  test('delete uses the frontend endpoint once and returns confirmed deletion', async () => {
+    utils.httpPost.mockResolvedValue({ success: true, content: true });
+
+    await expect(deleteConnector('Http_owned', '5', authRef)).resolves.toMatchObject({
+      success: true,
+      connectorName: 'Http_owned',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpPost.mock.calls[0][1]).toContain('/query/newconnector/deleteConnector.json');
+    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
+  });
+
+  test('listConnections follows the frontend POST pagination contract', async () => {
+    utils.httpPost.mockResolvedValue({
+      success: true,
+      content: { data: [{ id: 7 }], totalCount: 1 },
+    });
+
+    await expect(listConnections('Http_owned', authRef)).resolves.toEqual([{ id: 7 }]);
+
+    expect(utils.httpPost.mock.calls[0][1]).toContain('/query/connection/listConnection.json');
+    expect(utils.httpPost.mock.calls[0][2]).toContain('pageSize=100');
+    expect(utils.httpPost.mock.calls[0][2]).toContain('pageNumber=1');
+  });
+
+  test('connection creation writes once and recovers the exact owned account by readback', async () => {
+    utils.httpPost
+      .mockResolvedValueOnce({ success: true, content: { data: [], totalCount: 0 } })
+      .mockResolvedValueOnce({ success: true, content: { id: 7 } })
+      .mockResolvedValueOnce({
+        success: true,
+        content: { data: [{ id: 7, connectionName: 'Owned Account' }] },
+      });
+
+    await expect(createConnection({
+      connectionName: 'Owned Account',
+      securityValue: JSON.stringify({ token: 'synthetic-secret' }),
+      connectorName: 'Http_owned',
+      securitySchemes: JSON.stringify({ ApiKeyAuth: { name: 'X-API-Key' } }),
+      authType: 3,
+    }, authRef)).resolves.toMatchObject({
+      id: 7,
+      connectionName: 'Owned Account',
+      readbackVerified: true,
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(3);
+    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(2);
+  });
+
+  test('test action uses the frontend JSON testOperation request exactly once', async () => {
+    utils.httpPostJson.mockResolvedValue({ statusLine: 'HTTP/1.1 200 OK', content: '{"ok":true}' });
+
+    const result = await testConnector({
+      connector: buildConnectorParams(),
+      operation: { method: 'post', url: 'v1/ping' },
+      header: { 'X-Trace': 'owned' },
+      query: { q: '1' },
+      path: {},
+      body: { hello: 'world' },
+      authId: '7',
+    }, authRef);
+
+    expect(result.statusLine).toContain('200 OK');
+    expect(utils.httpPostJson).toHaveBeenCalledWith(
+      'https://www.aliwork.com',
+      expect.stringContaining('/query/newconnector/testOperation.json'),
+      {
+        url: 'https://api.example.com/v1/ping',
+        connection: '7',
+        method: 'post',
+        path: {},
+        query: { q: '1' },
+        header: { 'X-Trace': 'owned' },
+        connectorMode: 5,
+        body: { hello: 'world' },
+      },
+      {}
+    );
+    expect(utils.httpPostJson).toHaveBeenCalledTimes(1);
+    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
+  });
+
+  test('test action omits connection for a no-auth connector like the frontend', async () => {
+    utils.httpPostJson.mockResolvedValue({ statusLine: 'HTTP/1.1 200 OK', content: '{"ok":true}' });
+
+    await testConnector({
+      connector: buildConnectorParams(),
+      operation: { method: 'get', url: 'v1/ping' },
+      header: {},
+      query: { runId: 'owned' },
+      path: {},
+      body: {},
+      authId: '',
+    }, authRef);
+
+    expect(utils.httpPostJson.mock.calls[0][2]).not.toHaveProperty('connection');
+    expect(utils.httpPostJson.mock.calls[0][2].connectorMode).toBe(5);
+  });
+
+  test('connector metadata and auth definitions do not persist raw identity or credentials', () => {
+    const description = buildConnectorDesc(
+      'safe description',
+      'old\n---\n👤 创建人: legacy-sensitive-id',
+      authRef,
+      []
+    );
+    expect(description).not.toContain('sensitive-user-id');
+    expect(description).not.toContain('legacy-sensitive-id');
+
+    const basic = JSON.parse(buildSecuritySchemes({
+      authType: 'BASIC',
+      username: 'actual-user',
+      password: 'actual-password',
+    }));
+    expect(JSON.stringify(basic)).not.toContain('actual-user');
+    expect(JSON.stringify(basic)).not.toContain('actual-password');
+    expect(basic.BasicAuth).toEqual({
+      username: '用户名',
+      password: '密码',
+      type: 'http',
+      scheme: 'basic',
+    });
+  });
+
+  test('base URL parsing preserves the frontend connector base path', () => {
+    expect(parseBaseUrl('https://api.example.com/open/v1/')).toEqual({
+      scheme: 'https',
+      host: 'api.example.com',
+      basePath: '/open/v1/',
+    });
+  });
+});

--- a/tests/connector-delete.test.js
+++ b/tests/connector-delete.test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 jest.mock('../lib/connector/api', () => ({
   findConnectorById: jest.fn(),
   getAuthRef: jest.fn(),
@@ -51,5 +54,30 @@ describe('connector delete safety boundary', () => {
 
   test('the connector API does not expose an unguarded delete mutation', () => {
     expect(actualConnectorApi.deleteConnector).toBeUndefined();
+  });
+
+  test('public docs and every locale describe connector delete as read-only guidance', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const docs = [
+      ['README.md', 'Show manual deletion guidance (CLI does not delete)'],
+      ['README_zhCN.md', '显示平台手工删除指引（CLI 不执行删除）'],
+      ['yida-skills/skills/yida-connector/SKILL.md', 'CLI 不执行连接器删除'],
+    ];
+    for (const [relativePath, expected] of docs) {
+      expect(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')).toContain(expected);
+    }
+
+    const localePaths = [
+      'lib/core/locales/en.js',
+      'lib/core/locales/zh.js',
+      ...['ar', 'de', 'es', 'fr', 'hi', 'ja', 'ko', 'pt', 'vi', 'zh-HK']
+        .map((locale) => `locales-extra/core/${locale}.js`),
+    ];
+    expect(localePaths).toHaveLength(12);
+    for (const relativePath of localePaths) {
+      const locale = require(path.join(repoRoot, relativePath));
+      expect(locale.help.cmd_connector_delete).toContain('CLI');
+      expect(locale.cli.help).toMatch(/connector delete <connector-id> \[--force\].*CLI/);
+    }
   });
 });

--- a/tests/connector-delete.test.js
+++ b/tests/connector-delete.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+jest.mock('../lib/connector/api', () => ({
+  findConnectorById: jest.fn(),
+  getAuthRef: jest.fn(),
+}));
+
+const connectorApi = require('../lib/connector/api');
+const connectorDelete = require('../lib/connector/connector-delete');
+const actualConnectorApi = jest.requireActual('../lib/connector/api');
+
+describe('connector delete safety boundary', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    connectorApi.getAuthRef.mockReturnValue({ authMode: 'token' });
+    connectorApi.findConnectorById.mockResolvedValue({
+      id: '910244',
+      connectorName: 'Http_owned',
+      displayName: 'Owned Connector',
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  test('without --force only prints the first warning and performs no API lookup', async () => {
+    await connectorDelete.run(['910244']);
+
+    expect(connectorApi.getAuthRef).not.toHaveBeenCalled();
+    expect(connectorApi.findConnectorById).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('在平台删除连接器不可恢复');
+    expect(output).toContain('CLI 不会执行删除');
+  });
+
+  test('--force only identifies the connector and directs the user to manual deletion', async () => {
+    await connectorDelete.run(['910244', '--force']);
+
+    expect(connectorApi.getAuthRef).toHaveBeenCalledTimes(1);
+    expect(connectorApi.findConnectorById).toHaveBeenCalledTimes(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('CLI 未执行删除操作');
+    expect(output).toContain('无法确定性证明');
+    expect(output).toContain('customConnectorFactory');
+    expect(output).not.toContain('连接器删除成功');
+  });
+
+  test('the connector API does not expose an unguarded delete mutation', () => {
+    expect(actualConnectorApi.deleteConnector).toBeUndefined();
+  });
+});

--- a/tests/report-command.test.js
+++ b/tests/report-command.test.js
@@ -92,14 +92,15 @@ describe('report command helpers', () => {
     expect(querystring.parse(utils.httpPost.mock.calls[0][2])).toMatchObject({
       formType: 'report',
     });
-    expect(utils.httpPost.mock.calls[1][1]).toBe('/dingtalk/web/APP_XXX/_view/query/formdesign/saveFormSchema.json');
+    expect(utils.httpPost.mock.calls[1][1]).toBe('/alibaba/web/APP_XXX/_view/query/formdesign/saveFormSchema.json');
     expect(querystring.parse(utils.httpPost.mock.calls[1][2])).toMatchObject({
       formUuid: 'REPORT_1',
       schemaVersion: 'V5',
-      importSchema: 'true',
+      domainCode: 'tEXDRG',
       gmtModified: '100',
     });
-    expect(utils.requestWithAutoLogin).toHaveBeenCalledTimes(1);
+    expect(querystring.parse(utils.httpPost.mock.calls[1][2])).not.toHaveProperty('importSchema');
+    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
   });
 
   test.each([
@@ -127,7 +128,15 @@ describe('report command helpers', () => {
     utils.httpPost
       .mockResolvedValueOnce({ success: true, content: { formUuid: 'REPORT_1' } })
       .mockResolvedValueOnce({ success: true });
-    utils.httpGet.mockResolvedValueOnce({ success: true, content: { gmtModified: 100 } });
+    utils.httpGet
+      .mockResolvedValueOnce({ success: true, content: { gmtModified: 100 } })
+      .mockImplementationOnce(async () => {
+        const saveBody = querystring.parse(utils.httpPost.mock.calls[1][2]);
+        return {
+          success: true,
+          content: { ...JSON.parse(saveBody.content), gmtModified: 101 },
+        };
+      });
 
     const result = await createReport.run(['APP_XXX', '销售报表', JSON.stringify(chartConfig)]);
 
@@ -137,6 +146,7 @@ describe('report command helpers', () => {
       reportTitle: '销售报表',
       appType: 'APP_XXX',
       chartCount: 1,
+      readbackVerified: true,
       url: 'https://demo.aliwork.com/APP_XXX/workbench/REPORT_1',
     });
     const saveBody = querystring.parse(utils.httpPost.mock.calls[1][2]);
@@ -145,7 +155,29 @@ describe('report command helpers', () => {
       pages: expect.any(Array),
     });
     expect(saveBody.gmtModified).toBe('100');
+    expect(saveBody.domainCode).toBe('tEXDRG');
+    expect(utils.httpGet.mock.calls[0][2]).toMatchObject({
+      formUuid: 'REPORT_1',
+      schemaVersion: 'V5',
+      domainCode: 'tEXDRG',
+    });
     expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual(result);
+  });
+
+  test('create-report fails closed when the single create write returns no report identity', async () => {
+    utils.httpPost.mockResolvedValueOnce({ success: true, content: {} });
+
+    await expect(createReport.run([
+      'APP_XXX',
+      '销售报表',
+      JSON.stringify(chartConfig),
+    ])).rejects.toMatchObject({
+      code: 'CREATE_REPORT_IDENTITY_MISSING',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpGet).not.toHaveBeenCalled();
+    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
   });
 
   test('append-chart run fetches existing schema and saves appended chart', async () => {
@@ -154,6 +186,13 @@ describe('report command helpers', () => {
       content: makeReportSchema(),
     });
     utils.httpPost.mockResolvedValueOnce({ success: true });
+    utils.httpGet.mockImplementationOnce(async () => {
+      const saveBody = querystring.parse(utils.httpPost.mock.calls[0][2]);
+      return {
+        success: true,
+        content: { ...JSON.parse(saveBody.content), gmtModified: 101 },
+      };
+    });
 
     const result = await appendReport.run(['APP_XXX', 'REPORT_1', JSON.stringify(chartConfig)]);
 
@@ -162,6 +201,7 @@ describe('report command helpers', () => {
       reportId: 'REPORT_1',
       appType: 'APP_XXX',
       appendedChartCount: 1,
+      readbackVerified: true,
       url: 'https://demo.aliwork.com/APP_XXX/workbench/REPORT_1',
     });
     expect(utils.httpGet.mock.calls[0][1]).toBe('/alibaba/web/APP_XXX/_view/query/formdesign/getFormSchema.json');
@@ -171,6 +211,30 @@ describe('report command helpers', () => {
     const rootContent = savedSchema.pages[0].componentsTree[0].children[0];
     expect(rootContent.children).toHaveLength(1);
     expect(rootContent.props.layout).toHaveLength(1);
+  });
+
+  test('append-chart fails closed when the report schema readback differs', async () => {
+    utils.httpGet
+      .mockResolvedValueOnce({
+        success: true,
+        content: makeReportSchema(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        content: { ...makeReportSchema(), gmtModified: 101 },
+      });
+    utils.httpPost.mockResolvedValueOnce({ success: true });
+
+    await expect(appendReport.run([
+      'APP_XXX',
+      'REPORT_1',
+      JSON.stringify(chartConfig),
+    ])).rejects.toMatchObject({
+      code: 'REPORT_SCHEMA_READBACK_MISMATCH',
+    });
+
+    expect(utils.httpPost).toHaveBeenCalledTimes(1);
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
   });
 
   test('usage errors reject as CliError instead of exiting', async () => {

--- a/tests/report-contract.test.js
+++ b/tests/report-contract.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const {
+  REPORT_DOMAIN_CODE,
+  assertReportSchemaReadback,
+  collectReportI18nKeys,
+  normalizeReportSchemaContent,
+  normalizeReportConfig,
+  prepareReportSchemaForSave,
+} = require('../lib/report/contract');
+
+function buildSchema(overrides = {}) {
+  return {
+    id: 'REPORT_1',
+    gmtModified: 100,
+    i18nData: [{ key: 'legacy' }],
+    config: { existing: true },
+    pages: [{
+      componentsTree: [{
+        componentName: 'Page',
+        data: { key: 'page-title' },
+        children: [{
+          componentName: 'Chart',
+          data: { key: 'i18n-runtime-owned' },
+          children: [{
+            componentName: 'Filter',
+            data: { key: 'filter-title' },
+          }],
+        }],
+      }],
+    }],
+    ...overrides,
+  };
+}
+
+describe('report frontend contract', () => {
+  test('uses the report designer domain contract', () => {
+    expect(REPORT_DOMAIN_CODE).toBe('tEXDRG');
+  });
+
+  test('collects unique non-runtime i18n keys from component data', () => {
+    expect(collectReportI18nKeys(buildSchema())).toEqual([
+      'page-title',
+      'filter-title',
+    ]);
+  });
+
+  test('prepares a cloned schema like the frontend save path', () => {
+    const original = buildSchema();
+    const prepared = prepareReportSchemaForSave(original);
+
+    expect(prepared).not.toBe(original);
+    expect(prepared).not.toHaveProperty('i18nData');
+    expect(prepared.config).toEqual({
+      existing: true,
+      i18nKeyList: ['page-title', 'filter-title'],
+    });
+    expect(original).toHaveProperty('i18nData');
+  });
+
+  test('normalizes string and response-wrapped schema content', () => {
+    const schema = buildSchema();
+    expect(normalizeReportSchemaContent({ content: JSON.stringify(schema) })).toEqual(schema);
+  });
+
+  test('normalizes a JSON-string report config and rejects malformed config', () => {
+    expect(normalizeReportConfig('{"existing":true}')).toEqual({ existing: true });
+    expect(() => normalizeReportConfig('{')).toThrow(expect.objectContaining({
+      code: 'REPORT_SCHEMA_CONFIG_INVALID',
+    }));
+  });
+
+  test('readback ignores the server revision but requires exact saved content', () => {
+    const expected = prepareReportSchemaForSave(buildSchema());
+    const actual = { ...expected, gmtModified: 101 };
+
+    expect(assertReportSchemaReadback(expected, actual)).toMatchObject({
+      pages: expected.pages,
+    });
+  });
+
+  test('readback accepts deterministic platform normalization without weakening chart semantics', () => {
+    const expected = prepareReportSchemaForSave(buildSchema({
+      pages: [{
+        css: '',
+        utils: [],
+        componentsTree: [{
+          componentName: 'Page',
+          lifeCycles: { componentDidMount: '' },
+          props: { height: null, visible: true },
+          children: [{
+            componentName: 'Chart',
+            data: { cubeCode: 'FORM_1', fieldCode: 'numberField_1', aggregateType: 'SUM' },
+          }],
+        }],
+      }],
+    }));
+    const actual = {
+      ...expected,
+      id: undefined,
+      status: 'PUBLISHED',
+      gmtModified: 101,
+      i18nData: [{ key: 'server-owned' }],
+      config: JSON.stringify(expected.config),
+      pages: [{
+        componentsTree: [{
+          componentName: 'Page',
+          props: { visible: true },
+          children: [{
+            componentName: 'Chart',
+            data: { cubeCode: 'FORM_1', fieldCode: 'numberField_1', aggregateType: 'SUM' },
+          }],
+        }],
+      }],
+    };
+
+    expect(() => assertReportSchemaReadback(expected, actual)).not.toThrow();
+    actual.pages[0].componentsTree[0].children[0].data.aggregateType = 'COUNT';
+    expect(() => assertReportSchemaReadback(expected, actual)).toThrow(expect.objectContaining({
+      code: 'REPORT_SCHEMA_READBACK_MISMATCH',
+    }));
+  });
+
+  test('readback mismatch fails closed with a stable code', () => {
+    const expected = prepareReportSchemaForSave(buildSchema());
+    const actual = {
+      ...expected,
+      pages: [{ componentsTree: [] }],
+      gmtModified: 101,
+    };
+
+    expect(() => assertReportSchemaReadback(expected, actual)).toThrow(expect.objectContaining({
+      code: 'REPORT_SCHEMA_READBACK_MISMATCH',
+    }));
+  });
+});

--- a/tests/validate-i18n.test.js
+++ b/tests/validate-i18n.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const path = require('path');
+
+const { computeReport, findRegressions } = require('../scripts/validate-i18n');
+const en = require('../lib/core/locales/en');
+
+const optionalLocales = ['ar', 'de', 'es', 'fr', 'hi', 'ja', 'ko', 'pt', 'vi', 'zh-HK'];
+const translatedKeys = {
+  app_permission: Object.keys(en.app_permission),
+  corp_manager: Object.keys(en.corp_manager),
+  save_permission: Object.keys(en.save_permission),
+  save_share_config: ['err_page_url_prefix', 'verify_failed', 'current_state_incomplete'],
+  publish: [
+    'lint_jsx_text_identifier',
+    'lint_form_open_container',
+    'lint_form_detail_link',
+    'lint_searchformdata_http_path',
+    'lint_searchformdata_http_query_params',
+    'lint_searchformdata_http_csrf',
+    'lint_searchformdata_http_credentials',
+    'lint_canvas_yida_api_bridge_missing',
+  ],
+};
+
+function placeholders(value) {
+  return [...value.matchAll(/\{\d+\}/g)].map((match) => match[0]).sort();
+}
+
+describe('i18n baseline ratchet', () => {
+  test('detects a different missing key even when the total count is unchanged', () => {
+    const report = {
+      vi: {
+        missing: ['save_permission.new_verify_failed'],
+        typeMismatch: [],
+      },
+    };
+    const baseline = {
+      locales: {
+        vi: {
+          missing: 1,
+          missingKeys: ['save_permission.old_verify_failed'],
+          typeMismatch: 0,
+          typeMismatchKeys: [],
+        },
+      },
+    };
+
+    expect(findRegressions(report, baseline)).toEqual([
+      'vi 新增缺失 1 个：save_permission.new_verify_failed',
+    ]);
+  });
+
+  test('checks optional locales instead of limiting the ratchet to English', () => {
+    const report = {
+      en: { missing: [], typeMismatch: [] },
+      'zh-HK': { missing: ['corp_manager.admin_verify_failed'], typeMismatch: [] },
+    };
+    const baseline = {
+      locales: {
+        en: { missingKeys: [], typeMismatchKeys: [] },
+        'zh-HK': { missingKeys: [], typeMismatchKeys: [] },
+      },
+    };
+
+    expect(findRegressions(report, baseline)).toEqual([
+      'zh-HK 新增缺失 1 个：corp_manager.admin_verify_failed',
+    ]);
+  });
+
+  test('keeps backward compatibility with count-only baselines', () => {
+    const report = {
+      vi: { missing: ['a', 'b'], typeMismatch: [] },
+    };
+    const baseline = {
+      locales: {
+        vi: { missing: 1, typeMismatch: 0 },
+      },
+    };
+
+    expect(findRegressions(report, baseline)).toEqual(['vi 缺失 1 → 2']);
+  });
+
+  test('all locale packs are structurally complete', () => {
+    const { report } = computeReport();
+
+    Object.values(report).forEach((localeReport) => {
+      expect(localeReport.missing).toEqual([]);
+      expect(localeReport.typeMismatch).toEqual([]);
+    });
+  });
+
+  test.each(optionalLocales)('%s preserves placeholders in newly completed messages', (locale) => {
+    const translated = require(path.join('..', 'locales-extra', 'core', locale));
+
+    Object.entries(translatedKeys).forEach(([group, keys]) => {
+      keys.forEach((key) => {
+        expect(placeholders(translated[group][key])).toEqual(placeholders(en[group][key]));
+      });
+    });
+  });
+});

--- a/tests/yida-client.test.js
+++ b/tests/yida-client.test.js
@@ -173,4 +173,23 @@ describe('yida-client', () => {
       { referer: 'https://example.yida.test/settings' }
     );
   });
+
+  test.each([
+    ['login expiry', { __needLogin: true }],
+    ['CSRF expiry', { __csrfExpired: true }],
+    ['ordinary failure', { success: false, errorCode: 'FAILED' }],
+  ])('postJsonOnce sends exactly once on %s', async (label, response) => {
+    utils.httpPostJson.mockResolvedValue(response);
+    const client = createYidaClient();
+
+    await expect(client.postJsonOnce(
+      '/query/newconnector/testOperation.json',
+      { method: 'get' },
+      { referer: 'https://example.yida.test/settings' }
+    )).resolves.toEqual(response);
+
+    expect(label).toBeTruthy();
+    expect(utils.httpPostJson).toHaveBeenCalledTimes(1);
+    expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
+  });
 });

--- a/yida-skills/skills/yida-connector/SKILL.md
+++ b/yida-skills/skills/yida-connector/SKILL.md
@@ -9,7 +9,7 @@ description: 宜搭 HTTP 连接器创建与管理。打通钉钉/自建系统/�
 
 - 不要在代码中硬编码 API Key、密码等凭证，通过连接器鉴权配置管理
 - 不要编造 connector-id 或 action-id，必须从命令返回中提取
-- 不要删除连接器前确认是否有表单/页面正在使用
+- 不要把 `connector delete` 当作真实删除命令；CLI 仅查询目标并展示平台手工删除指引
 - 不要用 shell heredoc、`cat`/`echo`/`printf`/`tee` 或重定向生成连接器 action/config JSON
 
 ## 严格要求 (MUST DO)
@@ -33,7 +33,7 @@ description: 宜搭 HTTP 连接器创建与管理。打通钉钉/自建系统/�
 
 ## 危险操作确认
 
-删除连接器为不可逆操作，执行前必须确认无表单/页面依赖此连接器。
+CLI 不执行连接器删除。用户确需删除时，先确认并解除表单、页面、流程和集成自动化中的全部依赖，再根据命令指引前往宜搭平台管理后台手工删除；平台删除不可逆。
 
 ## 异常处理
 
@@ -43,7 +43,7 @@ description: 宜搭 HTTP 连接器创建与管理。打通钉钉/自建系统/�
 | 鉴权失败（401/403） | 检查鉴权方式和凭证配置，重新创建连接器或更新鉴权账号 |
 | API 调用超时 | 检查目标域名是否可达，确认网络连通性后重试 |
 | action-id 不存在 | 执行 `openyida connector list-actions <connector-id>` 重新获取有效 action-id |
-| 连接器被依赖无法删除 | 先在宜搭平台确认哪些表单/页面依赖此连接器，解除依赖后再删除 |
+| 需要删除连接器 | 执行 `openyida connector delete <connector-id> --force` 仅查询目标并获取平台指引；确认并解除全部依赖后，在宜搭平台管理后台手工删除 |
 | 智能创建解析失败 | 改用 `openyida connector gen-template` 生成模板，手动填写后再创建 |
 
 ## Agent 错误处理策略
@@ -58,7 +58,7 @@ description: 宜搭 HTTP 连接器创建与管理。打通钉钉/自建系统/�
 | 鉴权配置错误 | 停止执行，引导用户检查鉴权方式和凭证配置 |
 | 智能创建解析失败 | 降级为模板创建方式，引导用户使用 `gen-template` |
 | 网络超时 | 重试 1 次，仍失败则停止并提示用户检查网络 |
-| 删除操作前 | 必须先确认无依赖，展示确认提示后再执行 |
+| 用户要求删除连接器 | 明确说明 CLI 不执行删除；仅查询目标并展示平台手工删除指引，不得宣称命令已删除资源 |
 | 未知错误 | 停止执行，完整展示错误信息，建议用户反馈问题 |
 
 ---
@@ -89,8 +89,8 @@ openyida connector create "<名称>" "<域名>" [--auth "<鉴权方式>" --usern
 # 获取详情
 openyida connector detail <connector-id>
 
-# 删除连接器
-openyida connector delete <connector-id>
+# 查询连接器并获取平台手工删除指引（CLI 不执行删除）
+openyida connector delete <connector-id> --force
 ```
 
 ### 执行动作管理


### PR DESCRIPTION
## Summary

- harden aggregate-table validation, one-shot writes, revision handling, and canonical readback
- align native report save/readback with the frontend domain, i18n, and platform normalization contracts
- align custom connector CRUD/test operations with frontend endpoints, typed payloads, pagination, and exact readback
- remove persisted connector identity metadata and credential values

## Verification

- real E2E passed for aggregate table, native report, and custom connector
- targeted tests: 7 suites / 82 tests passed
- npm run check:ci passed
- 383 JavaScript files passed syntax check
- lint: 0 errors (28 existing warnings)

## Real E2E resources

- retained 11 owned resources by explicit cleanup waiver: 1 app, 2 forms, 5 instances, 1 aggregate table, 1 report, 1 connector
- cleanup status: waived / residual accepted (not cleanup passed)

## Safety

- no master operation
- no credential, token, profile, user, or real resource identifiers committed

Refs #83584385