### PR TITLE
docs: optimize LLM guardrail guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
+## [Unreleased]
+
+### Changed
+
+- `integration create --process-code` 执行整图替换时必须同时传入 `--replace`；LLM 在确认目标 `appType`、`formUuid`、`processCode` 和替换摘要后执行该命令。已有命令补充 `--replace` 后继续使用。
+- Canvas 源码中的非标准运行时能力通过 `window.<name>` 或 `parentWindow.<name>` 访问并检查目标方法；裸 `dd.biz.*` 改为通过 `window.dd` 调用。已发布页面继续运行，重新编译或发布源码时按该写法迁移。
+
 ## [2026.8.25-1] - 2026-08-25
 
 ### Fixed

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -789,6 +789,7 @@ describe('OpenYida skill contracts', () => {
     expect(appStep7).toContain('Canvas 本地校验不存在未绑定标识符');
     expect(appStep7).toContain('`window.<name>` / `parentWindow.<name>`');
     expect(commonIssues).toContain('Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`');
+    expect(commonIssues).toContain('或运行时报 `<name> is not defined`');
     expect(commonIssues).toContain('通过 `window.<name>` / `parentWindow.<name>` 获取能力');
   });
 
@@ -798,7 +799,9 @@ describe('OpenYida skill contracts', () => {
     expect(integration).toContain('## 命令选择');
     expect(integration).toContain('| 创建新自动化 | 使用 `integration create`，由 CLI 生成 `processCode` |');
     expect(integration).toContain('`integration create ... --process-code <code> --replace`');
+    expect(integration).toContain('CLI 无法读取原有节点定义；本次将整体覆盖，原节点不保留');
     expect(integration).toContain('| 更新已有自动化 | 使用 `integration update` 获取 capability 结果，并按结果报告当前状态 |');
+    expect(integration).toContain('不得把 `integration update` 的 fail-closed 结果降级为 `integration create --process-code --replace`');
     expect(integration).toContain('`INTEGRATION_FULL_REPLACEMENT_REQUIRES_REPLACE`');
     expect(integration).toContain('已获得整图替换确认时，补 `--replace` 重试一次');
     expect(integration).toContain('--process-code LPROC-XXX');

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -775,6 +775,9 @@ describe('OpenYida skill contracts', () => {
     expect(canvas).toContain('源码保持零未绑定标识符');
     expect(canvas).toContain('OPENYIDA_CANVAS_UNBOUND_IDENTIFIER');
     expect(canvas).toContain('`window.<name>` 或 `parentWindow.<name>`');
+    expect(canvas).toContain('一次修复 `details.issues` 中的全部名称');
+    expect(canvas).toContain('const dingTalk = window.dd;');
+    expect(canvas).toContain("typeof dingTalk?.biz?.navigation?.setTitle === 'function'");
     expect(canvas).toContain('未绑定标识符守卫边界');
     expect(canvas).toContain('不代表能发现全部拼写错误');
     expect(canvas).toContain('`name`、`status`、`length`、`event`、`origin`、`top`');
@@ -786,6 +789,20 @@ describe('OpenYida skill contracts', () => {
     expect(appStep7).toContain('Canvas 本地校验不存在未绑定标识符');
     expect(appStep7).toContain('`window.<name>` / `parentWindow.<name>`');
     expect(commonIssues).toContain('Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`');
+    expect(commonIssues).toContain('通过 `window.<name>` / `parentWindow.<name>` 获取能力');
+  });
+
+  test('integration skill selects create, replacement, and update commands by intent', () => {
+    const integration = readSkill('yida-skills/skills/yida-integration/SKILL.md');
+
+    expect(integration).toContain('## 命令选择');
+    expect(integration).toContain('| 创建新自动化 | 使用 `integration create`，由 CLI 生成 `processCode` |');
+    expect(integration).toContain('`integration create ... --process-code <code> --replace`');
+    expect(integration).toContain('| 更新已有自动化 | 使用 `integration update` 获取 capability 结果，并按结果报告当前状态 |');
+    expect(integration).toContain('`INTEGRATION_FULL_REPLACEMENT_REQUIRES_REPLACE`');
+    expect(integration).toContain('已获得整图替换确认时，补 `--replace` 重试一次');
+    expect(integration).toContain('--process-code LPROC-XXX');
+    expect(integration).toContain('--replace');
   });
 
   test('page visual lessons are codified in yida-design, chart, and report skills', () => {

--- a/yida-skills/skills/yida-app/references/common-issues.md
+++ b/yida-skills/skills/yida-app/references/common-issues.md
@@ -19,7 +19,7 @@
 | 页面视觉和设计不一致 | `design.md` 的 token、布局、背景、圆角、密度、组件和状态规则 | 回写或重读 `design.md`，再回到 Step 7 |
 | `page-spec.json` 和 PRD/design.md 冲突 | `sourceOfTruth`、`designFile`、`designRefs`、dataBinding | 丢弃旧 spec，从最新 PRD + `design.md` 重生成 |
 | JSX 运行时报中文变量未定义 | 页面源码中的 `{所有级别}`、`{处理中}` 等裸中文表达式 | 改成纯文本或 `{'所有级别'}` 形式，再重新校验 |
-| Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`，名称是辅助函数、Ref、状态或局部变量 | `details.issues` 中的全部名称和行列 | 回到 [Step 7](../workflow/step-7-page-code.md)；一次补齐声明或统一重命名，再重新执行 Canvas 本地校验 |
+| Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`，名称是辅助函数、Ref、状态或局部变量，或运行时报 `<name> is not defined` | `details.issues` 中的全部名称和行列 | 回到 [Step 7](../workflow/step-7-page-code.md)；一次补齐声明或统一重命名，再重新执行 Canvas 本地校验 |
 | Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`，名称由非标准运行时提供 | `details.issues` 中的名称和运行时能力路径 | 回到 [Step 7](../workflow/step-7-page-code.md)；通过 `window.<name>` / `parentWindow.<name>` 获取能力，检查目标方法后重新执行 Canvas 本地校验 |
 | emoji 导致 create/publish 失败 | 字段 JSON、`page-spec.json`、页面源码、发布 Schema、路径 | 删除 emoji；页面图标改成 `lucide-react` 或 `@ant-design/icons` 标准 import |
 | 本地源码改了但远端没更新 | 是否有成功的 `openyida publish <source> <appType> <displayPageFormUuid>` | 回到 [Step 8](../workflow/step-8-publish-navigation.md) 发布本轮源码 |

--- a/yida-skills/skills/yida-app/references/common-issues.md
+++ b/yida-skills/skills/yida-app/references/common-issues.md
@@ -19,7 +19,8 @@
 | 页面视觉和设计不一致 | `design.md` 的 token、布局、背景、圆角、密度、组件和状态规则 | 回写或重读 `design.md`，再回到 Step 7 |
 | `page-spec.json` 和 PRD/design.md 冲突 | `sourceOfTruth`、`designFile`、`designRefs`、dataBinding | 丢弃旧 spec，从最新 PRD + `design.md` 重生成 |
 | JSX 运行时报中文变量未定义 | 页面源码中的 `{所有级别}`、`{处理中}` 等裸中文表达式 | 改成纯文本或 `{'所有级别'}` 形式，再重新校验 |
-| Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER` 或运行时报 `<name> is not defined` | 错误详情中的全部名称和行列、辅助函数/Ref/状态的声明与引用 | 回到 [Step 7](../workflow/step-7-page-code.md)；补齐声明或统一重命名。若名称确由非标准运行时提供，改用 `window.<name>` / `parentWindow.<name>` 并先判断属性是否存在，再重新执行 Canvas 本地校验 |
+| Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`，名称是辅助函数、Ref、状态或局部变量 | `details.issues` 中的全部名称和行列 | 回到 [Step 7](../workflow/step-7-page-code.md)；一次补齐声明或统一重命名，再重新执行 Canvas 本地校验 |
+| Canvas 编译报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER`，名称由非标准运行时提供 | `details.issues` 中的名称和运行时能力路径 | 回到 [Step 7](../workflow/step-7-page-code.md)；通过 `window.<name>` / `parentWindow.<name>` 获取能力，检查目标方法后重新执行 Canvas 本地校验 |
 | emoji 导致 create/publish 失败 | 字段 JSON、`page-spec.json`、页面源码、发布 Schema、路径 | 删除 emoji；页面图标改成 `lucide-react` 或 `@ant-design/icons` 标准 import |
 | 本地源码改了但远端没更新 | 是否有成功的 `openyida publish <source> <appType> <displayPageFormUuid>` | 回到 [Step 8](../workflow/step-8-publish-navigation.md) 发布本轮源码 |
 | 发布失败后想重试 | 上一次 stdout/stderr、登录态、组织、参数、输入文件、字段 ID | 修改至少一项输入或上下文后重试；保留错误输出 |

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -85,7 +85,18 @@ UI 和产品设计输入来自 `yida-design` 输出的 `prd/<项目名>/prd.md` 
 7. **交互控件必须受控且真正驱动数据**：筛选 `Select`、搜索 `Input`/`Input.Search`、周期切换、`Tabs`/`Segmented`、批量/重置 `Button` 等控件都用 `useState` 建立受控状态，绑定 `onChange`/`onClick`，并让 `Table`/列表/卡片的数据源通过 `useMemo` 按状态派生后渲染。切换筛选后若当前选中项失效，回退选中态（如 `selected < filteredRows.length ? selected : 0`）。
 8. **视觉壳层必须消费 design.md**：工作台、门户、看板、首页、展示页和真实交付页写页面源码前，先从 `design.md` 抽取 `backgroundLayer`、`visualScaffold.rootShell`、`surfaceMap`、`componentRecipe`、`roundedRule`、`densityRule`、`breathingRule`、`themeProfile` 和 `yidaThemeRuntime`。若 `design.md` 声明 `backgroundLayer`，源码完成标准是：页面根节点带 `data-yida-theme-root="true"`；根节点或注入 CSS 承载背景层；背景 primitive 落到根节点、`::before`、`::after` 或等价背景层；内容层使用相对定位和更高 `z-index`；antd 页面包 `ConfigProvider`，并使用 `readBrandColor`、`getPopupContainer` 和控件 reset CSS 让主题、焦点和浮层生效。若 `design.md` 声明圆润高密和呼吸感规则，源码必须同步到 antd `borderRadius`、CSS `border-radius`、页面 padding/gap、区块间距、列表行高、状态摘要高度、空态高度和内容安全内距，并保证卡片 padding >20px、卡片 gap <20px、卡片圆角 0-32px。
 9. **表单数据读取必须使用 dataBinding 契约和 yida JS-API 桥**：完整应用、工作台、列表、看板、详情等真实交付页只要本轮已经创建或解析业务表单，先写入 `dataBinding.mode="form"`、真实 `appType/formUuid` 和字段 ID，再用本地 `useYidaData(binding)` / `DataBridge` 读取。发布层必须在外层页面 `didMount` 注册 `window.__OPENYIDA_YIDA_API__`，`YidaCodeCanvas` 组件内部默认调用 `window.__OPENYIDA_YIDA_API__.searchFormDatas(params)`；只有桥不可用时才降级同源直连 `/dingtalk/web/<appType>/v1/form/searchFormDatas.json`。页面不能使用 `/query/form/searchFormDatas.json`，也不能只写前端 seedRows 后声称已接真实数据。
-10. **源码保持零未绑定标识符**：每个 import、辅助函数、Ref、状态、局部变量和函数参数都必须在同一文件声明后使用；重命名时同时修改声明与全部引用。`compileCanvasLocal` 报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER` 时先按错误中的全部名称和位置补齐声明。确实由非标准运行时提供的能力必须写成 `window.<name>` 或 `parentWindow.<name>` 并先判断属性是否存在，不得把裸变量加入源码后绕过发布。
+10. **源码保持零未绑定标识符**：每个 import、辅助函数、Ref、状态、局部变量和函数参数都在同一文件声明后使用。非标准运行时能力通过 `window.<name>` 或 `parentWindow.<name>` 获取，调用前检查目标方法。`compileCanvasLocal` 报 `OPENYIDA_CANVAS_UNBOUND_IDENTIFIER` 时，一次修复 `details.issues` 中的全部名称，再重新编译。
+
+非标准运行时能力使用以下写法：
+
+```jsx
+function setNavigationTitle(title) {
+  const dingTalk = window.dd;
+  if (typeof dingTalk?.biz?.navigation?.setTitle === 'function') {
+    dingTalk.biz.navigation.setTitle({ title });
+  }
+}
+```
 
 > **未绑定标识符守卫边界**：该守卫只拦截不属于 ECMAScript、Browser 或 Canvas wrapper 白名单的裸标识符。`name`、`status`、`length`、`event`、`origin`、`top` 等浏览器标准短名会解析为 `window` 属性，无法判断它原本是否是业务变量拼写错误；例如把 `orderName` 误写成 `name`、把 `rowStatus` 误写成 `status` 或把 `listLength` 误写成 `length` 都不会被拦截。守卫主要兜底 `getInstId`、`loadedRef` 这类自定义名，不代表能发现全部拼写错误；生成或重命名代码后仍须逐项核对业务标识符。
 

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -10,7 +10,7 @@ description: 创建/管理宜搭集成自动化。
 | 用户目标 | 执行动作 |
 | --- | --- |
 | 创建新自动化 | 使用 `integration create`，由 CLI 生成 `processCode` |
-| 整图替换已有自动化 | 校验 `appType`、`formUuid`、`processCode`，展示替换摘要并获得明确确认，再使用 `integration create ... --process-code <code> --replace` |
+| 整图替换已有自动化 | 校验 `appType`、`formUuid`、`processCode`，明确告知“CLI 无法读取原有节点定义；本次将整体覆盖，原节点不保留”，获得确认后使用 `integration create ... --process-code <code> --replace` |
 | 更新已有自动化 | 使用 `integration update` 获取 capability 结果，并按结果报告当前状态 |
 | 目标或资源归属不明确 | 保持零远端写，并请求用户明确目标资源和操作类型 |
 
@@ -19,6 +19,7 @@ description: 创建/管理宜搭集成自动化。
 - 不要在未加载本技能内容的情况下编写逻辑流定义，节点格式复杂且易出错
 - 不要编造 formUuid 或 fieldId，必须从已有记录或 `yida-get-schema` 获取
 - 不要用此技能配置审批流程，应使用 `yida-process-rule`
+- 不得把 `integration update` 的 fail-closed 结果降级为 `integration create --process-code --replace`
 
 ## 严格要求 (MUST DO)
 

--- a/yida-skills/skills/yida-integration/SKILL.md
+++ b/yida-skills/skills/yida-integration/SKILL.md
@@ -5,12 +5,14 @@ description: 创建/管理宜搭集成自动化。
 
 # yida-integration — 宜搭集成&自动化（逻辑流）技能
 
-## 适用范围
+## 命令选择
 
-- 不得把不支持、冲突或状态不确定的任务改走 `integration create` 写入，不得按名称 discover/adopt、猜逻辑流 ID 或自动重建。
-- `integration create ... --process-code` 是整图替换（full replacement），必须显式传 `--replace`；它不是安全编辑，也不得作为 `integration update` 的降级路径。
-- `integration update` 当前仅检测安全更新 capability；完整平台定义 readback 未证明时，必须在认证、读取 spec 和远端写入前结构化 fail-closed，不得宣称已编辑。
-- 只有自动化目标明确属于当前普通 OpenYida 资源时，以下参数、stdout/stderr、发布/启停和返回行为才按本技能契约使用；所有权不明确时零远端写。
+| 用户目标 | 执行动作 |
+| --- | --- |
+| 创建新自动化 | 使用 `integration create`，由 CLI 生成 `processCode` |
+| 整图替换已有自动化 | 校验 `appType`、`formUuid`、`processCode`，展示替换摘要并获得明确确认，再使用 `integration create ... --process-code <code> --replace` |
+| 更新已有自动化 | 使用 `integration update` 获取 capability 结果，并按结果报告当前状态 |
+| 目标或资源归属不明确 | 保持零远端写，并请求用户明确目标资源和操作类型 |
 
 ## 严格禁止 (NEVER DO)
 
@@ -49,6 +51,7 @@ description: 创建/管理宜搭集成自动化。
 
 | 错误类型 | 默认处理策略 |
 |---------|-------------|
+| `INTEGRATION_FULL_REPLACEMENT_REQUIRES_REPLACE` | 已获得整图替换确认时，补 `--replace` 重试一次；未获得确认时，展示替换摘要并请求确认 |
 | 命令执行失败 | 停止执行，向用户展示错误信息，询问是否重试或调整参数 |
 | 参数缺失（appType/formUuid/userId 等） | 主动询问用户补充，不得猜测或编造 |
 | 权限不足 / 登录态失效 | 停止执行，提示用户执行 `openyida auth status` 检查登录态 |
@@ -93,8 +96,8 @@ openyida integration check <appType...> [--json] [--output result.xlsx] [--no-pr
 
 | 选项 | 默认值 | 说明 |
 | --- | --- | --- |
-| `--process-code <code>` | 自动生成 | 已有逻辑流的 processCode（`LPROC-xxx` 格式）；传入即整图替换，必须同时传 `--replace` |
-| `--replace` | 关闭 | 显式确认 `--process-code` 是 full replacement，不是安全 update |
+| `--process-code <code>` | 自动生成 | 已有逻辑流的 processCode（`LPROC-xxx` 格式）；与 `--replace` 同时使用，执行整图替换 |
+| `--replace` | 关闭 | 显式确认 `--process-code` 执行整图替换 |
 | `--receivers <userId,...>` | 空（无接收人） | 接收钉钉工作通知的用户 ID，多个用逗号分隔 |
 | `--title <title>` | 同 flowName | 通知标题，支持 `#{fieldId-ComponentType}#` 引用表单字段 |
 | `--content <content>` | `"表单有新记录提交，请及时查看。"` | 通知内容，支持 `#{fieldId-ComponentType}#` 引用表单字段 |
@@ -122,6 +125,12 @@ openyida integration check <appType...> [--json] [--output result.xlsx] [--no-pr
 ### 示例
 
 ```bash
+# 整图替换已有自动化
+openyida integration create APP_XXX FORM-XXX "替换已有自动化" \
+  --process-code LPROC-XXX \
+  --replace \
+  --spec .cache/openyida/<项目名或任务名>/integration/desired-spec.json
+
 # 最简用法：表单新增时通知指定用户，仅保存草稿
 openyida integration create APP_XXX FORM-XXX "新增记录通知" \
   --receivers user123 \
@@ -317,7 +326,7 @@ openyida integration diagnose --file project/tickets/automation-error.txt --json
 ## 调用流程
 
 1. 读取 token session 获取登录态（不存在则提示执行 `openyida login`）
-2. 若未传入 `--process-code`，调用 `createLogicflow.json` 接口新建绑定关系，获取真实 `processCode`；若传入，必须有 `--replace` 并明确执行整图替换
+2. 创建新自动化时调用 `createLogicflow.json` 获取真实 `processCode`；整图替换时使用已校验的 `processCode` 和 `--replace`
 3. 生成各节点 ID（`node_xxx` 格式，随机生成）
 4. 根据用户传入的节点配置，构建 `json` 参数（节点定义）和 `viewJson` 参数（画布 Schema）
 5. 调用 `saveProcess` 接口（`isOnline=false`）保存为草稿
@@ -327,9 +336,7 @@ openyida integration diagnose --file project/tickets/automation-error.txt --json
 
 ## 安全二次编辑
 
-`integration update` 当前是 capability-detection 命令，不是已实现的编辑器。capability manifest 将 `integration_detail_readback_wrapper` 标记为 `PLATFORM_PROBE_REQUIRED`：已观测的 `getProcess/getProcessById` 只有 view schema，不能证明 runtime `processJson`。
-
-因此命令只生成包含 probe verdict、目标脱敏 hash、blocker 和 `remoteWrites=0` 的本地 artifact，然后在认证、ownership、spec 读取/构建及任何远端写之前结构化失败。它不执行 merge、diff、save、readback 或 restore；不得猜接口、用 compiler 结果自证或降级成 `integration create --process-code --replace`。
+使用 `integration update` 获取 capability 结果。结果为 `PLATFORM_PROBE_REQUIRED` 时，保持 `remoteWrites=0`，输出本地 probe artifact 和 blocker，并向用户报告当前状态。
 
 ## 逻辑流节点结构
 


### PR DESCRIPTION
## Summary

- add a concise intent-to-command table for Integration create, replacement, and update flows
- add the canonical `window.dd` capability-check pattern and one-pass Canvas identifier recovery guidance
- update common issues, changelog, and skill contract coverage

## Behavior boundary

- keep the existing `--replace` hard guard
- keep the Canvas unbound-identifier hard guard
- do not change CLI behavior, error payloads, or runtime global allowlists

## Validation

- 4 related Jest suites: 102 tests passed
- `npm run check:skills`
- `npm run build:skills`
- `git diff --check`

Real Codex/Qoder Agent E2E remains a follow-up after merge.