### PR TITLE
fix(auth): prevent replaying non-idempotent creates

### DIFF
--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -4550,7 +4550,7 @@ function sendCreateFormRequest(authRef, appType, formTitle) {
     function (auth) {
       return sendGetRequest(
         auth.baseUrl,
-        `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
+        buildApiPath(appType, 'getFormNavigationListByOrder', { queryModule: 'formnav' }),
         { _api: 'Nav.queryList', _mock: false }
       );
     },
@@ -4906,9 +4906,12 @@ async function mainCreate(parsedArgs, authRef) {
 
   if (!createResult || !createResult.success || !createResult.content) {
     const errorMsg = createResult ? createResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
+    const errorCode = createResult && createResult.errorCode
+      ? createResult.errorCode
+      : 'CREATE_FORM_CREATE_BLANK_FAILED';
     fail(t('create_form.create_blank_failed', errorMsg));
-    console.log(JSON.stringify({ success: false, error: errorMsg }));
-    throwCreateFormError(errorMsg, 'CREATE_FORM_CREATE_BLANK_FAILED', {
+    console.log(JSON.stringify({ success: false, errorCode, error: errorMsg }));
+    throwCreateFormError(errorMsg, errorCode, {
       appType,
       result: createResult,
     });
@@ -5052,7 +5055,10 @@ async function createFormForLegacyProcessQuiet(context, input) {
 
   if (!createResult || !createResult.success || !createResult.content) {
     const errorMsg = createResult ? createResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
-    throwCreateFormError(errorMsg, 'CREATE_FORM_CREATE_BLANK_FAILED', {
+    const errorCode = createResult && createResult.errorCode
+      ? createResult.errorCode
+      : 'CREATE_FORM_CREATE_BLANK_FAILED';
+    throwCreateFormError(errorMsg, errorCode, {
       appType,
       result: createResult,
     });

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -47,7 +47,7 @@
  *
  * 前置条件：
  *   项目根目录下需存在有效 token session（由 openyida login 生成）。
- *   若接口返回 302（登录失效），脚本会自动调用 login.py 重新登录后重试。
+ *   创建前会用只读请求刷新登录态；创建 POST 不会在 302 后自动重放。
  *
  * 示例：
  *   # 创建表单
@@ -59,7 +59,12 @@
 const fs = require('fs');
 const path = require('path');
 const querystring = require('querystring');
-const { httpPost, httpGet, requestWithAutoLogin } = require('../core/utils');
+const {
+  httpPost,
+  httpGet,
+  requestWithAutoLogin,
+  requestNonIdempotentWithAuthPreflight,
+} = require('../core/utils');
 const { createAuthRef } = require('../core/yida-client');
 const { CliError } = require('../core/cli-error');
 const { t } = require('../core/i18n');
@@ -4531,6 +4536,28 @@ function sendPostRequest(baseUrl, requestPath, extraParams, formUuid, authRef) {
   return httpPost(baseUrl, requestPath, postData, { referer });
 }
 
+function sendCreateFormRequest(authRef, appType, formTitle) {
+  return requestNonIdempotentWithAuthPreflight(
+    function (auth) {
+      return sendPostRequest(
+        auth.baseUrl,
+        buildApiPath(appType, 'saveFormSchemaInfo'),
+        { formType: 'receipt', title: JSON.stringify(i18n(formTitle)) },
+        undefined,
+        auth
+      );
+    },
+    function (auth) {
+      return sendGetRequest(
+        auth.baseUrl,
+        `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
+        { _api: 'Nav.queryList', _mock: false }
+      );
+    },
+    authRef
+  );
+}
+
 // ── 发送 updateFormConfig 请求 ───────────────────────
 
 function sendUpdateConfigRequest(baseUrl, appType, formUuid, version, value, authRef) {
@@ -4875,15 +4902,7 @@ async function mainCreate(parsedArgs, authRef) {
 
   step(3, t('create_form.step_create_blank', 3));
   info(t('create_form.sending_create'));
-  const createResult = await requestWithAutoLogin(function (auth) {
-    return sendPostRequest(
-      auth.baseUrl,
-      buildApiPath(appType, 'saveFormSchemaInfo'),
-      { formType: 'receipt', title: JSON.stringify(i18n(formTitle)) },
-      undefined,
-      auth
-    );
-  }, authRef);
+  const createResult = await sendCreateFormRequest(authRef, appType, formTitle);
 
   if (!createResult || !createResult.success || !createResult.content) {
     const errorMsg = createResult ? createResult.errorMsg || t('common.unknown_error') : t('common.request_failed');
@@ -5029,15 +5048,7 @@ async function createFormForLegacyProcessQuiet(context, input) {
   assertNoEmojiInFormDefinition(formTitle, fields, validations, 'legacy create-form input');
   validateFormFieldDefinitions(fields);
   const fieldCount = countDataFieldDefinitions(fields);
-  const createResult = await requestWithAutoLogin(function (auth) {
-    return sendPostRequest(
-      auth.baseUrl,
-      buildApiPath(appType, 'saveFormSchemaInfo'),
-      { formType: 'receipt', title: JSON.stringify(i18n(formTitle)) },
-      undefined,
-      auth
-    );
-  }, authRef);
+  const createResult = await sendCreateFormRequest(authRef, appType, formTitle);
 
   if (!createResult || !createResult.success || !createResult.content) {
     const errorMsg = createResult ? createResult.errorMsg || t('common.unknown_error') : t('common.request_failed');

--- a/lib/app/create-form/api-path.js
+++ b/lib/app/create-form/api-path.js
@@ -10,14 +10,23 @@
  * @param {object} [options]       可选项
  * @param {string} [options.prefix]        额外的路径前缀（会以 / 拼接）
  * @param {string} [options.namespace]     命名空间，默认 dingtalk
+ * @param {'formdesign'|'formnav'} [options.queryModule] 查询模块，默认 formdesign
  * @param {boolean} [options.addTimestamp] 是否追加 _stamp 时间戳查询参数
  * @returns {string} 拼接完成的 API 请求路径
  */
 function buildApiPath(appType, apiName, options = {}) {
-  const { prefix = '', namespace = 'dingtalk', addTimestamp = false } = options;
+  const {
+    prefix = '',
+    namespace = 'dingtalk',
+    queryModule = 'formdesign',
+    addTimestamp = false,
+  } = options;
+  if (queryModule !== 'formdesign' && queryModule !== 'formnav') {
+    throw new Error(`Unsupported query module: ${queryModule}`);
+  }
   const prefixPath = prefix ? `/${prefix}` : '';
   const timestamp = addTimestamp ? `?_stamp=${Date.now()}` : '';
-  return `/${namespace}/web/${appType}${prefixPath}/query/formdesign/${apiName}.json${timestamp}`;
+  return `/${namespace}/web/${appType}${prefixPath}/query/${queryModule}/${apiName}.json${timestamp}`;
 }
 
 module.exports = {

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -8,8 +8,10 @@
 
 const querystring = require('querystring');
 const {
+  httpGet,
   httpPost,
   requestWithAutoLogin,
+  requestNonIdempotentWithAuthPreflight,
 } = require('../core/utils');
 const { createAuthRef } = require('../core/yida-client');
 const { t } = require('../core/i18n');
@@ -183,18 +185,26 @@ async function run(args) {
   step(2, t('create_page.step_create'));
   info(t('create_page.sending'));
 
-  const response = await requestWithAutoLogin((auth) => {
-    const postData = querystring.stringify({
-      _csrf_token: auth.csrfToken,
-      formType: 'display',
-      title: JSON.stringify(buildYidaI18n(pageName, { en_US: pageName, ja_JP: pageName })),
-    });
-    return httpPost(
+  const response = await requestNonIdempotentWithAuthPreflight(
+    (auth) => {
+      const postData = querystring.stringify({
+        _csrf_token: auth.csrfToken,
+        formType: 'display',
+        title: JSON.stringify(buildYidaI18n(pageName, { en_US: pageName, ja_JP: pageName })),
+      });
+      return httpPost(
+        auth.baseUrl,
+        `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
+        postData
+      );
+    },
+    (auth) => httpGet(
       auth.baseUrl,
-      `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
-      postData
-    );
-  }, authRef);
+      `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
+      { _api: 'Nav.queryList', _mock: false }
+    ),
+    authRef
+  );
 
   // 输出结果
   if (response && response.success && response.content) {

--- a/lib/app/create-page.js
+++ b/lib/app/create-page.js
@@ -18,6 +18,7 @@ const { t } = require('../core/i18n');
 const { buildYidaI18n, buildYidaTitleI18n, normalizeYidaLocale, resolveContentLocale } = require('../core/yida-i18n');
 const { parseOpenOption, withBrowserHandoff } = require('../core/browser-handoff');
 const { throwCommandError } = require('../core/command-errors');
+const { buildApiPath } = require('./create-form/api-path');
 
 function parseArgs(args) {
   const openOption = parseOpenOption(args);
@@ -194,13 +195,13 @@ async function run(args) {
       });
       return httpPost(
         auth.baseUrl,
-        `/dingtalk/web/${appType}/query/formdesign/saveFormSchemaInfo.json`,
+        buildApiPath(appType, 'saveFormSchemaInfo'),
         postData
       );
     },
     (auth) => httpGet(
       auth.baseUrl,
-      `/dingtalk/web/${appType}/query/formnav/getFormNavigationListByOrder.json`,
+      buildApiPath(appType, 'getFormNavigationListByOrder', { queryModule: 'formnav' }),
       { _api: 'Nav.queryList', _mock: false }
     ),
     authRef
@@ -238,9 +239,10 @@ async function run(args) {
     )));
   } else {
     const errorMsg = response ? response.errorMsg || response.error || t('common.unknown_error') : t('common.request_failed');
+    const errorCode = response && response.errorCode ? response.errorCode : 'CREATE_PAGE_FAILED';
     chalkResult(false, t('create_page.failed', errorMsg));
-    console.log(JSON.stringify({ success: false, error: errorMsg }));
-    throwCommandError(errorMsg);
+    console.log(JSON.stringify({ success: false, errorCode, error: errorMsg }));
+    throwCommandError(errorMsg, { code: errorCode });
   }
 }
 

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1801,3 +1801,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'Could not verify the type of form {0}. Creation stopped before any data write.',
   resource_required: 'data query is missing the form resource type. Suggested command: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'Authentication changed during the create request; the result is unknown. Verify the target state before retrying.',
+});

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1754,3 +1754,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: '无法验证表单 {0} 的类型，已停止创建；未执行任何数据写入。',
   resource_required: 'data query 缺少资源类型 form。建议：{0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: '身份验证在创建请求期间发生变化；创建结果未知。请先检查目标状态，再决定是否重试。',
+});

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1462,10 +1462,7 @@ async function requestNonIdempotentWithAuthPreflight(
       ...result,
       success: false,
       errorCode: 'NON_IDEMPOTENT_RESULT_UNKNOWN',
-      errorMsg: (
-        'Authentication changed during a non-idempotent request; the result '
-        + 'is unknown. Verify the target state before retrying.'
-      ),
+      errorMsg: t('common.non_idempotent_result_unknown'),
     };
   }
   return result;

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1438,6 +1438,39 @@ async function requestWithAutoLogin(requestFn, authRef) {
   return result;
 }
 
+/**
+ * Refresh authentication through a read-only probe, then issue one
+ * non-idempotent request without replaying it after an auth challenge.
+ */
+async function requestNonIdempotentWithAuthPreflight(
+  requestFn,
+  preflightFn,
+  authRef
+) {
+  const preflightResult = await requestWithAutoLogin(preflightFn, authRef);
+  if (
+    !preflightResult ||
+    preflightResult.__needLogin ||
+    preflightResult.__csrfExpired ||
+    preflightResult.success === false
+  ) {
+    return preflightResult;
+  }
+  const result = await requestFn(authRef);
+  if (result && (result.__needLogin || result.__csrfExpired)) {
+    return {
+      ...result,
+      success: false,
+      errorCode: 'NON_IDEMPOTENT_RESULT_UNKNOWN',
+      errorMsg: (
+        'Authentication changed during a non-idempotent request; the result '
+        + 'is unknown. Verify the target state before retrying.'
+      ),
+    };
+  }
+  return result;
+}
+
 function normalizeRefreshedTokenAuthData(refreshResult, fallbackBaseUrl) {
   if (!refreshResult || !refreshResult.access_token) {
     return null;
@@ -1503,6 +1536,7 @@ module.exports = {
   httpPostJson,
   httpGet,
   requestWithAutoLogin,
+  requestNonIdempotentWithAuthPreflight,
   getWukongNodeBinDir,
   getNpmExecutable,
   getNodeExecutable,

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1447,12 +1447,22 @@ async function requestNonIdempotentWithAuthPreflight(
   preflightFn,
   authRef
 ) {
-  const preflightResult = await requestWithAutoLogin(preflightFn, authRef);
+  let preflightResult;
+  try {
+    preflightResult = await requestWithAutoLogin(preflightFn, authRef);
+  } catch {
+    // The read-only probe is only used to refresh authentication. A probe
+    // outage must not become a new availability dependency for creation.
+    preflightResult = null;
+  }
   if (
-    !preflightResult ||
-    preflightResult.__needLogin ||
-    preflightResult.__csrfExpired ||
-    preflightResult.success === false
+    preflightResult &&
+    (
+      preflightResult.__needLogin ||
+      preflightResult.__csrfExpired ||
+      preflightResult.errorCode === 'TOKEN_AUTH_REQUIRED' ||
+      preflightResult.errorCode === 'TOKEN_REFRESH_FAILED'
+    )
   ) {
     return preflightResult;
   }

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -1848,3 +1848,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'تعذر التحقق من نوع النموذج {0}. تم إيقاف الإنشاء قبل كتابة أي بيانات.',
   resource_required: 'يفتقد data query إلى نوع المورد form. الأمر المقترح: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'تغيّرت المصادقة أثناء طلب الإنشاء؛ النتيجة غير معروفة. تحقّق من حالة الهدف قبل إعادة المحاولة.',
+});

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -1848,3 +1848,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'Der Typ des Formulars {0} konnte nicht verifiziert werden. Die Erstellung wurde vor jedem Datenschreibvorgang beendet.',
   resource_required: 'Bei data query fehlt der Ressourcentyp form. Empfohlener Befehl: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'Die Authentifizierung hat sich während der Erstellungsanfrage geändert; das Ergebnis ist unbekannt. Prüfen Sie den Zielstatus, bevor Sie es erneut versuchen.',
+});

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -1850,3 +1850,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'No se pudo verificar el tipo del formulario {0}. La creación se detuvo antes de escribir datos.',
   resource_required: 'Falta el tipo de recurso form en data query. Comando sugerido: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'La autenticación cambió durante la solicitud de creación; se desconoce el resultado. Verifica el estado del destino antes de volver a intentarlo.',
+});

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -1850,3 +1850,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'Impossible de vérifier le type du formulaire {0}. La création a été arrêtée avant toute écriture de données.',
   resource_required: 'Le type de ressource form manque à data query. Commande suggérée : {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'L’authentification a changé pendant la requête de création ; le résultat est inconnu. Vérifiez l’état de la cible avant de réessayer.',
+});

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -1848,3 +1848,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'फ़ॉर्म {0} का प्रकार सत्यापित नहीं हो सका। किसी भी डेटा लेखन से पहले निर्माण रोक दिया गया।',
   resource_required: 'data query में संसाधन प्रकार form नहीं है। सुझाया गया कमांड: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'निर्माण अनुरोध के दौरान प्रमाणीकरण बदल गया; परिणाम अज्ञात है। पुनः प्रयास करने से पहले लक्ष्य की स्थिति जाँचें।',
+});

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -1775,3 +1775,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'フォーム {0} の種類を検証できませんでした。データを書き込まずに作成を停止しました。',
   resource_required: 'data query にリソース種別 form がありません。推奨コマンド: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: '作成リクエスト中に認証状態が変化したため、作成結果を確認できません。再試行する前に対象の状態を確認してください。',
+});

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -1849,3 +1849,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: '폼 {0}의 유형을 확인할 수 없어 데이터 쓰기 전에 생성을 중지했습니다.',
   resource_required: 'data query에 리소스 유형 form이 없습니다. 권장 명령: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: '생성 요청 중 인증 상태가 변경되어 생성 결과를 확인할 수 없습니다. 다시 시도하기 전에 대상 상태를 확인하세요.',
+});

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -1850,3 +1850,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'Não foi possível verificar o tipo do formulário {0}. A criação foi interrompida antes de qualquer gravação de dados.',
   resource_required: 'O tipo de recurso form está ausente em data query. Comando sugerido: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'A autenticação mudou durante a solicitação de criação; o resultado é desconhecido. Verifique o estado do destino antes de tentar novamente.',
+});

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -1848,3 +1848,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: 'Không thể xác minh loại của biểu mẫu {0}. Việc tạo đã dừng trước khi ghi dữ liệu.',
   resource_required: 'data query thiếu loại tài nguyên form. Lệnh đề xuất: {0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: 'Xác thực đã thay đổi trong lúc gửi yêu cầu tạo; chưa xác định được kết quả. Hãy kiểm tra trạng thái đích trước khi thử lại.',
+});

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -1721,3 +1721,7 @@ Object.assign(module.exports.query_data || (module.exports.query_data = {}), {
   form_mode_unverified: '無法驗證表單 {0} 的類型，已停止建立；未執行任何資料寫入。',
   resource_required: 'data query 缺少資源類型 form。建議：{0}',
 });
+
+Object.assign(module.exports.common || (module.exports.common = {}), {
+  non_idempotent_result_unknown: '建立請求期間的身份驗證發生變化；建立結果未知。請先檢查目標狀態，再決定是否重試。',
+});

--- a/tests/create-auth-no-replay-cli-e2e.test.js
+++ b/tests/create-auth-no-replay-cli-e2e.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const BIN = path.join(ROOT, 'bin', 'yida.js');
+const PRELOAD = path.join(__dirname, 'fixtures', 'create-auth-no-replay-preload.js');
+
+const EXPECTED_MESSAGES = {
+  zh: '身份验证在创建请求期间发生变化；创建结果未知。请先检查目标状态，再决定是否重试。',
+  en: 'Authentication changed during the create request; the result is unknown. Verify the target state before retrying.',
+  'zh-HK': '建立請求期間的身份驗證發生變化；建立結果未知。請先檢查目標狀態，再決定是否重試。',
+  vi: 'Xác thực đã thay đổi trong lúc gửi yêu cầu tạo; chưa xác định được kết quả. Hãy kiểm tra trạng thái đích trước khi thử lại.',
+};
+
+function runCreateCommand(command, language) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-create-auth-e2e-'));
+  const counterFile = path.join(tempDir, 'counter.json');
+  const fieldsFile = path.join(tempDir, 'fields.json');
+  fs.writeFileSync(fieldsFile, JSON.stringify([
+    { type: 'TextField', label: 'Name' },
+  ]));
+
+  const args = command === 'create-page'
+    ? [BIN, 'create-page', 'APP_TEST', 'Auth Replay Page', '--open', 'off']
+    : [BIN, 'create-form', 'create', 'APP_TEST', 'Auth Replay Form', fieldsFile, '--open', 'off'];
+  const existingNodeOptions = String(process.env.NODE_OPTIONS || '').trim();
+  const preloadOption = `--require=${JSON.stringify(PRELOAD)}`;
+  const result = spawnSync(process.execPath, args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    timeout: 20000,
+    env: {
+      ...process.env,
+      OPENYIDA_LANG: language,
+      OPENYIDA_SKIP_UPDATE_CHECK: '1',
+      NO_UPDATE_NOTIFIER: '1',
+      NO_COLOR: '1',
+      FORCE_COLOR: '0',
+      OPENYIDA_CREATE_AUTH_COUNTER_FILE: counterFile,
+      NODE_OPTIONS: `${existingNodeOptions} ${preloadOption}`.trim(),
+    },
+  });
+
+  const counter = JSON.parse(fs.readFileSync(counterFile, 'utf8'));
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  return {
+    status: result.status,
+    output: `${result.stdout || ''}${result.stderr || ''}`,
+    counter,
+  };
+}
+
+describe('create auth no-replay CLI UI E2E', () => {
+  test.each(Object.entries(EXPECTED_MESSAGES))(
+    'create-page renders the direct %s locale message and never replays create',
+    (language, expectedMessage) => {
+      const result = runCreateCommand('create-page', language);
+
+      expect(result.status).toBe(1);
+      expect(result.output).toContain(expectedMessage);
+      expect(result.counter.get).toBe(2);
+      expect(result.counter.post).toBe(1);
+      expect(result.counter.paths).toEqual([
+        expect.objectContaining({ method: 'GET', path: expect.stringContaining('getFormNavigationListByOrder.json') }),
+        expect.objectContaining({ method: 'GET', path: expect.stringContaining('getFormNavigationListByOrder.json') }),
+        expect.objectContaining({ method: 'POST', path: expect.stringContaining('saveFormSchemaInfo.json') }),
+      ]);
+    }
+  );
+
+  test.each(['zh', 'en'])(
+    'create-form renders the %s locale message and never replays create',
+    (language) => {
+      const result = runCreateCommand('create-form', language);
+
+      expect(result.status).toBe(1);
+      expect(result.output).toContain(EXPECTED_MESSAGES[language]);
+      expect(result.counter.get).toBe(2);
+      expect(result.counter.post).toBe(1);
+    }
+  );
+});

--- a/tests/create-auth-no-replay-cli-e2e.test.js
+++ b/tests/create-auth-no-replay-cli-e2e.test.js
@@ -25,8 +25,8 @@ function runCreateCommand(command, language) {
   ]));
 
   const args = command === 'create-page'
-    ? [BIN, 'create-page', 'APP_TEST', 'Auth Replay Page', '--open', 'off']
-    : [BIN, 'create-form', 'create', 'APP_TEST', 'Auth Replay Form', fieldsFile, '--open', 'off'];
+    ? [BIN, 'create-page', 'APP_TEST', 'Auth Replay Page', '--open', 'off', '--json']
+    : [BIN, 'create-form', 'create', 'APP_TEST', 'Auth Replay Form', fieldsFile, '--open', 'off', '--json'];
   const existingNodeOptions = String(process.env.NODE_OPTIONS || '').trim();
   const preloadOption = `--require=${JSON.stringify(PRELOAD)}`;
   const result = spawnSync(process.execPath, args, {
@@ -49,9 +49,32 @@ function runCreateCommand(command, language) {
   fs.rmSync(tempDir, { recursive: true, force: true });
   return {
     status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
     output: `${result.stdout || ''}${result.stderr || ''}`,
     counter,
   };
+}
+
+function parseJsonLines(output) {
+  return String(output || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('{') && line.endsWith('}'))
+    .map((line) => JSON.parse(line));
+}
+
+function expectUnknownResultCode(result) {
+  const stderrJson = result.stderr.match(/\{\s*"success"[\s\S]*\}\s*$/);
+  expect(stderrJson).not.toBeNull();
+  const stderrPayload = JSON.parse(stderrJson[0]);
+  const payloads = [
+    ...parseJsonLines(result.stdout),
+    stderrPayload,
+  ]
+    .filter((payload) => payload && payload.success === false);
+  expect(payloads.length).toBeGreaterThanOrEqual(2);
+  expect(payloads.every((payload) => payload.errorCode === 'NON_IDEMPOTENT_RESULT_UNKNOWN')).toBe(true);
 }
 
 describe('create auth no-replay CLI UI E2E', () => {
@@ -62,6 +85,7 @@ describe('create auth no-replay CLI UI E2E', () => {
 
       expect(result.status).toBe(1);
       expect(result.output).toContain(expectedMessage);
+      expectUnknownResultCode(result);
       expect(result.counter.get).toBe(2);
       expect(result.counter.post).toBe(1);
       expect(result.counter.paths).toEqual([
@@ -79,6 +103,7 @@ describe('create auth no-replay CLI UI E2E', () => {
 
       expect(result.status).toBe(1);
       expect(result.output).toContain(EXPECTED_MESSAGES[language]);
+      expectUnknownResultCode(result);
       expect(result.counter.get).toBe(2);
       expect(result.counter.post).toBe(1);
     }

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -35,19 +35,25 @@ function stripNodeRuntimeWarnings(output) {
     .replace(/^\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/gm, '');
 }
 
+async function requestNonIdempotentOnce(requestFn, preflightFn, authRef) {
+  const preflightResult = await preflightFn(authRef);
+  if (!preflightResult || preflightResult.success === false) {
+    return preflightResult;
+  }
+  return requestFn(authRef);
+}
+
 // ── Bug #1: HTTP helpers must use master token auth / auto-login plumbing ──
 
 describe('create-form.js imports', () => {
   test('uses token-first authRef HTTP helpers while keeping auto-login wrapper', () => {
     expect(sourceCode).toContain("require('../core/yida-client')");
     expect(sourceCode).toContain('createAuthRef');
-    const requireLine = sourceCode
-      .split('\n')
-      .find((line) => line.includes('require("../core/utils")') || line.includes("require('../core/utils')"));
-    expect(requireLine).toBeDefined();
-    expect(requireLine).toContain('httpPost');
-    expect(requireLine).toContain('httpGet');
-    expect(requireLine).toContain('requestWithAutoLogin');
+    expect(sourceCode).toContain("require('../core/utils')");
+    expect(sourceCode).toContain('httpPost');
+    expect(sourceCode).toContain('httpGet');
+    expect(sourceCode).toContain('requestWithAutoLogin');
+    expect(sourceCode).toContain('requestNonIdempotentWithAuthPreflight');
   });
 
   test('request wrappers delegate to token auth HTTP helpers', () => {
@@ -96,6 +102,7 @@ describe('legacy process form bridge', () => {
         return Promise.resolve({ success: true });
       }),
       requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+      requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
       httpGet: jest.fn(() => Promise.resolve({ success: true, content: { gmtModified: 100 } })),
@@ -796,6 +803,7 @@ function loadIsolatedLegacyForm(schema) {
       return Promise.resolve({ success: true });
     }),
     requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+    requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
     detectActiveTool: jest.fn(() => null),
   };
   const mockChalk = {
@@ -2010,12 +2018,14 @@ describe('create-form create recovery guardrails', () => {
     ]));
 
     const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
-      httpGet: jest.fn(() => Promise.resolve({
-        success: false,
-        errorMsg: 'schema read failed',
-        errorCode: 'READ_FAILED',
-        content: { shouldNotLeak: true },
-      })),
+      httpGet: jest.fn()
+        .mockResolvedValueOnce({ success: true, content: [] })
+        .mockResolvedValueOnce({
+          success: false,
+          errorMsg: 'schema read failed',
+          errorCode: 'READ_FAILED',
+          content: { shouldNotLeak: true },
+        }),
     });
 
     await expect(isolatedCreateForm.run([
@@ -2382,6 +2392,7 @@ function loadIsolatedCreateFormCommand(overrides = {}) {
       return Promise.resolve({ success: true });
     }),
     requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+    requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
     detectActiveTool: jest.fn(() => null),
   }, overrides);
   jest.doMock('../lib/core/utils', () => mockUtils);
@@ -3076,6 +3087,7 @@ describe('legacy create-form compatibility', () => {
         return Promise.resolve({ success: true });
       }),
       requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
+      requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
       detectActiveTool: jest.fn(() => null),
     };
 
@@ -3103,7 +3115,16 @@ describe('legacy create-form compatibility', () => {
       JSON.stringify([{ key: 'visitorName', type: 'TextField', label: '访客姓名' }]),
     ]);
 
-    expect(mockUtils.httpGet).toHaveBeenCalledTimes(1);
+    expect(mockUtils.httpGet).toHaveBeenCalledTimes(2);
+    expect(mockUtils.httpGet.mock.calls[0][1]).toContain(
+      'getFormNavigationListByOrder.json'
+    );
+    expect(mockUtils.httpGet.mock.calls[1][1]).toContain('getFormSchema.json');
+    expect(
+      mockUtils.httpPost.mock.calls.filter((call) =>
+        call[1].includes('saveFormSchemaInfo.json')
+      )
+    ).toHaveLength(1);
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(JSON.parse(consoleSpy.mock.calls[0][0])).toMatchObject({
       success: true,

--- a/tests/create-page.test.js
+++ b/tests/create-page.test.js
@@ -4,6 +4,7 @@ const querystring = require('querystring');
 const fs = require('fs');
 const path = require('path');
 const { buildPageInfoPostData, parseArgs } = require('../lib/app/create-page');
+const { buildApiPath } = require('../lib/app/create-form/api-path');
 
 const sourceCode = fs.readFileSync(
   path.join(__dirname, '..', 'lib', 'app', 'create-page.js'),
@@ -13,7 +14,12 @@ const sourceCode = fs.readFileSync(
 describe('create-page locale handling', () => {
   test('uses a read-only auth preflight before the one-shot create request', () => {
     expect(sourceCode).toContain('requestNonIdempotentWithAuthPreflight');
-    expect(sourceCode).toContain('getFormNavigationListByOrder.json');
+    expect(sourceCode).toContain("buildApiPath(appType, 'getFormNavigationListByOrder', { queryModule: 'formnav' })");
+  });
+
+  test('buildApiPath supports the existing formnav query family', () => {
+    expect(buildApiPath('APP_X', 'getFormNavigationListByOrder', { queryModule: 'formnav' }))
+      .toBe('/dingtalk/web/APP_X/query/formnav/getFormNavigationListByOrder.json');
   });
 
   test('parseArgs accepts content locale flags', () => {

--- a/tests/create-page.test.js
+++ b/tests/create-page.test.js
@@ -1,9 +1,21 @@
 'use strict';
 
 const querystring = require('querystring');
+const fs = require('fs');
+const path = require('path');
 const { buildPageInfoPostData, parseArgs } = require('../lib/app/create-page');
 
+const sourceCode = fs.readFileSync(
+  path.join(__dirname, '..', 'lib', 'app', 'create-page.js'),
+  'utf8'
+);
+
 describe('create-page locale handling', () => {
+  test('uses a read-only auth preflight before the one-shot create request', () => {
+    expect(sourceCode).toContain('requestNonIdempotentWithAuthPreflight');
+    expect(sourceCode).toContain('getFormNavigationListByOrder.json');
+  });
+
   test('parseArgs accepts content locale flags', () => {
     expect(parseArgs(['APP_X', '経営ダッシュボード', '--mode', 'dashboard', '--locale', 'ja'])).toMatchObject({
       appType: 'APP_X',
@@ -41,6 +53,72 @@ describe('create-page locale handling', () => {
       en_US: '経営ダッシュボード',
       pureEn_US: '経営ダッシュボード',
       ja_JP: '経営ダッシュボード',
+    });
+  });
+});
+
+describe('create-page non-idempotent auth handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.dontMock('../lib/core/utils');
+    jest.dontMock('../lib/core/yida-client');
+    jest.dontMock('../lib/core/chalk');
+    jest.resetModules();
+  });
+
+  test('preflights with GET and sends the create POST once', async () => {
+    jest.resetModules();
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const authRef = {
+      baseUrl: 'https://example.test',
+      csrfToken: 'csrf',
+    };
+    const httpGet = jest.fn().mockResolvedValue({ success: true, content: [] });
+    const httpPost = jest.fn().mockResolvedValue({
+      success: true,
+      content: { formUuid: 'FORM_PAGE' },
+    });
+    const requestNonIdempotentWithAuthPreflight = jest.fn(
+      async (requestFn, preflightFn, ref) => {
+        const preflight = await preflightFn(ref);
+        if (!preflight || preflight.success === false) {
+          return preflight;
+        }
+        return requestFn(ref);
+      }
+    );
+    jest.doMock('../lib/core/utils', () => ({
+      httpGet,
+      httpPost,
+      requestWithAutoLogin: jest.fn((requestFn, ref) => requestFn(ref)),
+      requestNonIdempotentWithAuthPreflight,
+    }));
+    jest.doMock('../lib/core/yida-client', () => ({
+      createAuthRef: jest.fn(() => authRef),
+    }));
+    jest.doMock('../lib/core/chalk', () => ({
+      c: { cyan: '', reset: '' },
+      banner: jest.fn(),
+      step: jest.fn(),
+      label: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      success: jest.fn(),
+      result: jest.fn(),
+    }));
+
+    const isolatedCreatePage = require('../lib/app/create-page');
+    await isolatedCreatePage.run(['APP_TEST', '工作台', '--no-open']);
+
+    expect(requestNonIdempotentWithAuthPreflight).toHaveBeenCalledTimes(1);
+    expect(httpGet).toHaveBeenCalledTimes(1);
+    expect(httpGet.mock.calls[0][1]).toContain('getFormNavigationListByOrder.json');
+    expect(httpPost).toHaveBeenCalledTimes(1);
+    expect(httpPost.mock.calls[0][1]).toContain('saveFormSchemaInfo.json');
+    expect(JSON.parse(consoleSpy.mock.calls[0][0])).toMatchObject({
+      success: true,
+      pageId: 'FORM_PAGE',
+      appType: 'APP_TEST',
     });
   });
 });

--- a/tests/fixtures/create-auth-no-replay-preload.js
+++ b/tests/fixtures/create-auth-no-replay-preload.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const fs = require('fs');
+const Module = require('module');
+
+const originalLoad = Module._load;
+const counterFile = process.env.OPENYIDA_CREATE_AUTH_COUNTER_FILE;
+let preflightCalls = 0;
+
+function updateCounter(kind, requestPath) {
+  if (!counterFile) {
+    return;
+  }
+  let counter = { get: 0, post: 0, paths: [] };
+  try {
+    counter = JSON.parse(fs.readFileSync(counterFile, 'utf8'));
+  } catch {
+    // The first request creates the counter file.
+  }
+  counter[kind] = (counter[kind] || 0) + 1;
+  counter.paths = Array.isArray(counter.paths) ? counter.paths : [];
+  counter.paths.push({ method: kind.toUpperCase(), path: requestPath });
+  fs.writeFileSync(counterFile, JSON.stringify(counter));
+}
+
+function isCreateCommandParent(parent) {
+  return !!(
+    parent
+    && typeof parent.filename === 'string'
+    && /[/\\]lib[/\\]app[/\\]create-(form|page)\.js$/.test(parent.filename)
+  );
+}
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  const loaded = originalLoad.call(this, request, parent, isMain);
+  if (
+    parent
+    && /[/\\]lib[/\\]core[/\\]utils\.js$/.test(parent.filename || '')
+    && request === '../auth/token-auth'
+  ) {
+    return {
+      ...loaded,
+      async tokenRefresh() {
+        return {
+          ok: true,
+          access_token: 'x',
+          base_url: 'https://example.invalid',
+          corp_id: 'c',
+        };
+      },
+      isRefreshAuthRequired() {
+        return false;
+      },
+    };
+  }
+  if (!isCreateCommandParent(parent)) {
+    return loaded;
+  }
+
+  if (request === '../core/yida-client') {
+    return {
+      ...loaded,
+      createAuthRef() {
+        return {
+          baseUrl: 'https://example.invalid',
+          csrfToken: 'test-csrf',
+          authData: { corp_id: 'c' },
+        };
+      },
+    };
+  }
+
+  if (request === '../core/utils') {
+    return {
+      ...loaded,
+      async httpGet(baseUrl, requestPath) {
+        preflightCalls += 1;
+        updateCounter('get', requestPath);
+        if (preflightCalls === 1) {
+          return { __needLogin: true };
+        }
+        return { success: true, content: [] };
+      },
+      async httpPost(baseUrl, requestPath) {
+        updateCounter('post', requestPath);
+        return { __needLogin: true };
+      },
+    };
+  }
+
+  return loaded;
+};

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -442,6 +442,53 @@ describe('requestWithAutoLogin', () => {
   });
 });
 
+describe('requestNonIdempotentWithAuthPreflight', () => {
+  test('does not replay the mutation when its result has an auth challenge', async () => {
+    const utils = require('../lib/core/utils');
+    const preflightFn = jest.fn().mockResolvedValue({ success: true, content: [] });
+    const mutationFn = jest.fn().mockResolvedValue({
+      __needLogin: true,
+      __httpStatus: 302,
+    });
+
+    const result = await utils.requestNonIdempotentWithAuthPreflight(
+      mutationFn,
+      preflightFn,
+      { baseUrl: 'https://example.test' }
+    );
+
+    expect(preflightFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'NON_IDEMPOTENT_RESULT_UNKNOWN',
+      __needLogin: true,
+    });
+    expect(result.errorMsg).toContain('Verify the target state before retrying');
+  });
+
+  test('does not issue the mutation when the read-only preflight fails', async () => {
+    const utils = require('../lib/core/utils');
+    const preflightFn = jest.fn().mockResolvedValue({
+      success: false,
+      errorCode: 'TOKEN_REFRESH_FAILED',
+    });
+    const mutationFn = jest.fn();
+
+    const result = await utils.requestNonIdempotentWithAuthPreflight(
+      mutationFn,
+      preflightFn,
+      { baseUrl: 'https://example.test' }
+    );
+
+    expect(mutationFn).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'TOKEN_REFRESH_FAILED',
+    });
+  });
+});
+
 // ── loadCookieData ────────────────────────────────────────────────────
 
 describe('loadCookieData', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -464,7 +464,8 @@ describe('requestNonIdempotentWithAuthPreflight', () => {
       errorCode: 'NON_IDEMPOTENT_RESULT_UNKNOWN',
       __needLogin: true,
     });
-    expect(result.errorMsg).toContain('Verify the target state before retrying');
+    const { t } = require('../lib/core/i18n');
+    expect(result.errorMsg).toBe(t('common.non_idempotent_result_unknown'));
   });
 
   test('does not issue the mutation when the read-only preflight fails', async () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -468,7 +468,7 @@ describe('requestNonIdempotentWithAuthPreflight', () => {
     expect(result.errorMsg).toBe(t('common.non_idempotent_result_unknown'));
   });
 
-  test('does not issue the mutation when the read-only preflight fails', async () => {
+  test('does not issue the mutation when the read-only preflight proves auth refresh failed', async () => {
     const utils = require('../lib/core/utils');
     const preflightFn = jest.fn().mockResolvedValue({
       success: false,
@@ -487,6 +487,41 @@ describe('requestNonIdempotentWithAuthPreflight', () => {
       success: false,
       errorCode: 'TOKEN_REFRESH_FAILED',
     });
+  });
+
+  test('issues the mutation once when the read-only preflight endpoint reports a non-auth failure', async () => {
+    const utils = require('../lib/core/utils');
+    const preflightFn = jest.fn().mockResolvedValue({
+      success: false,
+      errorCode: 'FORM_NAV_UNAVAILABLE',
+    });
+    const mutationFn = jest.fn().mockResolvedValue({ success: true, content: { formUuid: 'FORM_X' } });
+
+    const result = await utils.requestNonIdempotentWithAuthPreflight(
+      mutationFn,
+      preflightFn,
+      { baseUrl: 'https://example.test' }
+    );
+
+    expect(preflightFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: true, content: { formUuid: 'FORM_X' } });
+  });
+
+  test('issues the mutation once when the read-only preflight endpoint is unavailable', async () => {
+    const utils = require('../lib/core/utils');
+    const preflightFn = jest.fn().mockRejectedValue(new Error('formnav unavailable'));
+    const mutationFn = jest.fn().mockResolvedValue({ success: true, content: { formUuid: 'FORM_X' } });
+
+    const result = await utils.requestNonIdempotentWithAuthPreflight(
+      mutationFn,
+      preflightFn,
+      { baseUrl: 'https://example.test' }
+    );
+
+    expect(preflightFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: true, content: { formUuid: 'FORM_X' } });
   });
 });
 


### PR DESCRIPTION
## Summary

- Preflight form and custom-page creation with a read-only request so authentication can refresh before mutation.
- Execute each non-idempotent create POST at most once; if authentication changes during the mutation, return NON_IDEMPOTENT_RESULT_UNKNOWN and require target-state verification before retrying.
- Localize the unknown-result message across all 12 supported languages.
- Add process-level CLI UI E2E coverage for create-page and create-form.

## E2E contract

The deterministic fault-injection test simulates:

1. the first read-only preflight requiring authentication refresh;
2. the retried preflight succeeding;
3. the create response becoming authentication-ambiguous.

Machine assertions require exactly two GET probes and one POST create. The POST must never be replayed. UI output is directly checked in zh, en, zh-HK, and vi. This test does not perform real platform writes.

## Validation

- Related Jest: 4 suites / 171 tests passed
- CLI UI E2E: 6 / 6 passed
- Locale-sensitive reruns passed with LANG=en_US.UTF-8 and with LANG unset
- check:i18n: 0 missing keys across all 12 languages
- npm run check:ci: passed
- check:skills and build:skills: passed via full CI
- release-risk scan: 0 errors; 2 existing browser-launch warnings
- git diff --check and sensitive-scope scan: passed

## Scope

No generic write-retry framework, automatic readback recovery, browser-launch changes, or real platform resources are introduced.