### PR TITLE
fix: enforce Canvas runtime acceptance

### DIFF
--- a/docs/features/canvas-runtime-acceptance.md
+++ b/docs/features/canvas-runtime-acceptance.md
@@ -1,0 +1,52 @@
+# Canvas 发布与运行时验收
+
+## 目标
+
+- 完整应用的主页面固定按 Canvas 模式发布。
+- 发布结果提供可机器判断的发布模式和读回摘要。
+- Canvas 编译阻断平台 JSX 实例 API。
+- 真实 E2E 在 Canvas 模式或读回不匹配时失败。
+
+## 已确认根因
+
+1. `publish` 只通过 `.canvas.jsx/.canvas.tsx` 或 `--canvas` 选择 Canvas；普通 `.jsx` 会走 native。
+2. 读回校验只验证当前选择的发布模式，无法推断 Agent 原本应交付 Canvas。
+3. `props.utils.getDataList`、`this.utils.yida.*` 等属性链不会触发未绑定标识符检查。
+4. cleanup、静默刷新和页面长期 loading 不能只靠静态语法可靠判断。
+
+## 最小实现
+
+1. `publish` JSON 增加 `publishMode`；health check 增加 `expectedPublishMode` 和读回页面摘要。
+2. 真实 E2E 要求 Canvas publish 的 health check 成功、发布模式为 `canvas`、读回包含 `YidaCodeCanvas` 且 `runtimeCodeBytes > 0`。
+3. Canvas 编译阻断 `props.utils.getDataList`、`this.utils.yida.*`、`this.dataSourceMap`、`this.$`，返回单一结构化错误码。
+4. `yida-app` 使用 `--canvas --health-check` 发布新主页面，收尾时回读 Canvas 信号并在已登录浏览器确认已知记录可见。
+5. `yida-canvas-data-binding` 增加一条简短浏览器完成条件。
+
+## 不做
+
+- 不改变 native `.jsx` 的默认发布行为。
+- 不把所有 publish health check warning 改成进程失败。
+- 不用启发式规则强制识别任意 dataBinding、cleanup 或静默刷新实现。
+- 不新建浏览器自动化框架；今晚继续使用真实 Codex、Qoder 搭建和已登录浏览器验收。
+
+## Done Contract
+
+- 窄范围测试覆盖模式摘要、严格 E2E 判断和 Canvas 实例 API 守卫。
+- `npm run check:skills`、`npm run build:skills`、相关 Jest 测试通过。
+- 今晚真实 E2E 能区分“保存成功”和“Canvas 运行时交付成功”。
+
+## Change Log
+
+- `publish` 输出 `publishMode`，读回结果输出 `expectedPublishMode` 和 Canvas 摘要。
+- Canvas 编译阻断无效平台实例 API，同时允许普通组件 props。
+- 真实 E2E 显式使用 `--canvas`，并严格校验 Canvas 模式和非空 runtime。
+- 完整应用技能使用显式 Canvas 发布命令，并增加浏览器真实数据完成条件。
+
+## Validation
+
+- 相关 5 个测试套件、111 个测试通过。
+- `npm run check:i18n`、`npm run check:skills`、`npm run build:skills` 通过。
+- `npm run check:ci` 通过。
+- 失败样例会返回 `OPENYIDA_CANVAS_INSTANCE_API_UNAVAILABLE`。
+- Qoder 原失败源码按 Canvas 本地编译后生成 14787 bytes runtimeCode。
+- Codex、Qoder 真实搭建和已登录浏览器验收留到今晚执行。

--- a/lib/app/canvas-compile.js
+++ b/lib/app/canvas-compile.js
@@ -338,6 +338,99 @@ function assertNoUnboundIdentifiers(source, options = {}) {
   });
 }
 
+function findUnavailableCanvasInstanceApiIssues(source) {
+  const issues = [];
+  const seen = new Set();
+
+  function addIssue(path, api) {
+    if (seen.has(api)) {
+      return;
+    }
+    seen.add(api);
+    issues.push({
+      api,
+      line: path.node.loc && path.node.loc.start ? path.node.loc.start.line : 0,
+      column: path.node.loc && path.node.loc.start ? path.node.loc.start.column : 0,
+    });
+  }
+
+  const guardPlugin = ({ types: types }) => ({
+    name: 'yida-canvas-instance-api-guard',
+    visitor: {
+      MemberExpression(path) {
+        const object = path.node.object;
+        const property = path.node.property;
+        const propertyName = path.node.computed && types.isStringLiteral(property)
+          ? property.value
+          : (types.isIdentifier(property) ? property.name : '');
+
+        if (types.isMemberExpression(object)) {
+          const owner = object.object;
+          const ownerProperty = object.property;
+          const ownerPropertyName = object.computed && types.isStringLiteral(ownerProperty)
+            ? ownerProperty.value
+            : (types.isIdentifier(ownerProperty) ? ownerProperty.name : '');
+          if (
+            types.isIdentifier(owner, { name: 'props' }) &&
+            ownerPropertyName === 'utils' &&
+            propertyName === 'getDataList'
+          ) {
+            addIssue(path, 'props.utils.getDataList');
+            return;
+          }
+          if (
+            types.isThisExpression(owner) &&
+            ownerPropertyName === 'utils' &&
+            propertyName === 'yida'
+          ) {
+            addIssue(path, 'this.utils.yida');
+            return;
+          }
+        }
+        if (!types.isThisExpression(object)) {
+          return;
+        }
+        if (propertyName === 'dataSourceMap') {
+          addIssue(path, 'this.dataSourceMap');
+        } else if (propertyName === '$') {
+          addIssue(path, 'this.$');
+        }
+      },
+    },
+  });
+
+  Babel.transform(source, {
+    filename: 'canvas.tsx',
+    presets: [
+      ['typescript', { allExtensions: true, isTSX: true, allowDeclareFields: true }],
+      ['react', { runtime: 'classic' }],
+    ],
+    plugins: [guardPlugin],
+    sourceType: 'module',
+    compact: false,
+    babelrc: false,
+    configFile: false,
+  });
+
+  return issues;
+}
+
+function assertNoUnavailableCanvasInstanceApis(source, options = {}) {
+  const issues = findUnavailableCanvasInstanceApiIssues(source);
+  if (issues.length === 0) {
+    return;
+  }
+  const summary = issues.map(issue => issue.api).join(', ');
+  throw new CliError(t('publish.canvas_instance_api_unavailable', summary), {
+    code: 'OPENYIDA_CANVAS_INSTANCE_API_UNAVAILABLE',
+    details: {
+      stage: 'canvas_compile',
+      sourcePath: options.sourcePath || '',
+      issues,
+    },
+  });
+}
+
 /**
  * 从源码里正则抽取裸包名（过滤相对/绝对路径），去重排序。
  * 对齐画布运行时的依赖抽取行为。
@@ -688,6 +781,7 @@ function compileCanvasLocal(source, options = {}) {
       },
     });
   }
+  assertNoUnavailableCanvasInstanceApis(source, options);
   assertNoBareDependencyGlobals(source, options);
   assertNoManualDependencyGlobals(source, options);
 

--- a/lib/app/publish.js
+++ b/lib/app/publish.js
@@ -50,6 +50,7 @@ const {
   buildCanvasPageSchemaContent,
 } = require('./services/canvas-page-schema-builder');
 const {
+  summarizeDisplayPublishInfo,
   verifyPublishedContentMatch,
 } = require('./display-page-readback');
 
@@ -454,6 +455,7 @@ async function runPublishReadbackHealthCheck(appType, formUuid, authRef, schemaC
   const baseResult = {
     ok: false,
     mode: 'publish_readback',
+    expectedPublishMode: publishMode,
     authMode: 'token',
     targetReadable: false,
     schemaParsed: false,
@@ -479,6 +481,7 @@ async function runPublishReadbackHealthCheck(appType, formUuid, authRef, schemaC
     schemaParsed: true,
     displayComponentPresent: match.displayComponentPresent,
     publishedContentMatched: match.publishedContentMatched,
+    readback: summarizeDisplayPublishInfo(match.readbackInfo),
   };
 
   if (!match.displayComponentPresent) {
@@ -651,6 +654,7 @@ async function runMain(argv) {
   baseUrl = authRef.baseUrl || baseUrl;
 
   const pageUrl = `${baseUrl}/${appType}/workbench/${savedFormUuid}`;
+  const publishMode = isCanvas ? 'canvas' : 'native';
   let healthCheckResult = null;
   let navOrderResult = null;
   let navOrderWarning = null;
@@ -668,6 +672,7 @@ async function runMain(argv) {
       healthCheckResult = {
         ok: false,
         mode: 'publish_readback',
+        expectedPublishMode: publishMode,
         authMode: 'token',
         targetReadable: false,
         schemaParsed: false,
@@ -707,7 +712,7 @@ async function runMain(argv) {
     ['URL', pageUrl],
   ]);
   console.log(JSON.stringify(withBrowserHandoff(
-    { success: true, appType, formUuid: savedFormUuid, version, url: pageUrl, healthCheck: healthCheckResult, navOrder: navOrderResult, navOrderWarning },
+    { success: true, appType, formUuid: savedFormUuid, version, url: pageUrl, publishMode, healthCheck: healthCheckResult, navOrder: navOrderResult, navOrderWarning },
     pageUrl,
     { stage: 'publish_page_success', title: savedFormUuid },
     browserOpenMode

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -1266,6 +1266,7 @@ Examples:
     canvas_compile_done: '  ✅ Custom page compiled!',
     canvas_compile_failed: '  ❌ Custom page compile failed: {0}',
     canvas_unbound_identifiers: 'Code Canvas source contains undeclared identifiers: {0}. Add the missing import, function, ref, state, or local declaration in the same file and keep every reference under the same name. If a non-standard runtime provides the identifier, access it explicitly through window.<name> or parentWindow.<name> and check that it exists first.',
+    canvas_instance_api_unavailable: 'Code Canvas components cannot use platform JSX instance APIs: {0}. Use React hooks, props, or the window.__OPENYIDA_YIDA_API__ data bridge.',
     step_login: '\n🔑 Step 2: Read login credentials',
     step_publish: '\n📤 Step 3: Publish Schema\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -1262,6 +1262,7 @@ openyida - 宜搭命令行工具
     canvas_compile_done: '  ✅ 自定义页面编译完成！',
     canvas_compile_failed: '  ❌ 自定义页面编译失败：{0}',
     canvas_unbound_identifiers: 'Code Canvas 源码存在未声明标识符：{0}。请在同一文件中补齐 import、函数、Ref、状态或局部变量声明，并保持声明与全部引用同名。若标识符由非标准运行时提供，请改用 window.<name> 或 parentWindow.<name> 显式访问并先检查是否存在。',
+    canvas_instance_api_unavailable: 'Code Canvas 组件不能使用平台 JSX 实例 API：{0}。请使用 React hooks、props 或 window.__OPENYIDA_YIDA_API__ 数据桥。',
     step_login: '\n🔑 Step 2: 读取登录态',
     step_publish: '\n📤 Step 3: 发布 Schema\n',
     resend_save_csrf: '  🔄 重新发送 saveFormSchema 请求（csrf_token 已刷新）...',

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -1208,6 +1208,7 @@ module.exports = {
     canvas_compile_done: '  ✅ تم تجميع الصفحة المخصصة!',
     canvas_compile_failed: '  ❌ فشل تجميع الصفحة المخصصة: {0}',
     canvas_unbound_identifiers: 'يحتوي مصدر Code Canvas على معرّفات غير مصرّح بها: {0}. أضف الاستيراد أو تعريف الدالة أو Ref أو الحالة أو المتغير المحلي المفقود في الملف نفسه، واستخدم الاسم نفسه في جميع المراجع. إذا كان المعرّف مقدمًا من بيئة تشغيل غير قياسية، فاستخدم window.<name> أو parentWindow.<name> بشكل صريح وتحقق من وجوده أولًا.',
+    canvas_instance_api_unavailable: 'لا يمكن لمكوّنات Code Canvas استخدام واجهات منصة JSX التالية: {0}. استخدم React hooks أو props أو جسر البيانات window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2: قراءة بيانات تسجيل الدخول',
     step_publish: '\n📤 Step 3: نشر المخطط\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -1208,6 +1208,7 @@ module.exports = {
     canvas_compile_done: '  ✅ Benutzerdefinierte Seite kompiliert!',
     canvas_compile_failed: '  ❌ Kompilierung der benutzerdefinierten Seite fehlgeschlagen: {0}',
     canvas_unbound_identifiers: 'Der Code-Canvas-Quelltext enthält nicht deklarierte Bezeichner: {0}. Ergänzen Sie Import, Funktion, Ref, Status oder lokale Variable in derselben Datei und verwenden Sie für alle Verweise denselben Namen. Bezeichner einer nicht standardmäßigen Laufzeit müssen explizit über window.<name> oder parentWindow.<name> aufgerufen und zuvor auf ihre Existenz geprüft werden.',
+    canvas_instance_api_unavailable: 'Code-Canvas-Komponenten können diese Plattform-JSX-Instanz-APIs nicht verwenden: {0}. Verwenden Sie React Hooks, props oder die Datenbrücke window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2: Anmeldedaten lesen',
     step_publish: '\n📤 Step 3: Schema veröffentlichen\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -1210,6 +1210,7 @@ module.exports = {
     canvas_compile_done: '  ✅ ¡Página personalizada compilada!',
     canvas_compile_failed: '  ❌ Error al compilar la página personalizada: {0}',
     canvas_unbound_identifiers: 'El código fuente de Code Canvas contiene identificadores no declarados: {0}. Añade en el mismo archivo la importación o declaración de función, Ref, estado o variable local que falte y usa el mismo nombre en todas las referencias. Si un entorno de ejecución no estándar proporciona el identificador, accede a él explícitamente mediante window.<name> o parentWindow.<name> y comprueba antes que exista.',
+    canvas_instance_api_unavailable: 'Los componentes de Code Canvas no pueden usar estas API de instancia JSX de la plataforma: {0}. Usa hooks de React, props o el puente de datos window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2: Leer credenciales de sesión',
     step_publish: '\n📤 Step 3: Publicar esquema\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -1210,6 +1210,7 @@ module.exports = {
     canvas_compile_done: '  ✅ Page personnalisée compilée !',
     canvas_compile_failed: '  ❌ Échec de la compilation de la page personnalisée : {0}',
     canvas_unbound_identifiers: 'Le code source Code Canvas contient des identifiants non déclarés : {0}. Ajoutez dans le même fichier la déclaration import, fonction, Ref, état ou variable locale manquante et conservez le même nom pour toutes les références. Si un environnement non standard fournit l’identifiant, utilisez explicitement window.<name> ou parentWindow.<name> et vérifiez d’abord son existence.',
+    canvas_instance_api_unavailable: 'Les composants Code Canvas ne peuvent pas utiliser ces API d’instance JSX de la plateforme : {0}. Utilisez les hooks React, props ou le pont de données window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2 : Lecture des identifiants',
     step_publish: '\n📤 Step 3 : Publication du schéma\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -1208,6 +1208,7 @@ module.exports = {
     canvas_compile_done: '  ✅ कस्टम पेज संकलित!',
     canvas_compile_failed: '  ❌ कस्टम पेज संकलन विफल: {0}',
     canvas_unbound_identifiers: 'Code Canvas स्रोत में अघोषित पहचानकर्ता हैं: {0}। उसी फ़ाइल में छूटा हुआ import, फ़ंक्शन, Ref, state या स्थानीय चर घोषित करें और सभी संदर्भों में वही नाम रखें। यदि पहचानकर्ता किसी गैर-मानक runtime से मिलता है, तो window.<name> या parentWindow.<name> से स्पष्ट रूप से पहुँचें और पहले उसके मौजूद होने की जाँच करें।',
+    canvas_instance_api_unavailable: 'Code Canvas कॉम्पोनेंट इन प्लेटफ़ॉर्म JSX इंस्टेंस API का उपयोग नहीं कर सकते: {0}। React hooks, props या window.__OPENYIDA_YIDA_API__ डेटा ब्रिज का उपयोग करें।',
     step_login: '\n🔑 Step 2: लॉगिन जानकारी पढ़ें',
     step_publish: '\n📤 Step 3: स्कीमा प्रकाशित करें\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -1159,6 +1159,7 @@ module.exports = {
     canvas_compile_done: '  ✅ カスタムページのコンパイルが完了しました！',
     canvas_compile_failed: '  ❌ カスタムページのコンパイルに失敗しました：{0}',
     canvas_unbound_identifiers: 'Code Canvas ソースに未宣言の識別子があります：{0}。同じファイルに import、関数、Ref、state、またはローカル変数の宣言を追加し、すべての参照で同じ名前を使用してください。非標準ランタイムが提供する識別子は window.<name> または parentWindow.<name> から明示的に参照し、先に存在を確認してください。',
+    canvas_instance_api_unavailable: 'Code Canvas コンポーネントでは、次のプラットフォーム JSX インスタンス API を使用できません：{0}。React Hooks、props、または window.__OPENYIDA_YIDA_API__ データブリッジを使用してください。',
     step_login: '\n🔑 Step 2: ログイン情報を読み込む',
     step_publish: '\n📤 Step 3: Schema を公開\n',
     resend_save_csrf: '  🔄 saveFormSchema リクエストを再送信中（csrf_token を更新済み）...',

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -1209,6 +1209,7 @@ module.exports = {
     canvas_compile_done: '  ✅ 사용자 지정 페이지 컴파일 완료!',
     canvas_compile_failed: '  ❌ 사용자 지정 페이지 컴파일 실패: {0}',
     canvas_unbound_identifiers: 'Code Canvas 소스에 선언되지 않은 식별자가 있습니다: {0}. 같은 파일에 import, 함수, Ref, 상태 또는 지역 변수 선언을 추가하고 모든 참조에서 같은 이름을 사용하세요. 비표준 런타임이 제공하는 식별자는 window.<name> 또는 parentWindow.<name>을 통해 명시적으로 접근하고 먼저 존재 여부를 확인하세요.',
+    canvas_instance_api_unavailable: 'Code Canvas 컴포넌트는 다음 플랫폼 JSX 인스턴스 API를 사용할 수 없습니다: {0}. React hooks, props 또는 window.__OPENYIDA_YIDA_API__ 데이터 브리지를 사용하세요.',
     step_login: '\n🔑 Step 2: 로그인 정보 읽기',
     step_publish: '\n📤 Step 3: 스키마 배포\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -1210,6 +1210,7 @@ module.exports = {
     canvas_compile_done: '  ✅ Página personalizada compilada!',
     canvas_compile_failed: '  ❌ Falha na compilação da página personalizada: {0}',
     canvas_unbound_identifiers: 'O código-fonte do Code Canvas contém identificadores não declarados: {0}. Adicione no mesmo arquivo a importação ou declaração de função, Ref, estado ou variável local ausente e mantenha o mesmo nome em todas as referências. Se um runtime não padrão fornecer o identificador, acesse-o explicitamente por window.<name> ou parentWindow.<name> e verifique antes se ele existe.',
+    canvas_instance_api_unavailable: 'Os componentes do Code Canvas não podem usar estas APIs de instância JSX da plataforma: {0}. Use hooks do React, props ou a ponte de dados window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2: Ler credenciais de login',
     step_publish: '\n📤 Step 3: Publicar esquema\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -1208,6 +1208,7 @@ module.exports = {
     canvas_compile_done: '  ✅ Đã biên dịch trang tùy chỉnh!',
     canvas_compile_failed: '  ❌ Biên dịch trang tùy chỉnh thất bại: {0}',
     canvas_unbound_identifiers: 'Mã nguồn Code Canvas chứa định danh chưa được khai báo: {0}. Hãy bổ sung import hoặc khai báo hàm, Ref, trạng thái hay biến cục bộ trong cùng tệp và dùng cùng một tên cho mọi tham chiếu. Nếu runtime không chuẩn cung cấp định danh, hãy truy cập rõ ràng qua window.<name> hoặc parentWindow.<name> và kiểm tra sự tồn tại trước.',
+    canvas_instance_api_unavailable: 'Thành phần Code Canvas không thể dùng các API phiên bản JSX của nền tảng sau: {0}. Hãy dùng React hooks, props hoặc cầu nối dữ liệu window.__OPENYIDA_YIDA_API__.',
     step_login: '\n🔑 Step 2: Đọc thông tin đăng nhập',
     step_publish: '\n📤 Step 3: Xuất bản schema\n',
     resend_save_csrf: '  🔄 Resending saveFormSchema request (csrf_token refreshed)...',

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -1146,6 +1146,7 @@ module.exports = {
     canvas_compile_done: '  ✅ 自訂頁面編譯完成！',
     canvas_compile_failed: '  ❌ 自訂頁面編譯失敗：{0}',
     canvas_unbound_identifiers: 'Code Canvas 原始碼存在未宣告識別字：{0}。請在同一檔案補齊 import、函式、Ref、狀態或區域變數宣告，並保持宣告與全部引用同名。若識別字由非標準執行環境提供，請改用 window.<name> 或 parentWindow.<name> 明確存取，並先檢查是否存在。',
+    canvas_instance_api_unavailable: 'Code Canvas 元件不能使用平台 JSX 執行個體 API：{0}。請使用 React hooks、props 或 window.__OPENYIDA_YIDA_API__ 資料橋接。',
     step_login: '\n🔑 Step 2：讀取登入態',
     step_publish: '\n📤 Step 3：發布 Schema\n',
     resend_save_csrf: '  🔄 重新傳送 saveFormSchema 請求（csrf_token 已刷新）...',

--- a/scripts/e2e-real/runner.js
+++ b/scripts/e2e-real/runner.js
@@ -154,6 +154,25 @@ function requireSuccess(stepName, commandResult) {
   return commandResult.json;
 }
 
+function requireCanvasPublishHealth(publishResult) {
+  const health = publishResult && publishResult.healthCheck;
+  const readback = health && health.readback;
+  if (
+    publishResult &&
+    publishResult.publishMode === 'canvas' &&
+    health && health.ok === true &&
+    health.expectedPublishMode === 'canvas' &&
+    readback && readback.hasYidaCodeCanvas === true &&
+    Number(readback.runtimeCodeBytes) > 0
+  ) {
+    return publishResult;
+  }
+  throw new Error(`publish Canvas health check failed: ${JSON.stringify({
+    publishMode: publishResult && publishResult.publishMode,
+    healthCheck: health || null,
+  })}`);
+}
+
 function run(options = {}) {
   const env = options.env || process.env;
   const config = options.config || getConfig(env);
@@ -227,14 +246,16 @@ function run(options = {}) {
         '--no-open',
       ]));
       trackResource(registry, registryPath, { type: 'page', appType: app.appType, pageId: page.pageId, name: config.pageName, url: page.url });
-      requireSuccess('publish page', runStep('publish', [
+      const publishResult = requireSuccess('publish page', runStep('publish', [
         'publish',
         config.pageSource,
         app.appType,
         page.pageId,
+        '--canvas',
         '--health-check',
         '--no-open',
       ]));
+      requireCanvasPublishHealth(publishResult);
     }
 
     registry.status = 'passed';
@@ -266,6 +287,7 @@ module.exports = {
   extractJsonObjects,
   getConfig,
   parseLastJson,
+  requireCanvasPublishHealth,
   run,
   runCli,
   writeRegistry,

--- a/tests/canvas-compile.test.js
+++ b/tests/canvas-compile.test.js
@@ -680,6 +680,44 @@ describe('compileCanvasLocal', () => {
     expect(() => compileCanvasLocal(source)).not.toThrow();
   });
 
+  test.each([
+    ['props.utils.getDataList', 'props.utils.getDataList({})'],
+    ['this.utils.yida.searchFormDatas', 'this.utils.yida.searchFormDatas({})'],
+    ['this.dataSourceMap.orders.load', 'this.dataSourceMap.orders.load()'],
+    ['this.$', 'this.$("textField_x")'],
+  ])('rejects unavailable Canvas instance API %s', (_label, expression) => {
+    const source = `
+      import React from 'react';
+      export default function App(props) {
+        function load() { return ${expression}; }
+        return <button onClick={load}>加载</button>;
+      }
+    `;
+
+    expect(() => compileCanvasLocal(source, {
+      sourcePath: 'pages/src/workbench.canvas.jsx',
+    })).toThrow(expect.objectContaining({
+      code: 'OPENYIDA_CANVAS_INSTANCE_API_UNAVAILABLE',
+      details: expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ api: expect.any(String) }),
+        ]),
+      }),
+    }));
+  });
+
+  test('allows ordinary component props in Canvas source', () => {
+    const source = `
+      import React from 'react';
+      export default function App(props) {
+        const title = props.utils ? props.utils.format(props.title) : props.title;
+        return <div>{title || '标题'}</div>;
+      }
+    `;
+
+    expect(() => compileCanvasLocal(source)).not.toThrow();
+  });
+
   test('maps lucide-react named icons to LucideReact and DynamicIcon to its runtime global', () => {
     const src = `
       import React from 'react';

--- a/tests/e2e-real-runner.test.js
+++ b/tests/e2e-real-runner.test.js
@@ -8,6 +8,7 @@ const {
   extractJsonObjects,
   getConfig,
   parseLastJson,
+  requireCanvasPublishHealth,
   run,
 } = require('../scripts/e2e-real/runner');
 const { compileCanvasLocal } = require('../lib/app/canvas-compile');
@@ -80,6 +81,20 @@ describe('real E2E runner', () => {
         if (command === 'create-app') {return { stdout: '{"success":true,"appType":"APP_E2E"}', json: { success: true, appType: 'APP_E2E' } };}
         if (command === 'create-form') {return { stdout: '{"success":true,"formUuid":"FORM-E2E"}', json: { success: true, formUuid: 'FORM-E2E' } };}
         if (command === 'create-page') {return { stdout: '{"success":true,"pageId":"PAGE-E2E"}', json: { success: true, pageId: 'PAGE-E2E' } };}
+        if (command === 'publish') {
+          return {
+            stdout: '{"success":true,"publishMode":"canvas"}',
+            json: {
+              success: true,
+              publishMode: 'canvas',
+              healthCheck: {
+                ok: true,
+                expectedPublishMode: 'canvas',
+                readback: { hasYidaCodeCanvas: true, runtimeCodeBytes: 128 },
+              },
+            },
+          };
+        }
         return { stdout: '{"success":true}', json: { success: true } };
       },
     });
@@ -93,10 +108,32 @@ describe('real E2E runner', () => {
       ['get-schema', 'APP_E2E', 'FORM-E2E', '--json', '--quiet'],
       ['data', 'query', 'form', 'APP_E2E', 'FORM-E2E', '--size', '1', '--quiet'],
       ['create-page', 'APP_E2E', 'OY_E2E_TEST_Page', '--mode', 'dashboard', '--no-open', '--quiet'],
-      ['publish', config.pageSource, 'APP_E2E', 'PAGE-E2E', '--health-check', '--no-open', '--quiet'],
+      ['publish', config.pageSource, 'APP_E2E', 'PAGE-E2E', '--canvas', '--health-check', '--no-open', '--quiet'],
     ]);
     expect(resources.map((resource) => resource.type)).toEqual(['app', 'form', 'page']);
     expect(registry.status).toBe('passed');
+  });
+
+  test('requires Canvas mode and non-empty Canvas runtime readback', () => {
+    expect(() => requireCanvasPublishHealth({
+      success: true,
+      publishMode: 'native',
+      healthCheck: {
+        ok: true,
+        expectedPublishMode: 'native',
+        readback: { hasYidaCodeCanvas: false, runtimeCodeBytes: 0 },
+      },
+    })).toThrow(/publish Canvas health check failed/);
+
+    expect(() => requireCanvasPublishHealth({
+      success: true,
+      publishMode: 'canvas',
+      healthCheck: {
+        ok: true,
+        expectedPublishMode: 'canvas',
+        readback: { hasYidaCodeCanvas: true, runtimeCodeBytes: 128 },
+      },
+    })).not.toThrow();
   });
 
   test('rejects an invalid Canvas fixture before running any CLI command', () => {

--- a/tests/publish-args.test.js
+++ b/tests/publish-args.test.js
@@ -25,12 +25,14 @@ describe('publish argument parsing', () => {
       'pages/src/home.canvas.jsx',
       'APP_XXX',
       'FORM-XXX',
+      '--canvas',
       '--auto-nav-order',
       '--health-check',
     ])).toMatchObject({
       sourceFile: 'pages/src/home.canvas.jsx',
       appType: 'APP_XXX',
       formUuid: 'FORM-XXX',
+      canvas: true,
       healthCheck: true,
       autoNavOrder: true,
     });

--- a/tests/publish-precheck.test.js
+++ b/tests/publish-precheck.test.js
@@ -413,11 +413,16 @@ describe('publish prechecks', () => {
       )).resolves.toMatchObject({
         ok: true,
         mode: 'publish_readback',
+        expectedPublishMode: 'canvas',
         authMode: 'token',
         targetReadable: true,
         schemaParsed: true,
         displayComponentPresent: true,
         publishedContentMatched: true,
+        readback: {
+          hasYidaCodeCanvas: true,
+          runtimeCodeBytes: expect.any(Number),
+        },
       });
 
       expect(requestSpy).not.toHaveBeenCalled();
@@ -544,8 +549,10 @@ describe('publish prechecks', () => {
         success: true,
         appType: 'APP_XXX',
         formUuid: 'FORM-PAGE',
+        publishMode: 'canvas',
         healthCheck: {
           ok: false,
+          expectedPublishMode: 'canvas',
           reason: 'display_component_missing',
         },
         navOrderWarning: 'nav order broke',

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -301,7 +301,7 @@ describe('OpenYida skill contracts', () => {
     expect(root).toContain('默认完成即停止');
     expect(app).toContain('[Step 8：发布页面并排序导航]');
     expect(step8).toContain('发布本轮修改过的页面源码到真实 display 页面，并执行轻量导航排序');
-    expect(step8).toContain('openyida publish <source> <appType> <displayPageFormUuid> --auto-nav-order');
+    expect(step8).toContain('openyida publish <source> <appType> <displayPageFormUuid> --canvas --health-check --auto-nav-order');
     expect(step8).toContain('PRD 写明页面/表单清单顺序时，执行 `openyida nav-group order <appType> <页面/表单...>`');
     expect(step4).toContain('PRD 包含审批、流程、申请、审核、工单等流程对象时');
     expect(publish).toContain('`--auto-nav-order`');
@@ -714,6 +714,7 @@ describe('OpenYida skill contracts', () => {
     const root = readSkill('yida-skills/SKILL.md');
     const app = readSkill('yida-skills/skills/yida-app/SKILL.md');
     const appStep7 = readSkill('yida-skills/skills/yida-app/workflow/step-7-page-code.md');
+    const appStep8 = readSkill('yida-skills/skills/yida-app/workflow/step-8-publish-navigation.md');
     const appStep9 = readSkill('yida-skills/skills/yida-app/workflow/step-9-output-finish.md');
     const canvas = readSkill('yida-skills/skills/yida-canvas-custom-page/SKILL.md');
     const native = readSkill('yida-skills/skills/yida-custom-page/SKILL.md');
@@ -729,8 +730,12 @@ describe('OpenYida skill contracts', () => {
 
     expect(app).toContain('[Step 7：编写或更新页面]');
     expect(appStep7).toContain('页面源码通过本地校验只表示“可发布”，不表示远端页面已更新');
+    expect(appStep8).toContain('--canvas --health-check --auto-nav-order');
+    expect(appStep8).toContain('`publishMode=canvas`');
+    expect(appStep8).toContain('`healthCheck.readback.hasYidaCodeCanvas=true`');
     expect(appStep9).toContain('没有成功执行 `openyida publish <source> <appType> <displayPageFormUuid>`');
     expect(appStep9).toContain('只能交付“源码已修改，尚未发布”的说明');
+    expect(appStep9).toContain('显示至少一条已 query 确认的记录');
 
     expect(canvas).toContain('final 前需要成功执行 `openyida publish <source> <appType> <displayPageFormUuid>`');
     expect(canvas).toContain('该历史源码只由 `yida-custom-page` 自身闭环维护');
@@ -750,6 +755,8 @@ describe('OpenYida skill contracts', () => {
     expect(publish).toContain('| `yida-canvas-custom-page` | 前置技能，编写 `.canvas.jsx` / `.canvas.tsx` 页面源码 |');
     expect(publish).toContain('本地文件编辑、diff、`check-page`、`compile`、`compileCanvasLocal` 或口头声明都不能证明远端页面已更新');
     expect(publish).toContain('发布了其他文件或其他目标页面，不满足本轮源码修改的 doneWhen');
+    expect(publish).toContain('`publishMode=canvas`');
+    expect(publish).toContain('`healthCheck.readback.hasYidaCodeCanvas=true`');
     expect(publish).not.toContain('## OpenYida 兼容编译');
     expect(publish).not.toContain('兼容构建会自动补齐 `renderJsx`');
 

--- a/yida-skills/skills/yida-app/workflow/step-8-publish-navigation.md
+++ b/yida-skills/skills/yida-app/workflow/step-8-publish-navigation.md
@@ -12,18 +12,19 @@
 ## 操作
 
 1. 执行 `use_skill("yida-publish-page", "发布主页面")`。
-2. 只要本轮 Write/Edit/Create 了 `project/pages/src/*.{canvas.jsx,canvas.tsx,oyd.jsx,jsx,tsx}`，final 前必须执行：
+2. 新建主页面或本轮使用 `YidaCodeCanvas` 实现页面时执行：
 
 ```text
-openyida publish <source> <appType> <displayPageFormUuid> --auto-nav-order
+openyida publish <source> <appType> <displayPageFormUuid> --canvas --health-check --auto-nav-order
 ```
 
-3. `<source>` 使用本轮修改过的页面源码。
-4. `<displayPageFormUuid>` 使用已解析的 display 自定义页面。
-5. PRD 写明页面/表单清单顺序时，执行 `openyida nav-group order <appType> <页面/表单...>`。
-6. PRD 缺少明确页面清单时，用 `--auto-nav-order` / `nav-group auto-order` 兜底。
-7. 兜底顺序为：门户/首页/工作台入口、业务办理、数据管理、经营分析、系统配置。
-8. 本步骤配置宜搭平台导航，不要求页面源码实现侧边栏或顶部应用导航；除非用户显式要求页面内自绘导航，否则不要回头在自定义页面中补导航壳。
+3. 已确认是存量平台 JSX 页面维护时执行 `openyida publish <source> <appType> <displayPageFormUuid> --health-check --auto-nav-order`。
+4. `<source>` 使用本轮修改过的页面源码。
+5. `<displayPageFormUuid>` 使用已解析的 display 自定义页面。
+6. PRD 写明页面/表单清单顺序时，执行 `openyida nav-group order <appType> <页面/表单...>`。
+7. PRD 缺少明确页面清单时，用 `--auto-nav-order` / `nav-group auto-order` 兜底。
+8. 兜底顺序为：门户/首页/工作台入口、业务办理、数据管理、经营分析、系统配置。
+9. 本步骤配置宜搭平台导航，不要求页面源码实现侧边栏或顶部应用导航；除非用户显式要求页面内自绘导航，否则不要回头在自定义页面中补导航壳。
 
 ## 产出
 
@@ -35,6 +36,7 @@ openyida publish <source> <appType> <displayPageFormUuid> --auto-nav-order
 
 - [ ] 发布 source 是本轮修改过的源码；
 - [ ] 发布目标是已解析的 display 页面；
+- [ ] Canvas 发布结果为 `publishMode=canvas`，且 `healthCheck.ok=true`、`healthCheck.readback.hasYidaCodeCanvas=true`、`runtimeCodeBytes>0`；
 - [ ] 已获得可访问 URL；
 - [ ] 导航排序已执行，或已有明确 warning。
 

--- a/yida-skills/skills/yida-app/workflow/step-9-output-finish.md
+++ b/yida-skills/skills/yida-app/workflow/step-9-output-finish.md
@@ -16,12 +16,14 @@
 完整应用默认完成需要同时满足：
 
 1. 主页面发布成功；
-2. 获得可访问 URL；
-3. 轻量导航排序已执行，或给出明确 warning；
-4. 新建或作为页面数据源的核心普通表单已写入 1-3 条真实示例记录并 query 抽查，或明确说明跳过原因；
-5. 普通表单和流程表单已注入全局主题样式，详情页已注入 formDetail CSS，或明确说明无法注入的阻塞原因；
-6. final 前先写入轻量 `prd/<项目名>/build-manifest.json`，再运行 `openyida check-prd-completeness prd/<项目名>/prd.md --app-type <appType> --build-manifest prd/<项目名>/build-manifest.json --json`；一期只检查页面/资源数量完整性，只有 `verdict=pass` 时才说“已按 PRD 完成搭建”，`verdict=needs_review` 时可以交付但不能使用“完全按 PRD 完成”口径，必须列出 `items` 中 `status=needs_review/not_checked` 的复核项，`verdict=fail` 时列出 `hardFailures` 并说明未完成；
-7. 未继续执行用户未要求的公开访问、截图验收、报表、大屏、数据源深接或精细导航分组。
+2. Canvas 主页面发布结果为 `publishMode=canvas`，读回 `hasYidaCodeCanvas=true` 且 `runtimeCodeBytes>0`；
+3. 真实数据页面在已登录浏览器中退出 loading、无业务错误，并显示至少一条已 query 确认的记录；
+4. 获得可访问 URL；
+5. 轻量导航排序已执行，或给出明确 warning；
+6. 新建或作为页面数据源的核心普通表单已写入 1-3 条真实示例记录并 query 抽查，或明确说明跳过原因；
+7. 普通表单和流程表单已注入全局主题样式，详情页已注入 formDetail CSS，或明确说明无法注入的阻塞原因；
+8. final 前先写入轻量 `prd/<项目名>/build-manifest.json`，再运行 `openyida check-prd-completeness prd/<项目名>/prd.md --app-type <appType> --build-manifest prd/<项目名>/build-manifest.json --json`；一期只检查页面/资源数量完整性，只有 `verdict=pass` 时才说“已按 PRD 完成搭建”，`verdict=needs_review` 时可以交付但不能使用“完全按 PRD 完成”口径，必须列出 `items` 中 `status=needs_review/not_checked` 的复核项，`verdict=fail` 时列出 `hardFailures` 并说明未完成；
+9. 未继续执行用户未要求的公开访问、截图验收、报表、大屏、数据源深接或精细导航分组。
 
 若本轮修改过页面源码但没有成功执行 `openyida publish <source> <appType> <displayPageFormUuid>`，只能交付“源码已修改，尚未发布”的说明。
 

--- a/yida-skills/skills/yida-canvas-data-binding/SKILL.md
+++ b/yida-skills/skills/yida-canvas-data-binding/SKILL.md
@@ -182,6 +182,7 @@ async function fetchFormRows(binding, signal) {
 - 页面首屏 KPI、列表、图表至少有一个区域来自真实数据源。
 - 接口异常时页面有明确错误态，不用 demo seed 伪装成成功态。
 - 发布后回读页面，确认 `YidaCodeCanvas` 组件的 `runtimeCode` 非空。
+- 在已登录浏览器中确认页面退出 loading、无数据加载错误，并显示至少一条已 query 确认的记录。
 
 验收命令：
 

--- a/yida-skills/skills/yida-publish-page/SKILL.md
+++ b/yida-skills/skills/yida-publish-page/SKILL.md
@@ -34,7 +34,7 @@ description: 自定义页面编译发布技能。
 
 - 发布前确认页面源码已通过对应页面开发技能编写：`.canvas.jsx` / `.canvas.tsx` 发布为 `YidaCodeCanvas` 组件；`.oyd.jsx` / `.jsx` / `.tsx` 发布为平台 `Jsx` 组件
 - 平台 `Jsx` 组件 / `oyb.jsx` / `renderJsx` 维护源码发布前优先执行 `openyida check-page <源文件路径>` 和 `openyida compile <源文件路径>`；本技能只把它们作为发布前 guard
-- 使用 `YidaCodeCanvas` 组件实现的页面不单独运行普通 JSX 编译命令；执行 `openyida publish <源文件> <appType> <displayPageFormUuid>` 时，由发布流程校验并写入 `runtimeCode + importedModules`
+- 使用 `YidaCodeCanvas` 组件实现的页面执行 `openyida publish <源文件> <appType> <displayPageFormUuid> --canvas --health-check`，由发布流程校验并写入 `runtimeCode + importedModules`
 - 推荐源码放在 `project/pages/src/`：使用 `YidaCodeCanvas` 组件实现的页面用 `<页面名>.canvas.jsx` / `<页面名>.canvas.tsx`；平台 `Jsx` 组件维护源码用 `<页面名>.oyd.jsx` / `<页面名>.jsx` / `<页面名>.tsx`
 - 发布前注意 CLI 会检查 `<workspace>/project/pages/src/` 与 `<workspace>/projects/<id>/artifacts/` 中同名源码是否内容不一致；出现警告时必须确认实际要发布哪一份
 - 发布前确认 `openyida env` 检测通过，登录态有效
@@ -95,7 +95,7 @@ openyida list-forms <appType> --keyword <页面名>
 
 ## Final 证据契约
 
-- final 中“页面已更新 / 已重新发布 / 已上线”的依据只能是成功的 `openyida publish <source> <appType> <displayPageFormUuid>` 命令结果，最好同时带发布输出中的 URL、`formUuid`、`success:true` 或 `healthCheck.mode=publish_readback` 摘要。
+- final 中“Canvas 页面已更新 / 已重新发布 / 已上线”的依据是成功的 `openyida publish <source> <appType> <displayPageFormUuid> --canvas --health-check`，且结果包含 `publishMode=canvas`、`healthCheck.ok=true`、`healthCheck.readback.hasYidaCodeCanvas=true` 和 `runtimeCodeBytes>0`。
 - `<source>` 必须是本轮实际 Write/Edit/Create 过的页面源码；`<displayPageFormUuid>` 必须是已解析的 display 自定义页面。发布了其他文件或其他目标页面，不满足本轮源码修改的 doneWhen。
 - 若 publish 没执行、执行失败、目标不明、登录态/组织不一致或用户要求先暂停，final 只能说“源码已修改，尚未发布”，并给出下一步需要执行的 publish 命令或阻塞原因。
 - 平台 JSX 组件页面的 `check-page` / `compile`、使用 `YidaCodeCanvas` 组件实现页面的 `compileCanvasLocal` 都是发布前 guard，不是远端完成证据。
@@ -128,7 +128,7 @@ openyida list-forms <appType> --keyword <页面名>
 ## 输出
 
 ```json
-{"success":true,"formUuid":"FORM-XXX","version":0,"healthCheck":{"ok":true,"mode":"publish_readback","authMode":"token","targetReadable":true,"schemaParsed":true,"displayComponentPresent":true,"publishedContentMatched":true}}
+{"success":true,"formUuid":"FORM-XXX","version":0,"publishMode":"canvas","healthCheck":{"ok":true,"mode":"publish_readback","expectedPublishMode":"canvas","displayComponentPresent":true,"publishedContentMatched":true,"readback":{"hasYidaCodeCanvas":true,"runtimeCodeBytes":1024}}}
 ```
 
 ## 自动注入的 CSS


### PR DESCRIPTION
## Summary

- expose Canvas publish mode and readback evidence in publish results
- reject unsupported platform JSX instance APIs during Canvas compilation
- make real E2E and OpenYida skills require explicit Canvas publication and browser-visible real data
- document the acceptance boundary and done contract

## Validation

- 5 Jest suites, 111 tests passed
- npm run check:i18n
- npm run check:skills
- npm run build:skills
- npm run check:ci
- Codex real build: Canvas runtime 11135 bytes, 3 known records visible, no loading/error
- Qoder real build: Canvas runtime 22146 bytes, 3 known records visible, no loading/error
- integration full replacement without --replace remained fail-closed in both runs
