### PR TITLE
fix: respect report time granularity

### DIFF
--- a/lib/report/chart-builder.js
+++ b/lib/report/chart-builder.js
@@ -20,6 +20,7 @@ const {
   normalizeField,
   normalizeFieldArray,
   getDefaultLayout,
+  isValidTimeGranularityType,
 } = require('./field-utils');
 
 const {
@@ -92,6 +93,31 @@ function validateChartConfig(chart, chartIndex) {
       hasError = true;
     }
   }
+
+  const fieldKeys = [
+    'fields',
+    'xField',
+    'yField',
+    'groupField',
+    'leftYFields',
+    'rightYFields',
+    'columnFields',
+    'columns',
+    'columnList',
+    'kpi',
+    'kpiField',
+    'helpKpi',
+    'valueField',
+    'assitValueField',
+  ];
+  fieldKeys.forEach((key) => {
+    const fields = Array.isArray(chart[key]) ? chart[key] : [chart[key]];
+    fields.forEach((field) => {
+      if (field && typeof field === 'object' && !isValidTimeGranularityType(field.timeGranularityType)) {
+        hasError = true;
+      }
+    });
+  });
 
   return !hasError;
 }

--- a/lib/report/data-model.js
+++ b/lib/report/data-model.js
@@ -1,7 +1,27 @@
 'use strict';
 
 const { genFieldAlias } = require('./constants');
-const { normalizeFieldCode, buildFieldObj, normalizeField, normalizeFieldArray } = require('./field-utils');
+const {
+  normalizeFieldCode,
+  buildFieldObj,
+  normalizeField,
+  normalizeFieldArray,
+  normalizeTimeGranularityType,
+} = require('./field-utils');
+
+function buildDisplayFieldObj(cubeCode, field, dataType, aggregateType) {
+  return buildFieldObj(
+    cubeCode,
+    field.fieldCode,
+    field.aliasName || field.fieldCode,
+    field._alias,
+    dataType || field.dataType,
+    aggregateType || field.aggregateType,
+    undefined,
+    undefined,
+    field.timeGranularityType
+  );
+}
 
 /**
  * 构建 dataViewQueryModel（图表数据查询模型）
@@ -49,7 +69,7 @@ function buildDataViewQueryModel(chart, cubeTenantId) {
       fieldCode: normalizeFieldCode(f.fieldCode),
       dataType: f.dataType || 'STRING',
       aggregateType: aggType,
-      timeGranularityType: isDateField ? 'DAY' : null,
+      timeGranularityType: isDateField ? normalizeTimeGranularityType(f.timeGranularityType) : null,
     });
 
     fieldList.push(alias);
@@ -94,23 +114,15 @@ function buildDataSetModelMap(chart, cubeTenantId) {
         aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
         classifiedCode: cubeCode, fieldCode: normalizeFieldCode(f.fieldCode),
         dataType: f.dataType || 'STRING', aggregateType: aggType,
-        timeGranularityType: isDateField ? 'DAY' : null,
+        timeGranularityType: isDateField ? normalizeTimeGranularityType(f.timeGranularityType) : null,
       });
       fieldListKeys.push(alias);
     });
 
-    const fieldListObjs = allFields.map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
-    const xFieldObjs = allFields.filter((f) => f.role === 'x').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
-    const leftYObjs = allFields.filter((f) => f.role === 'leftY').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
-    const rightYObjs = allFields.filter((f) => f.role === 'rightY').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
+    const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));
+    const xFieldObjs = allFields.filter((f) => f.role === 'x').map((f) => buildDisplayFieldObj(cubeCode, f));
+    const leftYObjs = allFields.filter((f) => f.role === 'leftY').map((f) => buildDisplayFieldObj(cubeCode, f));
+    const rightYObjs = allFields.filter((f) => f.role === 'rightY').map((f) => buildDisplayFieldObj(cubeCode, f));
 
     return {
       dataSetName: {
@@ -149,14 +161,12 @@ function buildDataSetModelMap(chart, cubeTenantId) {
         aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
         classifiedCode: cubeCode, fieldCode: normalizeFieldCode(f.fieldCode),
         dataType: f.dataType || 'STRING', aggregateType: aggType,
-        timeGranularityType: isDateField ? 'DAY' : null,
+        timeGranularityType: isDateField ? normalizeTimeGranularityType(f.timeGranularityType) : null,
       });
       fieldListKeys.push(alias);
     });
 
-    const fieldListObjs = allFields.map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
+    const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));
 
     return {
       table: {
@@ -197,15 +207,9 @@ function buildDataSetModelMap(chart, cubeTenantId) {
       fieldListKeys.push(alias);
     });
 
-    const fieldListObjs = allFields.map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
-    const kpiObjs = allFields.filter((f) => f.role === 'kpi').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
-    const helpKpiObjs = allFields.filter((f) => f.role === 'helpKpi').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
+    const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));
+    const kpiObjs = allFields.filter((f) => f.role === 'kpi').map((f) => buildDisplayFieldObj(cubeCode, f));
+    const helpKpiObjs = allFields.filter((f) => f.role === 'helpKpi').map((f) => buildDisplayFieldObj(cubeCode, f));
 
     return {
       youshuData: {
@@ -242,14 +246,12 @@ function buildDataSetModelMap(chart, cubeTenantId) {
         aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
         classifiedCode: cubeCode, fieldCode: normalizeFieldCode(f.fieldCode),
         dataType: f.dataType || 'STRING', aggregateType: aggType,
-        timeGranularityType: isDateField ? 'DAY' : null,
+        timeGranularityType: isDateField ? normalizeTimeGranularityType(f.timeGranularityType) : null,
       });
       fieldListKeys.push(alias);
     });
 
-    const fieldListObjs = allFields.map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-    );
+    const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));
 
     return {
       dataSetName: {
@@ -295,20 +297,16 @@ function buildDataSetModelMap(chart, cubeTenantId) {
         aliasName: { type: 'i18n', zh_CN: f.aliasName || f.fieldCode },
         classifiedCode: cubeCode, fieldCode: normalizeFieldCode(f.fieldCode),
         dataType: f.dataType || 'DOUBLE', aggregateType: aggType,
-        timeGranularityType: isDateField ? 'DAY' : null,
+        timeGranularityType: isDateField ? normalizeTimeGranularityType(f.timeGranularityType) : null,
       });
       fieldListKeys.push(alias);
     });
 
-    const fieldListObjs = allFields.map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType || 'DOUBLE', f.aggregateType || 'AVG')
-    );
-    const valueFieldObjs = allFields.filter((f) => f.role === 'value').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType || 'DOUBLE', f.aggregateType || 'AVG')
-    );
-    const assitValueFieldObjs = allFields.filter((f) => f.role === 'assit').map((f) =>
-      buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType || 'DOUBLE', f.aggregateType || 'AVG')
-    );
+    const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f, f.dataType || 'DOUBLE', f.aggregateType || 'AVG'));
+    const valueFieldObjs = allFields.filter((f) => f.role === 'value')
+      .map((f) => buildDisplayFieldObj(cubeCode, f, f.dataType || 'DOUBLE', f.aggregateType || 'AVG'));
+    const assitValueFieldObjs = allFields.filter((f) => f.role === 'assit')
+      .map((f) => buildDisplayFieldObj(cubeCode, f, f.dataType || 'DOUBLE', f.aggregateType || 'AVG'));
 
     return {
       chartData: {
@@ -331,18 +329,16 @@ function buildDataSetModelMap(chart, cubeTenantId) {
   // ── 通用图表（bar/line/pie/funnel/scatter/area）──
   const { model, allFields } = buildDataViewQueryModel(chart, cubeTenantId);
 
-  const fieldListObjs = allFields.map((f) =>
-    buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType)
-  );
+  const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));
   const xFieldObjs = allFields
     .filter((f) => f.role === 'x')
-    .map((f) => buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType));
+    .map((f) => buildDisplayFieldObj(cubeCode, f));
   const yFieldObjs = allFields
     .filter((f) => f.role === 'y')
-    .map((f) => buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType));
+    .map((f) => buildDisplayFieldObj(cubeCode, f));
   const groupFieldObjs = allFields
     .filter((f) => f.role === 'group')
-    .map((f) => buildFieldObj(cubeCode, f.fieldCode, f.aliasName || f.fieldCode, f._alias, f.dataType, f.aggregateType));
+    .map((f) => buildDisplayFieldObj(cubeCode, f));
 
   const extraFields = {};
   if (chartType === 'pie') {

--- a/lib/report/field-utils.js
+++ b/lib/report/field-utils.js
@@ -17,6 +17,15 @@ function normalizeCubeCode(code) {
  */
 const SELECT_LIKE_PREFIXES = ['selectField_', 'radioField_', 'checkboxField_', 'multiSelectField_', 'employeeField_'];
 
+const TIME_GRANULARITY_FORMATS = Object.freeze({
+  YEAR: 'yyyy',
+  MONTH: 'yyyy-MM',
+  DAY: 'yyyy-MM-dd',
+  HOUR: 'yyyy-MM-dd HH',
+  MINUTE: 'yyyy-MM-dd HH:mm',
+  SECOND: 'yyyy-MM-dd HH:mm:ss',
+});
+
 function normalizeFieldCode(fieldCode) {
   if (!fieldCode) {return fieldCode;}
   const needsValueSuffix = SELECT_LIKE_PREFIXES.some((prefix) => fieldCode.startsWith(prefix));
@@ -24,6 +33,27 @@ function normalizeFieldCode(fieldCode) {
     return fieldCode + '_value';
   }
   return fieldCode;
+}
+
+function isValidTimeGranularityType(value) {
+  return value === null
+    || value === undefined
+    || value === ''
+    || Object.prototype.hasOwnProperty.call(TIME_GRANULARITY_FORMATS, value);
+}
+
+function normalizeTimeGranularityType(value) {
+  if (value === null || value === undefined || value === '') {
+    return 'DAY';
+  }
+  if (!isValidTimeGranularityType(value)) {
+    throw new TypeError(`timeGranularityType 不支持: ${String(value)}`);
+  }
+  return value;
+}
+
+function getTimeFormat(timeGranularityType) {
+  return TIME_GRANULARITY_FORMATS[normalizeTimeGranularityType(timeGranularityType)];
 }
 
 // ── 通用构建工具 ──────────────────────────────────────
@@ -72,7 +102,17 @@ function buildLink() {
  * 3. dateField 不需要 measureType 属性
  * 4. selectField/radioField 的 fieldCode 需要加 _value 后缀（自动处理，无需调用方手动添加）
  */
-function buildFieldObj(cubeCode, fieldCode, aliasName, alias, dataType, aggregateType, orderType, _isDimension) {
+function buildFieldObj(
+  cubeCode,
+  fieldCode,
+  aliasName,
+  alias,
+  dataType,
+  aggregateType,
+  orderType,
+  _isDimension,
+  timeGranularityType
+) {
   const normalizedFieldCode = normalizeFieldCode(fieldCode);
   const aggType = aggregateType || 'NONE';
   const isDateField = (dataType === 'DATE') || (fieldCode && fieldCode.startsWith('dateField_'));
@@ -102,8 +142,8 @@ function buildFieldObj(cubeCode, fieldCode, aliasName, alias, dataType, aggregat
   };
 
   if (isDateField) {
-    obj.timeGranularityType = 'DAY';
-    obj.timeFormat = 'yyyy-MM-dd';
+    obj.timeGranularityType = normalizeTimeGranularityType(timeGranularityType);
+    obj.timeFormat = getTimeFormat(obj.timeGranularityType);
     obj.id = fieldCode + '5';
   }
 
@@ -193,6 +233,10 @@ function getDefaultLayout(chartType) {
 module.exports = {
   normalizeCubeCode,
   normalizeFieldCode,
+  TIME_GRANULARITY_FORMATS,
+  isValidTimeGranularityType,
+  normalizeTimeGranularityType,
+  getTimeFormat,
   buildAfterFetch,
   buildExportData,
   buildLink,

--- a/tests/report-command.test.js
+++ b/tests/report-command.test.js
@@ -180,6 +180,29 @@ describe('report command helpers', () => {
     expect(utils.requestWithAutoLogin).not.toHaveBeenCalled();
   });
 
+  test('create-report rejects an invalid timeGranularityType before remote writes', async () => {
+    const invalidConfig = [{
+      ...chartConfig[0],
+      xField: {
+        fieldCode: 'dateField_hireDate',
+        aliasName: '入职日期',
+        dataType: 'DATE',
+        timeGranularityType: 'DECADE',
+      },
+    }];
+
+    await expect(createReport.run([
+      'APP_XXX',
+      '入职报表',
+      JSON.stringify(invalidConfig),
+    ])).rejects.toMatchObject({
+      code: 'CREATE_REPORT_CHART_CONFIG_INVALID',
+    });
+
+    expect(utils.httpPost).not.toHaveBeenCalled();
+    expect(utils.httpGet).not.toHaveBeenCalled();
+  });
+
   test('append-chart run fetches existing schema and saves appended chart', async () => {
     utils.httpGet.mockResolvedValueOnce({
       success: true,

--- a/tests/report-time-granularity.test.js
+++ b/tests/report-time-granularity.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { buildDataSetModelMap } = require('../lib/report/data-model');
+const { validateChartConfig } = require('../lib/report/chart-builder');
+
+const CUBE_CODE = 'FORM_REPORT_GRANULARITY';
+
+function dateField(timeGranularityType) {
+  return {
+    fieldCode: 'dateField_hireDate',
+    aliasName: '入职日期',
+    dataType: 'DATE',
+    aggregateType: 'NONE',
+    ...(timeGranularityType ? { timeGranularityType } : {}),
+  };
+}
+
+const chartCases = [
+  {
+    name: '通用图表',
+    chart: (granularity) => ({
+      type: 'bar',
+      cubeCode: CUBE_CODE,
+      xField: dateField(granularity),
+      yField: [{ fieldCode: 'pid', aliasName: '人数', aggregateType: 'COUNT' }],
+    }),
+    dataSetKey: 'chartData',
+    displayFieldKey: 'xField',
+  },
+  {
+    name: '组合图',
+    chart: (granularity) => ({
+      type: 'combo',
+      cubeCode: CUBE_CODE,
+      xField: dateField(granularity),
+      leftYFields: [{ fieldCode: 'numberField_total', aliasName: '人数', aggregateType: 'SUM' }],
+    }),
+    dataSetKey: 'dataSetName',
+    displayFieldKey: 'xField',
+  },
+  {
+    name: '基础表格',
+    chart: (granularity) => ({
+      type: 'table',
+      cubeCode: CUBE_CODE,
+      columnFields: [dateField(granularity)],
+    }),
+    dataSetKey: 'table',
+    displayFieldKey: 'columnFields',
+  },
+  {
+    name: '交叉透视表',
+    chart: (granularity) => ({
+      type: 'pivot',
+      cubeCode: CUBE_CODE,
+      columnList: [dateField(granularity)],
+    }),
+    dataSetKey: 'dataSetName',
+    displayFieldKey: 'columnList',
+  },
+  {
+    name: '仪表盘',
+    chart: (granularity) => ({
+      type: 'gauge',
+      cubeCode: CUBE_CODE,
+      valueField: dateField(granularity),
+    }),
+    dataSetKey: 'chartData',
+    displayFieldKey: 'valueField',
+  },
+];
+
+describe('report timeGranularityType', () => {
+  test.each(chartCases)('$name 将 YEAR 同时写入查询模型和展示字段', ({ chart, dataSetKey, displayFieldKey }) => {
+    const dataSet = buildDataSetModelMap(chart('YEAR'), 'corp-1')[dataSetKey];
+
+    expect(dataSet.dataViewQueryModel.fieldDefinitionList[0].timeGranularityType).toBe('YEAR');
+    expect(dataSet[displayFieldKey][0]).toMatchObject({
+      timeGranularityType: 'YEAR',
+      timeFormat: 'yyyy',
+    });
+  });
+
+  test.each([
+    ['YEAR', 'yyyy'],
+    ['MONTH', 'yyyy-MM'],
+    ['DAY', 'yyyy-MM-dd'],
+    ['HOUR', 'yyyy-MM-dd HH'],
+    ['MINUTE', 'yyyy-MM-dd HH:mm'],
+    ['SECOND', 'yyyy-MM-dd HH:mm:ss'],
+  ])('%s 使用匹配的展示格式', (granularity, timeFormat) => {
+    const dataSet = buildDataSetModelMap(chartCases[0].chart(granularity), 'corp-1').chartData;
+
+    expect(dataSet.dataViewQueryModel.fieldDefinitionList[0].timeGranularityType).toBe(granularity);
+    expect(dataSet.xField[0]).toMatchObject({
+      timeGranularityType: granularity,
+      timeFormat,
+    });
+  });
+
+  test('日期字段缺省粒度保持 DAY，非日期字段保持 null', () => {
+    const dataSet = buildDataSetModelMap({
+      type: 'bar',
+      cubeCode: CUBE_CODE,
+      xField: dateField(),
+      yField: [{ fieldCode: 'pid', aliasName: '人数', aggregateType: 'COUNT' }],
+    }, 'corp-1').chartData;
+
+    expect(dataSet.dataViewQueryModel.fieldDefinitionList.map((field) => field.timeGranularityType)).toEqual([
+      'DAY',
+      null,
+    ]);
+    expect(dataSet.xField[0]).toMatchObject({
+      timeGranularityType: 'DAY',
+      timeFormat: 'yyyy-MM-dd',
+    });
+  });
+
+  test.each(['QUARTER', 'WEEK', 'DECADE'])('%s 不能通过配置校验，也不能被构建器静默回落', (granularity) => {
+    const chart = chartCases[0].chart(granularity);
+
+    expect(validateChartConfig(chart, 0)).toBe(false);
+    expect(() => buildDataSetModelMap(chart, 'corp-1')).toThrow(
+      new RegExp(`timeGranularityType.*${granularity}`)
+    );
+  });
+});

--- a/yida-skills/skills/yida-report/references/schema-builder-details.md
+++ b/yida-skills/skills/yida-report/references/schema-builder-details.md
@@ -31,7 +31,7 @@ buildDataSetEntry({
       isDim: true,                    // true=维度，false=度量
       dataType: 'DATE',              // STRING | NUMBER | DATE | BOOLEAN | ARRAY
       aggregateType: 'NONE',         // NONE | SUM | AVG | COUNT | MAX | MIN | COUNT_DISTINCT
-      timeGranularityType: 'DAY',    // YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | null
+      timeGranularityType: 'DAY',    // YEAR | MONTH | DAY | HOUR | MINUTE | SECOND | null
     }),
     buildFieldDefinition({
       alias: 'sales',


### PR DESCRIPTION
## 改动概述

修复 `create-report` / `append-chart` 在日期字段配置了 `timeGranularityType` 时仍固定生成 `DAY` 的问题。

生成器现在会把合法粒度同时写入查询模型和展示字段，并生成匹配的 `timeFormat`；未配置时仍保持 `DAY`，非法值会在远端写入前被拒绝。

## 改动类型

- [x] 🐛 Bug 修复
- [x] 📝 文档更新
- [ ] ✨ 新功能
- [ ] ♻️ 代码重构
- [ ] 🔧 配置 / CI 变更
- [ ] ⬆️ 依赖升级
- [ ] 🌐 国际化（i18n）
- [ ] 🎨 UI / 终端输出优化
- [ ] 📦 发布 / 打包流程调整

## 关联 Issue / 需求

VOC：`create-report` 的 `timeGranularityType` 仅表现为 `DAY`。

## 主要变更

- `lib/report/field-utils.js`：定义运行时支持的 `YEAR / MONTH / DAY / HOUR / MINUTE / SECOND` 粒度及展示格式，保留缺省 `DAY`。
- `lib/report/data-model.js`：在通用图、组合图、表格、透视表和仪表盘的查询模型及展示字段中透传粒度。
- `lib/report/chart-builder.js`：在远端写入前拒绝非法粒度，避免静默回落。
- `tests/`：补充各图表分支、全粒度格式、缺省兼容和非法输入回归测试。
- `yida-skills/`：修正报表字段配置文档中的粒度集合。

## 兼容性与风险

- [x] 无破坏性变更
- [ ] 涉及 CLI 参数或输出格式变更，已说明兼容策略
- [x] 涉及登录态、Cookie、组织上下文或私有化环境，已确认无敏感信息泄露
- [x] 涉及宜搭真实数据写入，已说明影响范围和回滚方式

兼容策略：日期字段不传 `timeGranularityType` 时仍输出 `DAY / yyyy-MM-dd`。真实验证仅在既有 E2E 应用中新增一个临时报表，不修改业务表单数据；当前 CLI 无删除报表命令，因此测试报表保留供复核。

## 测试与验证

- [x] `npm test`（通过 `npm run check:ci` 执行）
- [x] `npm run lint`
- [x] `npm run check:syntax`
- [x] `npm run check:skills`
- [x] `npm run build:skills`
- [x] `npm run check:package`
- [x] 已在真实宜搭环境验证相关功能
- [x] 私有化部署场景确认不受影响（未改动域名、认证或环境分支）

补充验证：

- focused Jest：2 suites、26 tests 全部通过。
- 全量 `npm run check:ci`：通过。
- 真实环境创建包含按年、月、日、秒四个折线图的报表；平台 Schema 回读确认四种粒度和对应 `timeFormat` 均正确持久化。
- 已登录 Chrome 中四个图表正常加载，无查询异常、空态或报表控制台错误。

## 文档与 Agent 技能

- [ ] 新增或调整 CLI 命令时，已更新 `README.md` 命令一览表（不适用）
- [ ] 新增用户可见文案时，已同步 `lib/core/locales/` 下所有语言包（不适用）
- [x] 涉及 Agent 工作流变化时，已更新 `yida-skills/` 相关技能说明
- [ ] 涉及 GitHub Release / npm 发布行为时，已更新 `CHANGELOG.md`（不适用）

## 截图 / 录屏

无 UI 代码改动；真实报表页面已完成浏览器运行态验证。

## Reviewer 关注点

- 支持集合以当前宜搭报表前端运行时为准，不包含 `QUARTER / WEEK`。
- 粒度需要同时存在于 `dataViewQueryModel.fieldDefinitionList` 和组件展示字段，否则查询与显示可能不一致。
- 非法粒度必须在 `create-report` / `append-chart` 发生远端写入前失败。
