### PR TITLE
chore: release 2026.8.27-2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,6 @@ jobs:
           npm install -g openyida
           ```
 
-          安装后即可在 Claude Code / OpenCode / Aone Copilot / Cursor / Qoder 中直接使用，零配置。
+          安装后即可在 Codex / Claude Code / OpenCode / Cursor / QwenWork / Qoder / Qoder IDE / QoderWork 中直接使用，零配置。
 
         generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2026.8.27-2] - 2026-08-27
+
 ### Added
 
 - npm 全局安装新增 Homebrew 风格自动更新：普通命令执行前至多每 24 小时检查一次 npm `latest`，发现新版本后安装精确版本并重跑原命令；提供缓存、非阻塞锁、完整 SemVer 比较和关闭开关。托管云端 Agent 在缓存、registry 与 npm 调用前直接跳过。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.8.27-1",
+  "version": "2026.8.27-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.8.27-1",
+      "version": "2026.8.27-2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.8.27-1",
+  "version": "2026.8.27-2",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",


### PR DESCRIPTION
## Summary

- release npm global auto-update
- remove retired Wukong and Aone Copilot compatibility
- support new Qoder, Qoder IDE, and QoderWork product detection
- align package manifests and release notes to 2026.8.27-2

## Validation

- npm run check:ci
- 145 test suites / 2070 tests passed
- cross-platform release risk scan: 0 errors
- npm package: 383 files, 1.25 MiB tarball