### PR TITLE
refactor: 清理报表死代码并完善 dynamicOrder 文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ openyida create-process APP_XXX "Purchase Request" .cache/openyida/process/field
 openyida configure-process APP_XXX FORM_XXX .cache/openyida/process/process.json
 openyida process preview APP_XXX PROC_INST_XXX --output .cache/openyida/process/process.html
 openyida data query form APP_XXX FORM_XXX --page 1 --size 20
+openyida data query form APP_XXX FORM_XXX --dynamic-order '{"dateField_xxx":"-"}'
 openyida data create form APP_XXX FORM_XXX --data-file .cache/openyida/data-import/record.json
 openyida get-permission APP_XXX FORM_XXX
 ```
@@ -226,6 +227,7 @@ openyida get-permission APP_XXX FORM_XXX
 发布成功还必须精确回读同一 PUBLISHED `processId/processVersion` 的 `getProcessById` 平台视图，并验证可见节点的组件、名称、顺序和审批模式。只有输出 `verificationLevel: "PLATFORM_VIEW_VERIFIED"` 才表示平台 view 已验证；`PUBLISHED_UNVERIFIED` 表示发布可能已生效但回读不完整，不能宣称 `processJson` 已验证，也不能直接重放写请求。
 
 When creating or updating test data with `openyida data`, Yida date fields must use 13-digit millisecond timestamps, for example `"dateField_xxx": 1719705600000`. Do not submit `YYYY-MM-DD` strings for `DateField` or `CascadeDateField` values.
+For deterministic query order, pass `--dynamic-order '{"fieldId":"+"}'` for ascending order or `--dynamic-order '{"fieldId":"-"}'` for descending order. Without `--dynamic-order`, `searchFormDatas` does not guarantee a stable result order; pagination, comparison, and pairing logic must not depend on the default order.
 Temporary JSON, CSV, and one-off import scripts should live under `.cache/openyida/` so generated run artifacts do not clutter the repository root.
 
 ### Real Environment E2E

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -24,7 +24,7 @@ const { readFormMode } = require('../app/services/form-mode-service');
 const USAGE = `openyida data - Unified Yida data CLI
 
 Usage:
-  openyida data query form <appType> <formUuid> [--page N] [--size N] [--all] [--max-pages N] [--search-json JSON|--search-file .cache/openyida/search.json] [--resolve-aliases] [--inst-id ID] [--no-hydrate-subforms]
+  openyida data query form <appType> <formUuid> [--page N] [--size N] [--all] [--max-pages N] [--search-json JSON|--search-file .cache/openyida/search.json] [--dynamic-order '{"fieldId":"+"}'] [--resolve-aliases] [--inst-id ID] [--no-hydrate-subforms]
   openyida data get form <appType> --inst-id <formInstId> [--form-uuid <formUuid>] [--no-hydrate-subforms]
   openyida data create form <appType> <formUuid> (--data-json <JSON>|--data-file .cache/openyida/data.json) [--dept-id ID] [--resolve-aliases]
     说明：若目标表单为流程表单，会自动使用 /v1/process/startInstance.json 发起流程。
@@ -41,6 +41,8 @@ Usage:
   openyida data query tasks <appType> --type <todo|done|submitted|cc> [--page N] [--size N] [--keyword TEXT] [--process-codes JSON] [--instance-status STATUS]
 
 Add --resolve-aliases when JSON keys use Yida component aliases instead of field IDs.
+Use --dynamic-order '{"fieldId":"+"}' for ascending order or '{"fieldId":"-"}' for descending order.
+When --dynamic-order is omitted, the API does not guarantee a stable result order.
 `;
 
 function fail(message) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -1237,6 +1237,26 @@ async function httpPostJson(baseUrl, requestPath, payload, optionsOrLegacyCookie
   });
 }
 
+function appendQueryParams(requestPath, queryParams) {
+  if (!queryParams) {
+    return requestPath;
+  }
+
+  const querystring = require('querystring');
+  const serialized = querystring.stringify(queryParams);
+  if (!serialized) {
+    return requestPath;
+  }
+
+  if (!requestPath.includes('?')) {
+    return `${requestPath}?${serialized}`;
+  }
+  if (requestPath.endsWith('?') || requestPath.endsWith('&')) {
+    return `${requestPath}${serialized}`;
+  }
+  return `${requestPath}&${serialized}`;
+}
+
 /**
  * 发送 HTTP GET 请求
  * @param {string} baseUrl
@@ -1248,7 +1268,6 @@ async function httpPostJson(baseUrl, requestPath, payload, optionsOrLegacyCookie
 async function httpGet(baseUrl, requestPath, queryParams, optionsOrLegacyCookies, maybeOptions) {
   const https = require('https');
   const http = require('http');
-  const querystring = require('querystring');
   const optionsOverride = resolveRequestOptions(optionsOrLegacyCookies, maybeOptions);
   const authHeaders = await resolveRequestAuthHeaders(optionsOverride);
 
@@ -1256,7 +1275,7 @@ async function httpGet(baseUrl, requestPath, queryParams, optionsOrLegacyCookies
     const parsedUrl = new URL(baseUrl);
     const isHttps = parsedUrl.protocol === 'https:';
     const requestModule = isHttps ? https : http;
-    const fullPath = queryParams ? `${requestPath}?${querystring.stringify(queryParams)}` : requestPath;
+    const fullPath = appendQueryParams(requestPath, queryParams);
 
     const options = {
       hostname: parsedUrl.hostname,

--- a/lib/report/chart-builder.js
+++ b/lib/report/chart-builder.js
@@ -153,37 +153,6 @@ function buildPieChartSettings() {
   };
 }
 
-function buildScatterChartSettings() {
-  return {
-    container: { height: 248 },
-    style: {
-      pointSize: 4, pointShape: 'circle',
-      colorType: 'SCHEMA_COLOR', chartColorsMode: 'defaultColorsMode',
-      customColor: '#5894FF,#394B76,#F7B900,#E55F24,#80D5F5,#9849B0,#3BC88A,#0E869D,#F4A49E,#80563C',
-    },
-    axisType: 'hz',
-    xAxis: {
-      showXAxis: true, showTitle: false,
-      title: { type: 'i18n', zh_CN: '', en_US: '' },
-      line: true, tickLine: true, grid: false, label: true,
-    },
-    yAxis: {
-      showYAxis: true, showTitle: false,
-      title: { type: 'i18n', zh_CN: '', en_US: '' },
-      line: false, tickLine: false, grid: true, label: true,
-      min: null, max: null, tickCount: 5,
-    },
-    legend: { showLegend: true, legendPosition: 'top-left', flipPage: true },
-    tooltip: { showTooltip: true },
-  };
-}
-
-function buildAreaChartSettings() {
-  const s = buildLineChartSettings();
-  s.style.showArea = true;
-  return s;
-}
-
 function buildFunnelChartSettings() {
   return {
     container: { height: 248 },
@@ -193,20 +162,6 @@ function buildFunnelChartSettings() {
     },
     legend: { showLegend: true, legendPosition: 'top-left', flipPage: true },
     label: { showLabel: true, fontSize: 12, color: '#000' },
-    tooltip: { showTooltip: true },
-  };
-}
-
-function buildRadarChartSettings() {
-  return {
-    container: { height: 248 },
-    style: {
-      colorType: 'SCHEMA_COLOR', chartColorsMode: 'defaultColorsMode',
-      customColor: '#5894FF,#394B76,#F7B900,#E55F24,#80D5F5,#9849B0,#3BC88A,#0E869D,#F4A49E,#80563C',
-      showArea: true, smooth: false, pointSize: 4, lineWidth: 2,
-    },
-    legend: { showLegend: true, legendPosition: 'top-left', flipPage: true },
-    label: { showLabel: false, fontSize: 12, color: '#000' },
     tooltip: { showTooltip: true },
   };
 }
@@ -365,14 +320,6 @@ function buildPivotSettings() {
   };
 }
 
-function buildNumberChartSettings() {
-  return {
-    container: { height: 120 },
-    style: { fontSize: 36, color: '#1a1a1a', unit: '', colorType: 'SCHEMA_COLOR' },
-    tooltip: { showTooltip: false },
-  };
-}
-
 /**
  * 根据图表类型获取 settings
  */
@@ -383,16 +330,12 @@ function getChartSettings(chartType) {
     case 'calendarheatmap': return buildCalendarHeatmapSettings();
     case 'map':       return buildMapSettings();
     case 'pie':       return buildPieChartSettings();
-    case 'scatter':   return buildScatterChartSettings();
-    case 'area':      return buildAreaChartSettings();
     case 'funnel':    return buildFunnelChartSettings();
-    case 'radar':     return buildRadarChartSettings();
     case 'gauge':     return buildGaugeChartSettings();
     case 'combo':     return buildComboChartSettings();
     case 'table':     return buildTableSettings();
     case 'indicator': return buildIndicatorSettings();
     case 'pivot':     return buildPivotSettings();
-    case 'number':    return buildNumberChartSettings();
     default: {
       const error = new Error(`unsupported report chart type: ${String(chartType)}`);
       error.code = 'REPORT_CHART_TYPE_UNSUPPORTED';
@@ -409,9 +352,6 @@ function buildUserConfig(chartType) {
   }
   if (chartType === 'funnel') {
     return { chartType: 'funnel', dataConfig: { xField: [], yField: [] } };
-  }
-  if (chartType === 'radar') {
-    return { chartType: 'radar', dataConfig: { xField: [], yField: [], groupField: [] } };
   }
   if (chartType === 'gauge') {
     return { chartType: 'gauge', dataConfig: { valueField: [], assitValueField: [] } };
@@ -456,10 +396,7 @@ function buildUserConfig(chartType) {
   if (chartType === 'pivot') {
     return { chartType: 'pivot', dataConfig: { columnList: [] } };
   }
-  if (chartType === 'number') {
-    return { chartType: 'number', dataConfig: { valueField: [] } };
-  }
-  // 默认：bar/line/scatter/area
+  // 默认：bar/line/calendarheatmap
   return { chartType: chartType || 'bar', dataConfig: { xField: [], yField: [], groupField: [], annotationField: [] } };
 }
 
@@ -498,8 +435,8 @@ function buildUserConfigWithFields(chartType) {
     }];
   }
 
-  // 柱状图 / 折线图 / 面积图 / 散点图 / 雷达图 / 漏斗图
-  if (['bar', 'line', 'calendarheatmap', 'area', 'scatter', 'radar', 'funnel'].includes(chartType)) {
+  // 柱状图 / 折线图 / 日历热力图 / 漏斗图
+  if (['bar', 'line', 'calendarheatmap', 'funnel'].includes(chartType)) {
     const items = [
       { setterName: 'ColumnFieldSetter', name: 'xField', title: '横轴',
         setterProps: { single: true, showFormatTab: true, showFormulaEditor: true, showFieldInfo: true, showAggregateTab: false, showDrillTab: true, showEditTab: true, showSortTab: true } },
@@ -608,7 +545,7 @@ function buildMockData(chartType) {
       },
     }];
   }
-  if (chartType === 'line' || chartType === 'area') {
+  if (chartType === 'line') {
     return [{
       name: 'chartData',
       data: {
@@ -657,23 +594,6 @@ function buildMockData(chartType) {
         meta: [
           { aliasName: '阶段', alias: 'xField', category: 'xField', dataType: 'STRING' },
           { aliasName: '数量', alias: 'yField', category: 'yField', dataType: 'NUMBER' },
-        ],
-        currentPage: 1, totalCount: 5,
-      },
-    }];
-  }
-  if (chartType === 'radar') {
-    return [{
-      name: 'chartData',
-      data: {
-        data: [
-          { xField: '销售', yField: 80 }, { xField: '管理', yField: 65 },
-          { xField: '技术', yField: 90 }, { xField: '客服', yField: 70 },
-          { xField: '研发', yField: 85 },
-        ],
-        meta: [
-          { aliasName: '维度', alias: 'xField', category: 'xField', dataType: 'STRING' },
-          { aliasName: '数值', alias: 'yField', category: 'yField', dataType: 'NUMBER' },
         ],
         currentPage: 1, totalCount: 5,
       },
@@ -1078,16 +998,12 @@ module.exports = {
   buildBarChartSettings,
   buildLineChartSettings,
   buildPieChartSettings,
-  buildScatterChartSettings,
-  buildAreaChartSettings,
   buildFunnelChartSettings,
-  buildRadarChartSettings,
   buildGaugeChartSettings,
   buildTableSettings,
   buildComboChartSettings,
   buildIndicatorSettings,
   buildPivotSettings,
-  buildNumberChartSettings,
   getChartSettings,
   buildUserConfig,
   buildUserConfigWithFields,

--- a/lib/report/data-model.js
+++ b/lib/report/data-model.js
@@ -373,7 +373,7 @@ function buildDataSetModelMap(chart, cubeTenantId) {
     };
   }
 
-  // ── 通用图表（bar/line/pie/funnel/scatter/area）──
+  // ── 通用图表（bar/line/pie/funnel/calendarheatmap）──
   const { model, allFields } = buildDataViewQueryModel(chart, cubeTenantId);
 
   const fieldListObjs = allFields.map((f) => buildDisplayFieldObj(cubeCode, f));

--- a/tests/http-encoding.test.js
+++ b/tests/http-encoding.test.js
@@ -56,3 +56,24 @@ describe('http response encoding', () => {
     });
   });
 });
+
+describe('httpGet query parameters', () => {
+  test.each([
+    ['/api', { added: '1' }, '/api?added=1'],
+    ['/api?existing=1', { added: '2' }, '/api?existing=1&added=2'],
+    ['/api?', { added: '3' }, '/api?added=3'],
+    ['/api?existing=1&', { added: '4' }, '/api?existing=1&added=4'],
+    ['/api?existing=1', {}, '/api?existing=1'],
+  ])('joins query params onto %s', async (requestPath, queryParams, expectedPath) => {
+    let actualPath = '';
+    await withServer((req, res) => {
+      actualPath = req.url;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ success: true }));
+    }, async (baseUrl) => {
+      await httpGet(baseUrl, requestPath, queryParams, { silentStatus: true });
+    });
+
+    expect(actualPath).toBe(expectedPath);
+  });
+});

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -113,7 +113,9 @@ describe('run() 参数校验', () => {
   });
 
   test('参数为空数组时打印错误并以 exit code 1 退出', async () => {
-    await expectCliError(run([]), '缺少必填参数');
+    const error = await expectCliError(run([]), '缺少必填参数');
+    expect(error.usage).toContain('--dynamic-order');
+    expect(error.usage).toContain('does not guarantee a stable result order');
   });
 
   test('未知 action/resource 组合时打印错误并退出', async () => {

--- a/tests/report-capability-registry.test.js
+++ b/tests/report-capability-registry.test.js
@@ -8,8 +8,8 @@ const {
   getReportChartCapability,
   listReportChartTypes,
 } = require('../lib/report/capability-registry');
-const { validateChartConfig } = require('../lib/report/chart-builder');
-const { buildReportSchema } = require('../lib/report/chart-builder');
+const chartBuilder = require('../lib/report/chart-builder');
+const { validateChartConfig, buildReportSchema } = chartBuilder;
 const { buildDataSetModelMap } = require('../lib/report/data-model');
 
 const SUPPORTED_TYPES = [
@@ -43,7 +43,7 @@ describe('report capability registry', () => {
     expect(Object.keys(REPORT_CHART_CAPABILITIES).sort()).toEqual(SUPPORTED_TYPES);
   });
 
-  test.each(['radar', 'heatmap', 'wordcloud', 'number', 'unknown'])('%s fails closed', (type) => {
+  test.each(['scatter', 'area', 'radar', 'heatmap', 'wordcloud', 'number', 'unknown'])('%s fails closed', (type) => {
     expect(getReportChartCapability(type)).toBeNull();
     expect(validateChartConfig({
       type,
@@ -51,6 +51,13 @@ describe('report capability registry', () => {
       xField: { fieldCode: 'textField_1' },
       yField: [{ fieldCode: 'numberField_1' }],
     }, 0)).toBe(false);
+  });
+
+  test('does not export builders for unsupported legacy chart types', () => {
+    expect(chartBuilder).not.toHaveProperty('buildScatterChartSettings');
+    expect(chartBuilder).not.toHaveProperty('buildAreaChartSettings');
+    expect(chartBuilder).not.toHaveProperty('buildRadarChartSettings');
+    expect(chartBuilder).not.toHaveProperty('buildNumberChartSettings');
   });
 
   test('map and calendar heatmap build platform-shaped datasets', () => {

--- a/yida-skills/references/yida-api.md
+++ b/yida-skills/references/yida-api.md
@@ -342,7 +342,7 @@ this.utils.yida.getFormDataById({
 | createTo | String | 否 | 创建时间范围结束，格式 yyyy-MM-dd | `'2024-02-01'` |
 | modifiedFrom | String | 否 | 修改时间范围起始，格式 yyyy-MM-dd | `'2024-01-01'` |
 | modifiedTo | String | 否 | 修改时间范围结束，格式 yyyy-MM-dd | `'2024-02-01'` |
-| dynamicOrder | String | 否 | 指定排序字段 | `'{"numberField_1ac":"+"}'` |
+| dynamicOrder | String | 否 | 指定排序字段；`+` 升序，`-` 降序。不传时返回顺序无稳定性保证 | `'{"numberField_1ac":"+"}'` |
 
 **searchFieldJson 示例**：
 
@@ -398,6 +398,8 @@ this.utils.yida.getFormDataById({
 > - **页面内部调用**（即在宜搭自定义页面的 JS 代码中调用 `this.utils.yida.searchFormDatas`）：**不需要传 `appType`**，SDK 会自动从当前页面上下文中获取。
 > - **外部 HTTP 直接调用**（如通过 `openyida data query form` CLI 或服务端脚本）：**必须传 `appType`**，即应用的唯一标识（可在宜搭应用 URL 中找到，格式如 `APP_XXXXXXXX`）。
 
+> 📌 **排序说明**：需要稳定顺序的分页、比对或配对逻辑必须显式传入 `dynamicOrder`。不传时不得依赖接口当前返回顺序；CLI 对应参数为 `--dynamic-order '{"fieldId":"+"}'` 或 `--dynamic-order '{"fieldId":"-"}'`。
+
 **请求示例**：
 
 ```javascript
@@ -411,7 +413,7 @@ this.utils.yida.searchFormDatas({
   createTo: '2024-02-01',
   modifiedFrom: '2024-01-01',
   modifiedTo: '2024-02-01',
-  dynamicOrder: '',
+  dynamicOrder: '{"dateField_xxx":"-"}',
 }).then((res) => {
   // 兼容两种返回结构
   var data = (res && res.data) || (res && res.content && res.content.data) || [];

--- a/yida-skills/skills/yida-data-management/SKILL.md
+++ b/yida-skills/skills/yida-data-management/SKILL.md
@@ -106,7 +106,7 @@ description: 宜搭数据管理。表单实例/子表/流程实例/任务中心�
 ### 表单实例
 
 ```bash
-openyida data query form <appType> <formUuid> [--page 1 --size 20] [--search-json '<json>'|--search-file .cache/openyida/<项目名或任务名>/data-import/search.json] [--resolve-aliases]
+openyida data query form <appType> <formUuid> [--page 1 --size 20] [--search-json '<json>'|--search-file .cache/openyida/<项目名或任务名>/data-import/search.json] [--dynamic-order '{"fieldId":"+"}'] [--resolve-aliases]
 openyida data get form <appType> --inst-id <formInstId>
 openyida data create form <appType> <formUuid> --data-json '<json>' [--resolve-aliases]
 openyida data create form <appType> <formUuid> --data-file .cache/openyida/<项目名或任务名>/data-import/record.json [--resolve-aliases]
@@ -258,6 +258,7 @@ openyida data create form APP_xxx FORM-商机表 --data-json '{
 
 - `pageSize` 最大 100，QPS 限制约 40 次/秒
 - `searchFieldJson` 和 `dynamicOrder` 必须传字符串
+- 需要稳定顺序的分页、比对或配对必须显式传 `--dynamic-order '{"fieldId":"+"}'`（升序）或 `--dynamic-order '{"fieldId":"-"}'`（降序）；未传时不得依赖默认返回顺序
 - 字段 ID 通过 `openyida get-schema` 获取，不要手写猜测
 - 批量脚本可以用 Python `subprocess` 调用 `openyida data ...`，也可以用 JS 复用 Node 工具；脚本必须由结构化文件写入工具创建到 `<projectRoot>/.cache/openyida/<项目名或任务名>/scripts/`，导入数据放在 `<projectRoot>/.cache/openyida/<项目名或任务名>/data-import/`
 


### PR DESCRIPTION
## 变更内容

- 删除未注册且不可达的 scatter、area、radar、number 原生报表构建死代码，保留 capability registry 的 fail-closed 行为
- 补充 dynamicOrder 的 CLI 帮助、README、数据管理技能与 API 参考，并明确默认返回顺序不稳定
- 修复 httpGet 在 requestPath 已带查询串时追加参数产生重复问号的问题，并补齐边界测试

## 验证

- npm run check:ci
- 6 个定向测试集，164 个用例通过
- check:skills、check:i18n、check:release-risks、node --check、git diff --check 通过
- 实际链路 auth → app → form → page → data → report 完成
- dynamicOrder 真实数据升序 10/20/30、降序 30/20/10
- scatter、area、radar、number 在创建空白报表前稳定拒绝
- bar 报表创建及 indicator 追加均通过严格 Schema 回读
- 已有查询串的真实只读 GET 请求成功

## 说明

- 按约定未执行浏览器人工检查
- 真实 E2E 初始 runner 因默认页面 fixture 路径失效中断；复用同一隔离应用和表单，以仓库现存 Canvas fixture 续跑通过，未重复创建应用
- 未执行真实资源物理删除，资源均已登记到本地 E2E registry