### PR TITLE
feat: create apps with modern theme

### DIFF
--- a/lib/app/create-app.js
+++ b/lib/app/create-app.js
@@ -269,6 +269,7 @@ function buildCreateAppPayload(params, auth, contentLocale, openExclusive, openP
     openPhysicColumn,
     openIsolationDatabase: 'n',
     openExclusiveUnit: 'n',
+    createWithModernTheme: 'y',
     group: 'ALL',
     fromBuilderAi: 'y',
     builderAiSource: resolveBuilderAiSource(),

--- a/tests/create-app.test.js
+++ b/tests/create-app.test.js
@@ -169,6 +169,7 @@ describe('create-app argument parsing', () => {
       group: 'ALL',
       openExclusive: 'n',
       openPhysicColumn: 'n',
+      createWithModernTheme: 'y',
       fromBuilderAi: 'y',
       builderAiSource: 'local',
     });


### PR DESCRIPTION
## Summary

- add `createWithModernTheme=y` to the `create-app` register request
- add a payload regression assertion
- intentionally leave `import-app` unchanged

## Validation

- full CI was intentionally not run after the scope adjustment, per request
- `git diff --check` passed