### PR TITLE
fix(auth): fence token cache by sandbox binding

### DIFF
--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -294,6 +294,7 @@ function normalizeTokenSession(session = {}) {
     auth_store: session.auth_store || session.authStore,
     auth_profile: session.auth_profile || session.authProfile,
     persistence_scope: session.persistence_scope || session.persistenceScope,
+    runtime_binding_id: session.runtime_binding_id || session.runtimeBindingId,
     user_auth_store_writable: typeof session.user_auth_store_writable === 'boolean'
       ? session.user_auth_store_writable
       : session.userAuthStoreWritable,
@@ -597,7 +598,10 @@ function saveTokenSession(session, options = {}) {
   const env = options.env || process.env;
   const normalized = normalizeTokenSession(session);
   if (isEnvTokenAuthMode(env) && normalized.auth_source === 'env') {
-    return saveProjectLegacyTokenSession(normalized, options);
+    return saveProjectLegacyTokenSession({
+      ...normalized,
+      runtime_binding_id: env.OPENYIDA_SANDBOX_BINDING_ID,
+    }, options);
   }
 
   try {
@@ -650,6 +654,7 @@ function loadEnvTokenSession(env = process.env) {
     token_type: env.OPENYIDA_TOKEN_TYPE,
     expires_at: env.OPENYIDA_ACCESS_TOKEN_EXPIRES_AT,
     expires_in: env.OPENYIDA_ACCESS_TOKEN_EXPIRES_IN,
+    runtime_binding_id: env.OPENYIDA_SANDBOX_BINDING_ID,
     auth_source: 'env',
   });
 }
@@ -787,8 +792,15 @@ function resolveTokenSession(options = {}) {
   const envSession = applyBusinessContextToEnvSession(loadEnvTokenSession(env), options);
   if (isEnvTokenAuthMode(env)) {
     const localSession = loadLocalTokenSession(options);
+    const runtimeBindingId = String(env.OPENYIDA_SANDBOX_BINDING_ID || '').trim();
+    // A project cache carries token rotations across CLI processes in one
+    // sandbox. It must not outlive the runtime binding that issued it.
+    const localBindingMatches = !runtimeBindingId || (
+      localSession && localSession.runtime_binding_id === runtimeBindingId
+    );
     if (
       localSession &&
+      localBindingMatches &&
       (localSession.access_token || localSession.refresh_token) &&
       sessionMatchesSelector(localSession, selector)
     ) {

--- a/tests/token-auth.test.js
+++ b/tests/token-auth.test.js
@@ -532,6 +532,7 @@ describe('token-auth', () => {
     const env = {
       OPENYIDA_AUTH_MODE: 'token',
       OPENYIDA_REFRESH_TOKEN: 'env-refresh-token',
+      OPENYIDA_SANDBOX_BINDING_ID: 'binding-current',
       OPENYIDA_ENDPOINT: `http://127.0.0.1:${port}`,
       OPENYIDA_TOKEN_CORP_ID: 'corp-env',
     };
@@ -559,6 +560,7 @@ describe('token-auth', () => {
       expect(JSON.parse(fs.readFileSync(tokenFile, 'utf8'))).toMatchObject({
         access_token: 'new-env-access-token',
         refresh_token: 'new-env-refresh-token',
+        runtime_binding_id: 'binding-current',
       });
       const contextFile = getBusinessContextFilePath({ projectRoot: tmpDir });
       const context = JSON.parse(fs.readFileSync(contextFile, 'utf8'));
@@ -577,6 +579,7 @@ describe('token-auth', () => {
           YIDA_AUTH_ENABLED: 'true',
           OPENYIDA_AUTH_MODE: 'token',
           OPENYIDA_REFRESH_TOKEN: 'next-process-refresh-token',
+          OPENYIDA_SANDBOX_BINDING_ID: 'binding-current',
           OPENYIDA_ENDPOINT: `http://127.0.0.1:${port}`,
           OPENYIDA_TOKEN_CORP_ID: 'corp-env',
         },
@@ -584,6 +587,22 @@ describe('token-auth', () => {
         base_url: 'https://customer.example.com',
         refresh_token: 'new-env-refresh-token',
         auth_source: 'project_legacy',
+      });
+      expect(loadTokenSession({
+        projectRoot: tmpDir,
+        authDir,
+        env: {
+          YIDA_AUTH_ENABLED: 'true',
+          OPENYIDA_AUTH_MODE: 'token',
+          OPENYIDA_REFRESH_TOKEN: 'replacement-refresh-token',
+          OPENYIDA_SANDBOX_BINDING_ID: 'binding-replacement',
+          OPENYIDA_ENDPOINT: `http://127.0.0.1:${port}`,
+          OPENYIDA_TOKEN_CORP_ID: 'corp-env',
+        },
+      })).toMatchObject({
+        refresh_token: 'replacement-refresh-token',
+        runtime_binding_id: 'binding-replacement',
+        auth_source: 'env',
       });
     } finally {
       await closeServer(server);

--- a/tests/token-store.test.js
+++ b/tests/token-store.test.js
@@ -455,6 +455,60 @@ describe('token-store', () => {
     expect(loaded.auth_store).toBe('project_cache');
   });
 
+  test('env token mode ignores a project cache from another sandbox binding', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      authDir,
+      env: {
+        OPENYIDA_AUTH_MODE: 'token',
+        OPENYIDA_ACCESS_TOKEN: 'fresh-env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'fresh-env-refresh-token',
+        OPENYIDA_SANDBOX_BINDING_ID: 'binding-new',
+      },
+    };
+    saveProjectLegacyTokenSession({
+      access_token: 'stale-local-access-token',
+      refresh_token: 'stale-local-refresh-token',
+      runtime_binding_id: 'binding-old',
+    }, options);
+
+    const loaded = loadTokenSession(options);
+
+    expect(loaded.access_token).toBe('fresh-env-access-token');
+    expect(loaded.refresh_token).toBe('fresh-env-refresh-token');
+    expect(loaded.runtime_binding_id).toBe('binding-new');
+    expect(loaded.auth_source).toBe('env');
+    expect(loaded.auth_store).toBe('env');
+  });
+
+  test('env token mode keeps a rotated project cache for the same sandbox binding', () => {
+    const options = {
+      projectRoot,
+      envName: 'public',
+      authDir,
+      env: {
+        OPENYIDA_AUTH_MODE: 'token',
+        OPENYIDA_ACCESS_TOKEN: 'bootstrap-env-access-token',
+        OPENYIDA_REFRESH_TOKEN: 'bootstrap-env-refresh-token',
+        OPENYIDA_SANDBOX_BINDING_ID: 'binding-current',
+      },
+    };
+    saveProjectLegacyTokenSession({
+      access_token: 'rotated-local-access-token',
+      refresh_token: 'rotated-local-refresh-token',
+      runtime_binding_id: 'binding-current',
+    }, options);
+
+    const loaded = loadTokenSession(options);
+
+    expect(loaded.access_token).toBe('rotated-local-access-token');
+    expect(loaded.refresh_token).toBe('rotated-local-refresh-token');
+    expect(loaded.runtime_binding_id).toBe('binding-current');
+    expect(loaded.auth_source).toBe('project_legacy');
+    expect(loaded.auth_store).toBe('project_cache');
+  });
+
   test('env token mode does not use project cache for another injected corp', () => {
     const options = {
       projectRoot,


### PR DESCRIPTION
## Summary

- persist the sandbox runtime binding ID with env-token project caches
- ignore cached rotated tokens when they belong to a different sandbox binding
- retain rotated project-cache tokens when the runtime binding still matches
- cover cross-binding isolation and same-binding reuse in token-store/token-auth tests

## Validation

- not rerun during this PR submission step
- branch is clean and contains only the three authentication/test files shown in the diff