### PR TITLE
feat: 创建表单后自动更新导航图标

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
+## [2026.9.2-1] - 2026-09-02
+
+### Added
+
+- `create-form create` 新增 `--icon auto|<name>`：表单创建并保存 Schema 后，按标题与字段语义从宜搭表单导航图标集中自动选图标，也可显式指定；新增 `create-form icons --json` 查询全部可选图标。
+
+### Changed
+
+- 表单导航图标更新对齐 yida-next 的 `Nav.update` 请求契约，并在写入后回读校验；命令参数同步注册到 command manifest 与 agent capabilities，确保云端 yida-agent 可发现和调用。
+
 ## [2026.9.2] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 
 | Command | Description |
 |---------|-------------|
-| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a form page |
+| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--icon auto\|<iconName>] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a form page |
+| `openyida create-form icons [--json]` | List available form navigation icons |
 | `openyida create-form validate-fields <fieldsJsonOrFile> [--json]` | Validate form field JSON locally |
 | `openyida create-form update <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Update a form page |
 | `openyida create-form patch <appType> <formUuid> <patchJsonOrFile> [--open\|--no-open]` | Update a form page |

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -285,7 +285,8 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 
 | 命令 | 说明 |
 |------|------|
-| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建表单页面 |
+| `openyida create-form create <appType> "<formTitle>" <fieldsJsonFile> [--icon auto\|<iconName>] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建表单页面 |
+| `openyida create-form icons [--json]` | 列出可用的表单导航图标 |
 | `openyida create-form validate-fields <fieldsJsonOrFile> [--json]` | 本地校验表单字段 JSON |
 | `openyida create-form update <appType> ... [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 更新表单页面 |
 | `openyida create-form patch <appType> <formUuid> <patchJsonOrFile> [--open\|--no-open]` | 更新表单页面 |

--- a/lib/app/create-form.js
+++ b/lib/app/create-form.js
@@ -82,6 +82,12 @@ const { createParseArgs } = require('./create-form/args');
 const { createDefinitionReaders } = require('./create-form/definition-reader');
 const { dispatchCreateFormCommand } = require('./create-form/commands');
 const { buildApiPath } = require('./create-form/api-path');
+const {
+  FORM_NAV_ICON_GROUPS,
+  FORM_NAV_ICONS,
+  resolveFormNavIcon,
+} = require('./create-form/nav-icon');
+const { createFormNavIconService } = require('./create-form/nav-icon-service');
 const { deepMerge, splitJsonPointer } = require('./create-form/schema-patch');
 const {
   actionRefName,
@@ -4647,11 +4653,13 @@ function applyChangesToSchema(schema, changes, options) {
 
 // ── 发送 POST 请求（支持 302 自动重登录） ────────────
 
-function sendPostRequest(baseUrl, requestPath, extraParams, formUuid, authRef) {
+function sendPostRequest(baseUrl, requestPath, extraParams, formUuid, authRef, requestOptions) {
+  requestOptions = requestOptions || {};
   const authParams = authRef && authRef.csrfToken ? { _csrf_token: authRef.csrfToken } : {};
   const postData = querystring.stringify(Object.assign(authParams, extraParams));
+  const refererAppType = requestOptions.appType || extraParams.appType || '';
   const referer = formUuid
-    ? `${baseUrl}/alibaba/web/${extraParams.appType || ''}/design/pageDesigner?formUuid=${formUuid}`
+    ? requestOptions.referer || `${baseUrl}/alibaba/web/${refererAppType}/design/pageDesigner?formUuid=${formUuid}`
     : baseUrl + '/';
   return httpPost(baseUrl, requestPath, postData, { referer });
 }
@@ -4677,6 +4685,19 @@ function sendCreateFormRequest(authRef, appType, formTitle) {
     authRef
   );
 }
+
+const {
+  resolveFormNavigationNode,
+  updateCreatedFormNavigationIcon,
+} = createFormNavIconService({
+  buildApiPath,
+  requestWithAutoLogin,
+  sendGetRequest,
+  sendPostRequest,
+  throwCreateFormError,
+  sanitizeFailureResult,
+  candidateLimit: FIELD_RESOLUTION_CANDIDATE_LIMIT,
+});
 
 // ── 登录态辅助：从 authData 中提取 corpId ──────────
 
@@ -4853,6 +4874,25 @@ async function mainValidateFields(parsedArgs) {
   return output;
 }
 
+async function mainListIcons(parsedArgs) {
+  const output = {
+    success: true,
+    count: FORM_NAV_ICONS.length,
+    default: 'auto',
+    groups: FORM_NAV_ICON_GROUPS.map(function (group) {
+      return {
+        key: group.key,
+        label: group.label,
+        icons: group.items.map(function (item) {
+          return { name: item[0], label: item[1] };
+        }),
+      };
+    }),
+  };
+  console.log(JSON.stringify(output, null, parsedArgs.json ? 2 : 0));
+  return output;
+}
+
 async function mainCreate(parsedArgs, authRef) {
   const { appType, formTitle, fieldsJsonOrFile, layout, theme, labelAlign } = parsedArgs;
 
@@ -4866,9 +4906,22 @@ async function mainCreate(parsedArgs, authRef) {
   const { fields, columns, validations } = readFieldsDefinition(fieldsJsonOrFile);
   assertNoEmojiInFormDefinition(formTitle, fields, validations);
   validateFormFieldDefinitions(fields);
+  const iconResolution = resolveFormNavIcon(parsedArgs.icon, formTitle, fields);
+  if (!iconResolution.icon) {
+    throwCreateFormError(
+      `Unsupported form navigation icon: ${parsedArgs.icon}. Run openyida create-form icons --json for the supported catalog.`,
+      'CREATE_FORM_NAV_ICON_INVALID',
+      {
+        icon: parsedArgs.icon,
+        availableIconCount: FORM_NAV_ICONS.length,
+      }
+    );
+  }
+  const formIcon = iconResolution.icon;
   const fieldCount = countDataFieldDefinitions(fields);
   success(t('create_form.fields_loaded', fieldCount));
   label('Columns:', String(columns));
+  label('Icon:', `${formIcon} (${iconResolution.source})`);
   fields.forEach(function (field, index) {
     listItem((index + 1) + '. ' + normalizeFormDefinitionType(field) + ': ' + getDefinitionDisplayName(field));
   });
@@ -4935,6 +4988,8 @@ async function mainCreate(parsedArgs, authRef) {
       formUuid,
       fieldCount,
     });
+    postCreateStage = 'updateFormNavigationIcon';
+    await updateCreatedFormNavigationIcon(authRef, appType, formUuid, formIcon);
   } catch (err) {
     emitCreateFormPostCreateFailure({
       appType,
@@ -4954,7 +5009,7 @@ async function mainCreate(parsedArgs, authRef) {
     ['URL', formUrl],
   ]);
   console.log(JSON.stringify(withBrowserHandoff(
-    { success: true, formUuid, formTitle, appType, fieldCount, url: formUrl },
+    { success: true, formUuid, formTitle, appType, fieldCount, icon: formIcon, iconSource: iconResolution.source, url: formUrl },
     formUrl,
     { stage: 'create_form_success', title: formTitle },
     parsedArgs.browserOpenMode
@@ -4991,6 +5046,7 @@ async function createFormForLegacyProcessQuiet(context, input) {
     layout: input.layout || 'single',
     theme: input.theme || 'default',
     labelAlign: input.labelAlign || 'top',
+    icon: input.icon || 'auto',
     contentLocale: input.contentLocale || null,
     browserOpenMode: 'off',
   };
@@ -5000,6 +5056,15 @@ async function createFormForLegacyProcessQuiet(context, input) {
   const { fields, validations } = readFieldsDefinition(fieldsJsonOrFile);
   assertNoEmojiInFormDefinition(formTitle, fields, validations, 'legacy create-form input');
   validateFormFieldDefinitions(fields);
+  const iconResolution = resolveFormNavIcon(parsedArgs.icon, formTitle, fields);
+  if (!iconResolution.icon) {
+    throwCreateFormError(
+      `Unsupported form navigation icon: ${parsedArgs.icon}. Run openyida create-form icons --json for the supported catalog.`,
+      'CREATE_FORM_NAV_ICON_INVALID',
+      { icon: parsedArgs.icon, availableIconCount: FORM_NAV_ICONS.length }
+    );
+  }
+  const formIcon = iconResolution.icon;
   const fieldCount = countDataFieldDefinitions(fields);
   const createResult = await sendCreateFormRequest(authRef, appType, formTitle);
 
@@ -5030,6 +5095,7 @@ async function createFormForLegacyProcessQuiet(context, input) {
     applySmartValidations(schema, createValidationRules);
   }
   const saveResult = await saveFormSchema(authRef, appType, formUuid, schema, serverRevision, 4);
+  const navIconResult = await updateCreatedFormNavigationIcon(authRef, appType, formUuid, formIcon);
   return {
     success: true,
     appType,
@@ -5038,6 +5104,9 @@ async function createFormForLegacyProcessQuiet(context, input) {
     fieldCount,
     createResult,
     saveResult,
+    navIconResult,
+    icon: formIcon,
+    iconSource: iconResolution.source,
     url: authRef.baseUrl + '/' + appType + '/workbench/' + formUuid,
   };
 }
@@ -6017,6 +6086,9 @@ async function run(args) {
   if (parsedArgs.mode === 'validate-fields') {
     return mainValidateFields(parsedArgs);
   }
+  if (parsedArgs.mode === 'icons') {
+    return mainListIcons(parsedArgs);
+  }
 
   step(1, t('common.step_login', 1));
   const authRef = createAuthRef();
@@ -6058,6 +6130,8 @@ module.exports = {
     normalizeFormDefinitionType,
     validateFormFieldDefinitions,
     collectFormFieldValidationDiagnostics,
+    resolveFormNavigationNode,
+    updateCreatedFormNavigationIcon,
     applyChangesToSchema,
     applyFormRules,
     applySchemaPatchOperations,

--- a/lib/app/create-form/api-path.js
+++ b/lib/app/create-form/api-path.js
@@ -11,6 +11,8 @@
  * @param {string} [options.prefix]        额外的路径前缀（会以 / 拼接）
  * @param {string} [options.namespace]     命名空间，默认 dingtalk
  * @param {'formdesign'|'formnav'} [options.queryModule] 查询模块，默认 formdesign
+ * @param {string} [options.api]            页面请求标识，例如 Nav.update
+ * @param {boolean} [options.mock]          是否使用 mock 接口
  * @param {boolean} [options.addTimestamp] 是否追加 _stamp 时间戳查询参数
  * @returns {string} 拼接完成的 API 请求路径
  */
@@ -19,14 +21,26 @@ function buildApiPath(appType, apiName, options = {}) {
     prefix = '',
     namespace = 'dingtalk',
     queryModule = 'formdesign',
+    api,
+    mock,
     addTimestamp = false,
   } = options;
   if (queryModule !== 'formdesign' && queryModule !== 'formnav') {
     throw new Error(`Unsupported query module: ${queryModule}`);
   }
   const prefixPath = prefix ? `/${prefix}` : '';
-  const timestamp = addTimestamp ? `?_stamp=${Date.now()}` : '';
-  return `/${namespace}/web/${appType}${prefixPath}/query/${queryModule}/${apiName}.json${timestamp}`;
+  const queryParams = [];
+  if (api) {
+    queryParams.push(`_api=${encodeURIComponent(api)}`);
+  }
+  if (mock !== undefined) {
+    queryParams.push(`_mock=${String(Boolean(mock))}`);
+  }
+  if (addTimestamp) {
+    queryParams.push(`_stamp=${Date.now()}`);
+  }
+  const query = queryParams.length > 0 ? `?${queryParams.join('&')}` : '';
+  return `/${namespace}/web/${appType}${prefixPath}/query/${queryModule}/${apiName}.json${query}`;
 }
 
 module.exports = {

--- a/lib/app/create-form/args.js
+++ b/lib/app/create-form/args.js
@@ -85,6 +85,7 @@ function createParseArgs(dependencies) {
       layout: 'single',
       theme: 'default',
       labelAlign: 'top',
+      icon: 'auto',
       contentLocale: null,
       browserOpenMode: openOption.mode,
     };
@@ -104,6 +105,12 @@ function createParseArgs(dependencies) {
         options.labelAlign = args[i + 1];
         args.splice(i, 2);
         i--;
+      } else if (args[i] === '--icon' && i + 1 < args.length) {
+        options.icon = args[i + 1];
+        args.splice(i, 2);
+        i--;
+      } else if (args[i] === '--icon') {
+        throwCreateFormError('--icon requires a value', 'CREATE_FORM_INVALID_ARGUMENTS');
       } else if ((args[i] === '--locale' || args[i] === '--content-locale' || args[i] === '--lang') && i + 1 < args.length) {
         options.contentLocale = args[i + 1];
         if (!normalizeYidaLocale(options.contentLocale)) {
@@ -137,6 +144,13 @@ function createParseArgs(dependencies) {
     }
 
     const mode = args[0];
+
+    if (mode === 'icons' || mode === 'list-icons') {
+      return {
+        mode: 'icons',
+        ...options
+      };
+    }
 
     if (mode === 'validate-fields') {
       if (args.length === 2) {

--- a/lib/app/create-form/nav-icon-service.js
+++ b/lib/app/create-form/nav-icon-service.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const FORM_NAVIGATION_UPDATE_KEYS = [
+  'gmtModified',
+  'parentNavUuid',
+  'hidden',
+  'mobileHidden',
+  'i18nTitle',
+  'isNewReport',
+  'id',
+  'isNewForm',
+  'slug',
+  'formType',
+  'formUuid',
+  'navUuid',
+  'navType',
+  'isNew',
+  'gmtCreate',
+  'parentId',
+  'url',
+  'topicId',
+  'displayType',
+  'relateFormUuid',
+  'processCode',
+  'listOrder',
+  'formStatus',
+  'relateFormType',
+];
+
+function buildFormNavigationIconUpdatePayload(navigationNode, icon) {
+  const updatePayload = {
+    _locale_time_zone_offset: 28800000,
+  };
+  FORM_NAVIGATION_UPDATE_KEYS.forEach(function (key) {
+    if (navigationNode[key] !== undefined) {
+      updatePayload[key] = key === 'i18nTitle' && navigationNode[key] !== null && typeof navigationNode[key] === 'object'
+        ? String(navigationNode[key])
+        : navigationNode[key];
+    }
+  });
+
+  const navigationTitle = navigationNode.title || navigationNode.i18nTitle || {};
+  updatePayload.title = typeof navigationTitle === 'string'
+    ? navigationTitle
+    : JSON.stringify(navigationTitle);
+  updatePayload.formUuid = navigationNode.formUuid || 'NAV-SYSTEM-FROM-ME-UUID';
+  updatePayload.icon = icon;
+  return updatePayload;
+}
+
+function createFormNavIconService(dependencies) {
+  const {
+    buildApiPath,
+    requestWithAutoLogin,
+    sendGetRequest,
+    sendPostRequest,
+    throwCreateFormError,
+    sanitizeFailureResult,
+    candidateLimit = 8,
+  } = dependencies;
+
+  function flattenNavigationNodes(nodes, output) {
+    const resultNodes = output || [];
+    (nodes || []).forEach(function (node) {
+      resultNodes.push(node);
+      if (Array.isArray(node.children)) {
+        flattenNavigationNodes(node.children, resultNodes);
+      }
+    });
+    return resultNodes;
+  }
+
+  async function fetchFormNavigationList(authRef, appType) {
+    const navigationResult = await requestWithAutoLogin(function (auth) {
+      return sendGetRequest(
+        auth.baseUrl,
+        buildApiPath(appType, 'getFormNavigationListByOrder', {
+          queryModule: 'formnav',
+          addTimestamp: true,
+        }),
+        {
+          _api: 'Nav.queryList',
+          _mock: false,
+          _locale_time_zone_offset: 28800000,
+        }
+      );
+    }, authRef);
+
+    if (!navigationResult || navigationResult.success === false || !Array.isArray(navigationResult.content)) {
+      const message = navigationResult
+        ? navigationResult.errorMsg || navigationResult.message || 'Failed to fetch form navigation list'
+        : 'Failed to fetch form navigation list';
+      throwCreateFormError(message, 'CREATE_FORM_NAV_ICON_LIST_FAILED', {
+        appType,
+        result: sanitizeFailureResult(navigationResult),
+      });
+    }
+
+    return flattenNavigationNodes(navigationResult.content);
+  }
+
+  function resolveFormNavigationNode(nodes, formUuid) {
+    const exactMatches = (nodes || []).filter(function (node) {
+      return node && (node.formUuid === formUuid || node.navUuid === formUuid);
+    });
+    const relatedMatches = (nodes || []).filter(function (node) {
+      return node && node.relateFormUuid === formUuid;
+    });
+    const matches = exactMatches.length > 0 ? exactMatches : relatedMatches;
+    if (matches.length !== 1) {
+      return null;
+    }
+    return matches[0];
+  }
+
+  async function updateCreatedFormNavigationIcon(authRef, appType, formUuid, icon) {
+    const navigationNodes = await fetchFormNavigationList(authRef, appType);
+    const navigationNode = resolveFormNavigationNode(navigationNodes, formUuid);
+    if (!navigationNode) {
+      throwCreateFormError('Created form navigation node could not be resolved uniquely.', 'CREATE_FORM_NAV_ICON_NODE_NOT_FOUND', {
+        appType,
+        formUuid,
+        candidates: navigationNodes.filter(function (node) {
+          return node && node.navType !== 'SYSTEM';
+        }).slice(0, candidateLimit).map(function (node) {
+          return {
+            id: node.id,
+            navUuid: node.navUuid,
+            formUuid: node.formUuid,
+            relateFormUuid: node.relateFormUuid,
+            formType: node.formType,
+          };
+        }),
+      });
+    }
+
+    const updatePayload = buildFormNavigationIconUpdatePayload(navigationNode, icon);
+
+    const updateResult = await requestWithAutoLogin(function (auth) {
+      return sendPostRequest(
+        auth.baseUrl,
+        buildApiPath(appType, 'updateFormNavigation', {
+          queryModule: 'formnav',
+          api: 'Nav.update',
+          mock: false,
+          addTimestamp: true,
+        }),
+        updatePayload,
+        formUuid,
+        auth,
+        {
+          appType,
+          referer: `${auth.baseUrl}/${appType}/admin/${formUuid}`,
+        }
+      );
+    }, authRef);
+
+    if (!updateResult || updateResult.success === false) {
+      const message = updateResult
+        ? updateResult.errorMsg || updateResult.message || 'Failed to update form navigation icon'
+        : 'Failed to update form navigation icon';
+      throwCreateFormError(message, 'CREATE_FORM_NAV_ICON_UPDATE_FAILED', {
+        appType,
+        formUuid,
+        navUuid: navigationNode.navUuid,
+        icon,
+        result: sanitizeFailureResult(updateResult),
+      });
+    }
+
+    const updatedNavigationNodes = await fetchFormNavigationList(authRef, appType);
+    const updatedNavigationNode = resolveFormNavigationNode(updatedNavigationNodes, formUuid);
+    if (!updatedNavigationNode || updatedNavigationNode.icon !== icon) {
+      throwCreateFormError('Form navigation icon readback did not match the requested icon.', 'CREATE_FORM_NAV_ICON_READBACK_MISMATCH', {
+        appType,
+        formUuid,
+        navUuid: navigationNode.navUuid,
+        expectedIcon: icon,
+        actualIcon: updatedNavigationNode && updatedNavigationNode.icon,
+      });
+    }
+
+    return {
+      id: updatedNavigationNode.id,
+      navUuid: updatedNavigationNode.navUuid,
+      icon: updatedNavigationNode.icon,
+    };
+  }
+
+  return {
+    fetchFormNavigationList,
+    flattenNavigationNodes,
+    resolveFormNavigationNode,
+    updateCreatedFormNavigationIcon,
+  };
+}
+
+module.exports = {
+  FORM_NAVIGATION_UPDATE_KEYS,
+  buildFormNavigationIconUpdatePayload,
+  createFormNavIconService,
+};

--- a/lib/app/create-form/nav-icon.js
+++ b/lib/app/create-form/nav-icon.js
@@ -1,0 +1,267 @@
+'use strict';
+
+// Keep this catalog aligned with yida-next's page navigation icon picker:
+// src/components/AppSubNav/SortMenuTree/Theme/nav-icon-config.json.
+const FORM_NAV_ICON_GROUPS = [
+  {
+    key: 'defaultIcons',
+    label: '常用图标',
+    items: [
+      ['zhuye', '首页'],
+      ['clock', '时钟'],
+      ['CalendarSeventeen', '日历'],
+      ['set', '设置'],
+      ['account-settings', '账号设置'],
+      ['account', '人'],
+      ['lock', '锁'],
+      ['Addresslist', '通讯录'],
+      ['App', '应用'],
+      ['application', '应用2'],
+      ['dashboard', '看板'],
+      ['biaodan', '表单'],
+      ['baobiao', '报表'],
+      ['juhebiao', '聚合表'],
+      ['liucheng', '流程'],
+      ['biaoge', '表格'],
+      ['list', '列表'],
+      ['gerenwendang', '文档'],
+      ['Project', '项目'],
+      ['Filemanage', '文件管理'],
+      ['add-doc', '添加文件'],
+      ['bumen', '部门'],
+      ['gongzuo', '工作'],
+      ['book', '书'],
+      ['bonus', '礼物'],
+      ['briefcase', '公文包'],
+      ['building', '建筑'],
+      ['dingdingka', '钉钉卡'],
+      ['desktop', '电脑'],
+      ['document', '文件'],
+      ['folder', '文件夹'],
+    ],
+  },
+  {
+    key: 'systemIcons',
+    label: '更多图标',
+    items: [
+      ['smile', '笑脸'],
+      ['rengongfuwu', '人工服务'],
+      ['shop', '商城'],
+      ['calendar', '日历'],
+      ['Documents', '文件包'],
+      ['DingDrive', '云'],
+      ['appointment', '职务'],
+      ['Mail', '邮件'],
+      ['Product_management', '产品管理'],
+      ['Todo', '任务'],
+      ['admin', '账号'],
+      ['airplane', '飞机'],
+      ['bianqian', '标签'],
+      ['bus', '汽车'],
+      ['caidan1', '菜单'],
+      ['calendar-span', '日历'],
+      ['cascade', '连接'],
+      ['certificate-type', '印章管理'],
+      ['chengyuan', '成员'],
+      ['chuangjiantuandui', '创建团队'],
+      ['command', '快捷键'],
+      ['custom-column', '列表'],
+      ['data-settings', '数据设置'],
+      ['dagangshu', '大纲树'],
+      ['diannao', '电脑'],
+      ['diqu', '地区'],
+      ['dizhi', '地址'],
+      ['fulishe', '福利社'],
+      ['keshihuadaping', '可视化大屏'],
+      ['employee-add', '新增成员'],
+      ['fujian', '附件'],
+      ['fuwushichang', '市场'],
+      ['gouwudai', '购物袋'],
+      ['guanlianzuzhi', '关联组织'],
+      ['huangguan', '皇冠'],
+      ['huiyishi', '会议室'],
+      ['huiyuan', '会员'],
+      ['image', '图片'],
+      ['list-container', '列表2'],
+      ['name-card', '名片'],
+      ['printer', '打印机'],
+      ['renwu', '任务2'],
+      ['riqiziduan', '日期'],
+      ['scan', '扫码'],
+      ['shezhi', '设置'],
+      ['shoucang', '收藏'],
+      ['wenjian', '文件2'],
+      ['shujuguanliye1', '数据管理页'],
+      ['shujuyuanshezhi', '数据源'],
+      ['suo', '锁'],
+      ['tianjia', '添加'],
+      ['tongxunlu', '通讯录'],
+      ['wode', '我的'],
+      ['zhuguanliyuan', '主管理员'],
+      ['ziguanliyuan', '子管理员'],
+    ],
+  },
+];
+
+const FORM_NAV_ICONS = FORM_NAV_ICON_GROUPS.flatMap(function (group) {
+  return group.items.map(function (item) {
+    return {
+      name: item[0],
+      label: item[1],
+      group: group.key,
+    };
+  });
+});
+
+const ICON_BY_LOWER_NAME = new Map(FORM_NAV_ICONS.map(function (icon) {
+  return [icon.name.toLowerCase(), icon.name];
+}));
+
+const SEMANTIC_ICON_RULES = [
+  { icon: 'clock', keywords: ['考勤', '打卡', '工时', '时钟', 'attendance', 'timesheet'] },
+  { icon: 'huiyishi', keywords: ['会议室', '会议预约', '会议', 'meeting'] },
+  { icon: 'CalendarSeventeen', keywords: ['日程', '日历', '排期', '计划', '预约', 'calendar', 'schedule'] },
+  { icon: 'Project', keywords: ['项目', 'project'] },
+  { icon: 'Todo', keywords: ['任务', '待办', '工单', 'task', 'todo', 'ticket'] },
+  { icon: 'name-card', keywords: ['客户', '联系人', '访客', '名片', 'crm', 'customer', 'contact', 'visitor'] },
+  { icon: 'chengyuan', keywords: ['员工', '人员', '成员', '人才', '招聘', 'employee', 'member', 'recruit'] },
+  { icon: 'bumen', keywords: ['部门', '组织', '团队', 'department', 'organization', 'team'] },
+  { icon: 'Product_management', keywords: ['产品', '需求', 'product', 'requirement'] },
+  { icon: 'shop', keywords: ['商品', '商城', '店铺', 'product catalog', 'store', 'shop'] },
+  { icon: 'gouwudai', keywords: ['订单', '采购', '销售', '购物', 'order', 'purchase', 'sales'] },
+  { icon: 'dingdingka', keywords: ['财务', '报销', '费用', '付款', '收款', '预算', '发票', 'finance', 'expense', 'payment', 'invoice'] },
+  { icon: 'document', keywords: ['合同', '协议', '公文', '文书', 'contract', 'agreement'] },
+  { icon: 'Filemanage', keywords: ['文件', '档案', '资料', 'file', 'archive'] },
+  { icon: 'book', keywords: ['知识', '图书', '课程', '培训', 'knowledge', 'book', 'course', 'training'] },
+  { icon: 'baobiao', keywords: ['报表', '统计', '分析', 'report', 'analytics'] },
+  { icon: 'dashboard', keywords: ['看板', '指标', '驾驶舱', 'dashboard', 'metric'] },
+  { icon: 'liucheng', keywords: ['审批', '流程', 'approval', 'workflow'] },
+  { icon: 'dizhi', keywords: ['地址', '地点', '场地', 'address', 'location'] },
+  { icon: 'building', keywords: ['仓库', '库房', '楼宇', '场馆', 'warehouse', 'building'] },
+  { icon: 'desktop', keywords: ['设备', '电脑', '终端', 'device', 'computer'] },
+  { icon: 'fuwushichang', keywords: ['市场', '营销', '活动', '推广', 'marketing', 'campaign'] },
+  { icon: 'bonus', keywords: ['礼品', '奖励', '福利', 'gift', 'reward', 'benefit'] },
+  { icon: 'rengongfuwu', keywords: ['客服', '服务', '咨询', 'service', 'support'] },
+  { icon: 'Mail', keywords: ['邮件', '消息', '通知', 'mail', 'message', 'notification'] },
+  { icon: 'image', keywords: ['图片', '照片', '素材', 'image', 'photo', 'media'] },
+  { icon: 'fujian', keywords: ['附件', 'attachment'] },
+  { icon: 'certificate-type', keywords: ['印章', '用印', '证书', 'seal', 'certificate'] },
+  { icon: 'admin', keywords: ['账号', '管理员', 'account', 'admin'] },
+  { icon: 'lock', keywords: ['权限', '安全', '密码', 'permission', 'security', 'password'] },
+  { icon: 'bus', keywords: ['车辆', '用车', '交通', 'vehicle', 'car', 'transport'] },
+  { icon: 'airplane', keywords: ['差旅', '航班', '机票', 'travel', 'flight'] },
+  { icon: 'diqu', keywords: ['地区', '区域', 'region', 'area'] },
+  { icon: 'scan', keywords: ['扫码', '二维码', '条码', 'scan', 'qrcode', 'barcode'] },
+  { icon: 'shezhi', keywords: ['配置', '设置', 'config', 'setting'] },
+  { icon: 'biaoge', keywords: ['台账', '清单', '表格', '明细', 'ledger', 'table', 'list'] },
+  { icon: 'liucheng', keywords: ['申请', 'request'] },
+];
+
+const GENERIC_FORM_ICONS = ['biaodan', 'list', 'document', 'briefcase', 'gongzuo'];
+
+function normalizeText(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value).toLowerCase();
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeText).filter(Boolean).join(' ');
+  }
+  if (typeof value === 'object') {
+    return Object.values(value).map(normalizeText).filter(Boolean).join(' ');
+  }
+  return '';
+}
+
+function collectFieldSemanticText(fields) {
+  const values = [];
+  const visit = function (fieldList) {
+    (fieldList || []).forEach(function (field) {
+      if (!field || typeof field !== 'object') {
+        return;
+      }
+      values.push(field.label, field.title, field.name, field.key);
+      if (field.props && typeof field.props === 'object') {
+        values.push(field.props.label, field.props.title, field.props.name);
+      }
+      if (Array.isArray(field.children)) {
+        field.children.forEach(function (children) {
+          visit(Array.isArray(children) ? children : [children]);
+        });
+      }
+    });
+  };
+  visit(fields);
+  return normalizeText(values);
+}
+
+function findSemanticIcon(text) {
+  return SEMANTIC_ICON_RULES.find(function (rule) {
+    return rule.keywords.some(function (keyword) {
+      return text.includes(keyword.toLowerCase());
+    });
+  });
+}
+
+function stableGenericIcon(text) {
+  let hash = 0;
+  for (let index = 0; index < text.length; index++) {
+    hash = ((hash * 31) + text.charCodeAt(index)) >>> 0;
+  }
+  return GENERIC_FORM_ICONS[hash % GENERIC_FORM_ICONS.length];
+}
+
+function inferFormNavIcon(formTitle, fields) {
+  const titleText = normalizeText(formTitle);
+  const titleMatch = findSemanticIcon(titleText);
+  if (titleMatch) {
+    return titleMatch.icon;
+  }
+
+  const fieldText = collectFieldSemanticText(fields);
+  const fieldMatch = findSemanticIcon(fieldText);
+  if (fieldMatch) {
+    return fieldMatch.icon;
+  }
+
+  return stableGenericIcon(titleText || fieldText || 'form');
+}
+
+function normalizeFormNavIcon(value) {
+  const raw = String(value || '').trim();
+  if (!raw || raw.toLowerCase() === 'auto') {
+    return null;
+  }
+  return ICON_BY_LOWER_NAME.get(raw.toLowerCase()) || '';
+}
+
+function resolveFormNavIcon(value, formTitle, fields) {
+  const normalized = normalizeFormNavIcon(value);
+  if (normalized) {
+    return {
+      icon: normalized,
+      source: 'explicit',
+    };
+  }
+  if (String(value || '').trim() && String(value).trim().toLowerCase() !== 'auto') {
+    return {
+      icon: '',
+      source: 'invalid',
+    };
+  }
+  return {
+    icon: inferFormNavIcon(formTitle, fields),
+    source: 'auto',
+  };
+}
+
+module.exports = {
+  FORM_NAV_ICON_GROUPS,
+  FORM_NAV_ICONS,
+  collectFieldSemanticText,
+  inferFormNavIcon,
+  normalizeFormNavIcon,
+  resolveFormNavIcon,
+};

--- a/lib/core/agent-capabilities.js
+++ b/lib/core/agent-capabilities.js
@@ -142,6 +142,7 @@ const BUILDER_CORE_COMMAND_IDS = Object.freeze([
   'save-permission',
   'create-app',
   'create-form.create',
+  'create-form.icons',
   'create-page',
   'publish',
 ]);
@@ -159,6 +160,8 @@ function commandBriefs(manifest, commandIds) {
       permission_mode: entry.permission && entry.permission.mode,
       side_effect_kind: entry.side_effect && entry.side_effect.kind,
       examples: entry.examples || [],
+      args: entry.args || [],
+      canonical: entry.canonical || null,
     }));
 }
 
@@ -484,6 +487,8 @@ function buildCommandManifestDigest(manifest) {
       side_effect_kind: entry.side_effect && entry.side_effect.kind,
       permission_mode: entry.permission && entry.permission.mode,
       permission_effect: entry.permission && entry.permission.effect,
+      args: entry.args || [],
+      canonical: entry.canonical || null,
     })),
   };
 

--- a/lib/core/command-contract.js
+++ b/lib/core/command-contract.js
@@ -163,8 +163,17 @@ function quoteDisplayArg(value, force) {
 
 function normalizeEntryArgs(entry) {
   return (entry.args || [])
+    .filter(arg => arg.source !== 'option')
     .slice()
     .sort((left, right) => (left.position || 0) - (right.position || 0));
+}
+
+function normalizeEntryOptions(entry) {
+  return (entry.args || []).filter(arg => arg.source === 'option');
+}
+
+function primaryBuilderOption(arg) {
+  return (arg.builder_options || [])[0] || `--${optionNameToken(arg.name)}`;
 }
 
 function getCreateFormCreateCanonical(entry = getCreateFormCreateEntry()) {
@@ -193,9 +202,25 @@ function getArgPlaceholder(entry, arg) {
 
 function buildCreateFormCreateCommand(params = {}, entry = getCreateFormCreateEntry()) {
   const args = normalizeEntryArgs(entry);
+  const optionArgv = [];
+  const optionDisplay = [];
+  normalizeEntryOptions(entry).forEach(arg => {
+    const value = params[arg.name];
+    if (value === undefined || value === null || value === false || value === '') {
+      return;
+    }
+    const option = primaryBuilderOption(arg);
+    optionArgv.push(option);
+    optionDisplay.push(option);
+    if (arg.type !== 'boolean') {
+      optionArgv.push(String(value));
+      optionDisplay.push(quoteDisplayArg(value, false));
+    }
+  });
   const argv = [
     ...canonicalPath(entry),
     ...args.map(arg => String(params[arg.name] || getArgPlaceholder(entry, arg))),
+    ...optionArgv,
   ];
   return {
     argv,
@@ -203,6 +228,7 @@ function buildCreateFormCreateCommand(params = {}, entry = getCreateFormCreateEn
       'openyida',
       ...canonicalPath(entry),
       ...args.map(arg => quoteDisplayArg(params[arg.name] || getArgPlaceholder(entry, arg), !!arg.display_quote)),
+      ...optionDisplay,
     ].join(' '),
   };
 }
@@ -317,15 +343,23 @@ function detectDeprecatedCreateFormInvocation(argv = [], options = {}) {
 function validateCreateFormCreateInvocation(tokens, entry = getCreateFormCreateEntry()) {
   const path = canonicalPath(entry);
   const args = normalizeEntryArgs(entry);
+  const parsed = parseOptionArgs(tokens.slice(path.length));
   const params = {};
   const missing = [];
 
   args.forEach(arg => {
-    const value = tokens[path.length + (arg.position || 0)];
+    const value = parsed.positionals[arg.position || 0];
     if (value) {
       params[arg.name] = value;
     } else if (arg.required) {
       missing.push(arg.name);
+    }
+  });
+
+  normalizeEntryOptions(entry).forEach(arg => {
+    const source = readParam(parsed, arg, undefined);
+    if (source.value !== undefined) {
+      params[arg.name] = source.value;
     }
   });
 
@@ -414,6 +448,13 @@ function buildCreateFormCreateFromArgs(args = [], entry = getCreateFormCreateEnt
       params[arg.name] = source.value;
     } else if (arg.required) {
       missing.push(arg.name);
+    }
+  });
+
+  normalizeEntryOptions(entry).forEach(arg => {
+    const source = readParam(parsed, arg, undefined);
+    if (source.value !== undefined) {
+      params[arg.name] = source.value;
     }
   });
 

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -365,6 +365,7 @@ const COMMAND_SIDE_EFFECTS = new Map([
     'agent-capabilities',
     'check-page',
     'commands',
+    'create-form.icons',
     'create-form.validate-fields',
     'dingtalk-link',
     'formula.evaluate',
@@ -626,6 +627,7 @@ const COMMAND_PERMISSIONS = new Map([
     'connector.list',
     'connector.list-actions',
     'connector.list-connections',
+    'create-form.icons',
     'create-form.validate-fields',
     'dingtalk-link',
     'dws.contact-user-search',
@@ -1051,7 +1053,7 @@ const COMMAND_GROUPS = [
     id: 'form',
     titleKey: 'help.group_form',
     commands: [
-      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> "<formTitle>" <fieldsJsonFile> [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_form', {
+      command('create-form.create', ['create-form', 'create'], 'create-form create <appType> "<formTitle>" <fieldsJsonFile> [--icon auto|<iconName>] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_form', {
         args: [
           {
             name: 'appType',
@@ -1082,13 +1084,23 @@ const COMMAND_GROUPS = [
             inline_json_rejected_options: ['--fields'],
             description: 'Path to a local JSON file containing field definitions.',
           },
+          {
+            name: 'icon',
+            type: 'string',
+            required: false,
+            source: 'option',
+            builder_options: ['--icon'],
+            default: 'auto',
+            value_catalog_command_id: 'create-form.icons',
+            description: 'Form navigation icon name. Use auto for semantic selection or run create-form.icons for supported values.',
+          },
         ],
         canonical: {
           command_id: 'create-form.create',
           path: ['create-form', 'create'],
           argv_template: ['create-form', 'create', '<appType>', '<formTitle>', '<fieldsJsonFile>'],
           display: 'openyida create-form create <appType> "<formTitle>" <fieldsJsonFile>',
-          builder: 'openyida commands build create-form.create --app-type <appType> --form-title "<formTitle>" --fields-json-file <fieldsJsonFile> --json',
+          builder: 'openyida commands build create-form.create --app-type <appType> --form-title "<formTitle>" --fields-json-file <fieldsJsonFile> [--icon <iconName>] --json',
         },
         deprecatedPatterns: [
           {
@@ -1118,8 +1130,31 @@ const COMMAND_GROUPS = [
         ],
         examples: [
           'openyida create-form create APP_XXX "访客登记" .cache/openyida/visitor/fields.json',
+          'openyida create-form create APP_XXX "访客登记" .cache/openyida/visitor/fields.json --icon name-card',
           'openyida commands build create-form.create --app-type APP_XXX --form-title "访客登记" --fields-json-file .cache/openyida/visitor/fields.json --json',
         ],
+      }),
+      command('create-form.icons', ['create-form', 'icons'], 'create-form icons [--json]', 'help.cmd_list_form_icons', {
+        requiresLogin: false,
+        output: 'json',
+        args: [
+          {
+            name: 'json',
+            type: 'boolean',
+            required: false,
+            source: 'option',
+            builder_options: ['--json'],
+            default: false,
+            description: 'Pretty-print the icon catalog as JSON.',
+          },
+        ],
+        canonical: {
+          command_id: 'create-form.icons',
+          path: ['create-form', 'icons'],
+          argv_template: ['create-form', 'icons', '[--json]'],
+          display: 'openyida create-form icons [--json]',
+        },
+        examples: ['openyida create-form icons --json'],
       }),
       command('create-form.validate-fields', ['create-form', 'validate-fields'], 'create-form validate-fields <fieldsJsonOrFile> [--json]', 'help.cmd_validate_form', {
         requiresLogin: false,

--- a/lib/core/locales/en.js
+++ b/lib/core/locales/en.js
@@ -32,6 +32,7 @@ module.exports = {
     cmd_import: 'Import migration package, rebuild app',
     group_form: 'Forms & Pages',
     cmd_create_form: 'Create a form page',
+    cmd_list_form_icons: 'List available form navigation icons',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Update a form page',
     cmd_list_forms: 'List forms/pages in an app',

--- a/lib/core/locales/zh.js
+++ b/lib/core/locales/zh.js
@@ -32,6 +32,7 @@ module.exports = {
     cmd_import: '导入迁移包，重建应用',
     group_form: '表单 & 页面',
     cmd_create_form: '创建表单页面',
+    cmd_list_form_icons: '列出可用的表单导航图标',
     cmd_validate_form: '本地校验表单字段 JSON',
     cmd_update_form: '更新表单页面',
     cmd_list_forms: '列出应用下的表单/页面',

--- a/locales-extra/core/ar.js
+++ b/locales-extra/core/ar.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'استيراد حزمة الترحيل، إعادة بناء التطبيق',
     group_form: 'النماذج & الصفحات',
     cmd_create_form: 'إنشاء صفحة نموذج',
+    cmd_list_form_icons: 'عرض رموز تنقل النماذج المتاحة',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'تحديث صفحة نموذج',
     cmd_list_forms: 'List forms/pages in an app',

--- a/locales-extra/core/de.js
+++ b/locales-extra/core/de.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'Migrationspaket importieren, App neu aufbauen',
     group_form: 'Formulare & Seiten',
     cmd_create_form: 'Formularseite erstellen',
+    cmd_list_form_icons: 'Verfügbare Formular-Navigationssymbole auflisten',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Formularseite aktualisieren',
     cmd_list_forms: 'Formulare/Seiten einer App auflisten',

--- a/locales-extra/core/es.js
+++ b/locales-extra/core/es.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'Importar paquete de migración, reconstruir app',
     group_form: 'Formularios & Páginas',
     cmd_create_form: 'Crear página de formulario',
+    cmd_list_form_icons: 'Listar iconos disponibles de navegación de formularios',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Actualizar página de formulario',
     cmd_list_forms: 'Listar formularios/páginas de una app',

--- a/locales-extra/core/fr.js
+++ b/locales-extra/core/fr.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'Importer un package de migration',
     group_form: 'Formulaires & Pages',
     cmd_create_form: 'Créer une page de formulaire',
+    cmd_list_form_icons: 'Lister les icônes de navigation de formulaire disponibles',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Mettre à jour une page de formulaire',
     cmd_list_forms: "Lister les formulaires/pages d'une app",

--- a/locales-extra/core/hi.js
+++ b/locales-extra/core/hi.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'माइग्रेशन पैकेज आयात करें, ऐप पुनर्निर्माण',
     group_form: 'फॉर्म & पेज',
     cmd_create_form: 'फॉर्म पेज बनाएं',
+    cmd_list_form_icons: 'उपलब्ध फ़ॉर्म नेविगेशन आइकन सूचीबद्ध करें',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'फॉर्म पेज अपडेट करें',
     cmd_list_forms: 'List forms/pages in an app',

--- a/locales-extra/core/ja.js
+++ b/locales-extra/core/ja.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: '移行パッケージをインポート、アプリを再構築',
     group_form: 'フォーム & ページ',
     cmd_create_form: 'フォームページを作成',
+    cmd_list_form_icons: '利用可能なフォームナビゲーションアイコンを一覧表示',
     cmd_validate_form: 'フォームフィールド JSON をローカル検証',
     cmd_update_form: 'フォームページを更新',
     cmd_list_forms: 'アプリ内のフォーム/ページを一覧表示',

--- a/locales-extra/core/ko.js
+++ b/locales-extra/core/ko.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: '마이그레이션 패키지 가져오기, 앱 재구축',
     group_form: '양식 & 페이지',
     cmd_create_form: '양식 페이지 생성',
+    cmd_list_form_icons: '사용 가능한 양식 탐색 아이콘 목록',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: '양식 페이지 업데이트',
     cmd_list_forms: 'List forms/pages in an app',

--- a/locales-extra/core/pt.js
+++ b/locales-extra/core/pt.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'Importar pacote de migração, reconstruir app',
     group_form: 'Formulários & Páginas',
     cmd_create_form: 'Criar página de formulário',
+    cmd_list_form_icons: 'Listar ícones de navegação de formulário disponíveis',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Atualizar página de formulário',
     cmd_list_forms: 'Listar formulários/páginas de um app',

--- a/locales-extra/core/vi.js
+++ b/locales-extra/core/vi.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: 'Nhập gói di chuyển, xây dựng lại ứng dụng',
     group_form: 'Biểu mẫu & Trang',
     cmd_create_form: 'Tạo trang biểu mẫu',
+    cmd_list_form_icons: 'Liệt kê biểu tượng điều hướng biểu mẫu khả dụng',
     cmd_validate_form: 'Validate form field JSON locally',
     cmd_update_form: 'Cập nhật trang biểu mẫu',
     cmd_list_forms: 'List forms/pages in an app',

--- a/locales-extra/core/zh-HK.js
+++ b/locales-extra/core/zh-HK.js
@@ -30,6 +30,7 @@ module.exports = {
     cmd_import: '匯入遷移包，重建應用程式',
     group_form: '表單 & 頁面',
     cmd_create_form: '建立表單頁面',
+    cmd_list_form_icons: '列出可用的表單導覽圖示',
     cmd_validate_form: '本機校驗表單欄位 JSON',
     cmd_update_form: '更新表單頁面',
     cmd_list_forms: '列出應用程式下的表單/頁面',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.9.2",
+  "version": "2026.9.2-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.9.2",
+      "version": "2026.9.2-1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.9.2",
+  "version": "2026.9.2-1",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",

--- a/tests/cli-smoke.test.js
+++ b/tests/cli-smoke.test.js
@@ -698,6 +698,14 @@ describe('CLI offline smoke', () => {
         expect.objectContaining({ name: 'appType', source: 'positional', required: true }),
         expect.objectContaining({ name: 'formTitle', source: 'positional', required: true }),
         expect.objectContaining({ name: 'fieldsJsonFile', source: 'positional', required: true }),
+        expect.objectContaining({
+          name: 'icon',
+          source: 'option',
+          required: false,
+          builder_options: ['--icon'],
+          default: 'auto',
+          value_catalog_command_id: 'create-form.icons',
+        }),
       ],
       canonical: {
         command_id: 'create-form.create',
@@ -720,6 +728,25 @@ describe('CLI offline smoke', () => {
       examples: expect.arrayContaining([
         expect.stringContaining('openyida create-form create APP_XXX'),
       ]),
+    });
+    expect(commandById['create-form.icons']).toMatchObject({
+      path: ['create-form', 'icons'],
+      requires_login: false,
+      output: 'json',
+      args: [
+        expect.objectContaining({
+          name: 'json',
+          type: 'boolean',
+          source: 'option',
+          builder_options: ['--json'],
+        }),
+      ],
+      canonical: {
+        command_id: 'create-form.icons',
+        path: ['create-form', 'icons'],
+        argv_template: ['create-form', 'icons', '[--json]'],
+        display: 'openyida create-form icons [--json]',
+      },
     });
     expect(commandById['generate-page']).toBeUndefined();
     expect(commandById['dws.contact-user-search'].side_effect).toMatchObject({
@@ -1045,6 +1072,35 @@ describe('CLI offline smoke', () => {
     ]);
   });
 
+  test('commands validate recognizes the manifest-declared create-form icon option', () => {
+    const output = runOk([
+      'commands',
+      'validate',
+      '--json',
+      '--',
+      'create-form',
+      'create',
+      'APP_xxx',
+      '访客登记',
+      '.cache/openyida/visitor/fields.json',
+      '--icon',
+      'name-card',
+    ]);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      command_id: 'create-form.create',
+      params: {
+        appType: 'APP_xxx',
+        formTitle: '访客登记',
+        fieldsJsonFile: '.cache/openyida/visitor/fields.json',
+        icon: 'name-card',
+      },
+      display: 'openyida create-form create APP_xxx "访客登记" .cache/openyida/visitor/fields.json --icon name-card',
+    });
+  });
+
   test('commands build renders canonical create-form argv without executing', () => {
     const manifestEntry = readManifestCommand('create-form.create');
     const output = runOk([
@@ -1071,6 +1127,41 @@ describe('CLI offline smoke', () => {
       canonical: manifestEntry.canonical,
     });
     expect(parsed.argv.slice(0, manifestEntry.path.length)).toEqual(manifestEntry.path);
+  });
+
+  test('commands build recognizes the manifest-declared create-form icon option', () => {
+    const output = runOk([
+      'commands',
+      'build',
+      'create-form.create',
+      '--app-type',
+      'APP_xxx',
+      '--form-title',
+      '访客登记',
+      '--fields-json-file',
+      '.cache/openyida/visitor/fields.json',
+      '--icon',
+      'name-card',
+      '--json',
+    ]);
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      command_id: 'create-form.create',
+      argv: [
+        'create-form',
+        'create',
+        'APP_xxx',
+        '访客登记',
+        '.cache/openyida/visitor/fields.json',
+        '--icon',
+        'name-card',
+      ],
+      params: {
+        icon: 'name-card',
+      },
+    });
   });
 
   test('direct create-form hallucinated shape returns clean JSON error before execution', () => {
@@ -1184,6 +1275,7 @@ describe('CLI offline smoke', () => {
             'get-schema',
             'create-app',
             'create-form.create',
+            'create-form.icons',
             'create-page',
             'publish',
           ]),
@@ -1557,11 +1649,19 @@ describe('CLI offline smoke', () => {
       'save-permission',
       'create-app',
       'create-form.create',
+      'create-form.icons',
       'create-page',
       'publish',
     ]));
     const builderCommands = new Map(parsed.builder_path.command_contract.canonical_builder_commands
       .map(entry => [entry.id, entry]));
+    expect(builderCommands.get('create-form.create').args).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'icon', source: 'option', builder_options: ['--icon'] }),
+    ]));
+    expect(builderCommands.get('create-form.icons')).toMatchObject({
+      usage: 'openyida create-form icons [--json]',
+      args: [expect.objectContaining({ name: 'json', source: 'option' })],
+    });
     expect(builderCommands.get('data').examples[0]).toContain('1787932800000');
     expect(builderCommands.get('nav-group').examples).toContain('openyida nav-group move APP_XXX FORM_XXX --to NAV_XXX');
     expect(builderCommands.get('save-permission').examples[0]).toContain('get-permission APP_XXX FORM_XXX');

--- a/tests/create-form.test.js
+++ b/tests/create-form.test.js
@@ -18,6 +18,8 @@ const createFormSplitSource = [
   'commands.js',
   'definition-reader.js',
   'field-normalizers.js',
+  'nav-icon.js',
+  'nav-icon-service.js',
   'rule-builder.js',
   'api-path.js',
   'schema-patch.js',
@@ -41,6 +43,69 @@ async function requestNonIdempotentOnce(requestFn, preflightFn, authRef) {
     return preflightResult;
   }
   return requestFn(authRef);
+}
+
+function createSuccessfulFormHttpMocks(formUuid, options = {}) {
+  let created = false;
+  let navigationIcon = '';
+  const navigationNode = function () {
+    return {
+      id: 101,
+      navUuid: formUuid,
+      formUuid,
+      parentNavUuid: 'NAV-SYSTEM-PARENT-UUID',
+      navType: 'PAGE',
+      formType: 'receipt',
+      title: { zh_CN: options.formTitle || '测试表单', en_US: options.formTitle || 'Test form', type: 'i18n' },
+      hidden: 'n',
+      mobileHidden: 'n',
+      icon: navigationIcon,
+      gmtModified: 1787765189000,
+      gmtCreate: 1787284627000,
+      i18nTitle: { zh_CN: options.formTitle || '测试表单' },
+      isNewReport: '',
+      isNewForm: 'y',
+      slug: '',
+      isNew: 'n',
+      parentId: 0,
+      url: '',
+      topicId: '',
+      displayType: '',
+      relateFormUuid: formUuid,
+      processCode: '',
+      listOrder: 21,
+      formStatus: 'ONLINE',
+      relateFormType: '',
+    };
+  };
+
+  return {
+    httpGet: jest.fn((baseUrl, requestPath) => {
+      if (requestPath.includes('getFormNavigationListByOrder')) {
+        return Promise.resolve({ success: true, content: created ? [navigationNode()] : [] });
+      }
+      return Promise.resolve({ success: true, content: { gmtModified: 100 } });
+    }),
+    httpPost: jest.fn((baseUrl, requestPath, postData) => {
+      if (requestPath.includes('saveFormSchemaInfo')) {
+        created = true;
+        return Promise.resolve({ success: true, content: { formUuid } });
+      }
+      if (requestPath.includes('updateFormNavigation')) {
+        if (!options.ignoreNavigationUpdate) {
+          navigationIcon = querystring.parse(postData).icon;
+        }
+        return Promise.resolve({ success: true });
+      }
+      if (requestPath.includes('updateFormConfig') && options.updateFormConfigResponse) {
+        return Promise.resolve(options.updateFormConfigResponse);
+      }
+      return Promise.resolve({ success: true });
+    }),
+    getNavigationIcon() {
+      return navigationIcon;
+    },
+  };
 }
 
 // ── Bug #1: HTTP helpers must use master token auth / auto-login plumbing ──
@@ -79,6 +144,7 @@ describe('legacy process form bridge', () => {
 
     jest.resetModules();
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_BRIDGE', { formTitle: '流程申请' });
     const mockUtils = {
       loadAuthData: jest.fn(() => ({
         corp_id: 'corp',
@@ -86,23 +152,12 @@ describe('legacy process form bridge', () => {
         auth_mode: 'token',
         auth_source: 'token',
       })),
-      httpPost: jest.fn((baseUrl, requestPath) => {
-        if (requestPath.includes('saveFormSchemaInfo')) {
-          return Promise.resolve({ success: true, content: { formUuid: 'FORM_BRIDGE' } });
-        }
-        if (requestPath.includes('/_view/query/formdesign/saveFormSchema.json')) {
-          return Promise.resolve({ success: true });
-        }
-        if (requestPath.includes('updateFormConfig')) {
-          return Promise.resolve({ success: false, errorMsg: 'config warning' });
-        }
-        return Promise.resolve({ success: true });
-      }),
+      httpPost: formHttpMocks.httpPost,
       requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
       requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
-      httpGet: jest.fn(() => Promise.resolve({ success: true, content: { gmtModified: 100 } })),
+      httpGet: formHttpMocks.httpGet,
     };
 
     jest.doMock('../lib/core/utils', () => mockUtils);
@@ -132,6 +187,7 @@ describe('legacy process form bridge', () => {
     const savedText = JSON.stringify(savedSchema);
     expect(savedText).toContain('textField_');
     expect(savedText).toContain('required');
+    expect(formHttpMocks.getNavigationIcon()).toBe('liucheng');
     expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(0);
     expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -1676,6 +1732,24 @@ describe('create-form module API', () => {
     });
   });
 
+  test('parseArgs supports explicit form navigation icons and local icon listing', () => {
+    expect(createForm.parseArgs([
+      'create',
+      'APP_XXX',
+      '客户登记',
+      '.cache/openyida/forms/fields.json',
+      '--icon',
+      'name-card',
+    ])).toMatchObject({
+      mode: 'create',
+      icon: 'name-card',
+    });
+    expect(createForm.parseArgs(['icons', '--json'])).toMatchObject({
+      mode: 'icons',
+      json: true,
+    });
+  });
+
   test('parseArgs keeps validate inline rule compatibility', () => {
     expect(createForm.parseArgs([
       'validate',
@@ -1953,6 +2027,46 @@ describe('create-form create recovery guardrails', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  test('create-form icons lists the local yida-next catalog without login or platform APIs', async () => {
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand();
+
+    await expect(isolatedCreateForm.run(['icons', '--json'])).resolves.toMatchObject({
+      success: true,
+      count: 86,
+      default: 'auto',
+    });
+
+    const payload = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(payload.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'defaultIcons', icons: expect.any(Array) }),
+      expect.objectContaining({ key: 'systemIcons', icons: expect.any(Array) }),
+    ]));
+    expect(mockUtils.httpPost).not.toHaveBeenCalled();
+    expect(mockUtils.httpGet).not.toHaveBeenCalled();
+    expect(mockUtils.requestWithAutoLogin).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('invalid explicit navigation icon fails before creating a blank form', async () => {
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand();
+
+    await expect(isolatedCreateForm.run([
+      'create',
+      'APP_TEST',
+      '客户登记',
+      JSON.stringify([{ type: 'TextField', label: '客户姓名' }]),
+      '--icon',
+      'not-an-icon',
+    ])).rejects.toMatchObject({
+      code: 'CREATE_FORM_NAV_ICON_INVALID',
+      details: expect.objectContaining({ availableIconCount: 86 }),
+    });
+
+    expect(mockUtils.httpPost).not.toHaveBeenCalled();
+    expect(mockUtils.httpGet).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   test('create-form validate-fields CLI emits exactly one JSON payload for invalid input', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-validate-cli-invalid-'));
     const fieldsPath = path.join(tmpDir, 'fields.json');
@@ -2084,17 +2198,8 @@ describe('create-form create recovery guardrails', () => {
       { type: 'TextField', label: '姓名' },
     ]));
 
-    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
-      httpPost: jest.fn((baseUrl, requestPath) => {
-        if (requestPath.includes('saveFormSchemaInfo')) {
-          return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_RETRY' } });
-        }
-        if (requestPath.includes('updateFormConfig')) {
-          throw new Error('updateFormConfig must not be called');
-        }
-        return Promise.resolve({ success: true });
-      }),
-    });
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_CONFIG_RETRY', { formTitle: '配置重试表单' });
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand(formHttpMocks);
 
     await expect(isolatedCreateForm.run([
       'create',
@@ -2115,9 +2220,84 @@ describe('create-form create recovery guardrails', () => {
       formTitle: '配置重试表单',
       formUuid: 'FORM_CONFIG_RETRY',
       fieldCount: 1,
+      icon: 'shezhi',
+      iconSource: 'auto',
     });
     expect(payload).not.toHaveProperty('configWarning');
+    expect(formHttpMocks.getNavigationIcon()).toBe('shezhi');
+    const navigationUpdateCalls = mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormNavigation'));
+    expect(navigationUpdateCalls).toHaveLength(1);
+    expect(navigationUpdateCalls[0][1]).toMatch(
+      /updateFormNavigation\.json\?_api=Nav\.update&_mock=false&_stamp=\d+$/
+    );
+    expect(querystring.parse(navigationUpdateCalls[0][2])).toMatchObject({
+      _locale_time_zone_offset: '28800000',
+      gmtModified: '1787765189000',
+      parentNavUuid: 'NAV-SYSTEM-PARENT-UUID',
+      hidden: 'n',
+      mobileHidden: 'n',
+      i18nTitle: '[object Object]',
+      isNewReport: '',
+      isNewForm: 'y',
+      slug: '',
+      formType: 'receipt',
+      formUuid: 'FORM_CONFIG_RETRY',
+      navUuid: 'FORM_CONFIG_RETRY',
+      navType: 'PAGE',
+      isNew: 'n',
+      gmtCreate: '1787284627000',
+      parentId: '0',
+      url: '',
+      topicId: '',
+      displayType: '',
+      relateFormUuid: 'FORM_CONFIG_RETRY',
+      processCode: '',
+      listOrder: '21',
+      formStatus: 'ONLINE',
+      relateFormType: '',
+      icon: 'shezhi',
+    });
+    expect(querystring.parse(navigationUpdateCalls[0][2])).not.toHaveProperty('appType');
     expect(mockUtils.httpPost.mock.calls.filter((call) => call[1].includes('updateFormConfig'))).toHaveLength(0);
+
+    consoleSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('create mode reports a partial-create failure when navigation icon readback mismatches', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openyida-icon-readback-'));
+    const fieldsPath = path.join(tmpDir, 'fields.json');
+    fs.writeFileSync(fieldsPath, JSON.stringify([
+      { type: 'TextField', label: '客户姓名' },
+    ]));
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_ICON_MISMATCH', {
+      formTitle: '客户登记',
+      ignoreNavigationUpdate: true,
+    });
+    const { isolatedCreateForm, consoleSpy } = loadIsolatedCreateFormCommand(formHttpMocks);
+
+    await expect(isolatedCreateForm.run([
+      'create',
+      'APP_TEST',
+      '客户登记',
+      fieldsPath,
+      '--icon',
+      'name-card',
+    ])).rejects.toMatchObject({
+      code: 'CREATE_FORM_NAV_ICON_READBACK_MISMATCH',
+    });
+
+    const recoveryPayload = consoleSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line) => typeof line === 'string' && line.startsWith('{'))
+      .map((line) => JSON.parse(line))
+      .find((payload) => payload && payload.formUuid === 'FORM_ICON_MISMATCH');
+    expect(recoveryPayload).toMatchObject({
+      success: false,
+      formUuid: 'FORM_ICON_MISMATCH',
+      stage: 'updateFormNavigationIcon',
+      errorCode: 'CREATE_FORM_NAV_ICON_READBACK_MISMATCH',
+    });
 
     consoleSpy.mockRestore();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -2130,17 +2310,11 @@ describe('create-form create recovery guardrails', () => {
       { type: 'TextField', label: '姓名' },
     ]));
 
-    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
-      httpPost: jest.fn((baseUrl, requestPath) => {
-        if (requestPath.includes('saveFormSchemaInfo')) {
-          return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_FAILED' } });
-        }
-        if (requestPath.includes('updateFormConfig')) {
-          return Promise.resolve({ success: false, errorMsg: '表单不存在', content: { shouldNotLeak: true } });
-        }
-        return Promise.resolve({ success: true });
-      }),
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_CONFIG_FAILED', {
+      formTitle: '配置失败表单',
+      updateFormConfigResponse: { success: false, errorMsg: '表单不存在', content: { shouldNotLeak: true } },
     });
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand(formHttpMocks);
 
     await expect(isolatedCreateForm.run([
       'create',
@@ -2177,17 +2351,11 @@ describe('create-form create recovery guardrails', () => {
       { type: 'TextField', label: '姓名' },
     ]));
 
-    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand({
-      httpPost: jest.fn((baseUrl, requestPath) => {
-        if (requestPath.includes('saveFormSchemaInfo')) {
-          return Promise.resolve({ success: true, content: { formUuid: 'FORM_CONFIG_PERMISSION' } });
-        }
-        if (requestPath.includes('updateFormConfig')) {
-          return Promise.resolve({ success: false, errorMsg: '权限不足', errorCode: 'PERMISSION_DENIED' });
-        }
-        return Promise.resolve({ success: true });
-      }),
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_CONFIG_PERMISSION', {
+      formTitle: '配置权限表单',
+      updateFormConfigResponse: { success: false, errorMsg: '权限不足', errorCode: 'PERMISSION_DENIED' },
     });
+    const { isolatedCreateForm, mockUtils, consoleSpy } = loadIsolatedCreateFormCommand(formHttpMocks);
 
     await expect(isolatedCreateForm.run([
       'create',
@@ -3153,6 +3321,7 @@ describe('legacy create-form compatibility', () => {
   test('create mode reads only the shell revision and does not discover semantic keys', async () => {
     jest.resetModules();
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const formHttpMocks = createSuccessfulFormHttpMocks('FORM_TEST', { formTitle: '访客登记' });
     const mockUtils = {
       loadAuthData: jest.fn(() => ({
         corp_id: 'corp',
@@ -3162,19 +3331,8 @@ describe('legacy create-form compatibility', () => {
       })),
       triggerLogin: jest.fn(),
       resolveBaseUrl: jest.fn(() => 'https://example.test'),
-      httpGet: jest.fn(() => Promise.resolve({ success: true, content: { gmtModified: 100 } })),
-      httpPost: jest.fn((baseUrl, requestPath) => {
-        if (requestPath.includes('saveFormSchemaInfo')) {
-          return Promise.resolve({ success: true, content: { formUuid: 'FORM_TEST' } });
-        }
-        if (requestPath.includes('saveFormSchema')) {
-          return Promise.resolve({ success: true });
-        }
-        if (requestPath.includes('updateFormConfig')) {
-          return Promise.resolve({ success: true });
-        }
-        return Promise.resolve({ success: true });
-      }),
+      httpGet: formHttpMocks.httpGet,
+      httpPost: formHttpMocks.httpPost,
       requestWithAutoLogin: jest.fn((requestFn, authRef) => requestFn(authRef)),
       requestNonIdempotentWithAuthPreflight: jest.fn(requestNonIdempotentOnce),
       detectActiveTool: jest.fn(() => null),
@@ -3204,11 +3362,13 @@ describe('legacy create-form compatibility', () => {
       JSON.stringify([{ key: 'visitorName', type: 'TextField', label: '访客姓名' }]),
     ]);
 
-    expect(mockUtils.httpGet).toHaveBeenCalledTimes(2);
+    expect(mockUtils.httpGet).toHaveBeenCalledTimes(4);
     expect(mockUtils.httpGet.mock.calls[0][1]).toContain(
       'getFormNavigationListByOrder.json'
     );
     expect(mockUtils.httpGet.mock.calls[1][1]).toContain('getFormSchema.json');
+    expect(mockUtils.httpGet.mock.calls[2][1]).toContain('getFormNavigationListByOrder.json');
+    expect(mockUtils.httpGet.mock.calls[3][1]).toContain('getFormNavigationListByOrder.json');
     expect(
       mockUtils.httpPost.mock.calls.filter((call) =>
         call[1].includes('saveFormSchemaInfo.json')
@@ -3221,6 +3381,8 @@ describe('legacy create-form compatibility', () => {
       formTitle: '访客登记',
       appType: 'APP_XXX',
       fieldCount: 1,
+      icon: 'name-card',
+      iconSource: 'auto',
       url: 'https://example.test/APP_XXX/workbench/FORM_TEST',
     });
 

--- a/tests/form-nav-icon.test.js
+++ b/tests/form-nav-icon.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const {
+  FORM_NAV_ICON_GROUPS,
+  FORM_NAV_ICONS,
+  inferFormNavIcon,
+  normalizeFormNavIcon,
+  resolveFormNavIcon,
+} = require('../lib/app/create-form/nav-icon');
+
+describe('form navigation icon catalog', () => {
+  test('matches the current yida-next navigation picker catalog', () => {
+    expect(FORM_NAV_ICON_GROUPS.map((group) => [group.key, group.items.length])).toEqual([
+      ['defaultIcons', 31],
+      ['systemIcons', 55],
+    ]);
+    expect(FORM_NAV_ICONS).toHaveLength(86);
+    expect(new Set(FORM_NAV_ICONS.map((item) => item.name)).size).toBe(86);
+    expect(FORM_NAV_ICONS).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'biaodan', label: '表单' }),
+      expect.objectContaining({ name: 'Project', label: '项目' }),
+      expect.objectContaining({ name: 'Todo', label: '任务' }),
+      expect.objectContaining({ name: 'name-card', label: '名片' }),
+    ]));
+  });
+
+  test('accepts explicit icon names case-insensitively and preserves canonical casing', () => {
+    expect(normalizeFormNavIcon('project')).toBe('Project');
+    expect(normalizeFormNavIcon('CalendarSeventeen')).toBe('CalendarSeventeen');
+    expect(normalizeFormNavIcon('not-an-icon')).toBe('');
+  });
+
+  test('infers business-specific icons from the title before field labels', () => {
+    expect(inferFormNavIcon('客户登记表', [{ label: '任务名称' }])).toBe('name-card');
+    expect(inferFormNavIcon('项目任务表', [])).toBe('Project');
+    expect(inferFormNavIcon('费用报销', [])).toBe('dingdingka');
+    expect(inferFormNavIcon('考勤记录', [])).toBe('clock');
+  });
+
+  test('uses nested field semantics when the title is generic', () => {
+    expect(inferFormNavIcon('信息登记', [{
+      type: 'ColumnContainer',
+      children: [[{ type: 'TextField', label: '会议室' }]],
+    }])).toBe('huiyishi');
+  });
+
+  test('resolves auto and explicit values while reporting invalid values', () => {
+    expect(resolveFormNavIcon('auto', '差旅申请', [])).toEqual({
+      icon: 'airplane',
+      source: 'auto',
+    });
+    expect(resolveFormNavIcon('todo', '普通表单', [])).toEqual({
+      icon: 'Todo',
+      source: 'explicit',
+    });
+    expect(resolveFormNavIcon('unknown', '普通表单', [])).toEqual({
+      icon: '',
+      source: 'invalid',
+    });
+  });
+});

--- a/yida-skills/skills/yida-create-form-page/SKILL.md
+++ b/yida-skills/skills/yida-create-form-page/SKILL.md
@@ -119,12 +119,16 @@ openyida create-form create <appType> <formTitle> <fieldsJsonOrFile> [--layout d
 # 文件路径示例：.cache/openyida/<项目名或任务名>/<表单名>-fields.json
 ```
 
+创建成功后 CLI 会根据表单标题和字段语义选择导航图标，再更新导航节点并回读校验。需要指定时传 `--icon <iconName>`；用 `openyida create-form icons --json` 查看与 yida-next 页面导航选择器一致的 86 个可用值。表单导航图标是纯图标名（如 `name-card`、`Project`、`Todo`、`clock`），不是应用图标的 `xian-*%%color` 协议。
+
+导航图标更新必须先读取 `getFormNavigationListByOrder.json` 的当前节点，像 yida-next 的 `DB.Nav.update({ ...node, title: JSON.stringify(node.title), formUuid: node.formUuid || 'NAV-SYSTEM-FROM-ME-UUID', icon })` 一样保留 `gmtModified`、`formType`、`isNewForm`、`listOrder` 等原值，再请求带 `_api=Nav.update&_mock=false&_stamp=...` 的 `updateFormNavigation.json`，最后重新读取导航列表校验图标。禁止仅凭 formUuid 拼一个精简更新 payload。
+
 > 文件先用 create_file / Write / file edit tool 创建。上方路径默认从 OpenYida project 工作目录执行；如果从 workspace 根执行命令，传 `project/.cache/openyida/<项目名或任务名>/<表单名>-fields.json`。
 
 输出：
 
 ```json
-{"success":true,"formUuid":"FORM-XXX","formTitle":"用户信息表","appType":"APP_xxx","fieldCount":4,"url":"{base_url}/APP_xxx/workbench/FORM-XXX"}
+{"success":true,"formUuid":"FORM-XXX","formTitle":"用户信息表","appType":"APP_xxx","fieldCount":4,"icon":"name-card","iconSource":"auto","url":"{base_url}/APP_xxx/workbench/FORM-XXX"}
 ```
 
 完整应用模式下的下一步：


### PR DESCRIPTION
## 变更说明

- 创建表单并保存 Schema 后，对齐 yida-next 的 Nav.update 请求契约更新导航图标，并在写入后回读校验
- 根据表单标题和字段语义从 86 个可选图标中自动选择，同时支持 --icon 显式指定和 create-form icons 查询图标目录
- 将新增命令及参数注册到 command manifest 和 agent capabilities，确保云端 yida-agent 可发现
- 更新版本与变更日志至 2026.9.2-1

## 验证

- NPM_CONFIG_USERCONFIG=/dev/null npm run check:ci
- npm run check:release-risks（0 error；2 条既有跨平台人工验证提醒）