### PR TITLE
fix: 补齐 dynamicOrder 字段校验

### DIFF
--- a/lib/app/page-linter.js
+++ b/lib/app/page-linter.js
@@ -501,21 +501,43 @@ function findDynamicOrderProperty(params) {
   return params.properties.find(property => getStaticPropertyName(property) === 'dynamicOrder') || null;
 }
 
-function reportForbiddenDynamicOrder(pathRef, params, errors, disableMap) {
-  const resolvedParams = resolveStaticBinding(params, pathRef);
-  const dynamicOrderProperty = findDynamicOrderProperty(resolvedParams);
-  const forbiddenFields = dynamicOrderProperty
-    ? findForbiddenDynamicOrderFields(dynamicOrderProperty.value, pathRef)
-    : [];
+function reportForbiddenDynamicOrderValue(pathRef, value, issueNode, errors, disableMap) {
+  const forbiddenFields = findForbiddenDynamicOrderFields(value, pathRef);
   if (forbiddenFields.length === 0) {
     return;
   }
   pushIssue(
     errors,
-    getNodeLine(dynamicOrderProperty),
+    getNodeLine(issueNode),
     'searchformdata-dynamic-order-metadata',
     t('publish.lint_searchformdata_dynamic_order_metadata', forbiddenFields.join(', ')),
     disableMap
+  );
+}
+
+function reportForbiddenDynamicOrder(pathRef, params, errors, disableMap) {
+  const resolvedParams = resolveStaticBinding(params, pathRef);
+  const dynamicOrderProperty = findDynamicOrderProperty(resolvedParams);
+  if (!dynamicOrderProperty) {
+    return;
+  }
+  reportForbiddenDynamicOrderValue(
+    pathRef,
+    dynamicOrderProperty.value,
+    dynamicOrderProperty,
+    errors,
+    disableMap
+  );
+}
+
+function isUrlSearchParamsInstance(node, pathRef) {
+  const resolved = resolveStaticBinding(node, pathRef);
+  return !!(
+    resolved &&
+    resolved.type === 'NewExpression' &&
+    resolved.callee &&
+    resolved.callee.type === 'Identifier' &&
+    resolved.callee.name === 'URLSearchParams'
   );
 }
 
@@ -751,6 +773,19 @@ function collectAstLintIssues(sourceCode, errors, warnings, disableMap) {
       if (getMemberPropertyName(callee) === 'searchFormDatas') {
         const params = pathRef.node.arguments && pathRef.node.arguments[0];
         reportForbiddenDynamicOrder(pathRef, params, errors, disableMap);
+      }
+
+      const urlSearchParamsMethod = getMemberPropertyName(callee);
+      if (
+        (urlSearchParamsMethod === 'append' || urlSearchParamsMethod === 'set') &&
+        callee &&
+        callee.type === 'MemberExpression' &&
+        isUrlSearchParamsInstance(callee.object, pathRef)
+      ) {
+        const args = pathRef.node.arguments || [];
+        if (getStaticStringValue(args[0]) === 'dynamicOrder') {
+          reportForbiddenDynamicOrderValue(pathRef, args[1], pathRef.node, errors, disableMap);
+        }
       }
 
       const isSetState = callee &&

--- a/lib/core/query-data.js
+++ b/lib/core/query-data.js
@@ -479,8 +479,8 @@ function resolveFieldRef(value, aliasContext) {
   return aliasContext.fieldIdByAlias[value] || value;
 }
 
-function requireKnownDataFieldRef(value, aliasContext) {
-  const fieldId = resolveFieldRef(value, aliasContext);
+function requireKnownDataFieldRef(value, aliasContext, resolveAliases = true) {
+  const fieldId = resolveAliases ? resolveFieldRef(value, aliasContext) : value;
   if (!aliasContext || aliasContext.fieldInfoById[fieldId]) {
     return fieldId;
   }
@@ -495,6 +495,27 @@ function requireKnownDataFieldRef(value, aliasContext) {
       nextStep: `openyida get-schema ${aliasContext.appType} ${aliasContext.formUuid} --field-map-json`,
     }
   );
+}
+
+function prepareDynamicOrderJson(jsonValue, fieldContext, resolveAliases) {
+  if (!jsonValue) {
+    return jsonValue;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonValue);
+  } catch (err) {
+    parseError(`--dynamic-order 只能处理合法 JSON：${err.message}`);
+  }
+  if (!isPlainObject(parsed)) {
+    parseError('--dynamic-order 必须是字段 ID 到排序方向的 JSON 对象');
+  }
+  const translated = {};
+  Object.entries(parsed).forEach(([fieldRef, direction]) => {
+    const fieldId = requireKnownDataFieldRef(fieldRef, fieldContext, resolveAliases);
+    translated[fieldId] = direction;
+  });
+  return JSON.stringify(translated);
 }
 
 function translateSubformRows(value, aliasContext) {
@@ -804,8 +825,13 @@ async function queryForm(positionals, options, session) {
   const [appType, formUuid] = positionals;
   clampPageSize(options, options.all ? 100 : 20);
   const rawSearchJson = readJsonOption(options, 'search_json', 'search_file', '查询条件');
-  const aliasContext = await resolveAliasContextIfNeeded(session, appType, formUuid, options, rawSearchJson || options.dynamic_order);
+  const resolveAliases = shouldResolveAliases(options);
+  const fieldContext = options.dynamic_order
+    ? await fetchFormAliasContext(session, appType, formUuid)
+    : await resolveAliasContextIfNeeded(session, appType, formUuid, options, rawSearchJson);
+  const aliasContext = resolveAliases ? fieldContext : null;
   const searchJson = translateJsonWithAliases(rawSearchJson, aliasContext, translateSearchValue);
+  const dynamicOrder = prepareDynamicOrderJson(options.dynamic_order, fieldContext, resolveAliases);
 
   let result;
   if (options.inst_id) {
@@ -833,9 +859,7 @@ async function queryForm(positionals, options, session) {
       }
       for (const key of ['originator_id', 'create_from', 'create_to', 'modified_from', 'modified_to', 'dynamic_order']) {
         if (options[key]) {
-          params[snakeToCamel(key)] = key === 'dynamic_order' && aliasContext
-            ? translateJsonWithAliases(options[key], aliasContext, translateSearchValue)
-            : options[key];
+          params[snakeToCamel(key)] = key === 'dynamic_order' ? dynamicOrder : options[key];
         }
       }
       const requestPath = options.ids_only
@@ -855,9 +879,7 @@ async function queryForm(positionals, options, session) {
     }
     for (const key of ['originator_id', 'create_from', 'create_to', 'modified_from', 'modified_to', 'dynamic_order']) {
       if (options[key]) {
-        params[snakeToCamel(key)] = key === 'dynamic_order' && aliasContext
-          ? translateJsonWithAliases(options[key], aliasContext, translateSearchValue)
-          : options[key];
+        params[snakeToCamel(key)] = key === 'dynamic_order' ? dynamicOrder : options[key];
       }
     }
     const requestPath = options.ids_only

--- a/tests/page-linter.test.js
+++ b/tests/page-linter.test.js
@@ -547,12 +547,25 @@ export function buildDirectQuery() {
   var params = { formUuid: 'FORM-X', pageSize: '50', dynamicOrder: '{"gmtCreate":"-"}' };
   return new URLSearchParams(params).toString();
 }
+
+export function buildAppendedQuery() {
+  var params = new URLSearchParams();
+  params.append('dynamicOrder', JSON.stringify({ gmtCreate: '-' }));
+  return params.toString();
+}
+
+export function buildSetQuery() {
+  var order = '{"gmtCreate":"-"}';
+  var params = new URLSearchParams({ pageSize: '50' });
+  params.set('dynamicOrder', order);
+  return params.toString();
+}
 `;
     const result = lintYidaSource(source, '/tmp/searchformdata-dynamic-order-bad.jsx');
     const issues = result.errors.filter(issue => issue.rule === 'searchformdata-dynamic-order-metadata');
 
-    expect(issues).toHaveLength(4);
-    expect(issues.map(issue => issue.line)).toEqual([3, 7, 12, 17]);
+    expect(issues).toHaveLength(6);
+    expect(issues.map(issue => issue.line)).toEqual([3, 7, 12, 17, 23, 30]);
     expect(issues.every(issue => issue.message.includes('gmtCreate'))).toBe(true);
   });
 
@@ -570,6 +583,20 @@ export function loadRows() {
 }
 `;
     const result = lintYidaSource(source, '/tmp/searchformdata-dynamic-order-good.jsx');
+
+    expect(result.errors.map(issue => issue.rule)).not.toContain('searchformdata-dynamic-order-metadata');
+  });
+
+  test('does not treat append/set on ordinary objects as URLSearchParams', () => {
+    const source = `
+export function updateState() {
+  var params = createParams();
+  params.append('dynamicOrder', '{"gmtCreate":"-"}');
+  var cache = new Map();
+  cache.set('dynamicOrder', JSON.stringify({ gmtCreate: '-' }));
+}
+`;
+    const result = lintYidaSource(source, '/tmp/searchformdata-dynamic-order-ordinary-objects.jsx');
 
     expect(result.errors.map(issue => issue.rule)).not.toContain('searchformdata-dynamic-order-metadata');
   });

--- a/tests/query-data.test.js
+++ b/tests/query-data.test.js
@@ -399,6 +399,70 @@ describe('run() query form', () => {
     mockError.mockRestore();
   });
 
+  test('dynamicOrder 使用真实 fieldId 时先校验 Schema 再查询', async () => {
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet
+      .mockResolvedValueOnce(buildAliasSchema())
+      .mockResolvedValueOnce({
+        success: true,
+        content: { totalCount: 0, data: [] },
+      });
+
+    const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--dynamic-order', '{"textField_phone":"-"}']);
+
+    expect(utils.httpGet).toHaveBeenCalledTimes(2);
+    expect(utils.httpGet.mock.calls[1][2]).toMatchObject({
+      dynamicOrder: '{"textField_phone":"-"}',
+    });
+
+    mockLog.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('dynamicOrder 未知字段在查询接口前阻断', async () => {
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet.mockResolvedValueOnce(buildAliasSchema());
+
+    const error = await expectCliError(run([
+      'query',
+      'form',
+      'APP_XXX',
+      'FORM-XXX',
+      '--dynamic-order',
+      '{"gmtCreate":"-"}',
+    ]));
+
+    expect(error.code).toBe('DATA_FIELD_REFERENCE_UNKNOWN');
+    expect(error.details).toMatchObject({
+      fieldRef: 'gmtCreate',
+      retrySafe: true,
+      sideEffectState: 'none',
+      nextStep: 'openyida get-schema APP_XXX FORM-XXX --field-map-json',
+    });
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+  });
+
+  test('dynamicOrder 不带 --resolve-aliases 时不接受字段别名', async () => {
+    utils.requestWithAutoLogin.mockImplementation((fn, session) => fn(session));
+    utils.httpGet.mockResolvedValueOnce(buildAliasSchema());
+
+    const error = await expectCliError(run([
+      'query',
+      'form',
+      'APP_XXX',
+      'FORM-XXX',
+      '--dynamic-order',
+      '{"phone":"+"}',
+    ]));
+
+    expect(error.code).toBe('DATA_FIELD_REFERENCE_UNKNOWN');
+    expect(error.details.fieldRef).toBe('phone');
+    expect(utils.httpGet).toHaveBeenCalledTimes(1);
+  });
+
   test('同时传入 --search-json 和 --search-file 时打印错误并退出', async () => {
     await expectCliError(
       run(['query', 'form', 'APP_XXX', 'FORM-XXX', '--search-json', '[]', '--search-file', '.cache/openyida/search.json']),


### PR DESCRIPTION
## 变更内容

- 补齐 `URLSearchParams.append/set` 写入 `dynamicOrder` 时的 Canvas 静态守卫
- 仅识别真实 `URLSearchParams` 实例，避免误判普通对象的同名方法
- `data query form --dynamic-order` 在查询前读取表单 Schema 并校验字段
- 保持别名仅在 `--resolve-aliases` 下生效，未知字段返回 `DATA_FIELD_REFERENCE_UNKNOWN`

这是 #545 的后续正确性修复。

## 验证

- `npx jest tests/page-linter.test.js tests/query-data.test.js --runInBand`：105/105 通过
- `npm run check:ci`：通过
- 全局 link `openyida check-page` smoke：`URLSearchParams.append` 场景正确阻断

未执行真实宜搭远端写入，无远端副作用。