### PR TITLE
fix: preserve app watermark and sentry settings

### DIFF
--- a/lib/app/update-app.js
+++ b/lib/app/update-app.js
@@ -294,6 +294,8 @@ function buildUpdateAppPostData(params, currentApp = {}, authRef) {
 
   const currentThemeColor = pickAppField(currentApp, 'themeColor', 'THEME_COLOR');
   const currentCustomThemeStyle = pickAppField(currentApp, 'customThemeStyle', 'CUSTOM_THEME_STYLE');
+  const addWaterMark = pickAppField(currentApp, 'addWaterMark', 'ADDWATERMARK');
+  const sentryMode = pickAppField(currentApp, 'sentryMode', 'SENTRY_MODE');
   if (params.colour === 'custom' && !params.themeColor && !currentThemeColor) {
     throw new Error(t('update_app.custom_theme_color_required'));
   }
@@ -342,10 +344,14 @@ function buildUpdateAppPostData(params, currentApp = {}, authRef) {
     navigation: currentApp.navigation || (currentApp.config && currentApp.config.NAVIGATION) || 'TODO,DONE,SUBMIT',
     pageHeader: currentApp.pageHeader || '',
     pageFooter: currentApp.pageFooter || '',
-    addWaterMark: currentApp.addWaterMark || (currentApp.config && currentApp.config.ADDWATERMARK) || 'y',
-    sentryMode: currentApp.sentryMode || (currentApp.config && currentApp.config.SENTRY_MODE) || 'y',
   };
 
+  if (addWaterMark !== undefined && addWaterMark !== null) {
+    postDataObj.addWaterMark = addWaterMark;
+  }
+  if (sentryMode !== undefined && sentryMode !== null) {
+    postDataObj.sentryMode = sentryMode;
+  }
   if (params.hideAppNav !== null && params.hideAppNav !== undefined) {
     postDataObj.hideAppNav = params.hideAppNav;
   } else {

--- a/tests/update-app.test.js
+++ b/tests/update-app.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const querystring = require('querystring');
+
 const {
   assertPresetThemeKey,
   assertAppThemeKey,
@@ -194,6 +196,43 @@ describe('update-app helpers', () => {
     expect(JSON.parse(payload.appName)).toMatchObject({
       zh_CN: 'OpenYida官方Samples展示0716',
     });
+  });
+
+  test('buildUpdateAppPostData preserves security settings without inventing defaults', () => {
+    const params = parseArgs(['APP_1', '--nav-theme', 'light']);
+    const currentApp = {
+      appName: { zh_CN: '应用' },
+      description: { zh_CN: '描述' },
+      mode: 'normal',
+      type: 'single',
+    };
+
+    const empty = buildUpdateAppPostData(
+      params,
+      { ...currentApp, addWaterMark: '', sentryMode: '' },
+      { csrfToken: 'csrf' }
+    );
+    expect(empty).toMatchObject({ addWaterMark: '', sentryMode: '' });
+    expect(querystring.stringify(empty)).toContain('addWaterMark=&sentryMode=');
+
+    const explicit = buildUpdateAppPostData(
+      params,
+      { ...currentApp, addWaterMark: 'n', sentryMode: 'y' },
+      { csrfToken: 'csrf' }
+    );
+    expect(explicit).toMatchObject({ addWaterMark: 'n', sentryMode: 'y' });
+
+    const configFallback = buildUpdateAppPostData(
+      params,
+      { ...currentApp, config: { ADDWATERMARK: 'y', SENTRY_MODE: 'n' } },
+      { csrfToken: 'csrf' }
+    );
+    expect(configFallback).toMatchObject({ addWaterMark: 'y', sentryMode: 'n' });
+
+    const absent = buildUpdateAppPostData(params, currentApp, { csrfToken: 'csrf' });
+    expect(absent).not.toHaveProperty('addWaterMark');
+    expect(absent).not.toHaveProperty('sentryMode');
+    expect(querystring.stringify(absent)).not.toMatch(/addWaterMark|sentryMode/);
   });
 
   test('buildUpdateAppPostData writes hideAppNav as y/n only when requested', () => {


### PR DESCRIPTION
## 问题

`update-app` 使用 `|| "y"` 合并 `addWaterMark` 和 `sentryMode`。平台应用详情会返回空字符串，JavaScript 会将其视为假值，从而在更新主题、导航或图标时意外把两个安全设置写成 `y`。

## 修改

- 复用 `pickAppField`，优先读取顶层字段，顶层缺失时读取 `config`。
- 原样保留空字符串以及显式的 `y`/`n`。
- 顶层和 `config` 都真正缺失时省略请求字段，不臆造 `y` 或 `n` 默认值。
- 增加空字符串、显式值、配置兜底和完全缺失四类回归测试。

## 验证

- `npm test -- --runInBand tests/update-app.test.js`：17 项通过。
- `npm run check:ci`：189 个测试套件、2803 项测试通过。
- 只读抽样 10 个真实应用：9 个返回空字符串，1 个返回 `y`；使用修复后的本地构造逻辑均保持原值。
- 未调用远端更新接口，未修改真实应用。

## 影响范围

仅调整 `update-app` 构造请求时两个安全设置字段的保留语义，不修改创建应用接口、CLI 参数或平台协议。