### PR TITLE
chore: 校准集成修复后的 npm 包体积守卫

### DIFF
--- a/scripts/validate-package-size.js
+++ b/scripts/validate-package-size.js
@@ -11,11 +11,11 @@ const path = require('path');
 // samples, skills). Raise them intentionally when new content is justified; the
 // per-file cap stays fixed to catch accidental large-blob embeds.
 const MAX_TARBALL_BYTES = 1792 * 1024;
-// Includes Phase 6 stability guards and the DingTalk OpenAPI connector skill
-// with their runtime and workflow contracts (6165031 bytes before conflict cleanup).
-const MAX_UNPACKED_BYTES = 6030 * 1024;
-// Connector runtime guards and skill references bring the merged package to 489 files.
-const MAX_ENTRY_COUNT = 489;
+// Includes process-form metadata and integration sub-table compiler contracts
+// (6205451 bytes after PRs #507 and #527).
+const MAX_UNPACKED_BYTES = 6070 * 1024;
+// The process-form metadata helper brings the merged package to 490 files.
+const MAX_ENTRY_COUNT = 490;
 const MAX_SINGLE_FILE_BYTES = 512 * 1024;
 
 const REQUIRED_PACKAGE_FILES = [


### PR DESCRIPTION
## 背景

PR #507 与 #527 的合法运行时代码增长使 npm 包超过旧的解包体积与文件数阈值。

## 修改

- 解包预算从 6030 KiB 调整为 6070 KiB（当前 6,205,451 bytes）
- 文件数预算从 489 调整为 490（新增 process-form metadata helper）
- tarball、单文件上限、禁止目录与必需文件检查保持不变

## 验证

- `npm_config_userconfig=/dev/null npm run check:package-size`
- `npm test -- --runInBand tests/package-smoke.test.js`
- #527 合入前完整 `check:ci`：189 suites / 2851 tests 全通过，唯一失败为旧体积预算