### PR TITLE
feat: 新增 OpenYida 快速版本发布技能

### DIFF
--- a/.agents/skills/openyida-cross-platform-release-guard/SKILL.md
+++ b/.agents/skills/openyida-cross-platform-release-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openyida-cross-platform-release-guard
-description: OpenYida 跨端发布风险守卫。当改动涉及浏览器/URL 拉起（openyida login、bridge 页面唤起、resolveBrowserLauncher、openBrowser、spawn 打开浏览器）、或在 macOS 上开发但需要发布给 Windows/Linux 用户、或准备打 tag 发布新版本时使用。用于在发布前静态扫描并拦截「cmd /c start 截断 URL」「open -n 假装开新窗口」等只在非 macOS 端暴露的历史坑，并输出跨端人工验证清单。
+description: OpenYida 跨端发布风险守卫。当改动涉及浏览器/URL 拉起（openyida login、bridge 页面唤起、resolveBrowserLauncher、openBrowser、spawn 打开浏览器），或用户明确要求检查 Windows/Linux 发布风险时使用。用于静态扫描并拦截「cmd /c start 截断 URL」「open -n 假装开新窗口」等跨端问题；普通版本 tag 发布请使用 openyida-release。
 ---
 
 # OpenYida 跨端发布风险守卫
@@ -14,7 +14,7 @@ Windows/Linux 用户侧直接炸掉——因为每个平台的浏览器拉起命
 - 改动 `lib/auth/oauth-loopback.js`、`lib/bridge/bridge.js`，或任何 `resolveBrowserLauncher` /
   `openBrowser` / `spawn(...浏览器...)` 相关逻辑。
 - 在 macOS 开发、发布对象包含 Windows / Linux 用户。
-- 准备打 tag、bump 版本、发布新的 openyida。
+- 用户明确要求对浏览器拉起或 URL 传递改动做跨端发布检查。
 
 ## 第一步：跑发布风险静态扫描（必做）
 

--- a/.agents/skills/openyida-release/SKILL.md
+++ b/.agents/skills/openyida-release/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: openyida-release
+description: 快速发布 OpenYida npm 正式版或测试版。用户说“发布正式版”“发布测试版”“发 beta”或要求按当天日期生成版本 tag 时使用；不用于宜搭应用或自定义页面发布。
+---
+
+# OpenYida 快速版本发布
+
+通过 Git tag 触发现有 GitHub Publish 工作流。发布过程不运行任何本地 CI、测试、lint、构建或 `npm run check:*`；远端工作流保持原样。
+
+## 发布类型
+
+- 正式版：北京时间当天首次为 `vYYYY.M.D`，之后依次为 `vYYYY.M.D-1`、`vYYYY.M.D-2`。
+- 测试版：北京时间当天从 `vYYYY.M.D-beta.0` 开始，之后依次递增。
+- 仅把明确包含“测试版”“beta”或“预发布”的请求视为测试版；其余明确的版本发布请求按正式版处理。
+
+## 准备发布
+
+1. 确认仓库和工作树状态，但不要修改、暂存或清理用户文件：
+
+   ```bash
+   git rev-parse --show-toplevel
+   git status --short
+   git fetch origin --tags
+   ```
+
+2. 默认发布最新 `origin/main`，与当前 checkout 的分支无关。不要 checkout、merge、commit，也不要 push 分支。
+3. 从本技能目录运行版本计算脚本：
+
+   ```bash
+   node .agents/skills/openyida-release/scripts/next-version.js stable
+   node .agents/skills/openyida-release/scripts/next-version.js beta
+   ```
+
+   脚本同时读取本地 tag 和 `origin` 远端 tag，并按 `Asia/Shanghai` 日期生成下一个版本。不要凭记忆手写编号。
+4. 读取目标 commit：
+
+   ```bash
+   git rev-parse refs/remotes/origin/main
+   git show -s --format='%h %s' refs/remotes/origin/main
+   ```
+
+5. 在任何写操作前，向用户展示发布类型、完整 tag、目标 commit 和 commit 标题，并明确说明“只推 tag，不推分支；本地不跑 CI；远端 Publish 工作流仍会运行”。取得一次明确确认。
+
+工作树有未提交改动时也不得擅自 stash 或清理；因为发布目标固定为 `origin/main`，只需说明这些改动不会进入本次版本。
+
+## 执行发布
+
+得到确认后，先再次 `git fetch origin --tags`，重新计算版本并重新读取 `origin/main`：
+
+- 如果 tag 或目标 commit 与用户确认时不同，停止并用新值再次确认。
+- 如果两者都未变化，创建轻量 tag 并只推送该 tag：
+
+  ```bash
+  git tag "v${RELEASE_VERSION}" "${RELEASE_COMMIT}"
+  git push origin "refs/tags/v${RELEASE_VERSION}"
+  ```
+
+不要运行以下操作：
+
+- `npm test`、`npm run check:ci`、`npm run check:*`、lint、build 或安装依赖；
+- `npm version`，以及直接修改 `package.json` / `package-lock.json`；
+- branch push、自动 commit、自动 merge；
+- 等待远端 CI 完成。
+
+现有 `.github/workflows/publish.yml` 会从 tag 同步 npm 包版本，并把 beta 发布到 npm `beta` dist-tag；正式版及同日 `-1`、`-2` 发布到 `latest`。
+
+## 回读与失败处理
+
+推送后只回读远端 tag，确认它存在且指向预期 commit：
+
+```bash
+git ls-remote --tags origin "refs/tags/v${RELEASE_VERSION}"
+```
+
+- 回读一致即报告 tag 已推送、远端发布已触发，不等待工作流结束。
+- push 返回不确定结果时，先回读远端 tag；远端已存在且 commit 一致则视为成功，不重复推送。
+- 远端不存在时，报告本地 tag 仍保留并等待用户决定；不得自动重试或删除 tag。
+- 远端 tag 已存在但 commit 不一致时立即停止，不覆盖、不删除、不 force push。
+

--- a/.agents/skills/openyida-release/scripts/next-version.js
+++ b/.agents/skills/openyida-release/scripts/next-version.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+
+const TIME_ZONE = 'Asia/Shanghai';
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function dateVersion(now = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: TIME_ZONE,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  }).formatToParts(now);
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  return `${values.year}.${Number(values.month)}.${Number(values.day)}`;
+}
+
+function parseDate(value) {
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(value);
+  if (!match) {
+    throw new Error(`无效日期：${value}，应为 YYYY-MM-DD`);
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, month - 1, day, 4));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    throw new Error(`无效日期：${value}`);
+  }
+  return parsed;
+}
+
+function nextVersion(channel, base, tags) {
+  const escapedBase = escapeRegExp(base);
+
+  if (channel === 'stable') {
+    const pattern = new RegExp(`^v?${escapedBase}(?:-(\\d+))?$`);
+    const suffixes = tags.flatMap((tag) => {
+      const match = pattern.exec(tag);
+      if (!match) {
+        return [];
+      }
+      return [match[1] === undefined ? 0 : Number(match[1])];
+    });
+    if (suffixes.length === 0) {
+      return base;
+    }
+    return `${base}-${Math.max(...suffixes) + 1}`;
+  }
+
+  if (channel === 'beta') {
+    const pattern = new RegExp(`^v?${escapedBase}-beta\\.(\\d+)$`);
+    const suffixes = tags.flatMap((tag) => {
+      const match = pattern.exec(tag);
+      return match ? [Number(match[1])] : [];
+    });
+    const next = suffixes.length === 0 ? 0 : Math.max(...suffixes) + 1;
+    return `${base}-beta.${next}`;
+  }
+
+  throw new Error(`未知发布类型：${channel}，仅支持 stable 或 beta`);
+}
+
+function commandOutput(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function collectTags(base, remote, cwd) {
+  const local = commandOutput(['tag', '--list', `v${base}*`], cwd)
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  let remoteOutput;
+  try {
+    remoteOutput = commandOutput(
+      ['ls-remote', '--tags', remote, `refs/tags/v${base}*`],
+      cwd,
+    );
+  } catch (_error) {
+    throw new Error(`无法读取远端 ${remote} 的 tag；未生成发布版本`);
+  }
+
+  const remoteTags = remoteOutput
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => line.split('\t')[1])
+    .filter(Boolean)
+    .map((ref) => ref.replace(/^refs\/tags\//, '').replace(/\^\{\}$/, ''));
+
+  return [...new Set([...local, ...remoteTags])];
+}
+
+function parseArgs(argv) {
+  const channel = argv[0];
+  let now = new Date();
+  let remote = 'origin';
+
+  for (let index = 1; index < argv.length; index += 1) {
+    if (argv[index] === '--date' && argv[index + 1]) {
+      now = parseDate(argv[index + 1]);
+      index += 1;
+    } else if (argv[index] === '--remote' && argv[index + 1]) {
+      remote = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`未知参数：${argv[index]}`);
+    }
+  }
+
+  return { channel, now, remote };
+}
+
+function main() {
+  try {
+    const { channel, now, remote } = parseArgs(process.argv.slice(2));
+    const base = dateVersion(now);
+    const tags = collectTags(base, remote, process.cwd());
+    process.stdout.write(`${nextVersion(channel, base, tags)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  collectTags,
+  dateVersion,
+  nextVersion,
+  parseArgs,
+  parseDate,
+};

--- a/.agents/skills/openyida-release/tests/next-version.test.js
+++ b/.agents/skills/openyida-release/tests/next-version.test.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+const {
+  dateVersion,
+  nextVersion,
+  parseArgs,
+  parseDate,
+} = require('../scripts/next-version');
+
+describe('openyida release version generator', () => {
+  test('uses the Asia/Shanghai calendar date', () => {
+    expect(dateVersion(new Date('2026-09-07T16:30:00.000Z'))).toBe('2026.9.8');
+  });
+
+  test('starts a stable release at the bare date version', () => {
+    expect(nextVersion('stable', '2026.9.8', ['v2026.9.8-beta.0'])).toBe('2026.9.8');
+  });
+
+  test('increments stable releases independently from beta releases', () => {
+    expect(nextVersion('stable', '2026.9.8', [
+      'v2026.9.8',
+      'v2026.9.8-1',
+      'v2026.9.8-2',
+      'v2026.9.8-beta.7',
+    ])).toBe('2026.9.8-3');
+  });
+
+  test('starts beta releases at zero and increments the highest beta', () => {
+    expect(nextVersion('beta', '2026.9.8', ['v2026.9.8'])).toBe('2026.9.8-beta.0');
+    expect(nextVersion('beta', '2026.9.8', [
+      'v2026.9.8-beta.0',
+      'v2026.9.8-beta.2',
+      'v2026.9.8-1',
+    ])).toBe('2026.9.8-beta.3');
+  });
+
+  test('supports a deterministic date override', () => {
+    const args = parseArgs(['beta', '--date', '2026-09-08', '--remote', 'upstream']);
+    expect(dateVersion(args.now)).toBe('2026.9.8');
+    expect(args.remote).toBe('upstream');
+    expect(() => parseDate('2026-02-30')).toThrow('无效日期');
+  });
+
+  test('rejects unknown channels', () => {
+    expect(() => nextVersion('rc', '2026.9.8', [])).toThrow('仅支持 stable 或 beta');
+  });
+});

--- a/docs/features/openyida-release-skill.md
+++ b/docs/features/openyida-release-skill.md
@@ -1,0 +1,51 @@
+# OpenYida 快速版本发布技能
+
+## 状态
+
+- 阶段：已完成本地实现与窄范围验证
+- 核心目标：用一句自然语言请求快速发布 OpenYida 正式版或测试版，并自动生成不冲突的日期版本号
+
+## 已确认需求
+
+- “发布正式版”使用北京时间当天的 `YYYY.M.D`；同日重复发布依次使用 `YYYY.M.D-1`、`YYYY.M.D-2`。
+- “发布测试版”使用北京时间当天的 `YYYY.M.D-beta.0`；同日重复发布依次使用 `-beta.1`、`-beta.2`。
+- 发布过程不运行本地 CI。
+- 继续复用 tag 触发的 GitHub Publish 工作流；远端现有校验与 npm 发布行为不变。
+
+## 最小实现
+
+- 新增项目技能 `.agents/skills/openyida-release/`。
+- 用技能内脚本结合本地与远端 tag 确定下一版本，避免让 Agent 临时拼接版本算法。
+- 发布 tag 默认指向最新 `origin/main`，不切换工作树、不修改 package manifests、不推送分支。
+- 推送 tag 前展示发布类型、tag 和目标 commit，并取得一次明确确认；推送后只做远端 tag 回读，不等待 CI。
+- 收窄跨端发布守卫的自动路由，避免普通版本发布被其全量 CI 要求覆盖。
+
+## Done Contract
+
+- 正式版和测试版的首次、同日连续编号都由自动化测试证明。
+- 技能结构校验通过，且指令明确禁止本地 CI、branch push 和 package version 修改。
+- 真实发布仍必须由用户在看到准确 tag 与 commit 后确认；本任务不实际发布任何版本。
+
+## 非目标
+
+- 不删除或跳过远端 GitHub Publish 工作流中的校验。
+- 不自动生成 changelog、提交代码、合并分支或推送业务分支。
+- 不改变 npm dist-tag 规则。
+
+## Change Log
+
+- 2026-09-08：根据用户确认，选择“本地跳过 CI、远端工作流保持不变”的最小方案。
+- 2026-09-08：新增 `openyida-release` 技能、日期版本计算脚本及单元测试；普通版本发布不再触发跨端发布守卫。
+
+## Validation
+
+- `node --check .agents/skills/openyida-release/scripts/next-version.js`：通过。
+- `npx jest .agents/skills/openyida-release/tests/next-version.test.js --runInBand`：6 项通过。
+- `npx eslint --no-ignore .../next-version.js .../next-version.test.js`：通过。
+- `quick_validate.py .agents/skills/openyida-release`：技能结构有效。
+- 使用远端 tag 试算 2026-09-08：正式版为 `2026.9.8`，测试版为 `2026.9.8-beta.0`；未创建或推送 tag。
+- `git diff --check`：通过。
+
+## Project Sync
+
+发布约定已经固化在项目技能及其算法测试中，无额外长期知识同步候选。


### PR DESCRIPTION
## 变更说明

- 新增 `openyida-release` 项目技能，支持正式版与 beta 测试版
- 按北京时间和已有远端 tag 自动生成日期版本号
- 发布时只推送 tag，不推分支、不修改 package manifests、不运行本地 CI
- 保留现有远端 Publish 工作流，并收窄跨端发布守卫的普通版本发布路由

## 验证

- 版本算法 Jest 测试 6 项通过
- 新增脚本通过语法与 ESLint 检查
- 技能通过 `quick_validate.py` 校验
- 远端 tag 试算结果符合 `YYYY.M.D[-N]` 与 `YYYY.M.D-beta.N` 规则