### PR TITLE
fix: retry known form recovery within batch

### DIFF
--- a/lib/app/create-form/batch.js
+++ b/lib/app/create-form/batch.js
@@ -246,6 +246,9 @@ async function schedule(forms, concurrency, results, worker, save) {
     return !result || result.status === 'blocked' || (result.status === 'failed' && result.formUuid);
   }).map(form => form.key));
   const active = new Map();
+  const recoveryAttempted = new Set(forms.filter(form =>
+    form.formUuid || (results[form.key]?.status === 'failed' && results[form.key]?.formUuid)
+  ).map(form => form.key));
   try {
     while (pending.size || active.size) {
       const pendingBefore = pending.size;
@@ -257,6 +260,8 @@ async function schedule(forms, concurrency, results, worker, save) {
         }
         if (active.size >= concurrency || deps.some(status => status !== 'success')) { continue; }
         pending.delete(form.key);
+        const hadKnownFormUuid = Boolean(form.formUuid || results[form.key]?.formUuid);
+        if (hadKnownFormUuid) { recoveryAttempted.add(form.key); }
         results[form.key] = { ...results[form.key], status: 'running' };
         save(); // Record intent before the request; an interrupted create is never retried automatically.
         const task = Promise.resolve().then(() => worker(form)).then(output => {
@@ -264,6 +269,13 @@ async function schedule(forms, concurrency, results, worker, save) {
         }, error => {
           results[form.key] = { ...results[form.key], status: 'failed', error: error.message,
             ...((error.output?.formUuid || error.output?.details?.formUuid) ? { formUuid: error.output.formUuid || error.output.details.formUuid } : {}) };
+          // A create may persist the form before a later schema/readback stage fails.
+          // Retry that known UUID once inside the same authoritative batch so its
+          // dependents remain pending and can run after conservative resume.
+          if (!hadKnownFormUuid && results[form.key].formUuid && !recoveryAttempted.has(form.key)) {
+            recoveryAttempted.add(form.key);
+            pending.add(form.key);
+          }
         }).then(() => { save(); }).finally(() => active.delete(form.key));
         active.set(form.key, task);
       }

--- a/tests/batch.test.js
+++ b/tests/batch.test.js
@@ -101,11 +101,12 @@ describe('batch loadCommandsFromFile', () => {
   });
 
   test('文件不存在时退出', () => {
+    const missingFile = path.join(os.tmpdir(), `openyida-batch-missing-${process.pid}-${Date.now()}.txt`);
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('__exit__'); });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      expect(() => loadCommandsFromFile('/nonexistent/file.txt')).toThrow('__exit__');
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('命令文件不存在: /nonexistent/file.txt'));
+      expect(() => loadCommandsFromFile(missingFile)).toThrow('__exit__');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(`命令文件不存在: ${path.resolve(missingFile)}`));
       expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       errorSpy.mockRestore();

--- a/tests/create-form-batch.test.js
+++ b/tests/create-form-batch.test.js
@@ -149,7 +149,27 @@ describe('dependency-aware form batches', () => {
     expect(results.a).toMatchObject({ status: 'failed', formUuid: 'FORM-A' });
     expect(results.b.status).toBe('blocked');
     expect(results.c.status).toBe('success');
-    expect(worker).toHaveBeenCalledTimes(2);
+    expect(worker).toHaveBeenCalledTimes(3);
+  });
+
+  test('a newly known form ID is resumed once before dependents are classified as blocked', async () => {
+    const results = {};
+    const calls = [];
+    const forms = [{ key: 'a', dependsOn: [] }, { key: 'b', dependsOn: ['a'] }];
+    const worker = jest.fn(async item => {
+      calls.push(item.key);
+      if (item.key === 'a' && calls.filter(key => key === 'a').length === 1) {
+        results.a.formUuid = 'FORM-A';
+        throw new Error('post-create readback failed');
+      }
+      return { formUuid: item.key === 'a' ? 'FORM-A' : 'FORM-B' };
+    });
+
+    await schedule(forms, 2, results, worker, () => {});
+
+    expect(calls).toEqual(['a', 'a', 'b']);
+    expect(results.a).toMatchObject({ status: 'success', formUuid: 'FORM-A' });
+    expect(results.b).toMatchObject({ status: 'success', formUuid: 'FORM-B' });
   });
 
   test('failure propagates through a reverse-ordered dependency chain', async () => {


### PR DESCRIPTION
## Summary\n\n- retry a form once inside the authoritative batch when a failed create exposes a durable formUuid\n- keep dependent forms pending until conservative recovery succeeds or the retry fails\n- cover both successful recovery and one-retry-only failure behavior\n\n## Validation\n\n- npm run check:ci (passed)\n