### PR TITLE
chore: 发布 2026.9.11-1 并修正导航日志版本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 海外版宜搭暂不适用当前 OAuth token 登录与创建应用链路；如需在海外版宜搭创建应用，请使用 `2026.7.14-2` 以前的版本，例如 `npm install -g openyida@2026.7.13`。
 
-## [2026.9.11] - 2026-09-11
+## [2026.9.11-1] - 2026-09-11
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyida",
-  "version": "2026.9.11",
+  "version": "2026.9.11-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyida",
-      "version": "2026.9.11",
+      "version": "2026.9.11-1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyida",
-  "version": "2026.9.11",
+  "version": "2026.9.11-1",
   "description": "OpenYida CLI - 宜搭低代码 AI 开发工具（安装即用，零配置）",
   "bin": {
     "openyida": "bin/yida.js",


### PR DESCRIPTION
现有 2026.9.11 已发布旧提交。本次将包含已合入导航改动的版本调整为 2026.9.11-1，同步 package.json、package-lock.json 和导航日志标题，避免覆盖现有版本。

验证：完整 check:ci 通过，包括单测、命令与技能校验、发布风险扫描及打包检查。