### PR TITLE
feat: 增加确定性 Canvas 编译与数据创建指引

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Run `openyida --help` or `openyida <command> --help` for detailed usage.
 | `openyida create-page <appType> "<name>" [--mode dashboard] [--hide-nav] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | Create a custom display page |
 | `openyida build-page <sourceFile> [--output file\|--write]` | Build Yida-compatible page source |
 | `openyida check-page <src> [--compat]` | Check custom page standards |
-| `openyida compile <src>` | Compile custom page locally |
+| `openyida compile <src> [--canvas] [--json]` | Compile custom page locally |
 | `openyida publish <src> <appType> <formUuid> [--health-check] [--force] [--canvas] [--auto-nav-order] [--open\|--no-open]` | Compile and publish custom page |
 | `openyida update-form-config <appType> <formUuid> <true\|false\|keep> "<title>" [--locale zh_CN\|en_US\|ja_JP]` | Update form configuration |
 | `openyida get-form-config <appType> <formUuid> [--json]` | Query form configuration |

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -312,7 +312,7 @@ openyida integration enable APP_XXX FORM_XXX PROC_CODE
 | `openyida create-page <appType> "<name>" [--mode dashboard] [--hide-nav] [--locale zh_CN\|en_US\|ja_JP] [--open\|--no-open]` | 创建自定义展示页面 |
 | `openyida build-page <sourceFile> [--output file\|--write]` | 构建宜搭兼容页面源码 |
 | `openyida check-page <src> [--compat]` | 检查自定义页面规范 |
-| `openyida compile <src>` | 本地编译自定义页面 |
+| `openyida compile <src> [--canvas] [--json]` | 本地编译自定义页面 |
 | `openyida publish <src> <appType> <formUuid> [--health-check] [--force] [--canvas] [--auto-nav-order] [--open\|--no-open]` | 编译并发布自定义页面 |
 | `openyida update-form-config <appType> <formUuid> <true\|false\|keep> "<title>" [--locale zh_CN\|en_US\|ja_JP]` | 更新表单配置 |
 | `openyida get-form-config <appType> <formUuid> [--json]` | 查询表单配置 |

--- a/lib/app/compile.js
+++ b/lib/app/compile.js
@@ -3,6 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 const { compileSource } = require('./page-compiler');
+const { compileCanvasPageSource } = require('./services/canvas-page-compiler');
+const { loadPageSource } = require('./services/page-source-loader');
 const { runLintCheck } = require('./page-linter');
 const { buildPageFile, shouldBuildPageSource } = require('./page-compat');
 const { warnLargePageSource } = require('./page-size-guard');
@@ -23,13 +25,49 @@ async function run(args) {
 
   const skipLint = args.includes('--skip-lint');
   const compat = args.includes('--compat') || args.includes('--modern');
-  const filteredArgs = args.filter(arg => arg !== '--skip-lint' && arg !== '--compat' && arg !== '--modern');
+  const canvas = args.includes('--canvas');
+  const json = args.includes('--json');
+  const filteredArgs = args.filter(arg => ![
+    '--skip-lint',
+    '--compat',
+    '--modern',
+    '--canvas',
+    '--json',
+  ].includes(arg));
+  if (filteredArgs.length < 1) {
+    throwUsage(t('cli.compile_usage'), t('cli.compile_example'), {
+      code: 'COMPILE_INVALID_ARGUMENTS',
+    });
+  }
   let sourcePath = path.resolve(filteredArgs[0]);
   if (!fs.existsSync(sourcePath)) {
     throwCommandError(t('publish.source_not_found', sourcePath), {
       code: 'COMPILE_SOURCE_NOT_FOUND',
       details: { sourcePath },
     });
+  }
+
+  if (canvas || /\.canvas\.(?:jsx?|tsx?)$/i.test(sourcePath)) {
+    const workspaceRoot = process.cwd();
+    const relativeSourcePath = path.relative(workspaceRoot, sourcePath);
+    const loadedSource = loadPageSource(relativeSourcePath, { workspaceRoot });
+    const compiled = compileCanvasPageSource(loadedSource);
+    const payload = {
+      ok: true,
+      pageType: 'canvas',
+      sourcePath: fs.realpathSync(sourcePath),
+      profile: compiled.profile,
+      inputHash: compiled.inputHash,
+      sourceHash: compiled.sourceHash,
+      compiledHash: compiled.compiledHash,
+      importedModules: JSON.parse(compiled.importedModules),
+    };
+    if (json) {
+      console.log(JSON.stringify(payload));
+    } else {
+      info(JSON.stringify(payload, null, 2));
+    }
+    return payload;
   }
 
   const initialSourceCode = fs.readFileSync(sourcePath, 'utf-8');

--- a/lib/core/command-manifest.js
+++ b/lib/core/command-manifest.js
@@ -1251,7 +1251,7 @@ const COMMAND_GROUPS = [
       command('create-page', ['create-page'], 'create-page <appType> "<name>" [--mode dashboard] [--hide-nav] [--locale zh_CN|en_US|ja_JP] [--open|--no-open]', 'help.cmd_create_page'),
       command('build-page', ['build-page'], 'build-page <sourceFile> [--output file|--write]', 'help.cmd_build_page', { requiresLogin: false }),
       command('check-page', ['check-page'], 'check-page <src> [--compat]', 'help.cmd_check_page', { output: 'text|json' }),
-      command('compile', ['compile'], 'compile <src>', 'help.cmd_compile', { requiresLogin: false }),
+      command('compile', ['compile'], 'compile <src> [--canvas] [--json]', 'help.cmd_compile', { requiresLogin: false, output: 'text|json' }),
       command('publish', ['publish'], 'publish <src> <appType> <formUuid> [--health-check] [--force] [--canvas] [--auto-nav-order] [--open|--no-open]', 'help.cmd_publish'),
       command('update-form-config', ['update-form-config'], 'update-form-config <appType> <formUuid> <true|false|keep> "<title>" [--locale zh_CN|en_US|ja_JP]', 'help.cmd_update_form_config'),
       command('get-form-config', ['get-form-config'], 'get-form-config <appType> <formUuid> [--json]', 'help.cmd_get_form_config', { output: 'json' }),

--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -69,6 +69,39 @@ describe('compile command', () => {
     expect(fs.statSync(compiledPath).size).toBeGreaterThan(1000);
   });
 
+  test('compiles a Canvas page to deterministic JSON without publishing', () => {
+    const sourcePath = path.join(tmpDir, 'pages', 'src', 'dashboard.canvas.jsx');
+    fs.writeFileSync(sourcePath, `
+import React from 'react';
+
+export default function YidaComp() {
+  return <div>访客看板</div>;
+}
+`, 'utf8');
+
+    const stdout = execFileSync(process.execPath, [
+      BIN,
+      'compile',
+      'pages/src/dashboard.canvas.jsx',
+      '--json',
+    ], {
+      cwd: tmpDir,
+      env: { ...cliEnv(), YIDA_QUIET: '1' },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    const payload = JSON.parse(stdout.trim());
+
+    expect(payload).toMatchObject({
+      ok: true,
+      pageType: 'canvas',
+      sourcePath: fs.realpathSync(sourcePath),
+    });
+    expect(payload.compiledHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(payload.importedModules).toEqual(['react']);
+    expect(fs.existsSync(path.join(tmpDir, 'pages', 'dist', 'dashboard.canvas.js'))).toBe(false);
+  });
+
   test('rejects emoji even when lint is skipped', () => {
     const sourcePath = path.join(tmpDir, 'pages', 'src', 'emoji.jsx');
     fs.writeFileSync(sourcePath, `

--- a/tests/skill-contracts.test.js
+++ b/tests/skill-contracts.test.js
@@ -708,6 +708,12 @@ describe('OpenYida skill contracts', () => {
     expect(skill).toContain('[写入初始表单数据](workflow/step-5-seed-records.md)');
     expect(appStep5).toContain('use_skill("yida-data-management", "为核心业务表单写入 1-3 条示例记录")');
     expect(appStep5).toContain('完整应用默认给本轮新建或页面数据源依赖的核心普通表单写入 1-3 条业务化 seed records');
+    expect(appStep5).toContain('openyida data create form');
+    expect(appStep5).toContain('--expect-form-type receipt');
+    expect(appStep5).toContain('openyida data create process');
+    expect(appStep5).toContain('--process-code <真实 processCode>');
+    expect(appStep5).toContain('--expect-form-type process');
+    expect(appStep5).toContain('流程表单没有确认 `processCode` 时禁止写入实例');
     expect(appStep4).toContain('拿到真实 `formUuid` 后写入资源上下文');
     expect(appStep9).toContain('自定义页面只在 `YidaComp` 内消费对应 token');
     expect(appStep9).toContain('新建或作为页面数据源的核心普通表单已写入 1-3 条真实示例记录并 query 抽查');
@@ -1133,7 +1139,8 @@ describe('OpenYida skill contracts', () => {
     expect(canvas).toContain('不得用 Python、Node、Shell 或 `run_workspace_script`');
     expect(canvas).toContain('已有 JSX/CSS/JSON 源码只做定点 Edit');
     expect(canvas).toContain('不要写 `project/.cache/...`');
-    expect(canvas).toContain('现成的 `./lib/app/canvas-compile`');
+    expect(canvas).toContain('openyida compile <页面源码.canvas.jsx> --json');
+    expect(canvas).not.toContain('node -e');
     expect(canvas).toContain('该历史源码只由 `yida-custom-page` 自身闭环维护');
     expect(canvas).toContain('交给 `yida-canvas-upgrade`');
     expect(canvas).toContain('有 publish 成功证据时表述为“页面已发布”');

--- a/yida-skills/skills/yida-app/workflow/step-5-seed-records.md
+++ b/yida-skills/skills/yida-app/workflow/step-5-seed-records.md
@@ -1,11 +1,12 @@
 # Step 5：写入初始表单数据
 
-完整应用默认给本轮新建或页面数据源依赖的核心普通表单写入 1-3 条业务化 seed records。
+完整应用默认给本轮新建或页面数据源依赖的核心普通表单写入 1-3 条业务化 seed records。流程表单仅在已确认真实 `processCode` 后按独立命令写入。
 
 ## 输入
 
 - 真实 `appType`；
-- 核心普通表单 `formUuid`；
+- 核心表单 `formUuid`、真实表单类型；
+- 流程表单已确认的真实 `processCode`；
 - `.cache/<项目名>-schema.json` 或字段 schema；
 - PRD 中的业务对象和示例数据语义。
 
@@ -14,27 +15,30 @@
 1. 执行 `use_skill("yida-data-management", "为核心业务表单写入 1-3 条示例记录")`。
 2. 先执行 `openyida get-schema <appType> <formUuid> --field-map-json` 获取真实字段 ID。
 3. 生成当前业务语义的字段值，不写“测试1 / demo / mock”。
-4. 每个核心普通表单 1-3 条即可；列表/工作台通常 2 条，看板/排行/状态分布通常 3 条。
+4. 每个核心表单 1-3 条即可；列表/工作台通常 2 条，看板/排行/状态分布通常 3 条。
 5. `DateField` / `CascadeDateField` 使用 13 位毫秒时间戳。
-6. 每条记录单独执行 `openyida data create form <appType> <formUuid> --expect-form-name <真实名称> --expect-form-type receipt --data-file ...` 或 `--data-json ...`；名称/UUID/类型不一致时停止。
-7. 最后执行 `openyida data query form` 抽查至少 1 条，确认 `formData` 非空。
+6. 普通表单每条记录单独执行 `openyida data create form <appType> <formUuid> --expect-form-name <真实名称> --expect-form-type receipt --data-file ...` 或 `--data-json ...`；最后执行 `openyida data query form` 抽查至少 1 条。
+7. 流程表单只有在已确认真实 `processCode` 后，才执行 `openyida data create process <appType> <formUuid> --process-code <真实 processCode> --expect-form-name <真实名称> --expect-form-type process --data-file ...` 或 `--data-json ...`；最后执行 `openyida data query process` 抽查至少 1 条。
+8. 名称、UUID、类型或 `processCode` 不一致时停止，不得在 `form` 与 `process` 命令之间盲目重试。
 
 以下情况可以跳过，并在 final 说明原因：
 
 - 用户明确要求不要造数；
 - 表单是配置字典、权限表、敏感个人数据表或纯附件表；
 - 字段缺少可安全构造的有效值；
-- 流程表单没有确认 `processCode`，且页面不需要流程实例。
+- 流程表单没有确认 `processCode` 时禁止写入实例；若页面依赖流程实例，先补齐真实 `processCode`，否则说明跳过原因并保留空态。
 
 ## 产出
 
-- 1-3 条真实普通表单记录；
+- 1-3 条真实普通表单或流程表单记录；
 - query 抽查结果；
 - 或明确跳过原因和页面空态方案。
 
 ## Checklist
 
 - [ ] seed records 使用真实 `fieldId`；
+- [ ] 普通表单使用 `data create form`，流程表单使用 `data create process`；
+- [ ] 流程实例创建前已确认真实 `processCode`；
 - [ ] 每条记录单独创建；
 - [ ] query 抽查已确认 `formData` 非空；
 - [ ] 跳过时已写明原因和页面空态方案。

--- a/yida-skills/skills/yida-canvas-custom-page/SKILL.md
+++ b/yida-skills/skills/yida-canvas-custom-page/SKILL.md
@@ -170,7 +170,7 @@ openyida create-page <appType> "<页面名>"
 
 # 使用 Provider 标记时，先按主题脚本指南生成 <页面名>.themed.canvas.jsx；以下快检与发布都改用该生成文件。
 # 4. 本地快检
-node -e "const fs=require('fs'); const {compileCanvasLocal}=require('./lib/app/canvas-compile'); const src=fs.readFileSync('project/pages/src/<页面名>.canvas.jsx','utf8'); console.log(compileCanvasLocal(src).importedModules)"
+openyida compile project/pages/src/<页面名>.canvas.jsx --json
 
 # 5. 发布（本轮修改源码后的远端完成证据）
 openyida publish project/pages/src/<页面名>.canvas.jsx <appType> <formUuid>
@@ -179,9 +179,11 @@ openyida publish project/pages/src/<页面名>.canvas.jsx <appType> <formUuid>
 openyida get-schema <appType> <formUuid> --field-map-json
 ```
 
-`openyida check-page` / `openyida compile` 当前面向平台 JSX 组件页面 `.oyd.jsx` / `.jsx`；使用 `YidaCodeCanvas` 组件实现的页面以 `compileCanvasLocal` 和 `openyida publish .canvas.jsx` 的构建阶段为准。`compileCanvasLocal` 是发布前快检，`openyida publish` 是远端写入证据。
+`openyida compile` 会自动识别 `.canvas.jsx` / `.canvas.tsx` 并调用 Canvas 编译器；`--json` 返回可机器读取的 hash 和依赖清单。该命令只读、无需登录、不访问网络、不发布页面，也不写入构建产物。`openyida publish` 仍是远端写入证据。
 
-快检固定从 workspace 根使用现成的 `./lib/app/canvas-compile`，不要搜索其他 compiler 路径或安装依赖。`run_workspace_script` 的 `script_path` 以项目根为基准，写 `.cache/yida-agent/scripts/...`；不要写 `project/.cache/...`，否则运行时会解析成 `project/project/.cache/...`。
+云端与本地 Agent 都使用同一条 `openyida compile <页面源码.canvas.jsx> --json` 快检命令，不依赖仅云端 Builder 提供的 `run_workspace_script`。
+
+其他确需保存的云端 workspace 脚本放在项目根 `.cache/yida-agent/scripts/...`，不要写 `project/.cache/...`，否则运行时会解析成重复的 `project/project/.cache/...`；Canvas 快检本身不需要创建脚本。
 
 如需保存完整 Schema，使用 create_file / Write / file edit tool 创建 `<projectRoot>/.cache/openyida/<页面名或任务名>/<页面名>-schema.json`；从 workspace 根执行后续 Bash 命令时路径加 `project/` 前缀。
 

--- a/yida-skills/skills/yida-canvas-custom-page/references/component-library-guide.md
+++ b/yida-skills/skills/yida-canvas-custom-page/references/component-library-guide.md
@@ -95,7 +95,7 @@ OpenYida 禁止页面源码和 page-spec 中出现 emoji。遇到 `contains emoj
 可直接按推荐组合编写页面并执行本地快检：
 
 ```bash
-node -e "const fs=require('fs'); const {compileCanvasLocal}=require('./lib/app/canvas-compile'); const src=fs.readFileSync('project/pages/src/dashboard-starter.canvas.jsx','utf8'); console.log(compileCanvasLocal(src).importedModules)"
+openyida compile project/pages/src/dashboard-starter.canvas.jsx --json
 ```
 
 ## 自查清单

--- a/yida-skills/skills/yida-canvas-table-form/SKILL.md
+++ b/yida-skills/skills/yida-canvas-table-form/SKILL.md
@@ -125,7 +125,7 @@ openyida get-schema <appType> <formUuid> --field-map-json
 # 未验证前保持 writeBridge.verified !== true
 
 # 4. 本地快检
-node -e "const fs=require('fs'); const {compileCanvasLocal}=require('./lib/app/canvas-compile'); const src=fs.readFileSync('project/pages/src/table-form-batch-submit.canvas.jsx','utf8'); console.log(compileCanvasLocal(src).importedModules)"
+openyida compile project/pages/src/table-form-batch-submit.canvas.jsx --json
 
 # 5. 真实交付时发布
 openyida publish project/pages/src/table-form-batch-submit.canvas.jsx <appType> <displayPageFormUuid>

--- a/yida-skills/skills/yida-rechart/SKILL.md
+++ b/yida-skills/skills/yida-rechart/SKILL.md
@@ -107,7 +107,7 @@ export default YidaComp;
 # yida-report 负责统计口径；yida-canvas-data-binding 负责接口接入
 
 # 2. 本地快检
-node -e "const fs=require('fs'); const {compileCanvasLocal}=require('./lib/app/canvas-compile'); const src=fs.readFileSync('project/pages/src/trend-combo.canvas.jsx','utf8'); console.log(compileCanvasLocal(src).importedModules)"
+openyida compile project/pages/src/trend-combo.canvas.jsx --json
 
 # 3. 真实交付时发布
 openyida publish project/pages/src/trend-combo.canvas.jsx <appType> <displayPageFormUuid>


### PR DESCRIPTION
## 变更内容

- 新增 `openyida compile <file.canvas.jsx> --json` 确定性 Canvas 编译入口，支持自动识别 Canvas 文件及显式 `--canvas`
- 保持原有 JSX compile 行为，并确保命令只读、无登录/网络/发布副作用
- 明确普通表单与流程表单的数据创建命令，避免 Builder 盲目重试
- 更新 Canvas 相关技能与命令文档

## 验证

- `tests/compile.test.js`
- `tests/skill-contracts.test.js`
- 共 51 项测试通过
- 原提交已执行完整 `npm run check:ci`：195 suites / 3029 tests 通过
